### PR TITLE
Changes requested by Donal Hill

### DIFF
--- a/eos/b-decays/b-to-dstar-l-nu.cc
+++ b/eos/b-decays/b-to-dstar-l-nu.cc
@@ -252,19 +252,19 @@ namespace eos
         }
 
         // normalization cf. [DSD2014] eq. (7), p. 5
-        double norm(const double & s) const
+        double norm(const double & q2) const
         {
             // charged lepton velocity in the dilepton rest frame
-            double v    = (1.0 - m_l * m_l / s);
-            double lam  = lambda(m_B * m_B, m_Dstar * m_Dstar, s);
+            double v    = (1.0 - m_l * m_l / q2);
+            double lam  = lambda(m_B * m_B, m_Dstar * m_Dstar, q2);
             double p    = std::sqrt(lam) / (2.0 * m_B);
             // universal electroweak correction, cf. [S1982]
             double etaEW = 1.0066;
             // normalized prefactor (|Vcb|^2=1)
-            return power_of<2>(g_fermi() * etaEW) * p * s * power_of<2>(v) / (3.0 * 64.0 * power_of<3>(M_PI) * m_B * m_B);
+            return power_of<2>(g_fermi() * etaEW) * p * q2 * power_of<2>(v) / (3.0 * 64.0 * power_of<3>(M_PI) * m_B * m_B);
         }
 
-        b_to_dstar_l_nu::Amplitudes amplitudes(const double & s)
+        b_to_dstar_l_nu::Amplitudes amplitudes(const double & q2)
         {
             b_to_dstar_l_nu::Amplitudes result;
 
@@ -281,32 +281,32 @@ namespace eos
             const complex<double> TL = wc.ct();
 
             // form factors
-            double aff0  = form_factors->a_0(s);
-            double aff1  = form_factors->a_1(s);
-            double aff2  = form_factors->a_2(s);
-            double vff   = form_factors->v(s);
-            double tff1  = form_factors->t_1(s);
-            double tff2  = form_factors->t_2(s);
-            double tff3  = form_factors->t_3(s);
+            double aff0  = form_factors->a_0(q2);
+            double aff1  = form_factors->a_1(q2);
+            double aff2  = form_factors->a_2(q2);
+            double vff   = form_factors->v(q2);
+            double tff1  = form_factors->t_1(q2);
+            double tff2  = form_factors->t_2(q2);
+            double tff3  = form_factors->t_3(q2);
             // running quark masses
             double mbatmu = model->m_b_msbar(mu);
             double mcatmu = model->m_c_msbar(mu);
             // charged lepton velocity in the dilepton rest frame
-            double v        = (1.0 - m_l * m_l / s);
+            double v        = (1.0 - m_l * m_l / q2);
             double m_l_hat  = std::sqrt(1.0 - v);
-            double lam      = lambda(m_B * m_B, m_Dstar * m_Dstar, s);
+            double lam      = lambda(m_B * m_B, m_Dstar * m_Dstar, q2);
 
-            double sqrts = std::sqrt(s);
-            double NF = norm(s);
+            double sqrtq2 = std::sqrt(q2);
+            double NF = norm(q2);
 
             // transversity amplitudes A's. cf. [DSD2014], p.17
-            result.a_0          = (1.0 - gA) * (m_B + m_Dstar) / (2.0 * m_Dstar * sqrts) * ( (m_B * m_B - m_Dstar * m_Dstar - s) * aff1 - lam * aff2 / power_of<2>(m_B + m_Dstar) );
-            result.a_0_T        = TL / (2.0 * m_Dstar) * ( (m_B * m_B + 3.0 * m_Dstar * m_Dstar - s) * tff2 - lam * tff3 / (m_B * m_B - m_Dstar * m_Dstar) );
+            result.a_0          = (1.0 - gA) * (m_B + m_Dstar) / (2.0 * m_Dstar * sqrtq2) * ( (m_B * m_B - m_Dstar * m_Dstar - q2) * aff1 - lam * aff2 / power_of<2>(m_B + m_Dstar) );
+            result.a_0_T        = TL / (2.0 * m_Dstar) * ( (m_B * m_B + 3.0 * m_Dstar * m_Dstar - q2) * tff2 - lam * tff3 / (m_B * m_B - m_Dstar * m_Dstar) );
             result.a_plus       = ( (m_B + m_Dstar) * aff1 * (1.0 - gA) - std::sqrt(lam) * vff * (1.0 + gV) / (m_B + m_Dstar) );
             result.a_minus      = ( (m_B + m_Dstar) * aff1 * (1.0 - gA) + std::sqrt(lam) * vff * (1.0 + gV) / (m_B + m_Dstar) );
-            result.a_plus_T     = TL * ( (m_B * m_B - m_Dstar * m_Dstar) * tff2 / sqrts + std::sqrt(lam) * tff1 / sqrts );
-            result.a_minus_T    = TL * ( (m_B * m_B - m_Dstar * m_Dstar) * tff2 / sqrts - std::sqrt(lam) * tff1 / sqrts );
-            result.a_t          =  std::sqrt(lam) * aff0 * (1.0 - gA) / sqrts;
+            result.a_plus_T     = TL * ( (m_B * m_B - m_Dstar * m_Dstar) * tff2 / sqrtq2 + std::sqrt(lam) * tff1 / sqrtq2 );
+            result.a_minus_T    = TL * ( (m_B * m_B - m_Dstar * m_Dstar) * tff2 / sqrtq2 - std::sqrt(lam) * tff1 / sqrtq2 );
+            result.a_t          =  std::sqrt(lam) * aff0 * (1.0 - gA) / sqrtq2;
             result.a_P          =  std::sqrt(lam) * aff0 * gP / (mbatmu + mcatmu);
             result.a_t_P        =  result.a_t + result.a_P / m_l_hat;
             result.a_para       =  (result.a_plus + result.a_minus) / std::sqrt(2.0);
@@ -320,27 +320,27 @@ namespace eos
             return result;
         }
 
-        std::array<double, 12> _differential_angular_observables(const double & s)
+        std::array<double, 12> _differential_angular_observables(const double & q2)
         {
-            return b_to_dstar_l_nu::AngularObservables(this->amplitudes(s))._vv;
+            return b_to_dstar_l_nu::AngularObservables(this->amplitudes(q2))._vv;
         }
 
         // define below integrated observables in generic form
-        std::array<double, 12> _integrated_angular_observables(const double & s_min, const double & s_max)
+        std::array<double, 12> _integrated_angular_observables(const double & q2_min, const double & q2_max)
         {
             std::function<std::array<double, 12> (const double &)> integrand(std::bind(&Implementation::_differential_angular_observables, this, std::placeholders::_1));
             // second argument of integrate1D is some power of 2
-            return integrate1D(integrand, 64, s_min, s_max);
+            return integrate1D(integrand, 64, q2_min, q2_max);
         }
 
-        inline b_to_dstar_l_nu::AngularObservables differential_angular_observables(const double & s)
+        inline b_to_dstar_l_nu::AngularObservables differential_angular_observables(const double & q2)
         {
-            return b_to_dstar_l_nu::AngularObservables{ _differential_angular_observables(s) };
+            return b_to_dstar_l_nu::AngularObservables{ _differential_angular_observables(q2) };
         }
 
-        inline b_to_dstar_l_nu::AngularObservables integrated_angular_observables(const double & s_min, const double & s_max)
+        inline b_to_dstar_l_nu::AngularObservables integrated_angular_observables(const double & q2_min, const double & q2_max)
         {
-            return b_to_dstar_l_nu::AngularObservables{ _integrated_angular_observables(s_min, s_max) };
+            return b_to_dstar_l_nu::AngularObservables{ _integrated_angular_observables(q2_min, q2_max) };
         }
     };
 
@@ -357,110 +357,110 @@ namespace eos
 
     // |Vcb|=1
     double
-    BToDstarLeptonNeutrino::normalized_differential_branching_ratio(const double & s) const
+    BToDstarLeptonNeutrino::normalized_differential_branching_ratio(const double & q2) const
     {
-        return _imp->differential_angular_observables(s).normalized_decay_width() * _imp->tau_B / _imp->hbar;
+        return _imp->differential_angular_observables(q2).normalized_decay_width() * _imp->tau_B / _imp->hbar;
     }
 
     double
-    BToDstarLeptonNeutrino::differential_branching_ratio(const double & s) const
+    BToDstarLeptonNeutrino::differential_branching_ratio(const double & q2) const
     {
-        return _imp->differential_angular_observables(s).normalized_decay_width() * std::norm(_imp->model->ckm_cb()) * _imp->tau_B / _imp->hbar;
+        return _imp->differential_angular_observables(q2).normalized_decay_width() * std::norm(_imp->model->ckm_cb()) * _imp->tau_B / _imp->hbar;
     }
 
     double
-    BToDstarLeptonNeutrino::differential_a_fb_leptonic(const double & s) const
+    BToDstarLeptonNeutrino::differential_a_fb_leptonic(const double & q2) const
     {
-        return _imp->differential_angular_observables(s).a_fb_leptonic();
+        return _imp->differential_angular_observables(q2).a_fb_leptonic();
     }
 
     /* q^2-integrated observables */
 
     // |Vcb|=1
         double
-    BToDstarLeptonNeutrino::normalized_integrated_branching_ratio(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::normalized_integrated_branching_ratio(const double & q2_min, const double & q2_max) const
     {
-        return _imp->integrated_angular_observables(s_min, s_max).normalized_decay_width() * _imp->tau_B / _imp->hbar;
+        return _imp->integrated_angular_observables(q2_min, q2_max).normalized_decay_width() * _imp->tau_B / _imp->hbar;
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_branching_ratio(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_branching_ratio(const double & q2_min, const double & q2_max) const
     {
-        return _imp->integrated_angular_observables(s_min, s_max).normalized_decay_width() * std::norm(_imp->model->ckm_cb()) * _imp->tau_B / _imp->hbar;
+        return _imp->integrated_angular_observables(q2_min, q2_max).normalized_decay_width() * std::norm(_imp->model->ckm_cb()) * _imp->tau_B / _imp->hbar;
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_a_fb_leptonic(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_a_fb_leptonic(const double & q2_min, const double & q2_max) const
     {
-        return _imp->integrated_angular_observables(s_min, s_max).a_fb_leptonic();
+        return _imp->integrated_angular_observables(q2_min, q2_max).a_fb_leptonic();
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_amplitude_polarization_L(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_amplitude_polarization_L(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.normalized_amplitude_polarization_L() * std::norm(_imp->model->ckm_cb());
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_amplitude_polarization_T(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_amplitude_polarization_T(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.normalized_amplitude_polarization_T() * std::norm(_imp->model->ckm_cb());
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_f_L(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_f_L(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.f_L();
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_a_c_1(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_a_c_1(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.a_c_1();
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_a_c_2(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_a_c_2(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.a_c_2();
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_a_c_3(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_a_c_3(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.a_c_3();
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_a_t_1(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_a_t_1(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.a_t_1();
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_a_t_2(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_a_t_2(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.a_t_2();
     }
 
     double
-    BToDstarLeptonNeutrino::integrated_a_t_3(const double & s_min, const double & s_max) const
+    BToDstarLeptonNeutrino::integrated_a_t_3(const double & q2_min, const double & q2_max) const
     {
-        auto   o = _imp->integrated_angular_observables(s_min, s_max);
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.a_t_3();
     }
 
     //* cf. [DSD2014], eq. (6), p. 5 - normalized(|Vcb|=1)
     double
-    BToDstarLeptonNeutrino::normalized_four_differential_decay_width(const double & s, const double & c_theta_l, const double & c_theta_d, const double & phi) const
+    BToDstarLeptonNeutrino::normalized_four_differential_decay_width(const double & q2, const double & c_theta_l, const double & c_theta_d, const double & phi) const
     {
         // compute d^4 Gamma, cf. [DSD2014], p. 5, eq. (6)
         // Trigonometric identities: Cosine squared of the angles
@@ -483,7 +483,7 @@ namespace eos
         double s_2_theta_l = 2.0 * s_theta_l * c_theta_l;
         double s_2_phi = std::sin(2.0 * phi);
 
-        b_to_dstar_l_nu::AngularObservables a_o = _imp->differential_angular_observables(s);
+        b_to_dstar_l_nu::AngularObservables a_o = _imp->differential_angular_observables(q2);
 
         double result = 9.0 / 32.0 / M_PI * (
                                             (a_o.vv10() + a_o.vv20() * c_2_theta_l + a_o.vv30() * c_theta_l) * c_theta_d_2
@@ -501,7 +501,7 @@ namespace eos
     The decay B->D^* l nu, where l=e,mu,tau is a lepton.";
 
     const std::string
-    BToDstarLeptonNeutrino::kinematics_description_s = "\
+    BToDstarLeptonNeutrino::kinematics_description_q2 = "\
     The invariant mass of the l-nubar pair in GeV^2.";
 
     const std::string

--- a/eos/b-decays/b-to-dstar-l-nu.cc
+++ b/eos/b-decays/b-to-dstar-l-nu.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2018, 2019 Ahmet Kokulu
+ * Copyright (c) 2019 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -374,6 +375,90 @@ namespace eos
         return _imp->differential_angular_observables(q2).a_fb_leptonic();
     }
 
+    double
+    BToDstarLeptonNeutrino::differential_J1c_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * o.vv10() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J1s_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * o.vv1T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J2c_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * o.vv20() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J2s_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * o.vv2T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J3_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * o.vv4T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J4_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * -o.vv10T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J5_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * o.vv20T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J6c_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * -o.vv30() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J6s_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * -o.vv3T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J7_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * -o.vv30T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J8_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * o.vv40T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::differential_J9_normalized(const double & q2) const
+    {
+        auto   o = _imp->differential_angular_observables(q2);
+        return 3.0 / 4.0 * -o.vv5T() / o.normalized_decay_width();
+    }
+
     /* q^2-integrated observables */
 
     // |Vcb|=1
@@ -456,6 +541,90 @@ namespace eos
     {
         auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
         return o.a_t_3();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J1c_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * o.vv10() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J1s_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * o.vv1T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J2c_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * o.vv20() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J2s_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * o.vv2T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J3_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * o.vv4T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J4_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * -o.vv10T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J5_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * o.vv20T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J6c_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * -o.vv30() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J6s_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * -o.vv3T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J7_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * -o.vv30T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J8_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * o.vv40T() / o.normalized_decay_width();
+    }
+
+    double
+    BToDstarLeptonNeutrino::integrated_J9_normalized(const double & q2_min, const double & q2_max) const
+    {
+        auto   o = _imp->integrated_angular_observables(q2_min, q2_max);
+        return 3.0 / 4.0 * -o.vv5T() / o.normalized_decay_width();
     }
 
     //* cf. [DSD2014], eq. (6), p. 5 - normalized(|Vcb|=1)

--- a/eos/b-decays/b-to-dstar-l-nu.cc
+++ b/eos/b-decays/b-to-dstar-l-nu.cc
@@ -277,7 +277,6 @@ namespace eos
             const complex<double> SR = wc.csr();
             const complex<double> gV = VR + VL;
             const complex<double> gA = VR - VL;
-            const complex<double> gS = SR + SL;
             const complex<double> gP = SR - SL;
             const complex<double> TL = wc.ct();
 

--- a/eos/b-decays/b-to-dstar-l-nu.hh
+++ b/eos/b-decays/b-to-dstar-l-nu.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2018, 2019 Ahmet Kokulu
+ * Copyright (c) 2019 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -41,6 +42,18 @@ namespace eos
             // Differential Observables
             double differential_branching_ratio(const double & q2) const;
             double differential_a_fb_leptonic(const double & q2) const;
+            double differential_J1c_normalized(const double & q2) const;
+            double differential_J1s_normalized(const double & q2) const;
+            double differential_J2c_normalized(const double & q2) const;
+            double differential_J2s_normalized(const double & q2) const;
+            double differential_J3_normalized(const double & q2) const;
+            double differential_J4_normalized(const double & q2) const;
+            double differential_J5_normalized(const double & q2) const;
+            double differential_J6c_normalized(const double & q2) const;
+            double differential_J6s_normalized(const double & q2) const;
+            double differential_J7_normalized(const double & q2) const;
+            double differential_J8_normalized(const double & q2) const;
+            double differential_J9_normalized(const double & q2) const;
             double differential_ratio_tau_mu(const double & q2) const;
 
             // Differential Observables - normalized(|Vcb|=1)
@@ -62,6 +75,18 @@ namespace eos
             double integrated_a_t_1(const double & q2_min, const double & q2_max) const;
             double integrated_a_t_2(const double & q2_min, const double & q2_max) const;
             double integrated_a_t_3(const double & q2_min, const double & q2_max) const;
+            double integrated_J1c_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J1s_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J2c_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J2s_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J3_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J4_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J5_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J6c_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J6s_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J7_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J8_normalized(const double & q2_min, const double & q2_max) const;
+            double integrated_J9_normalized(const double & q2_min, const double & q2_max) const;
 
             // Integrated Observables - normalized(|Vcb|=1)
             double normalized_integrated_branching_ratio(const double & q2_min, const double & q2_max) const;

--- a/eos/b-decays/b-to-dstar-l-nu.hh
+++ b/eos/b-decays/b-to-dstar-l-nu.hh
@@ -39,38 +39,38 @@ namespace eos
             ~BToDstarLeptonNeutrino();
 
             // Differential Observables
-            double differential_branching_ratio(const double & s) const;
-            double differential_a_fb_leptonic(const double & s) const;
-            double differential_ratio_tau_mu(const double & s) const;
+            double differential_branching_ratio(const double & q2) const;
+            double differential_a_fb_leptonic(const double & q2) const;
+            double differential_ratio_tau_mu(const double & q2) const;
 
             // Differential Observables - normalized(|Vcb|=1)
-            double normalized_differential_branching_ratio(const double & s) const;
+            double normalized_differential_branching_ratio(const double & q2) const;
 
             // Four Differential Observables - normalized(|Vcb|=1)
-            double normalized_four_differential_decay_width(const double & s, const double & c_theta_l, const double & c_theta_d, const double & phi) const;
+            double normalized_four_differential_decay_width(const double & q2, const double & c_theta_l, const double & c_theta_d, const double & phi) const;
 
             // Integrated Observables
-            double integrated_branching_ratio(const double & s_min, const double & s_max) const;
-            double integrated_a_fb_leptonic(const double & s_min, const double & s_max) const;
+            double integrated_branching_ratio(const double & q2_min, const double & q2_max) const;
+            double integrated_a_fb_leptonic(const double & q2_min, const double & q2_max) const;
 
-            double integrated_amplitude_polarization_L(const double & s_min, const double & s_max) const;
-            double integrated_amplitude_polarization_T(const double & s_min, const double & s_max) const;
-            double integrated_f_L(const double & s_min, const double & s_max) const;
-            double integrated_a_c_1(const double & s_min, const double & s_max) const;
-            double integrated_a_c_2(const double & s_min, const double & s_max) const;
-            double integrated_a_c_3(const double & s_min, const double & s_max) const;
-            double integrated_a_t_1(const double & s_min, const double & s_max) const;
-            double integrated_a_t_2(const double & s_min, const double & s_max) const;
-            double integrated_a_t_3(const double & s_min, const double & s_max) const;
+            double integrated_amplitude_polarization_L(const double & q2_min, const double & q2_max) const;
+            double integrated_amplitude_polarization_T(const double & q2_min, const double & q2_max) const;
+            double integrated_f_L(const double & q2_min, const double & q2_max) const;
+            double integrated_a_c_1(const double & q2_min, const double & q2_max) const;
+            double integrated_a_c_2(const double & q2_min, const double & q2_max) const;
+            double integrated_a_c_3(const double & q2_min, const double & q2_max) const;
+            double integrated_a_t_1(const double & q2_min, const double & q2_max) const;
+            double integrated_a_t_2(const double & q2_min, const double & q2_max) const;
+            double integrated_a_t_3(const double & q2_min, const double & q2_max) const;
 
             // Integrated Observables - normalized(|Vcb|=1)
-            double normalized_integrated_branching_ratio(const double & s_min, const double & s_max) const;
+            double normalized_integrated_branching_ratio(const double & q2_min, const double & q2_max) const;
 
             /*!
              * Descriptions of the process and its kinematics.
              */
             static const std::string description;
-            static const std::string kinematics_description_s;
+            static const std::string kinematics_description_q2;
             static const std::string kinematics_description_c_theta_l;
             static const std::string kinematics_description_c_theta_d;
             static const std::string kinematics_description_phi;

--- a/eos/b-decays/b-to-dstar-l-nu_TEST.cc
+++ b/eos/b-decays/b-to-dstar-l-nu_TEST.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2018, 2019 Ahmet Kokulu
+ * Copyright (c) 2019 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -95,8 +96,20 @@ class BToDstarLeptonNeutrinoTest :
                 BToDstarLeptonNeutrino d(p, o);
 
                 const double eps = 1e-3;
-                TEST_CHECK_NEARLY_EQUAL(d.integrated_branching_ratio(0.001, 10.689), 33.311, eps);
-                TEST_CHECK_NEARLY_EQUAL(d.integrated_f_L(0.001, 10.689),              0.546, eps);
+                TEST_CHECK_NEARLY_EQUAL(33.311,       d.integrated_branching_ratio(0.001, 10.689), eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.546,       d.integrated_f_L(0.001, 10.689),             eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.409302220, d.integrated_J1c_normalized(0.001, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.255523335, d.integrated_J1s_normalized(0.001, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.409302220, d.integrated_J2c_normalized(0.001, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.085174445, d.integrated_J2s_normalized(0.001, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.134468151, d.integrated_J3_normalized(0.001, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.231808464, d.integrated_J4_normalized(0.001, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.165381861, d.integrated_J5_normalized(0.001, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.0,         d.integrated_J6c_normalized(0.001, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.200153929, d.integrated_J6s_normalized(0.001, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.0,         d.integrated_J7_normalized(0.001, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.0,         d.integrated_J8_normalized(0.001, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.0,         d.integrated_J9_normalized(0.001, 10.689),   eps);
             }
 
             // comparison with Martin Jung in 3/2/1 model
@@ -147,8 +160,20 @@ class BToDstarLeptonNeutrinoTest :
                 BToDstarLeptonNeutrino d(p, o);
 
                 const double eps = 1e-3;
-                TEST_CHECK_NEARLY_EQUAL(d.integrated_branching_ratio(3.157, 10.689),  8.209, eps);
-                TEST_CHECK_NEARLY_EQUAL(d.integrated_f_L(3.157, 10.689),              0.475, eps);
+                TEST_CHECK_NEARLY_EQUAL( 8.209,        d.integrated_branching_ratio(3.157, 10.689), eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.475,        d.integrated_f_L(3.157, 10.689),             eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.4325856250, d.integrated_J1c_normalized(3.157, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.2779590234, d.integrated_J1s_normalized(3.157, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.1287773345, d.integrated_J2c_normalized(3.157, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.0471441750, d.integrated_J2s_normalized(3.157, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.0819412032, d.integrated_J3_normalized(3.157, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.1057578408, d.integrated_J4_normalized(3.157, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.2056068494, d.integrated_J5_normalized(3.157, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.2766922602, d.integrated_J6c_normalized(3.157, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.1598442669, d.integrated_J6s_normalized(3.157, 10.689),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.0,          d.integrated_J7_normalized(3.157, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.0,          d.integrated_J8_normalized(3.157, 10.689),   eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.0,          d.integrated_J9_normalized(3.157, 10.689),   eps);
             }
 
             // SM tests cf. [DSD2014]

--- a/eos/b-decays/observables.cc
+++ b/eos/b-decays/observables.cc
@@ -279,6 +279,14 @@ namespace eos
                                 &BToDstarLeptonNeutrino::normalized_differential_branching_ratio,
                                 std::make_tuple("q2")),
 
+                make_observable("B->D^*lnu::A_FB(q2)", R"(A_{\text{FB}}(B\to \bar{D}^*\ell^-\bar\nu)(q^2))",
+                                &BToDstarLeptonNeutrino::differential_a_fb_leptonic,
+                                std::make_tuple("q2")),
+
+                make_observable("B->D^*lnu::J_6s(q2)", R"(J_{6s}(B\to \bar{D}^*\ell^-\bar\nu)(q^2))",
+                                &BToDstarLeptonNeutrino::differential_J6s_normalized,
+                                std::make_tuple("q2")),
+
                 make_observable("B->D^*lnu::BR", R"(\mathcal{B}(B\to \bar{D}^*\ell^-\bar\nu))",
                                 &BToDstarLeptonNeutrino::integrated_branching_ratio,
                                 std::make_tuple("q2_min", "q2_max")),
@@ -302,10 +310,6 @@ namespace eos
                                 &BToDstarLeptonNeutrino::integrated_branching_ratio,
                                 std::make_tuple("q2_mu_min", "q2_mu_max"),
                                 Options{ { "l", "mu" } }),
-
-                make_observable("B->D^*lnu::A_FB(q2)", R"(A_{\text{FB}}(B\to \bar{D}^*\ell^-\bar\nu)(q^2))",
-                                &BToDstarLeptonNeutrino::differential_a_fb_leptonic,
-                                std::make_tuple("q2")),
 
                 make_observable("B->D^*lnu::A_FB", R"(A_{\text{FB}}(B\to \bar{D}^*\ell^-\bar\nu))",
                                 &BToDstarLeptonNeutrino::integrated_a_fb_leptonic,
@@ -345,6 +349,54 @@ namespace eos
 
                 make_observable("B->D^*lnu::A_T^3", R"(A_{\text{T}}^3(B\to \bar{D}^*\ell^-\bar\nu))",
                                 &BToDstarLeptonNeutrino::integrated_a_t_3,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_1c", R"(J_{1c}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J1c_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_1s", R"(J_{1s}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J1s_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_2c", R"(J_{2c}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J2c_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_2s", R"(J_{2s}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J2s_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_3", R"(J_{3}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J3_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_4", R"(J_{4}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J4_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_5", R"(J_{5}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J5_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_6c", R"(J_{6c}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J6c_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_6s", R"(J_{6s}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J6s_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_7", R"(J_{7}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J7_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_8", R"(J_{8}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J8_normalized,
+                                std::make_tuple("q2_min", "q2_max")),
+
+                make_observable("B->D^*lnu::J_9", R"(J_{9}(B\to \bar{D}^*\ell^-\bar\nu))",
+                                &BToDstarLeptonNeutrino::integrated_J9_normalized,
                                 std::make_tuple("q2_min", "q2_max")),
 
                 // B -> D pi l nu

--- a/eos/signal-pdf.cc
+++ b/eos/signal-pdf.cc
@@ -214,12 +214,12 @@ namespace eos
                     Options{ {"l", "mu"} },
                     &BToDstarLeptonNeutrino::differential_branching_ratio,
                     std::make_tuple(
-                        KinematicRange{ "s", 0.0, 10.68, BToDstarLeptonNeutrino::kinematics_description_s }
+                        KinematicRange{ "q2", 0.0, 10.68, BToDstarLeptonNeutrino::kinematics_description_q2 }
                     ),
                     &BToDstarLeptonNeutrino::integrated_branching_ratio,
                     std::make_tuple(
-                        "s_min",
-                        "s_max"
+                        "q2_min",
+                        "q2_max"
                     )
                 ),
 
@@ -227,15 +227,15 @@ namespace eos
                     Options{ {"l", "mu"} },
                     &BToDstarLeptonNeutrino::normalized_four_differential_decay_width,
                     std::make_tuple(
-                        KinematicRange{ "s", 0.0, 10.68, BToDstarLeptonNeutrino::kinematics_description_s },
+                        KinematicRange{ "q2", 0.0, 10.68, BToDstarLeptonNeutrino::kinematics_description_q2 },
                         KinematicRange{ "cos(theta_l)", -1.0, +1.0, BToDstarLeptonNeutrino::kinematics_description_c_theta_l },
                         KinematicRange{ "cos(theta_d)", -1.0, +1.0, BToDstarLeptonNeutrino::kinematics_description_c_theta_d },
                         KinematicRange{ "phi", 0.0, 2.0 * M_PI, BToDstarLeptonNeutrino::kinematics_description_phi }
                     ),
                     &BToDstarLeptonNeutrino::integrated_branching_ratio,
                     std::make_tuple(
-                        "s_min",
-                        "s_max"
+                        "q2_min",
+                        "q2_max"
                     )
                 ),
 

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -620,6 +620,7 @@ class Plotter:
 
             # extract information
             self.names            = item['constraints']
+            self.rotation         = 'vertical' if 'rotation' not in item else item['rotation']
             self.constraints      = []
 
             if type(self.names) == str:
@@ -691,7 +692,7 @@ class Plotter:
             yerrors = np.array(yerrors)
 
             self.plotter.ax.tick_params(axis='x', which='minor', bottom=False)
-            plt.xticks(xvalues, xticklabels, rotation='vertical')
+            plt.xticks(xvalues, xticklabels, rotation=self.rotation)
             plt.errorbar(x=xvalues, y=yvalues, xerr=None, yerr=yerrors.T,
                 color=self.color, elinewidth=1.0, fmt='_', linestyle='none', label=self.label)
             plt.margins(0.2)


### PR DESCRIPTION
This exports the q^2-differential and q^2-integrated angular observables in the J_i convention (J_i = 3/4 I_i). Some convenience changes are also included.

Github: resolves #209 