### PR TITLE
Move to GSL integration methods

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ if test "x$with_hdf5" == xno ; then
 fi
 if test "x$with_hdf5" != x -a "x$with_hdf5" != xyes ; then
 	if ! test -d "$with_hdf5" ; then
-		AC_MSG_FAILURE(["$with_hdf5 is not a directory"])
+		AC_MSG_FAILURE(["$with_hdf5 is not a directory. Please check the manual for how to compile with HDF5"])
 	fi
 	HDF5_CXXFLAGS="-I$with_hdf5/include"
 	HDF5_LDFLAGS="-L$with_hdf5/lib"
@@ -74,7 +74,7 @@ if test "x$with_gsl" == xno ; then
 fi
 if test "x$with_gsl" != x -a "x$with_gsl" != xyes ; then
 	if ! test -d "$with_gsl" ; then
-		AC_MSG_FAILURE(["$with_gsl is not a directory"])
+	AC_MSG_FAILURE(["$with_gsl is not a directory. Please check the manual for how to compile with GSL."])
 	fi
 	GSL_CXXFLAGS="-I$with_gsl/include"
 	GSL_LDFLAGS="-L$with_gsl/lib"
@@ -103,7 +103,7 @@ dnl }}}
 
 dnl {{{ use Minuit2 path if supplied via --with-minuit2=
 AC_ARG_WITH([minuit2],
-	[AS_HELP_STRING([--with-minuit2], [used to find starting points for population montecarlo sampling])]
+	[AS_HELP_STRING([--with-minuit2], [used to find starting points for population Monte Carlo sampling])]
 	[],
 	[])
 if test "x$with_minuit2" == xroot ; then
@@ -116,7 +116,7 @@ if test "x$with_minuit2" == xroot ; then
 	fi
 elif test "x$with_minuit2" != xno -a "x$with_minuit2" != x ; then
 	if ! test -d "$with_minuit2" ; then
-		AC_MSG_FAILURE(["$with_minuit2 is not a directory"])
+	AC_MSG_FAILURE(["$with_minuit2 is not a directory. Please check the manual for how to compile with Minuit2"])
 	fi
 	CXXFLAGS="-I$with_minuit2/include $CXXFLAGS"
 	LDFLAGS="-L$with_minuit2/lib $LDFLAGS"
@@ -124,12 +124,12 @@ fi
 dnl }}}
 dnl {{{ use PMC path if supplied via --with-pmc=
 AC_ARG_WITH([pmc],
-	[AS_HELP_STRING([--with-pmc], [used to perform population montecarlo sampling])]
+	[AS_HELP_STRING([--with-pmc], [used to perform population Monte Carlo sampling])]
 	[],
 	[])
 if test "x$with_pmc" != x ; then
 	if ! test -d "$with_pmc" ; then
-		AC_MSG_FAILURE(["$with_pmc is not a directory"])
+	AC_MSG_FAILURE(["$with_pmc is not a directory. Please check the manual for how to compile with pmclib"])
 	else
 		CXXFLAGS="-I$with_pmc/include $CXXFLAGS"
 		LDFLAGS="-Wl,-rpath,$with_pmc/lib -L$with_pmc/lib $LDFLAGS"

--- a/eos/b-decays/b-to-d-l-nu.cc
+++ b/eos/b-decays/b-to-d-l-nu.cc
@@ -123,7 +123,7 @@ namespace eos
         std::function<double (const double &)> f = std::bind(&Implementation<BToDLeptonNeutrino>::differential_branching_ratio,
                 _imp.get(), std::placeholders::_1);
 
-        return integrate1D(f, 128, s_min, s_max);
+        return integrate<GSL::QNG>(f, s_min, s_max);
     }
 
     double
@@ -153,13 +153,13 @@ namespace eos
         double br_muons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, 0 /*_imp->parameters["mass::mu"]()*/);
-            br_muons = integrate1D(f, 128, 0.02, 11.62);
+            br_muons = integrate<GSL::QNG>(f, 0.02, 11.62);
         }
 
         double br_taus;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::tau"]());
-            br_taus = integrate1D(f, 128, 3.16, 11.62);
+            br_taus = integrate<GSL::QNG>(f, 3.16, 11.62);
         }
 
         return br_taus / br_muons;

--- a/eos/b-decays/b-to-d-l-nu.cc
+++ b/eos/b-decays/b-to-d-l-nu.cc
@@ -123,7 +123,7 @@ namespace eos
         std::function<double (const double &)> f = std::bind(&Implementation<BToDLeptonNeutrino>::differential_branching_ratio,
                 _imp.get(), std::placeholders::_1);
 
-        return integrate(f, 128, s_min, s_max);
+        return integrate1D(f, 128, s_min, s_max);
     }
 
     double
@@ -153,13 +153,13 @@ namespace eos
         double br_muons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, 0 /*_imp->parameters["mass::mu"]()*/);
-            br_muons = integrate(f, 128, 0.02, 11.62);
+            br_muons = integrate1D(f, 128, 0.02, 11.62);
         }
 
         double br_taus;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::tau"]());
-            br_taus = integrate(f, 128, 3.16, 11.62);
+            br_taus = integrate1D(f, 128, 3.16, 11.62);
         }
 
         return br_taus / br_muons;

--- a/eos/b-decays/b-to-d-l-x-nu.cc
+++ b/eos/b-decays/b-to-d-l-x-nu.cc
@@ -83,7 +83,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand = std::bind(&Implementation<BToDLeptonInclusiveNeutrinos>::differential_decay_width_1nu, this, std::placeholders::_1);
             const double s_min = 0.0, s_max = power_of<2>(m_B() - m_D());
-            double Gamma_1 = integrate1D(integrand, 128, s_min, s_max);
+            double Gamma_1 = integrate<GSL::QNG>(integrand, s_min, s_max);
 
             double fp = form_factors->f_p(s);
             double lam = lambda(m_B * m_B, m_D * m_D, s);
@@ -110,7 +110,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand = std::bind(&Implementation<BToDLeptonInclusiveNeutrinos>::differential_decay_width_3nu, this, std::placeholders::_1);
             const double s_min = 3.16, s_max = power_of<2>(m_B() - m_D());
-            const double Gamma_3 = integrate1D(integrand, 128, s_min, s_max);
+            const double Gamma_3 = integrate<GSL::QNG>(integrand, s_min, s_max);
 
             const double fp = form_factors->f_p(s), fp2 = fp * fp;
             const double f0 = form_factors->f_0(s), f02 = f0 * f0;

--- a/eos/b-decays/b-to-d-l-x-nu.cc
+++ b/eos/b-decays/b-to-d-l-x-nu.cc
@@ -83,7 +83,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand = std::bind(&Implementation<BToDLeptonInclusiveNeutrinos>::differential_decay_width_1nu, this, std::placeholders::_1);
             const double s_min = 0.0, s_max = power_of<2>(m_B() - m_D());
-            double Gamma_1 = integrate(integrand, 128, s_min, s_max);
+            double Gamma_1 = integrate1D(integrand, 128, s_min, s_max);
 
             double fp = form_factors->f_p(s);
             double lam = lambda(m_B * m_B, m_D * m_D, s);
@@ -110,7 +110,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand = std::bind(&Implementation<BToDLeptonInclusiveNeutrinos>::differential_decay_width_3nu, this, std::placeholders::_1);
             const double s_min = 3.16, s_max = power_of<2>(m_B() - m_D());
-            const double Gamma_3 = integrate(integrand, 128, s_min, s_max);
+            const double Gamma_3 = integrate1D(integrand, 128, s_min, s_max);
 
             const double fp = form_factors->f_p(s), fp2 = fp * fp;
             const double f0 = form_factors->f_0(s), f02 = f0 * f0;

--- a/eos/b-decays/b-to-pi-l-nu.cc
+++ b/eos/b-decays/b-to-pi-l-nu.cc
@@ -125,7 +125,7 @@ namespace eos
         std::function<double (const double &)> f = std::bind(&Implementation<BToPiLeptonNeutrino>::differential_branching_ratio,
                 _imp.get(), std::placeholders::_1);
 
-        return integrate(f, 64, s_min, s_max);
+        return integrate1D(f, 64, s_min, s_max);
     }
 
     double
@@ -134,7 +134,7 @@ namespace eos
         std::function<double (const double &)> f = std::bind(&Implementation<BToPiLeptonNeutrino>::differential_decay_width,
                 _imp.get(), std::placeholders::_1);
 
-        return integrate(f, 64, s_min, s_max);
+        return integrate1D(f, 64, s_min, s_max);
     }
 
     double
@@ -149,6 +149,6 @@ namespace eos
         std::function<double (const double &)> f = std::bind(&Implementation<BToPiLeptonNeutrino>::differential_zeta,
                 _imp.get(), std::placeholders::_1);
 
-        return integrate(f, 64, s_min, s_max);
+        return integrate1D(f, 64, s_min, s_max);
     }
 }

--- a/eos/b-decays/b-to-pi-l-nu.cc
+++ b/eos/b-decays/b-to-pi-l-nu.cc
@@ -125,7 +125,7 @@ namespace eos
         std::function<double (const double &)> f = std::bind(&Implementation<BToPiLeptonNeutrino>::differential_branching_ratio,
                 _imp.get(), std::placeholders::_1);
 
-        return integrate1D(f, 64, s_min, s_max);
+        return integrate<GSL::QNG>(f, s_min, s_max);
     }
 
     double
@@ -134,7 +134,7 @@ namespace eos
         std::function<double (const double &)> f = std::bind(&Implementation<BToPiLeptonNeutrino>::differential_decay_width,
                 _imp.get(), std::placeholders::_1);
 
-        return integrate1D(f, 64, s_min, s_max);
+        return integrate<GSL::QNG>(f, s_min, s_max);
     }
 
     double
@@ -149,6 +149,6 @@ namespace eos
         std::function<double (const double &)> f = std::bind(&Implementation<BToPiLeptonNeutrino>::differential_zeta,
                 _imp.get(), std::placeholders::_1);
 
-        return integrate1D(f, 64, s_min, s_max);
+        return integrate<GSL::QNG>(f, s_min, s_max);
     }
 }

--- a/eos/b-decays/b-to-pi-l-x-nu.cc
+++ b/eos/b-decays/b-to-pi-l-x-nu.cc
@@ -83,7 +83,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand = std::bind(&Implementation<BToPiLeptonInclusiveNeutrinos>::differential_decay_width_1nu, this, std::placeholders::_1);
             const double s_min = 0.0, s_max = power_of<2>(m_B() - m_pi());
-            double Gamma_1 = integrate(integrand, 128, s_min, s_max);
+            double Gamma_1 = integrate1D(integrand, 128, s_min, s_max);
 
             double fp = form_factors->f_p(s);
             double lam = lambda(m_B * m_B, m_pi * m_pi, s);
@@ -110,7 +110,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand = std::bind(&Implementation<BToPiLeptonInclusiveNeutrinos>::differential_decay_width_3nu, this, std::placeholders::_1);
             const double s_min = 3.16, s_max = power_of<2>(m_B() - m_pi());
-            const double Gamma_3 = integrate(integrand, 128, s_min, s_max);
+            const double Gamma_3 = integrate1D(integrand, 128, s_min, s_max);
 
             const double fp = form_factors->f_p(s), fp2 = fp * fp;
             const double f0 = form_factors->f_0(s), f02 = f0 * f0;

--- a/eos/b-decays/b-to-pi-l-x-nu.cc
+++ b/eos/b-decays/b-to-pi-l-x-nu.cc
@@ -83,7 +83,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand = std::bind(&Implementation<BToPiLeptonInclusiveNeutrinos>::differential_decay_width_1nu, this, std::placeholders::_1);
             const double s_min = 0.0, s_max = power_of<2>(m_B() - m_pi());
-            double Gamma_1 = integrate1D(integrand, 128, s_min, s_max);
+            double Gamma_1 = integrate<GSL::QNG>(integrand, s_min, s_max);
 
             double fp = form_factors->f_p(s);
             double lam = lambda(m_B * m_B, m_pi * m_pi, s);
@@ -110,7 +110,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand = std::bind(&Implementation<BToPiLeptonInclusiveNeutrinos>::differential_decay_width_3nu, this, std::placeholders::_1);
             const double s_min = 3.16, s_max = power_of<2>(m_B() - m_pi());
-            const double Gamma_3 = integrate1D(integrand, 128, s_min, s_max);
+            const double Gamma_3 = integrate<GSL::QNG>(integrand, s_min, s_max);
 
             const double fp = form_factors->f_p(s), fp2 = fp * fp;
             const double f0 = form_factors->f_0(s), f02 = f0 * f0;

--- a/eos/b-decays/b-to-pi-pi-l-nu.cc
+++ b/eos/b-decays/b-to-pi-pi-l-nu.cc
@@ -202,7 +202,7 @@ namespace eos
                 &Implementation<BToPiPiLeptonNeutrino>::differential_branching_ratio,
                 _imp.get(), q2, k2, std::placeholders::_1);
 
-        return integrate(integrand, 64, -1.0, +1.0);
+        return integrate1D(integrand, 64, -1.0, +1.0);
     }
 
     double
@@ -218,8 +218,8 @@ namespace eos
                 &Implementation<BToPiPiLeptonNeutrino>::normalized_differential_decay_width,
                 _imp.get(), q2, k2, std::placeholders::_1);
 
-        const double numerator = integrate(integrand, 64, 0.0, +1.0) - integrate(integrand, 64, -1.0, 0.0);
-        const double denominator = integrate(integrand, 64, -1.0, +1.0);
+        const double numerator = integrate1D(integrand, 64, 0.0, +1.0) - integrate1D(integrand, 64, -1.0, 0.0);
+        const double denominator = integrate1D(integrand, 64, -1.0, +1.0);
 
         return numerator / denominator;
     }
@@ -233,7 +233,7 @@ namespace eos
                 _imp.get(), q2, k2, std::placeholders::_1);
 
         return integrand(z)
-            / integrate(integrand, 64, -1.0, +1.0);
+            / integrate1D(integrand, 64, -1.0, +1.0);
     }
 
     double

--- a/eos/b-decays/b-to-pi-pi-l-nu.cc
+++ b/eos/b-decays/b-to-pi-pi-l-nu.cc
@@ -202,7 +202,7 @@ namespace eos
                 &Implementation<BToPiPiLeptonNeutrino>::differential_branching_ratio,
                 _imp.get(), q2, k2, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, -1.0, +1.0);
+        return integrate<GSL::QNG>(integrand, -1.0, +1.0);
     }
 
     double
@@ -218,8 +218,8 @@ namespace eos
                 &Implementation<BToPiPiLeptonNeutrino>::normalized_differential_decay_width,
                 _imp.get(), q2, k2, std::placeholders::_1);
 
-        const double numerator = integrate1D(integrand, 64, 0.0, +1.0) - integrate1D(integrand, 64, -1.0, 0.0);
-        const double denominator = integrate1D(integrand, 64, -1.0, +1.0);
+        const double numerator = integrate<GSL::QNG>(integrand, 0.0, +1.0) - integrate<GSL::QNG>(integrand, -1.0, 0.0);
+        const double denominator = integrate<GSL::QNG>(integrand, -1.0, +1.0);
 
         return numerator / denominator;
     }
@@ -233,7 +233,7 @@ namespace eos
                 _imp.get(), q2, k2, std::placeholders::_1);
 
         return integrand(z)
-            / integrate1D(integrand, 64, -1.0, +1.0);
+            / integrate<GSL::QNG>(integrand, -1.0, +1.0);
     }
 
     double

--- a/eos/b-decays/bs-to-kstar-l-nu.cc
+++ b/eos/b-decays/bs-to-kstar-l-nu.cc
@@ -139,7 +139,7 @@ namespace eos
         {
             std::function<std::array<double, 12> (const double &)> integrand =
                     std::bind(&Implementation<BsToKstarLeptonNeutrino>::differential_angular_coefficients_array, this, std::placeholders::_1);
-            std::array<double, 12> integrated_angular_coefficients_array = integrate(integrand, 64, s_min, s_max);
+            std::array<double, 12> integrated_angular_coefficients_array = integrate1D(integrand, 64, s_min, s_max);
 
             return AngularCoefficients(integrated_angular_coefficients_array);
         }

--- a/eos/form-factors/analytic-b-to-kstar.cc
+++ b/eos/form-factors/analytic-b-to-kstar.cc
@@ -232,7 +232,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -386,7 +386,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -555,7 +555,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -723,7 +723,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -856,7 +856,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1017,7 +1017,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1198,7 +1198,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1266,7 +1266,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1322,7 +1322,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 

--- a/eos/form-factors/analytic-b-to-kstar.cc
+++ b/eos/form-factors/analytic-b-to-kstar.cc
@@ -232,7 +232,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -386,7 +386,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -555,7 +555,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -723,7 +723,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -856,7 +856,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1017,7 +1017,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1198,7 +1198,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1266,7 +1266,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1322,7 +1322,7 @@ namespace eos
             const auto etaf0   = etaf(q2, sigma0);
             const auto Detaf0  = Detaf(q2, sigma0);
 
-            const auto integral = integrate1D(integrand, 128, 0.0, sigma0);
+            const auto integral = integrate<GSL::QNG>(integrand, 0.0, sigma0);
             const auto delta = (iota20 - (1.0 / M2 + Detaf0 / m_B2) / 2.0 * iota30 - etaf0 / (2.0 * m_B2) * Diota30)
                 * std::exp(-s0 / M2) / m_B2 * etaf0;
 
@@ -1671,4 +1671,3 @@ namespace eos
         return _imp->diagnostics();
     }
 }
-

--- a/eos/form-factors/analytic-b-to-pi-pi.cc
+++ b/eos/form-factors/analytic-b-to-pi-pi.cc
@@ -168,7 +168,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand(std::bind(&Implementation<AnalyticFormFactorBToPiPiBFvD2016>::R_int_denom_integrand, *this, std::placeholders::_1));
 
-            return integrate1D(integrand, 64, 0.02, 0.95);
+            return integrate<GSL::QNG>(integrand, 0.02, 0.95);
         }
 
         inline void check_thorsten()
@@ -565,4 +565,3 @@ namespace eos
         return _imp->diagnostics();
     }
 }
-

--- a/eos/form-factors/analytic-b-to-pi-pi.cc
+++ b/eos/form-factors/analytic-b-to-pi-pi.cc
@@ -168,7 +168,7 @@ namespace eos
         {
             std::function<double (const double &)> integrand(std::bind(&Implementation<AnalyticFormFactorBToPiPiBFvD2016>::R_int_denom_integrand, *this, std::placeholders::_1));
 
-            return integrate(integrand, 64, 0.02, 0.95);
+            return integrate1D(integrand, 64, 0.02, 0.95);
         }
 
         inline void check_thorsten()

--- a/eos/form-factors/analytic-b-to-pi.cc
+++ b/eos/form-factors/analytic-b-to-pi.cc
@@ -131,7 +131,7 @@ namespace eos
                     return std::exp(-s / Mprime2) * ((s - mb2) * (s - mb2) / s + 4.0 * alpha_s_mu / (3.0 * pi) * rho_1(s, mb, mu));
                 }
             );
-            const double integral = integrate1D(integrand, 64, mb2 + eps, sprime0B);
+            const double integral = integrate<GSL::QNG>(integrand, mb2 + eps, sprime0B);
 
             double result = std::exp(MB2 / Mprime2) / MB4 * (3.0 * mb2 / (8.0 * pi2) * integral
                 + mb2 * std::exp(-mb2 / Mprime2) * (
@@ -176,14 +176,14 @@ namespace eos
                     return std::exp(-s / Mprime2) * ((s - mb2) * (s - mb2) + 4.0 * s * alpha_s_mu / (3.0 * pi) * rho_1(s, mb, mu));
                 }
             );
-            const double integral_numerator = integrate1D(integrand_numerator, 64, mb2 + eps, sprime0B);
+            const double integral_numerator = integrate<GSL::QNG>(integrand_numerator, mb2 + eps, sprime0B);
             std::function<double (const double &)> integrand_denominator(
                 [&] (const double & s) -> double
                 {
                     return std::exp(-s / Mprime2) * ((s - mb2) * (s - mb2) / s + 4.0 * alpha_s_mu / (3.0 * pi) * rho_1(s, mb, mu));
                 }
             );
-            const double integral_denominator = integrate1D(integrand_denominator, 64, mb2 + eps, sprime0B);
+            const double integral_denominator = integrate<GSL::QNG>(integrand_denominator, mb2 + eps, sprime0B);
 
             double numerator = 3.0 * mb2 / (8.0 * pi2) * integral_numerator
                 + mb4 * std::exp(-mb2 / Mprime2) * (
@@ -222,7 +222,7 @@ namespace eos
 
             std::function<double (const double &)> integrand(std::bind(&Implementation<AnalyticFormFactorBToPiDKMMO2008>::F_lo_tw2_integrand, this, std::placeholders::_1, q2, _M2));
 
-            return mb2 * fpi * integrate1D(integrand, 64, u0, 1.000);
+            return mb2 * fpi * integrate<GSL::QNG>(integrand, u0, 1.000);
         }
 
         double F_lo_tw3_integrand(const double & u, const double & q2, const double & _M2) const
@@ -280,7 +280,7 @@ namespace eos
 
             std::function<double (const double &)> integrand(std::bind(&Implementation<AnalyticFormFactorBToPiDKMMO2008>::F_lo_tw3_integrand, this, std::placeholders::_1, q2, _M2));
 
-            return mb2 * fpi * integrate1D(integrand, 64, u0, 1.000);
+            return mb2 * fpi * integrate<GSL::QNG>(integrand, u0, 1.000);
         }
 
         double F_lo_tw4(const double & q2, const double & _M2) const
@@ -378,7 +378,7 @@ namespace eos
                 }
             );
 
-            return mb2 * fpi * integrate1D(integrand, 64, u0, 1 - 1e-10);
+            return mb2 * fpi * integrate<GSL::QNG>(integrand, u0, 1 - 1e-10);
         }
 
         double F_nlo_tw2(const double & q2, const double & _M2) const
@@ -568,7 +568,9 @@ namespace eos
 
             static const double eps = 1e-12;
 
-            return mb2 * fpi * integrate1D(integrand, 64, 1.0 + eps, s0B / mb2);
+            auto config = GSL::QAGS::Config().epsrel(1e-6);
+
+            return mb2 * fpi * integrate<GSL::QAGS>(integrand, 1.0 + eps, s0B / mb2, config);
         }
 
         double F_nlo_tw3(const double & q2, const double _M2) const
@@ -747,8 +749,10 @@ namespace eos
 
             static const double eps = 1e-12;
 
+            auto config = GSL::QAGS::Config().epsrel(1e-6);
+
             return fpi * mupi * mb * (
-                    integrate1D(integrand, 64, 1.0 + eps, s0B / mb2)
+                    integrate<GSL::QAGS>(integrand, 1.0 + eps, s0B / mb2, config)
                     - (
                         2.0 / (1.0 - r1) * (4.0 - 3.0 * lmu)
                         + 2.0 * (1.0 + r1) / power_of<2>(1.0 - r1) * (4.0 - 3.0 * lmu)
@@ -787,8 +791,8 @@ namespace eos
                 }
             );
 
-            double result = integrate1D(integrand_numerator_zero, 64, u0_zero, 1.000) / integrate1D(integrand_numerator_q2, 64, u0_q2, 1.000)
-                / integrate1D(integrand_denominator_zero, 64, u0_zero, 1.000) * integrate1D(integrand_denominator_q2, 64, u0_q2, 1.000);
+            double result = integrate<GSL::QNG>(integrand_numerator_zero, u0_zero, 1.000) / integrate<GSL::QNG>(integrand_numerator_q2, u0_q2, 1.000)
+                / integrate<GSL::QNG>(integrand_denominator_zero, u0_zero, 1.000) * integrate<GSL::QNG>(integrand_denominator_q2, u0_q2, 1.000);
 
             return result;
         }
@@ -941,4 +945,3 @@ namespace eos
         return _imp->diagnostics();
     }
 }
-

--- a/eos/form-factors/analytic-b-to-pi.cc
+++ b/eos/form-factors/analytic-b-to-pi.cc
@@ -131,7 +131,7 @@ namespace eos
                     return std::exp(-s / Mprime2) * ((s - mb2) * (s - mb2) / s + 4.0 * alpha_s_mu / (3.0 * pi) * rho_1(s, mb, mu));
                 }
             );
-            const double integral = integrate(integrand, 64, mb2 + eps, sprime0B);
+            const double integral = integrate1D(integrand, 64, mb2 + eps, sprime0B);
 
             double result = std::exp(MB2 / Mprime2) / MB4 * (3.0 * mb2 / (8.0 * pi2) * integral
                 + mb2 * std::exp(-mb2 / Mprime2) * (
@@ -176,14 +176,14 @@ namespace eos
                     return std::exp(-s / Mprime2) * ((s - mb2) * (s - mb2) + 4.0 * s * alpha_s_mu / (3.0 * pi) * rho_1(s, mb, mu));
                 }
             );
-            const double integral_numerator = integrate(integrand_numerator, 64, mb2 + eps, sprime0B);
+            const double integral_numerator = integrate1D(integrand_numerator, 64, mb2 + eps, sprime0B);
             std::function<double (const double &)> integrand_denominator(
                 [&] (const double & s) -> double
                 {
                     return std::exp(-s / Mprime2) * ((s - mb2) * (s - mb2) / s + 4.0 * alpha_s_mu / (3.0 * pi) * rho_1(s, mb, mu));
                 }
             );
-            const double integral_denominator = integrate(integrand_denominator, 64, mb2 + eps, sprime0B);
+            const double integral_denominator = integrate1D(integrand_denominator, 64, mb2 + eps, sprime0B);
 
             double numerator = 3.0 * mb2 / (8.0 * pi2) * integral_numerator
                 + mb4 * std::exp(-mb2 / Mprime2) * (
@@ -222,7 +222,7 @@ namespace eos
 
             std::function<double (const double &)> integrand(std::bind(&Implementation<AnalyticFormFactorBToPiDKMMO2008>::F_lo_tw2_integrand, this, std::placeholders::_1, q2, _M2));
 
-            return mb2 * fpi * integrate(integrand, 64, u0, 1.000);
+            return mb2 * fpi * integrate1D(integrand, 64, u0, 1.000);
         }
 
         double F_lo_tw3_integrand(const double & u, const double & q2, const double & _M2) const
@@ -280,7 +280,7 @@ namespace eos
 
             std::function<double (const double &)> integrand(std::bind(&Implementation<AnalyticFormFactorBToPiDKMMO2008>::F_lo_tw3_integrand, this, std::placeholders::_1, q2, _M2));
 
-            return mb2 * fpi * integrate(integrand, 64, u0, 1.000);
+            return mb2 * fpi * integrate1D(integrand, 64, u0, 1.000);
         }
 
         double F_lo_tw4(const double & q2, const double & _M2) const
@@ -378,7 +378,7 @@ namespace eos
                 }
             );
 
-            return mb2 * fpi * integrate(integrand, 64, u0, 1 - 1e-10);
+            return mb2 * fpi * integrate1D(integrand, 64, u0, 1 - 1e-10);
         }
 
         double F_nlo_tw2(const double & q2, const double & _M2) const
@@ -568,7 +568,7 @@ namespace eos
 
             static const double eps = 1e-12;
 
-            return mb2 * fpi * integrate(integrand, 64, 1.0 + eps, s0B / mb2);
+            return mb2 * fpi * integrate1D(integrand, 64, 1.0 + eps, s0B / mb2);
         }
 
         double F_nlo_tw3(const double & q2, const double _M2) const
@@ -748,7 +748,7 @@ namespace eos
             static const double eps = 1e-12;
 
             return fpi * mupi * mb * (
-                    integrate(integrand, 64, 1.0 + eps, s0B / mb2)
+                    integrate1D(integrand, 64, 1.0 + eps, s0B / mb2)
                     - (
                         2.0 / (1.0 - r1) * (4.0 - 3.0 * lmu)
                         + 2.0 * (1.0 + r1) / power_of<2>(1.0 - r1) * (4.0 - 3.0 * lmu)
@@ -787,8 +787,8 @@ namespace eos
                 }
             );
 
-            double result = integrate(integrand_numerator_zero, 64, u0_zero, 1.000) / integrate(integrand_numerator_q2, 64, u0_q2, 1.000)
-                / integrate(integrand_denominator_zero, 64, u0_zero, 1.000) * integrate(integrand_denominator_q2, 64, u0_q2, 1.000);
+            double result = integrate1D(integrand_numerator_zero, 64, u0_zero, 1.000) / integrate1D(integrand_numerator_q2, 64, u0_q2, 1.000)
+                / integrate1D(integrand_denominator_zero, 64, u0_zero, 1.000) * integrate1D(integrand_denominator_q2, 64, u0_q2, 1.000);
 
             return result;
         }

--- a/eos/form-factors/analytic-b-to-pi_TEST.cc
+++ b/eos/form-factors/analytic-b-to-pi_TEST.cc
@@ -129,22 +129,24 @@ class AnalyticFormFactorBToPiDKMMO2008Test :
                 TEST_CHECK_NEARLY_EQUAL(-0.0087, ff.F_lo_tw4(10.0),  eps);
 
                 // NLO, tw2
-                TEST_CHECK_NEARLY_EQUAL(+0.7706, ff.F_nlo_tw2( 0.0), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.8190, ff.F_nlo_tw2( 1.0), eps);
-                TEST_CHECK_NEARLY_EQUAL(+1.0609, ff.F_nlo_tw2( 5.0), eps);
-                TEST_CHECK_NEARLY_EQUAL(+1.4741, ff.F_nlo_tw2(10.0), eps);
+                const auto nlo_eps = 400 * eps;
+                TEST_CHECK_NEARLY_EQUAL(+0.7706, ff.F_nlo_tw2( 0.0), nlo_eps);
+                TEST_CHECK_NEARLY_EQUAL(+0.8190, ff.F_nlo_tw2( 1.0), nlo_eps);
+                TEST_CHECK_NEARLY_EQUAL(+1.0609, ff.F_nlo_tw2( 5.0), nlo_eps);
+                TEST_CHECK_NEARLY_EQUAL(+1.4741, ff.F_nlo_tw2(10.0), nlo_eps);
 
                 // NLO, tw3
-                TEST_CHECK_NEARLY_EQUAL(-0.9221, ff.F_nlo_tw3( 0.0), eps);
-                TEST_CHECK_NEARLY_EQUAL(-0.9963, ff.F_nlo_tw3( 1.0), eps);
-                TEST_CHECK_NEARLY_EQUAL(-1.4371, ff.F_nlo_tw3( 5.0), eps);
-                TEST_CHECK_NEARLY_EQUAL(-2.7571, ff.F_nlo_tw3(10.0), eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.9221, ff.F_nlo_tw3( 0.0), nlo_eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.9963, ff.F_nlo_tw3( 1.0), nlo_eps);
+                TEST_CHECK_NEARLY_EQUAL(-1.4371, ff.F_nlo_tw3( 5.0), nlo_eps);
+                TEST_CHECK_NEARLY_EQUAL(-2.7571, ff.F_nlo_tw3(10.0), nlo_eps);
 
                 // form factor @ mu = 3.0
-                TEST_CHECK_NEARLY_EQUAL( 0.2831, ff.f_p( 0.0),       eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.2988, ff.f_p( 1.0),       eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.3777, ff.f_p( 5.0),       eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.5346, ff.f_p(10.0),       eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.2831, ff.f_p( 0.0), 10 * eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.2988, ff.f_p( 1.0), 10 * eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.3777, ff.f_p( 5.0), 10 * eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.5346, ff.f_p(10.0), 10 * eps);
+
             }
         }
 } analytic_form_factor_b_to_pi_DKMMO2008_test;

--- a/eos/rare-b-decays/bremsstrahlung.cc
+++ b/eos/rare-b-decays/bremsstrahlung.cc
@@ -199,7 +199,7 @@ namespace eos
         if (1.0 - s_hat < eps)
             return 0.0;
 
-        return integrate(std::function<complex<double> (const double &)>(
+        return integrate1D(std::function<complex<double> (const double &)>(
                     std::bind(&Bremsstrahlung::tau_22, s_hat, std::placeholders::_1, z)),
                 128, s_hat + eps, 1.0);
     }
@@ -212,7 +212,7 @@ namespace eos
         if (1.0 - s_hat < eps)
             return 0.0;
 
-        return integrate(std::function<complex<double> (const double &)>(
+        return integrate1D(std::function<complex<double> (const double &)>(
                     std::bind(&Bremsstrahlung::tau_27, s_hat, std::placeholders::_1, z)),
                 128, s_hat + eps, 1.0);
     }
@@ -225,7 +225,7 @@ namespace eos
         if (1.0 - s_hat < eps)
             return 0.0;
 
-        return integrate(std::function<complex<double> (const double &)>(
+        return integrate1D(std::function<complex<double> (const double &)>(
                     std::bind(&Bremsstrahlung::tau_28, s_hat, std::placeholders::_1, z)),
                 128, s_hat + eps, 1.0);
     }
@@ -238,7 +238,7 @@ namespace eos
         if (1.0 - s_hat < eps)
             return 0.0;
 
-        return integrate(std::function<complex<double> (const double &)>(
+        return integrate1D(std::function<complex<double> (const double &)>(
                     std::bind(&Bremsstrahlung::tau_29, s_hat, std::placeholders::_1, z)),
                 128, s_hat + eps, 1.0);
     }

--- a/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil.cc
+++ b/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil.cc
@@ -2091,14 +2091,14 @@ namespace eos
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::e"]());
             Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "e");
-            br_electrons = integrate1D(integrand, 256, s_min, s_max);
+            br_electrons = integrate<GSL::QNG>(integrand, s_min, s_max);
         }
 
         double br_muons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::mu"]());
             Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "mu");
-            br_muons = integrate1D(integrand, 256, s_min, s_max);
+            br_muons = integrate<GSL::QNG>(integrand, s_min, s_max);
         }
 
         return br_muons / br_electrons;
@@ -2703,7 +2703,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> f = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        return integrate1D(f, 64, s_min, s_max);
+        return integrate<GSL::QNG>(f, s_min, s_max);
     }
 
     double
@@ -2712,7 +2712,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> f = std::bind(std::mem_fn(&BToKDilepton<LargeRecoil>::differential_branching_ratio),
                 this, std::placeholders::_1);
 
-        return integrate1D(f, 64, s_min, s_max);
+        return integrate<GSL::QNG>(f, s_min, s_max);
     }
 
     double
@@ -2722,9 +2722,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> f = std::bind(&BToKDilepton<LargeRecoil>::differential_branching_ratio,
                 this, std::placeholders::_1);
 
-        double br = integrate1D(f, 64, s_min, s_max);
+        double br = integrate<GSL::QNG>(f, s_min, s_max);
         _imp->cp_conjugate = true;
-        double br_bar = integrate1D(f, 64, s_min, s_max);
+        double br_bar = integrate<GSL::QNG>(f, s_min, s_max);
 
         return (br + br_bar) / 2.0;
     }
@@ -2736,9 +2736,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> f = std::bind(&BToKDilepton<LargeRecoil>::differential_branching_ratio,
                 this, std::placeholders::_1);
 
-        double br = integrate1D(f, 64, s_min, s_max);
+        double br = integrate<GSL::QNG>(f, s_min, s_max);
         _imp->cp_conjugate = true;
-        double br_bar = integrate1D(f, 64, s_min, s_max);
+        double br_bar = integrate<GSL::QNG>(f, s_min, s_max);
 
         return (br - br_bar) / (br + br_bar);
     }
@@ -2751,8 +2751,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate1D(num, 64, s_min, s_max);
-        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
+        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2766,13 +2766,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate1D(num, 64, s_min, s_max);
-        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
+        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate1D(num, 64, s_min, s_max);
-        denom_integrated += integrate1D(denom, 64, s_min, s_max);
+        num_integrated += integrate<GSL::QNG>(num, s_min, s_max);
+        denom_integrated += integrate<GSL::QNG>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2786,8 +2786,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate1D(num, 64, s_min, s_max);
-        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
+        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2801,13 +2801,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate1D(num, 64, s_min, s_max);
-        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
+        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate1D(num, 64, s_min, s_max);
-        denom_integrated += integrate1D(denom, 64, s_min, s_max);
+        num_integrated += integrate<GSL::QNG>(num, s_min, s_max);
+        denom_integrated += integrate<GSL::QNG>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2822,14 +2822,15 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::e"]());
             Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "e");
-            br_electrons = integrate1D(integrand, 64, s_min, s_max);
+            // br_electrons = integrate<GSL::QNG>(integrand, s_min, s_max);
+            br_electrons = integrate<GSL::QNG>(integrand, s_min, s_max);
         }
 
         double br_muons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::mu"]());
             Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "mu");
-            br_muons = integrate1D(integrand, 64, s_min, s_max);
+            br_muons = integrate<GSL::QNG>(integrand, s_min, s_max);
         }
 
         // cf. [BHP2007], Eq. (4.10), p. 6

--- a/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil.cc
+++ b/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil.cc
@@ -992,7 +992,7 @@ namespace eos
         {
             std::function<std::array<double, 12> (const double &)> integrand =
                     std::bind(&Implementation<BToKstarDilepton<LargeRecoil>>::differential_angular_coefficients_array, this, std::placeholders::_1);
-            std::array<double, 12> integrated_angular_coefficients_array = integrate(integrand, 64, s_min, s_max);
+            std::array<double, 12> integrated_angular_coefficients_array = integrate1D(integrand, 64, s_min, s_max);
 
             return array_to_angular_coefficients(integrated_angular_coefficients_array);
         }
@@ -2091,14 +2091,14 @@ namespace eos
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::e"]());
             Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "e");
-            br_electrons = integrate(integrand, 256, s_min, s_max);
+            br_electrons = integrate1D(integrand, 256, s_min, s_max);
         }
 
         double br_muons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::mu"]());
             Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "mu");
-            br_muons = integrate(integrand, 256, s_min, s_max);
+            br_muons = integrate1D(integrand, 256, s_min, s_max);
         }
 
         return br_muons / br_electrons;
@@ -2703,7 +2703,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> f = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        return integrate(f, 64, s_min, s_max);
+        return integrate1D(f, 64, s_min, s_max);
     }
 
     double
@@ -2712,7 +2712,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> f = std::bind(std::mem_fn(&BToKDilepton<LargeRecoil>::differential_branching_ratio),
                 this, std::placeholders::_1);
 
-        return integrate(f, 64, s_min, s_max);
+        return integrate1D(f, 64, s_min, s_max);
     }
 
     double
@@ -2722,9 +2722,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> f = std::bind(&BToKDilepton<LargeRecoil>::differential_branching_ratio,
                 this, std::placeholders::_1);
 
-        double br = integrate(f, 64, s_min, s_max);
+        double br = integrate1D(f, 64, s_min, s_max);
         _imp->cp_conjugate = true;
-        double br_bar = integrate(f, 64, s_min, s_max);
+        double br_bar = integrate1D(f, 64, s_min, s_max);
 
         return (br + br_bar) / 2.0;
     }
@@ -2736,9 +2736,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> f = std::bind(&BToKDilepton<LargeRecoil>::differential_branching_ratio,
                 this, std::placeholders::_1);
 
-        double br = integrate(f, 64, s_min, s_max);
+        double br = integrate1D(f, 64, s_min, s_max);
         _imp->cp_conjugate = true;
-        double br_bar = integrate(f, 64, s_min, s_max);
+        double br_bar = integrate1D(f, 64, s_min, s_max);
 
         return (br - br_bar) / (br + br_bar);
     }
@@ -2751,8 +2751,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate(num, 64, s_min, s_max);
-        double denom_integrated = integrate(denom, 64, s_min, s_max);
+        double num_integrated = integrate1D(num, 64, s_min, s_max);
+        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2766,13 +2766,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate(num, 64, s_min, s_max);
-        double denom_integrated = integrate(denom, 64, s_min, s_max);
+        double num_integrated = integrate1D(num, 64, s_min, s_max);
+        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate(num, 64, s_min, s_max);
-        denom_integrated += integrate(denom, 64, s_min, s_max);
+        num_integrated += integrate1D(num, 64, s_min, s_max);
+        denom_integrated += integrate1D(denom, 64, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2786,8 +2786,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate(num, 64, s_min, s_max);
-        double denom_integrated = integrate(denom, 64, s_min, s_max);
+        double num_integrated = integrate1D(num, 64, s_min, s_max);
+        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2801,13 +2801,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate(num, 64, s_min, s_max);
-        double denom_integrated = integrate(denom, 64, s_min, s_max);
+        double num_integrated = integrate1D(num, 64, s_min, s_max);
+        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate(num, 64, s_min, s_max);
-        denom_integrated += integrate(denom, 64, s_min, s_max);
+        num_integrated += integrate1D(num, 64, s_min, s_max);
+        denom_integrated += integrate1D(denom, 64, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2822,14 +2822,14 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::e"]());
             Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "e");
-            br_electrons = integrate(integrand, 64, s_min, s_max);
+            br_electrons = integrate1D(integrand, 64, s_min, s_max);
         }
 
         double br_muons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::mu"]());
             Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "mu");
-            br_muons = integrate(integrand, 64, s_min, s_max);
+            br_muons = integrate1D(integrand, 64, s_min, s_max);
         }
 
         // cf. [BHP2007], Eq. (4.10), p. 6

--- a/eos/rare-b-decays/exclusive-b-to-s-dilepton-low-recoil.cc
+++ b/eos/rare-b-decays/exclusive-b-to-s-dilepton-low-recoil.cc
@@ -332,7 +332,7 @@ namespace eos
         {
             std::function<std::array<double, 12> (const double &)> integrand =
                     std::bind(&Implementation<BToKstarDilepton<LowRecoil>>::differential_angular_coefficients_array, this, std::placeholders::_1);
-            std::array<double, 12> integrated_angular_coefficients_array = integrate(integrand, 64, s_min, s_max);
+            std::array<double, 12> integrated_angular_coefficients_array = integrate1D(integrand, 64, s_min, s_max);
 
             return array_to_angular_coefficients(integrated_angular_coefficients_array);
         }
@@ -908,7 +908,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_forward_backward_asymmetry, this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -972,7 +972,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_longitudinal_polarisation, this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1022,7 +1022,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_transverse_asymmetry_2, this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1039,7 +1039,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_transverse_asymmetry_3, this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1056,7 +1056,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_transverse_asymmetry_4, this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1136,7 +1136,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_h_1, this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1152,7 +1152,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_h_2, this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1168,7 +1168,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_h_3, this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1929,7 +1929,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> integrand = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max);
+        return integrate1D(integrand, 64, s_min, s_max);
     }
 
     double
@@ -1938,7 +1938,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> integrand = std::bind(std::mem_fn(&BToKDilepton<LowRecoil>::differential_branching_ratio),
                 this, std::placeholders::_1);
 
-        return integrate(integrand, 64, s_min, s_max);
+        return integrate1D(integrand, 64, s_min, s_max);
     }
 
     double
@@ -1948,9 +1948,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> integrand = std::bind(&BToKDilepton<LowRecoil>::differential_branching_ratio,
                 this, std::placeholders::_1);
 
-        double br = integrate(integrand, 64, s_min, s_max);
+        double br = integrate1D(integrand, 64, s_min, s_max);
         _imp->cp_conjugate = true;
-        double br_bar = integrate(integrand, 64, s_min, s_max);
+        double br_bar = integrate1D(integrand, 64, s_min, s_max);
 
         return (br + br_bar) / 2.0;
     }
@@ -1963,8 +1963,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate(num, 64, s_min, s_max);
-        double denom_integrated = integrate(denom, 64, s_min, s_max);
+        double num_integrated = integrate1D(num, 64, s_min, s_max);
+        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -1978,13 +1978,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate(num, 64, s_min, s_max);
-        double denom_integrated = integrate(denom, 64, s_min, s_max);
+        double num_integrated = integrate1D(num, 64, s_min, s_max);
+        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate(num, 64, s_min, s_max);
-        denom_integrated += integrate(denom, 64, s_min, s_max);
+        num_integrated += integrate1D(num, 64, s_min, s_max);
+        denom_integrated += integrate1D(denom, 64, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -1997,8 +1997,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate(num, 64, s_min, s_max);
-        double denom_integrated = integrate(denom, 64, s_min, s_max);
+        double num_integrated = integrate1D(num, 64, s_min, s_max);
+        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2012,13 +2012,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate(num, 64, s_min, s_max);
-        double denom_integrated = integrate(denom, 64, s_min, s_max);
+        double num_integrated = integrate1D(num, 64, s_min, s_max);
+        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate(num, 64, s_min, s_max);
-        denom_integrated += integrate(denom, 64, s_min, s_max);
+        num_integrated += integrate1D(num, 64, s_min, s_max);
+        denom_integrated += integrate1D(denom, 64, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2032,13 +2032,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         double br_electrons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::e"]());
-            br_electrons = integrate(integrand, 64, s_min, s_max);
+            br_electrons = integrate1D(integrand, 64, s_min, s_max);
         }
 
         double br_muons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::mu"]());
-            br_muons = integrate(integrand, 64, s_min, s_max);
+            br_muons = integrate1D(integrand, 64, s_min, s_max);
         }
 
         // cf. [BHP2007], Eq. (4.10), p. 6
@@ -2053,9 +2053,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> integrand = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double gamma = integrate(integrand, 64, s_min, s_max);
+        double gamma = integrate1D(integrand, 64, s_min, s_max);
         _imp->cp_conjugate = true;
-        double gamma_bar = integrate(integrand, 64, s_min, s_max);
+        double gamma_bar = integrate1D(integrand, 64, s_min, s_max);
 
         return (gamma - gamma_bar) / (gamma + gamma_bar);
     }

--- a/eos/rare-b-decays/exclusive-b-to-s-dilepton-low-recoil.cc
+++ b/eos/rare-b-decays/exclusive-b-to-s-dilepton-low-recoil.cc
@@ -908,7 +908,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_forward_backward_asymmetry, this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate<GSL::QNG>(integrand, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -972,7 +972,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_longitudinal_polarisation, this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate<GSL::QNG>(integrand, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1022,7 +1022,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_transverse_asymmetry_2, this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate<GSL::QNG>(integrand, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1039,7 +1039,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_transverse_asymmetry_3, this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate<GSL::QNG>(integrand, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1056,7 +1056,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_transverse_asymmetry_4, this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate<GSL::QNG>(integrand, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1136,7 +1136,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_h_1, this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate<GSL::QNG>(integrand, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1152,7 +1152,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_h_2, this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate<GSL::QNG>(integrand, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1168,7 +1168,7 @@ namespace eos
     {
         std::function<double (const double &)> integrand = std::bind(&BToKstarDilepton<LowRecoil>::differential_h_3, this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max) / (s_max - s_min);
+        return integrate<GSL::QNG>(integrand, s_min, s_max) / (s_max - s_min);
     }
 
     double
@@ -1929,7 +1929,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> integrand = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max);
+        return integrate<GSL::QNG>(integrand, s_min, s_max);
     }
 
     double
@@ -1938,7 +1938,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> integrand = std::bind(std::mem_fn(&BToKDilepton<LowRecoil>::differential_branching_ratio),
                 this, std::placeholders::_1);
 
-        return integrate1D(integrand, 64, s_min, s_max);
+        return integrate<GSL::QNG>(integrand, s_min, s_max);
     }
 
     double
@@ -1948,9 +1948,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> integrand = std::bind(&BToKDilepton<LowRecoil>::differential_branching_ratio,
                 this, std::placeholders::_1);
 
-        double br = integrate1D(integrand, 64, s_min, s_max);
+        double br = integrate<GSL::QNG>(integrand, s_min, s_max);
         _imp->cp_conjugate = true;
-        double br_bar = integrate1D(integrand, 64, s_min, s_max);
+        double br_bar = integrate<GSL::QNG>(integrand, s_min, s_max);
 
         return (br + br_bar) / 2.0;
     }
@@ -1963,8 +1963,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate1D(num, 64, s_min, s_max);
-        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
+        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -1978,13 +1978,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate1D(num, 64, s_min, s_max);
-        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
+        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate1D(num, 64, s_min, s_max);
-        denom_integrated += integrate1D(denom, 64, s_min, s_max);
+        num_integrated += integrate<GSL::QNG>(num, s_min, s_max);
+        denom_integrated += integrate<GSL::QNG>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -1997,8 +1997,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate1D(num, 64, s_min, s_max);
-        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
+        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2012,13 +2012,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate1D(num, 64, s_min, s_max);
-        double denom_integrated = integrate1D(denom, 64, s_min, s_max);
+        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate1D(num, 64, s_min, s_max);
-        denom_integrated += integrate1D(denom, 64, s_min, s_max);
+        num_integrated += integrate<GSL::QNG>(num, s_min, s_max);
+        denom_integrated += integrate<GSL::QNG>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2032,13 +2032,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         double br_electrons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::e"]());
-            br_electrons = integrate1D(integrand, 64, s_min, s_max);
+            br_electrons = integrate<GSL::QNG>(integrand, s_min, s_max);
         }
 
         double br_muons;
         {
             Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::mu"]());
-            br_muons = integrate1D(integrand, 64, s_min, s_max);
+            br_muons = integrate<GSL::QNG>(integrand, s_min, s_max);
         }
 
         // cf. [BHP2007], Eq. (4.10), p. 6
@@ -2053,9 +2053,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane.";
         std::function<double (const double &)> integrand = std::bind(std::mem_fn(&Implementation<BToKDilepton<LowRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double gamma = integrate1D(integrand, 64, s_min, s_max);
+        double gamma = integrate<GSL::QNG>(integrand, s_min, s_max);
         _imp->cp_conjugate = true;
-        double gamma_bar = integrate1D(integrand, 64, s_min, s_max);
+        double gamma_bar = integrate<GSL::QNG>(integrand, s_min, s_max);
 
         return (gamma - gamma_bar) / (gamma + gamma_bar);
     }

--- a/eos/rare-b-decays/exclusive-b-to-s-dilepton-low-recoil_TEST.cc
+++ b/eos/rare-b-decays/exclusive-b-to-s-dilepton-low-recoil_TEST.cc
@@ -763,7 +763,7 @@ class BToKDileptonLowRecoilTest :
                     TEST_CHECK_RELATIVE_ERROR(d.differential_flat_term(22.0), 0.008213626852, eps);
 
                     TEST_CHECK_RELATIVE_ERROR(d.integrated_branching_ratio(14.18, 22.8),       1.5267386e-07, eps);
-                    TEST_CHECK_RELATIVE_ERROR(d.integrated_flat_term(14.18, 22.8),             5.4236817e-03, eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.integrated_flat_term(14.18, 22.8),             5.4236817e-03, 2*eps);
                     TEST_CHECK_RELATIVE_ERROR(d.integrated_ratio_muons_electrons(14.18, 22.8), 1.0015589,     eps);
                     TEST_CHECK_RELATIVE_ERROR(d.integrated_cp_asymmetry(14.18, 22.8),          2.2706273e-05, eps);
                 }
@@ -811,7 +811,7 @@ class BToKDileptonLowRecoilTest :
 
                     TEST_CHECK_RELATIVE_ERROR(d.integrated_branching_ratio(14.18, 22.8),              1.5520940e-07, eps);
                     TEST_CHECK_RELATIVE_ERROR(d.integrated_branching_ratio_cp_averaged(14.18, 22.8),  1.4629637e-07, eps);
-                    TEST_CHECK_RELATIVE_ERROR(d.integrated_flat_term(14.18, 22.8),                    5.3935506e-03, eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.integrated_flat_term(14.18, 22.8),                    5.3935506e-03, 2*eps);
                     TEST_CHECK_RELATIVE_ERROR(d.integrated_ratio_muons_electrons(14.18, 22.8),        1.0015315,     eps);
                     TEST_CHECK_RELATIVE_ERROR(d.integrated_cp_asymmetry(14.18, 22.8),                 0.0609245,     eps);
                 }

--- a/eos/rare-b-decays/inclusive-b-to-s-dilepton.cc
+++ b/eos/rare-b-decays/inclusive-b-to-s-dilepton.cc
@@ -553,7 +553,7 @@ namespace eos
     double
     BToXsDilepton<HLMW2005>::integrated_branching_ratio(const double & s_min, const double & s_max) const
     {
-        return integrate(std::function<double (const double &)>(
+        return integrate1D(std::function<double (const double &)>(
                     std::bind(&BToXsDilepton<HLMW2005>::differential_branching_ratio, this, std::placeholders::_1)),
                 32, s_min, s_max);
     }

--- a/eos/rare-b-decays/lambda-b-to-lambda-dilepton.cc
+++ b/eos/rare-b-decays/lambda-b-to-lambda-dilepton.cc
@@ -486,7 +486,7 @@ namespace eos
         {
             std::function<std::array<double, 34> (const double &)> integrand(std::bind(&Implementation::_differential_angular_observables, this, std::placeholders::_1));
 
-            return integrate(integrand, 32, s_min, s_max);
+            return integrate1D(integrand, 32, s_min, s_max);
         }
 
         inline lambdab_to_lambda_dilepton::AngularObservables differential_angular_observables(const double & s)
@@ -1076,7 +1076,7 @@ namespace eos
         {
             std::function<std::array<double, 34> (const double &)> integrand(std::bind(&Implementation::_differential_angular_observables, this, std::placeholders::_1));
 
-            return integrate(integrand, 32, s_min, s_max);
+            return integrate1D(integrand, 32, s_min, s_max);
         }
 
         inline lambdab_to_lambda_dilepton::AngularObservables differential_angular_observables(const double & s)

--- a/eos/rare-b-decays/lambda-b-to-lambda-dilepton.cc
+++ b/eos/rare-b-decays/lambda-b-to-lambda-dilepton.cc
@@ -486,7 +486,7 @@ namespace eos
         {
             std::function<std::array<double, 34> (const double &)> integrand(std::bind(&Implementation::_differential_angular_observables, this, std::placeholders::_1));
 
-            return integrate1D(integrand, 32, s_min, s_max);
+            return integrate1D(integrand, 64, s_min, s_max);
         }
 
         inline lambdab_to_lambda_dilepton::AngularObservables differential_angular_observables(const double & s)
@@ -1076,7 +1076,7 @@ namespace eos
         {
             std::function<std::array<double, 34> (const double &)> integrand(std::bind(&Implementation::_differential_angular_observables, this, std::placeholders::_1));
 
-            return integrate1D(integrand, 32, s_min, s_max);
+            return integrate1D(integrand, 64, s_min, s_max);
         }
 
         inline lambdab_to_lambda_dilepton::AngularObservables differential_angular_observables(const double & s)

--- a/eos/utils/integrate-impl.hh
+++ b/eos/utils/integrate-impl.hh
@@ -28,7 +28,7 @@
 
 namespace eos
 {
-    template <std::size_t k> std::array<double, k> integrate(const std::function<std::array<double, k> (const double &)> & f, unsigned n, const double & a, const double & b)
+    template <std::size_t k> std::array<double, k> integrate1D(const std::function<std::array<double, k> (const double &)> & f, unsigned n, const double & a, const double & b)
     {
         if (n & 0x1)
             n += 1;
@@ -110,7 +110,7 @@ namespace eos
                 std::cerr << "Q2 = " << Q2 << std::endl;
                 std::cerr << "Reintegrating with twice the number of data points" << std::endl;
 #endif
-                return integrate(f, 2 * n, a, b);
+                return integrate1D(f, 2 * n, a, b);
             }
         }
     }

--- a/eos/utils/integrate.cc
+++ b/eos/utils/integrate.cc
@@ -29,7 +29,7 @@ namespace eos
     using std::real;
     using std::imag;
 
-    double integrate(const std::function<double (const double &)> & f, unsigned n, const double & a, const double & b)
+    double integrate1D(const std::function<double (const double &)> & f, unsigned n, const double & a, const double & b)
     {
         if (n & 0x1)
             n += 1;
@@ -84,13 +84,13 @@ namespace eos
             std::cerr << "Q2 = " << Q2 << std::endl;
             std::cerr << "Reintegrating with twice the number of data points" << std::endl;
 #endif
-            result = integrate(f, 2 * n, a, b);
+            result = integrate1D(f, 2 * n, a, b);
         }
 
         return result;
     }
 
-    complex<double> integrate(const std::function<complex<double> (const double &)> & f, unsigned n, const double & a, const double & b)
+    complex<double> integrate1D(const std::function<complex<double> (const double &)> & f, unsigned n, const double & a, const double & b)
     {
         if (n & 0x1)
             n += 1;
@@ -145,7 +145,7 @@ namespace eos
             std::cerr << "Q2 = " << Q2 << std::endl;
             std::cerr << "Reintegrating with twice the number of data points" << std::endl;
 #endif
-            result = integrate(f, 2 * n, a, b);
+            result = integrate1D(f, 2 * n, a, b);
         }
 
         return result;

--- a/eos/utils/integrate.cc
+++ b/eos/utils/integrate.cc
@@ -165,7 +165,7 @@ namespace eos
     namespace GSL
     {
         QNG::Config::Config() :
-            _epsabs(1e-3),
+            _epsabs(0),
             _epsrel(1e-4)
         {
         }

--- a/eos/utils/integrate.hh
+++ b/eos/utils/integrate.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2010 Danny van Dyk
+ * Copyright (c) 2018 Danny van Dyk and Frederik Beaujean
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -116,8 +117,8 @@ namespace GSL
      *
      * Two methods from the
      * GNU scientific library are wrapped:
-     * 1) QNG: the non-adaptive Gauss-Kronrod rule
-     * 2) QAGS: the adaptive Clenshaw-Kurtis rule
+     * 1) `QNG`: the non-adaptive Gauss-Kronrod rule
+     * 2) `QAGS`: the adaptive Clenshaw-Kurtis rule
      */
     /// @}
     template <typename Method_>

--- a/eos/utils/integrate.hh
+++ b/eos/utils/integrate.hh
@@ -38,10 +38,10 @@ namespace eos
      * @param a      Lower limit of the domain of integration.
      * @param b      Upper limit of the domain of integration.
      */
-    double integrate(const std::function<double (const double &)> & f, unsigned n, const double & a, const double & b);
-    complex<double> integrate(const std::function<complex<double> (const double &)> & f, unsigned n, const double & a, const double & b);
+    double integrate1D(const std::function<double (const double &)> & f, unsigned n, const double & a, const double & b);
+    complex<double> integrate1D(const std::function<complex<double> (const double &)> & f, unsigned n, const double & a, const double & b);
 
-    template <std::size_t k> std::array<double, k> integrate(const std::function<std::array<double, k> (const double &)> & f, unsigned n, const double & a, const double & b);
+    template <std::size_t k> std::array<double, k> integrate1D(const std::function<std::array<double, k> (const double &)> & f, unsigned n, const double & a, const double & b);
     /// @}
 }
 

--- a/eos/utils/integrate_TEST.cc
+++ b/eos/utils/integrate_TEST.cc
@@ -59,19 +59,19 @@ class IntegrateTest :
 
         virtual void run() const
         {
-            double q1 = integrate(std::function<double (const double &)>(&f1), 16, 0.0, 1.0), i1 = 1.0;
+            double q1 = integrate1D(std::function<double (const double &)>(&f1), 16, 0.0, 1.0), i1 = 1.0;
             std::cout << "\\int_0.0^1.0 f1(x) dx = " << q1 << ", eps = " << std::abs(i1 - q1) / q1 << " over 16 points" << std::endl;
             TEST_CHECK(std::abs(i1 - q1) / i1 < 0.01);
 
-            double q2 = integrate(std::function<double (const double &)>(&f2), 16, 0.00, 0.999999), i2 = 3.0;
+            double q2 = integrate1D(std::function<double (const double &)>(&f2), 16, 0.00, 0.999999), i2 = 3.0;
             std::cout << "\\int_0.0^1.0 f2(x) dx = " << q2 << ", eps = " << std::abs(i2 - q2) / q2 << " over 16 points" << std::endl;
             TEST_CHECK(std::abs(i2 - q2) / i2 < 0.01);
 
-            double q3 = integrate(std::function<double (const double &)>(&f3), 16, 0.00, 10.0), i3 = 1.0 - std::exp(-10.0);
+            double q3 = integrate1D(std::function<double (const double &)>(&f3), 16, 0.00, 10.0), i3 = 1.0 - std::exp(-10.0);
             std::cout << "\\int_0.0^10.0 f3(x) dx = " << q3 << ", eps = " << std::abs(i3 - q3) / q3 << " over 16 points" << std::endl;
             TEST_CHECK(std::abs(i3 - q3) / i3 < 0.01);
 
-            double q4 = integrate(std::function<double (const double &)>(&f4), 16, 1.0, std::exp(1)), i4 = 1.0;
+            double q4 = integrate1D(std::function<double (const double &)>(&f4), 16, 1.0, std::exp(1)), i4 = 1.0;
             std::cout << "\\int_0.0^10.0 f4(x) dx = " << q4 << ", eps = " << std::abs(i4 - q4) / q4 << " over 16 points" << std::endl;
             TEST_CHECK(std::abs(i4 - q4) / i4 < 0.01);
         }

--- a/eos/utils/integrate_TEST.cc
+++ b/eos/utils/integrate_TEST.cc
@@ -59,20 +59,32 @@ class IntegrateTest :
 
         virtual void run() const
         {
+            constexpr double eps = 0.01;
+
             double q1 = integrate1D(std::function<double (const double &)>(&f1), 16, 0.0, 1.0), i1 = 1.0;
             std::cout << "\\int_0.0^1.0 f1(x) dx = " << q1 << ", eps = " << std::abs(i1 - q1) / q1 << " over 16 points" << std::endl;
-            TEST_CHECK(std::abs(i1 - q1) / i1 < 0.01);
+            TEST_CHECK_RELATIVE_ERROR(i1, q1, eps);
 
             double q2 = integrate1D(std::function<double (const double &)>(&f2), 16, 0.00, 0.999999), i2 = 3.0;
             std::cout << "\\int_0.0^1.0 f2(x) dx = " << q2 << ", eps = " << std::abs(i2 - q2) / q2 << " over 16 points" << std::endl;
-            TEST_CHECK(std::abs(i2 - q2) / i2 < 0.01);
+            TEST_CHECK_RELATIVE_ERROR(i2, q2, eps);
 
             double q3 = integrate1D(std::function<double (const double &)>(&f3), 16, 0.00, 10.0), i3 = 1.0 - std::exp(-10.0);
             std::cout << "\\int_0.0^10.0 f3(x) dx = " << q3 << ", eps = " << std::abs(i3 - q3) / q3 << " over 16 points" << std::endl;
-            TEST_CHECK(std::abs(i3 - q3) / i3 < 0.01);
+            TEST_CHECK_RELATIVE_ERROR(i3, q3, eps);
 
             double q4 = integrate1D(std::function<double (const double &)>(&f4), 16, 1.0, std::exp(1)), i4 = 1.0;
-            std::cout << "\\int_0.0^10.0 f4(x) dx = " << q4 << ", eps = " << std::abs(i4 - q4) / q4 << " over 16 points" << std::endl;
-            TEST_CHECK(std::abs(i4 - q4) / i4 < 0.01);
+            std::cout << "\\int_0.0^exp(1) f4(x) dx = " << q4 << ", eps = " << std::abs(i4 - q4) / q4 << " over 16 points" << std::endl;
+            TEST_CHECK_RELATIVE_ERROR(i4, q4, eps);
+
+            auto config_QNG = GSL::QNG::Config().epsrel(eps);
+            q4 = integrate<GSL::QNG>(std::function<double (const double &)>(&f4), 1.0, std::exp(1), config_QNG);
+            std::cout << "\\int_0.0^exp(1) f4(x) dx = " << q4 << ", eps = " << std::abs(i4 - q4) / q4 << " with QNG" << std::endl;
+            TEST_CHECK_RELATIVE_ERROR(i4, q4, eps);
+
+            auto config_QAGS = GSL::QAGS::Config().epsrel(1e-12);
+            q4 = integrate<GSL::QAGS>(std::function<double (const double &)>(&f4), 1.0, std::exp(1), config_QAGS);
+            std::cout << "\\int_0.0^exp(1) f4(x) dx = " << q4 << ", eps = " << std::abs(i4 - q4) / q4 << " with QAGS" << std::endl;
+            TEST_CHECK_RELATIVE_ERROR(i4, q4, eps);
         }
 } model_test;


### PR DESCRIPTION
This is to address #40 . It's not done yet but @dvandyk may review already. In particula, I'm happy about where to put what.

While implementing, I noticed that multithreading can be an issue. Right now the integration is thread safe if the integrand is. But every call to the adaptive integration reserves and frees memory. This memory could be shared if EOS is not used in multiple threads. Else one would need a pool of gsl_memory that one thread could reuse. These are performance issues that don't afffect correctness. Profiling a real use case will show if such compilcations are called for.