### PR TITLE
[parameters] Fix the default s-quark mass(2GeV)

### DIFF
--- a/eos/parameters/masses.yaml
+++ b/eos/parameters/masses.yaml
@@ -30,7 +30,7 @@
 "mass::s(2GeV)" :
     central: +0.095
     min:     +0.090
-    max:     +0.010
+    max:     +0.10
     comments: "cf. [PDG2012], p. 21"
 "mass::c" :
     central: +1.275


### PR DESCRIPTION
Mistake on the max value of the s-quark mass(2GeV) is fixed. @dvandyk, please merge.