### PR TITLE
Fix issue #162: Provide .deb files for Ubuntu 'disco' (19.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ matrix:
       env:
         - DOCKER_TARGET=bionic DOCKER_CXX=g++          DOCKER_USE=distcheck
 
+    - <<: *linux-template
+      env:
+        - DOCKER_TARGET=disco  DOCKER_CXX=g++          DOCKER_USE=deploy
+
     - os: osx
       osx_image: xcode9.3
       language: cpp

--- a/.travis/build-and-test.bash
+++ b/.travis/build-and-test.bash
@@ -131,7 +131,7 @@ echo "==========="
 [[ -n ${PACKAGECLOUD_TOKEN} ]] || echo 'Skipping packagecloud.io deployment since $PACKAGECLOUD_TOKEN is empty'
 echo "==========="
 
-if [[ "xenial" == ${OS} ]] || [[ "bionic" == ${OS} ]]; then
+if [[ "xenial" == ${OS} ]] || [[ "bionic" == ${OS} ]] || [[ "disco" == ${OS} ]]; then
     case ${USE} in
         "distcheck")
             ubuntu_distcheck $@

--- a/.travis/disco
+++ b/.travis/disco
@@ -1,0 +1,3 @@
+FROM eoshep/build-essentials:disco
+RUN mkdir -p /src /build
+ADD . /src

--- a/configure.ac
+++ b/configure.ac
@@ -410,6 +410,7 @@ AC_SUBST([AM_CXXFLAGS], '-I$(top_srcdir) -std=c++14 -Wall -Wextra -pedantic')
 AC_OUTPUT(
 	Makefile
 	debian/control-bionic
+	debian/control-disco
 	debian/control-xenial
 	debian/Makefile
 	eos/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -327,7 +327,19 @@ if test "x$enable_python" == xyes ; then
 	if test "x$has_boost_python_suffix" == "xno"; then
 		os_id="`. /etc/os-release ; echo $ID`"
 		if test "x$os_id" == xubuntu -o "x$os_id" == xdebian ; then
-			BOOST_PYTHON_SUFFIX="-py`echo $PYTHON_VERSION | sed -e 's/\.//'`"
+			codename="`. /etc/os-release ; echo $VERSION_CODENAME`"
+			case $codename in
+				xenial|bionic)
+					BOOST_PYTHON_SUFFIX="-py`echo $PYTHON_VERSION | sed -e 's/\.//'`"
+					;;
+				disco)
+					BOOST_PYTHON_SUFFIX="`echo $PYTHON_VERSION | sed -e 's/\.//'`"
+					;;
+				*)
+					AC_MSG_NOTICE([assuming Ubuntu Disco or more recent, BOOST_PYTHON_SUFFIX might be wrong!])
+					BOOST_PYTHON_SUFFIX="`echo $PYTHON_VERSION | sed -e 's/\.//'`"
+					;;
+			esac
 		elif test "x$os_id" == xcentos ; then
 			BOOST_PYTHON_SUFFIX=""
 		fi

--- a/debian/control-disco.in
+++ b/debian/control-disco.in
@@ -1,0 +1,6 @@
+Package: eos
+Version: @VERSION@
+Architecture: amd64
+Depends: libc6 (>= 2.19), libstdc++6 (>= 4.8), minuit2 (>= 5.28.00), libpmc (>= 1.01), libhdf5-103 (>= 1.8.16), libboost-filesystem-dev, libboost-python-dev, libboost-system-dev, libgsl-dev, libyaml-cpp0.6, python3-h5py, python3-matplotlib, python3-numpy, python3-scipy
+Maintainer: Danny van Dyk <danny.van.dyk@gmail.com>
+Description: EOS -- A HEP program for flavor observables

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,6 +26,7 @@ import eos
 project = 'EOS'
 copyright = '2019, Danny van Dyk and others'
 author = 'Danny van Dyk and others'
+master_doc = 'index'
 
 # The full version, including alpha/beta/rc tags
 release = eos.version()


### PR DESCRIPTION
At some point between 'bionic' and 'disco', Debian/Ubuntu have decided that their convention for the name of the ```libboost_python3-py37.so.${BOOST_VERSION}``` was stupid. So far, so good. In their unfathomable wisdom, they decided to replace it with ```libboost_python37.so.${BOOST_VERSION}```. So far, so bad.

@daritter Please be so kind to review the commit touching ```configure.ac```, to confirm that this will not break your Belle 2 Externals setup.

Fixes: #162 