### PR TITLE
[travis] Switch MacOSX testing image to use XCode 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
         - DOCKER_TARGET=disco  DOCKER_CXX=g++          DOCKER_USE=deploy
 
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode11
       language: cpp
       sudo: required
       before_install:


### PR DESCRIPTION
TravisCI's ```xcode9.3``` consistently produces errors. Let's switch to a more recent XCode version.