### PR TITLE
[infra] Fix various problems with non-standard locations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,12 +100,40 @@ AC_CHECK_LIB([boost_system], main,
 	)
 dnl }}}
 dnl {{{ yaml-cpp
+PKG_CHECK_MODULES([YAMLCPP],
+	[yaml-cpp],
+	[
+		YAMLCPP_CXXFLAGS="$YAMLCPP_CFLAGS"
+		YAMLCPP_LDFLAGS="$YAMLCPP_LIBS"
+		AC_MSG_NOTICE([using pkg-config for yaml-cpp location])
+	],
+	[
+		YAMLCPP_CXXFLAGS=""
+		YAMLCPP_LDFLAGS="-lyaml-cpp"
+		AC_MSG_NOTICE([falling back to default for yaml-cpp location])
+	])
+
+AC_SUBST([YAMLCPP_CXXFLAGS])
+AC_SUBST([YAMLCPP_LDFLAGS])
+
+_CXXFLAGS=$CXXFLAGS
+_LDFLAGS=$LDFLAGS
+_LIBS=$LIBS
+
+CXXFLAGS="$YAMLCPP_CXXFLAGS $CXXFLAGS"
+LDFLAGS="$YAMLCPP_LDFLAGS $LDFLAGS"
+LIBS=""
+
 AC_CHECK_LIB([yaml-cpp], main)
 AC_CHECK_HEADERS([yaml-cpp/yaml.h],
         [eos_found_yaml_cpp_headers=yes; break;])
 
 AS_IF([test "x$eos_found_yaml_cpp_headers" != "xyes"],
         [AC_MSG_ERROR([you do seem to be lacking 'libyaml-cpp-dev'.])])
+
+CXXFLAGS=$_CXXFLAGS
+LDFLAGS=$_LDFLAGS
+LIBS=$_LIBS
 dnl }}}
 dnl }}}
 

--- a/configure.ac
+++ b/configure.ac
@@ -259,10 +259,11 @@ AC_ARG_ENABLE([python],
 	[],
 	[])
 AM_CONDITIONAL([EOS_ENABLE_PYTHON], [test "x$enable_python" == "xyes"])
+has_boost_python_suffix=no
 AC_ARG_WITH([boost-python-suffix],
-	[AS_HELP_STRING([--with-boost-python-suffix], [suffix used to specify the libboost-python shared object])]
-	[],
-	[])
+	[AS_HELP_STRING([--with-boost-python-suffix], [suffix used to specify the libboost-python shared object])],
+	[has_boost_python_suffix=yes],
+	[with_boost_python_suffix=""])
 dnl }}}
 dnl {{{ python checks (you can change the required python version below)
 if test "x$enable_python" == xyes ; then
@@ -271,12 +272,14 @@ if test "x$enable_python" == xyes ; then
 	PYTHON_LIBS="-lpython$PYTHON_VERSION"
 	PYTHON_LDFLAGS="`python$PYTHON_VERSION-config --ldflags`"
 	PYTHON_CXXFLAGS="`python$PYTHON_VERSION-config --includes`"
-	os_id="`. /etc/os-release ; echo $ID`"
-	if test "x$os_id" == xubuntu -o "x$os_id" == xdebian ; then
-		BOOST_PYTHON_SUFFIX="-py`echo $PYTHON_VERSION | sed -e 's/\.//'`"
-	elif test "x$os_id" == xcentos ; then
-		BOOST_PYTHON_SUFFIX=""
-	elif test "x`uname`" == xDarwin ; then
+	if test "x$has_boost_python_suffix" == "xno"; then
+		os_id="`. /etc/os-release ; echo $ID`"
+		if test "x$os_id" == xubuntu -o "x$os_id" == xdebian ; then
+			BOOST_PYTHON_SUFFIX="-py`echo $PYTHON_VERSION | sed -e 's/\.//'`"
+		elif test "x$os_id" == xcentos ; then
+			BOOST_PYTHON_SUFFIX=""
+		fi
+	else
 		BOOST_PYTHON_SUFFIX=$with_boost_python_suffix
 	fi
 	AC_SUBST([PYTHON_LIBS])

--- a/configure.ac
+++ b/configure.ac
@@ -269,7 +269,7 @@ dnl {{{ python checks (you can change the required python version below)
 if test "x$enable_python" == xyes ; then
 	AM_PATH_PYTHON([3.5])
 	PY_PREFIX=`$PYTHON -c 'import sys ; print(sys.prefix)'`
-	PYTHON_LIBS="-lpython$PYTHON_VERSION"
+	PYTHON_LIBS="`python$PYTHON_VERSION-config --libs`"
 	PYTHON_LDFLAGS="`python$PYTHON_VERSION-config --ldflags`"
 	PYTHON_CXXFLAGS="`python$PYTHON_VERSION-config --includes`"
 	if test "x$has_boost_python_suffix" == "xno"; then

--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,8 @@ AC_CHECK_LIB(gsl, gsl_sf_zeta,
 CXXFLAGS=$_CXXFLAGS
 LDFLAGS=$_LDFLAGS
 LIBS="$LIBS $_LIBS"
+AC_SUBST([GSL_LDFLAGS])
+AC_SUBST([GSL_CXXFLAGS])
 dnl }}}
 
 dnl {{{ use Minuit2 path if supplied via --with-minuit2=

--- a/eos/Makefile.am
+++ b/eos/Makefile.am
@@ -13,6 +13,7 @@ libeos_la_SOURCES = \
 	decays.hh \
 	observable.cc observable.hh \
 	signal-pdf.cc signal-pdf.hh
+libeos_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 libeos_la_LIBADD = \
 	$(top_builddir)/eos/utils/libeosutils.la \
 	$(top_builddir)/eos/statistics/libeosstatistics.la \
@@ -48,6 +49,7 @@ check_PROGRAMS = \
 	references_TEST
 
 constraint_TEST_SOURCES = constraint_TEST.cc
+constraint_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 references_TEST_SOURCES = references_TEST.in
 

--- a/eos/Makefile.am
+++ b/eos/Makefile.am
@@ -20,6 +20,8 @@ libeos_la_LIBADD = \
 	$(top_builddir)/eos/form-factors/libeosformfactors.la \
 	$(top_builddir)/eos/b-decays/libeosbdecays.la \
 	$(top_builddir)/eos/rare-b-decays/libeosrarebdecays.la
+libeos_la_CXXFLAGS = $(AM_CXXFLAGS) $(YAMLCPP_CXXFLAGS)
+libeos_la_LDFLAGS = $(AM_CXXFLAGS) $(YAMLCPP_LDFLAGS)
 
 include_eosdir = $(includedir)/eos
 include_eos_HEADERS = \
@@ -50,6 +52,7 @@ check_PROGRAMS = \
 
 constraint_TEST_SOURCES = constraint_TEST.cc
 constraint_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
+constraint_TEST_LDADD = $(LDADD) -lyaml-cpp
 
 references_TEST_SOURCES = references_TEST.in
 

--- a/eos/b-decays/Makefile.am
+++ b/eos/b-decays/Makefile.am
@@ -18,6 +18,7 @@ libeosbdecays_la_SOURCES = \
 	lambdab-to-lambdac2625-l-nu.cc lambdab-to-lambdac2625-l-nu.hh \
 	inclusive-b-to-u.cc inclusive-b-to-u.hh \
 	properties.cc properties.hh
+libeosbdecays_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) 
 libeosbdecays_la_LIBADD = \
 	$(top_builddir)/eos/utils/libeosutils.la \
 	$(top_builddir)/eos/form-factors/libeosformfactors.la \

--- a/eos/form-factors/Makefile.am
+++ b/eos/form-factors/Makefile.am
@@ -17,6 +17,7 @@ libeosformfactors_la_SOURCES = \
 	mesonic.cc mesonic.hh mesonic-impl.hh \
 	pi-lcdas.cc pi-lcdas.hh \
 	zero-recoil-sum-rule.cc zero-recoil-sum-rule.hh
+libeosformfactors_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 libeosformfactors_la_LIBADD = \
 	$(top_builddir)/eos/utils/libeosutils.la \
 	-lgslcblas \
@@ -58,6 +59,7 @@ analytic_b_to_kstar_TEST_SOURCES = analytic-b-to-kstar_TEST.cc
 analytic_b_to_pi_TEST_SOURCES = analytic-b-to-pi_TEST.cc
 
 analytic_b_to_pi_pi_TEST_SOURCES = analytic-b-to-pi-pi_TEST.cc
+analytic_b_to_pi_pi_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 baryonic_TEST_SOURCES = baryonic_TEST.cc
 

--- a/eos/form-factors/Makefile.am
+++ b/eos/form-factors/Makefile.am
@@ -21,8 +21,7 @@ libeosformfactors_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 libeosformfactors_la_LIBADD = \
 	$(top_builddir)/eos/utils/libeosutils.la \
 	-lgslcblas \
-	-lgsl \
-	-lyaml-cpp
+	-lgsl
 
 include_eos_rarebdecaysdir = $(includedir)/eos/form-factors
 include_eos_rarebdecays_HEADERS = \

--- a/eos/optimize/Makefile.am
+++ b/eos/optimize/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libeosoptimize.la
 libeosoptimize_la_SOURCES = \
 	optimizer.cc optimizer.hh \
 	optimizer-gsl.cc optimizer-gsl.hh
-libeosoptimize_la_CXXFLAGS = $(AM_CXXFLAGS)
+libeosoptimize_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 libeosoptimize_la_LIBADD =
 
 include_eos_optimizedir = $(includedir)/eos/optimize
@@ -23,3 +23,4 @@ LDADD = \
 check_PROGRAMS = $(TESTS)
 
 optimizer_gsl_TEST_SOURCES = optimizer-gsl_TEST.cc
+optimizer_gsl_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)

--- a/eos/rare-b-decays/Makefile.am
+++ b/eos/rare-b-decays/Makefile.am
@@ -24,8 +24,7 @@ libeosrarebdecays_la_LIBADD = \
 	$(top_builddir)/eos/utils/libeosutils.la \
 	$(top_builddir)/eos/form-factors/libeosformfactors.la \
 	-lboost_filesystem -lboost_system \
-	-lgsl -lgslcblas -lm \
-	-lyaml-cpp
+	-lgsl -lgslcblas -lm
 
 include_eos_rarebdecaysdir = $(includedir)/eos/rare-b-decays
 include_eos_rarebdecays_HEADERS = \

--- a/eos/rare-b-decays/Makefile.am
+++ b/eos/rare-b-decays/Makefile.am
@@ -19,6 +19,7 @@ libeosrarebdecays_la_SOURCES = \
 	long-distance.cc long-distance.hh \
 	lambda-b-to-lambda-dilepton.cc lambda-b-to-lambda-dilepton.hh \
 	qcdf_integrals.cc qcdf_integrals.hh
+libeosrarebdecays_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) 
 libeosrarebdecays_la_LIBADD = \
 	$(top_builddir)/eos/utils/libeosutils.la \
 	$(top_builddir)/eos/form-factors/libeosformfactors.la \

--- a/eos/statistics/Makefile.am
+++ b/eos/statistics/Makefile.am
@@ -102,18 +102,22 @@ chi_squared_TEST_SOURCES = chi-squared_TEST.cc
 density_wrapper_TEST_SOURCES = density-wrapper_TEST.cc density-wrapper_TEST.hh
 
 hierarchical_clustering_TEST_SOURCES = hierarchical-clustering_TEST.cc
+hierarchical_clustering_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 histogram_TEST_SOURCES = histogram_TEST.cc
 
 log_likelihood_TEST_SOURCES = log-likelihood_TEST.cc
+log_likelihood_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 log_posterior_TEST_SOURCES = log-posterior_TEST.cc log-posterior_TEST.hh
-log_posterior_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(MINUIT2_CXXFLAGS)
+log_posterior_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(MINUIT2_CXXFLAGS)
 log_posterior_TEST_LDFLAGS = $(MINUIT2_LDFLAGS) -lMinuit2
 
 log_prior_TEST_SOURCES = log-prior_TEST.cc
+log_prior_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 markov_chain_TEST_SOURCES = markov-chain_TEST.cc
+markov_chain_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 markov_chain_sampler_TEST_SOURCES = markov-chain-sampler_TEST.cc density-wrapper_TEST.cc
 markov_chain_sampler_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS)

--- a/eos/statistics/Makefile.am
+++ b/eos/statistics/Makefile.am
@@ -122,6 +122,7 @@ markov_chain_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 markov_chain_sampler_TEST_SOURCES = markov-chain-sampler_TEST.cc density-wrapper_TEST.cc
 markov_chain_sampler_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS)
 markov_chain_sampler_TEST_LDFLAGS = $(AM_CXXFLAGS) $(HDF5_LDFLAGS)
+markov_chain_sampler_TEST_LDADD = $(LDADD) -lhdf5
 
 if EOS_ENABLE_PMC
 population_monte_carlo_sampler_TEST_SOURCES = population-monte-carlo-sampler_TEST.cc density-wrapper_TEST.cc
@@ -132,10 +133,12 @@ endif
 prior_sampler_TEST_SOURCES = prior-sampler_TEST.cc
 prior_sampler_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS)
 prior_sampler_TEST_LDFLAGS = $(AM_CXXFLAGS) $(HDF5_LDFLAGS)
+prior_sampler_TEST_LDADD = $(LDADD) -lhdf5
 
 proposal_functions_TEST_SOURCES = proposal-functions_TEST.cc
 proposal_functions_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS)
 proposal_functions_TEST_LDFLAGS = $(AM_CXXFLAGS) $(HDF5_LDFLAGS)
+proposal_functions_TEST_LDADD = $(LDADD) -lhdf5
 
 rvalue_TEST_SOURCES = rvalue_TEST.cc
 

--- a/eos/statistics/Makefile.am
+++ b/eos/statistics/Makefile.am
@@ -35,9 +35,9 @@ libeosstatistics_la_SOURCES = \
 	simple-parameters.cc simple-parameters.hh \
 	test-statistic.cc test-statistic.hh test-statistic-impl.hh \
 	welford.cc welford.hh
-libeosstatistics_la_LIBADD = -lpthread -lgsl -lgslcblas -lm -lMinuit2
-libeosstatistics_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(HDF5_CXXFLAGS) $(MINUIT2_CXXFLAGS)
-libeosstatistics_la_LDFLAGS = $(AM_CXXFLAGS) $(GSL_LDFLAGS) $(MINUIT2_LDFLAGS)
+libeosstatistics_la_LIBADD = -lpthread -lgsl -lgslcblas -lm -lMinuit2 -lyaml-cpp
+libeosstatistics_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(HDF5_CXXFLAGS) $(MINUIT2_CXXFLAGS) $(YAMLCPP_CXXFLAGS)
+libeosstatistics_la_LDFLAGS = $(AM_CXXFLAGS) $(GSL_LDFLAGS) $(MINUIT2_LDFLAGS) $(YAMLCPP_LDFLAGS)
 
 if EOS_ENABLE_PMC
 libeosstatistics_la_SOURCES += \

--- a/eos/utils/Makefile.am
+++ b/eos/utils/Makefile.am
@@ -76,8 +76,8 @@ libeosutils_la_LIBADD = \
 	-lMinuit2 \
 	-lpthread \
 	-lyaml-cpp
-libeosutils_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(HDF5_CXXFLAGS) $(MINUIT2_CXXFLAGS)
-libeosutils_la_LDFLAGS = $(AM_CXXFLAGS) $(GSL_LDFLAGS) $(HDF5_LDFLAGS) $(MINUIT2_LDFLAGS)
+libeosutils_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(HDF5_CXXFLAGS) $(MINUIT2_CXXFLAGS) $(YAMLCPP_CXXFLAGS)
+libeosutils_la_LDFLAGS = $(AM_CXXFLAGS) $(GSL_LDFLAGS) $(HDF5_LDFLAGS) $(MINUIT2_LDFLAGS) $(YAMLCPP_LDFLAGS)
 
 EXTRA_DIST = \
 	polylog_TEST_dilog.bin \
@@ -176,7 +176,6 @@ TESTS = \
 	wilson-polynomial_TEST \
 	wilson_scan_model_TEST
 LDADD = \
-	-lyaml-cpp \
 	$(top_builddir)/test/libeostest.a \
 	libeosutils.la \
 	$(top_builddir)/eos/libeos.la

--- a/eos/utils/Makefile.am
+++ b/eos/utils/Makefile.am
@@ -76,8 +76,8 @@ libeosutils_la_LIBADD = \
 	-lMinuit2 \
 	-lpthread \
 	-lyaml-cpp
-libeosutils_la_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS) $(MINUIT2_CXXFLAGS)
-libeosutils_la_LDFLAGS = $(AM_CXXFLAGS) $(HDF5_LDFLAGS) $(MINUIT2_LDFLAGS)
+libeosutils_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(HDF5_CXXFLAGS) $(MINUIT2_CXXFLAGS)
+libeosutils_la_LDFLAGS = $(AM_CXXFLAGS) $(GSL_LDFLAGS) $(HDF5_LDFLAGS) $(MINUIT2_LDFLAGS)
 
 EXTRA_DIST = \
 	polylog_TEST_dilog.bin \
@@ -196,12 +196,13 @@ hdf5_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS)
 hdf5_TEST_LDFLAGS = $(AM_CXXFLAGS) $(HDF5_LDFLAGS)
 
 equation_solver_TEST_SOURCES = equation_solver_TEST.cc
-equation_solver_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(MINUIT2_CXXFLAGS)
+equation_solver_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(MINUIT2_CXXFLAGS) $(GSL_CXXFLAGS)
 equation_solver_TEST_LDFLAGS = $(MINUIT2_LDFLAGS)
 
 indirect_iterator_TEST_SOURCES = indirect-iterator_TEST.cc
 
 integrate_TEST_SOURCES = integrate_TEST.cc
+integrate_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 join_TEST_SOURCES = join_TEST.cc
 
@@ -248,6 +249,7 @@ top_loops_TEST_SOURCES = top-loops_TEST.cc
 verify_TEST_SOURCES = verify_TEST.cc
 
 wilson_coefficients_TEST_SOURCES = wilson_coefficients_TEST.cc
+wilson_coefficients_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 wilson_polynomial_TEST_SOURCES = wilson-polynomial_TEST.cc
 

--- a/eos/utils/Makefile.am
+++ b/eos/utils/Makefile.am
@@ -193,6 +193,7 @@ derivative_TEST_SOURCES = derivative_TEST.cc
 hdf5_TEST_SOURCES = hdf5_TEST.cc
 hdf5_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS)
 hdf5_TEST_LDFLAGS = $(AM_CXXFLAGS) $(HDF5_LDFLAGS)
+hdf5_TEST_LDADD = $(LDADD) -lhdf5
 
 equation_solver_TEST_SOURCES = equation_solver_TEST.cc
 equation_solver_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(MINUIT2_CXXFLAGS) $(GSL_CXXFLAGS)

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -38,7 +38,7 @@ eosplot_SCRIPTS = \
 _eosdir = $(pythondir)
 _eos_LTLIBRARIES = _eos.la
 _eos_la_SOURCES = _eos.cc
-_eos_la_CXXFLAGS = $(PYTHON_CXXFLAGS) @AM_CXXFLAGS@
+_eos_la_CXXFLAGS = $(PYTHON_CXXFLAGS) @AM_CXXFLAGS@ @GSL_CXXFLAGS@
 _eos_la_LDFLAGS = -module -avoid-version -export-symbols-regex PyInit__eos
 _eos_la_LIBADD = $(top_builddir)/eos/libeos.la $(top_builddir)/eos/utils/libeosutils.la -lboost_python$(BOOST_PYTHON_SUFFIX)
 

--- a/src/clients/Makefile.am
+++ b/src/clients/Makefile.am
@@ -40,8 +40,7 @@ LDADD = \
 	$(top_builddir)/eos/libeos.la \
 	libcli.a \
 	-lboost_filesystem -lboost_system \
-	-lMinuit2 \
-	-lyaml-cpp
+	$(YAMLCPP_LDFLAGS)
 
 if EOS_ENABLE_PMC
 bin_PROGRAMS += \
@@ -58,10 +57,11 @@ endif
 eos_evaluate_SOURCES = eos-evaluate.cc
 
 eos_find_mode_SOURCES = eos-find-mode.cc
-eos_find_mode_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(MINUIT2_CXXFLAGS)
+eos_find_mode_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(MINUIT2_CXXFLAGS) $(YAMLCPP_CXXFLAGS)
 eos_find_mode_LDADD = $(LDADD) $(MINUIT2_LDFLAGS)
 
 eos_list_constraints_SOURCES = eos-list-constraints.cc
+eos_list_constraints_CXXFLAGS = $(AM_CXXFLAGS) $(YAMLCPP_CXXFLAGS)
 
 eos_list_observables_SOURCES = eos-list-observables.cc
 
@@ -84,7 +84,7 @@ eos_sample_events_mcmc_LDADD = $(LDADD) $(HDF5_LDFLAGS)
 
 eos_scan_mc_SOURCES = eos-scan-mc.cc
 eos_scan_mc_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS) $(GSL_CXXFLAGS) $(MINUIT2_CXXFLAGS)
-eos_scan_mc_LDADD = $(LDADD) $(HDF5_LDFLAGS) $(MINUIT2_LDFLAGS)
+eos_scan_mc_LDADD = $(LDADD) $(HDF5_LDFLAGS) -lMinuit2 $(MINUIT2_LDFLAGS)
 
 integrated_SOURCES = integrated.cc
 

--- a/src/clients/Makefile.am
+++ b/src/clients/Makefile.am
@@ -73,7 +73,7 @@ eos_print_polynomial_SOURCES = eos-print-polynomial.cc
 
 eos_propagate_uncertainty_SOURCES = eos-propagate-uncertainty.cc
 eos_propagate_uncertainty_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS) $(GSL_CXXFLAGS)
-eos_propagate_uncertainty_LDADD = $(LDADD) $(HDF5_LDFLAGS)
+eos_propagate_uncertainty_LDADD = $(LDADD) -lhdf5 $(HDF5_LDFLAGS)
 
 eos_sample_mcmc_SOURCES = eos-sample-mcmc.cc
 eos_sample_mcmc_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)

--- a/src/clients/Makefile.am
+++ b/src/clients/Makefile.am
@@ -58,7 +58,7 @@ endif
 eos_evaluate_SOURCES = eos-evaluate.cc
 
 eos_find_mode_SOURCES = eos-find-mode.cc
-eos_find_mode_CXXFLAGS = $(AM_CXXFLAGS) $(MINUIT2_CXXFLAGS)
+eos_find_mode_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(MINUIT2_CXXFLAGS)
 eos_find_mode_LDADD = $(LDADD) $(MINUIT2_LDFLAGS)
 
 eos_list_constraints_SOURCES = eos-list-constraints.cc
@@ -72,17 +72,18 @@ eos_list_signal_pdfs_SOURCES = eos-list-signal-pdfs.cc
 eos_print_polynomial_SOURCES = eos-print-polynomial.cc
 
 eos_propagate_uncertainty_SOURCES = eos-propagate-uncertainty.cc
-eos_propagate_uncertainty_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS)
+eos_propagate_uncertainty_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS) $(GSL_CXXFLAGS)
 eos_propagate_uncertainty_LDADD = $(LDADD) $(HDF5_LDFLAGS)
 
 eos_sample_mcmc_SOURCES = eos-sample-mcmc.cc
+eos_sample_mcmc_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 
 eos_sample_events_mcmc_SOURCES = eos-sample-events-mcmc.cc
-eos_sample_events_mcmc_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS)
+eos_sample_events_mcmc_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS) $(GSL_CXXFLAGS)
 eos_sample_events_mcmc_LDADD = $(LDADD) $(HDF5_LDFLAGS)
 
 eos_scan_mc_SOURCES = eos-scan-mc.cc
-eos_scan_mc_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS) $(MINUIT2_CXXFLAGS)
+eos_scan_mc_CXXFLAGS = $(AM_CXXFLAGS) $(HDF5_CXXFLAGS) $(GSL_CXXFLAGS) $(MINUIT2_CXXFLAGS)
 eos_scan_mc_LDADD = $(LDADD) $(HDF5_LDFLAGS) $(MINUIT2_LDFLAGS)
 
 integrated_SOURCES = integrated.cc


### PR DESCRIPTION
I tried to compile the latest master with all dependencies in non-standard locations (and custom compiled boost). This lead to a variety of problems

* `boost_python_suffix` was not determined correctly
* abi flag was missing from python library (I only have `libpython3.6m`)
* GSL includes were not found as GSL was in non-standard location
* yaml-cpp was not found but the commit from pr #67 worked fine after rebasing
* missing `-lhdf5` leading to undefined reference

This pr fixes all of these issues for me but since I'm not an expert on the internal structure there might be better ways to do this.