### PR TITLE
[statistics] Fix bugs in hierarchical clustering

### DIFF
--- a/eos/statistics/hierarchical-clustering.cc
+++ b/eos/statistics/hierarchical-clustering.cc
@@ -193,7 +193,8 @@ namespace eos
                     gsl_vector_memcpy(mu_diff, output_components[j].mean());
                     gsl_vector_sub(mu_diff, input_components[*i].mean());
                     // sigma = (mu'_j - mu_i) (mu'_j - mu_i)^T
-                    gsl_blas_dsyr(CblasUpper, 1.0, mu_diff, sigma);
+                    gsl_matrix_set_all(sigma, 0);
+                    gsl_blas_dger(1.0, mu_diff, mu_diff, sigma);
                     // sigma += sigma_i
                     gsl_matrix_add(sigma, input_components[*i].covariance());
                     // multiply with alpha_i


### PR DESCRIPTION
This fixes two long-standing bug in the hierarchical clustering that are
cause by the following piece of code:

    // update covariance
    for (auto i = inverse_mapping[j].cbegin() ; i != inverse_mapping[j].cend() ; ++i)
    {
        [...]
        // sigma = (mu'_j - mu_i) (mu'_j - mu_i)^T
        gsl_blas_dsyr(CblasUpper, 1.0, mu_diff, sigma);
        [...]
    }

 1. This accumulates the previous results in the variable sigma.
 2. The 'dsyr' BLAS operation produces a symmetric matrix in
    either upper or lower triangular shape. Since the result is
    added to existing dense matrices, the triangular shape causes
    severe asymmetries in some cases. This problem was exacerbated
    in a setup that required the reduction of a larger number of
    input components to a single output component.

Github: resolves #83