### PR TITLE
Fix some bugs when installing in virgin Ubuntu installations

### DIFF
--- a/.travis/build-and-test.bash
+++ b/.travis/build-and-test.bash
@@ -38,12 +38,11 @@ function ubuntu_deploy() {
     popd
     pushd /build
     export CXXFLAGS="-O2 -g -march=x86-64" # build for generic x86-64 architecture
-    CONFIGURE_FLAGS="--enable-pmc --enable-python --prefix=/usr"
+    CONFIGURE_FLAGS="--enable-pmc --enable-python --prefix=/usr --with-custom-pythondir=dist-packages"
     /src/configure ${CONFIGURE_FLAGS}
     make -j2 all
     make -j2 check VERBOSE=1
     make install
-    export PYTHONPATH+=":$(make print-pythondir)"
     make -C /src/manual/examples examples
     echo Building debian package for ${OS}
     export DESTDIR=/tmp/eos-${EOS_VERSION}

--- a/configure.ac
+++ b/configure.ac
@@ -298,6 +298,13 @@ if test "x$enable_pmc" == "xyes" ; then
 fi
 AM_CONDITIONAL([EOS_ENABLE_PMC], [test "x$enable_pmc" == "xyes"])
 dnl }}}
+
+dnl {{{ use custom pythondir if supplied via --with-pmc=
+AC_ARG_WITH([custom-pythondir],
+	[AS_HELP_STRING([--with-custom-pythondir], [used to override Debian/Ubuntu default choice for \${pythondir} and \${pyexecdir}])],
+	[],
+	[])
+dnl }}}
 dnl {{{ check if we should enable Python
 AC_ARG_ENABLE([python],
 	[AS_HELP_STRING([--enable-python], [enables interfacing EOS within python])],
@@ -331,6 +338,15 @@ if test "x$enable_python" == xyes ; then
 	AC_SUBST([PYTHON_LDFLAGS])
 	AC_SUBST([PYTHON_CXXFLAGS])
 	AC_SUBST([BOOST_PYTHON_SUFFIX])
+	if test "x$with_custom_pythondir" != "x"; then
+		# override: Debian/Ubuntu use 'dist-packages' rather than 'site-packages'
+		AC_MSG_NOTICE([replacing python script directory with \${prefix}/lib/python$PYTHON_VERSION/$with_custom_pythondir])
+		pythondir="\${prefix}/lib/python$PYTHON_VERSION/$with_custom_pythondir"
+		AC_MSG_NOTICE([replacing python extension directory with \${exec_prefix}/lib/python$PYTHON_VERSION/$with_custom_pythondir])
+		pyexecdir="\${exec_prefix}/lib/python$PYTHON_VERSION/$with_custom_pythondir"
+		AC_SUBST([pythondir])
+		AC_SUBST([pyexecdir])
+	fi
 
 	_CXXFLAGS=$CXXFLAGS
 	_LDFLAGS=$LDFLAGS

--- a/debian/control-bionic.in
+++ b/debian/control-bionic.in
@@ -1,6 +1,6 @@
 Package: eos
 Version: @VERSION@
 Architecture: amd64
-Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-100 (>= 1.8.16), libboost-filesystem-dev, libboost-python-dev, libboost-system-dev, libgsl-dev
+Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-100 (>= 1.8.16), libboost-filesystem-dev, libboost-python-dev, libboost-system-dev, libgsl-dev, libyaml-cpp0.5v5
 Maintainer: Danny van Dyk <danny.van.dyk@gmail.com>
 Description: EOS -- A HEP program for flavor observables

--- a/debian/control-bionic.in
+++ b/debian/control-bionic.in
@@ -1,6 +1,6 @@
 Package: eos
 Version: @VERSION@
 Architecture: amd64
-Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-100 (>= 1.8.16), libboost-filesystem-dev, libboost-python-dev, libboost-system-dev, libgsl-dev, libyaml-cpp0.5v5
+Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-100 (>= 1.8.16), libboost-filesystem-dev, libboost-python-dev, libboost-system-dev, libgsl-dev, libyaml-cpp0.5v5, python3-h5py, python3-matplotlib, python3-numpy, python3-scipy
 Maintainer: Danny van Dyk <danny.van.dyk@gmail.com>
 Description: EOS -- A HEP program for flavor observables

--- a/debian/control-xenial.in
+++ b/debian/control-xenial.in
@@ -1,6 +1,6 @@
 Package: eos
 Version: @VERSION@
 Architecture: amd64
-Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-10 (>= 1.8.16), libboost-filesystem1.58.0, libboost-python1.58.0, libboost-system1.58.0, libgsl2
+Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-10 (>= 1.8.16), libboost-filesystem1.58.0, libboost-python1.58.0, libboost-system1.58.0, libgsl2, libyaml-cpp0.5v5
 Maintainer: Danny van Dyk <danny.van.dyk@gmail.com>
 Description: EOS -- A HEP program for flavor observables

--- a/debian/control-xenial.in
+++ b/debian/control-xenial.in
@@ -1,6 +1,6 @@
 Package: eos
 Version: @VERSION@
 Architecture: amd64
-Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-10 (>= 1.8.16), libboost-filesystem1.58.0, libboost-python1.58.0, libboost-system1.58.0, libgsl2, libyaml-cpp0.5v5
+Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-10 (>= 1.8.16), libboost-filesystem1.58.0, libboost-python1.58.0, libboost-system1.58.0, libgsl2, libyaml-cpp0.5v5, python3-h5py, python3-matplotlib, python3-numpy, python3-scipy
 Maintainer: Danny van Dyk <danny.van.dyk@gmail.com>
 Description: EOS -- A HEP program for flavor observables


### PR DESCRIPTION
1. The binary packages were missing a runtime dependency on ```libyaml-cpp0.5v5``` on both xenial and bionic.
2. Debian/Ubuntu do not use 'site-packages' for the installation of distribution-provided Python modules and extensions. Instead, they use 'dist-packages'. Changed the ```$(pythondir)``` and ```$(pyexecdir)``` variables on Debian/Ubuntu only.