### PR TITLE
[C++14] Replace all uses of typedef with using

### DIFF
--- a/eos/constraint.cc
+++ b/eos/constraint.cc
@@ -59,7 +59,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<ConstraintEntry::ObservableNameIteratorTag>
     {
-        typedef std::vector<QualifiedName>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<QualifiedName>::const_iterator;
     };
     template class WrappedForwardIterator<ConstraintEntry::ObservableNameIteratorTag, const QualifiedName>;
 
@@ -1641,14 +1641,14 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Constraint::BlockIteratorTag>
     {
-        typedef std::vector<LogLikelihoodBlockPtr>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<LogLikelihoodBlockPtr>::iterator;
     };
     template class WrappedForwardIterator<Constraint::BlockIteratorTag, LogLikelihoodBlockPtr>;
 
     template <>
     struct WrappedForwardIteratorTraits<Constraint::ObservableIteratorTag>
     {
-        typedef ObservableSet::Iterator UnderlyingIterator;
+        using UnderlyingIterator = ObservableSet::Iterator;
     };
     template class WrappedForwardIterator<Constraint::ObservableIteratorTag, ObservablePtr>;
 
@@ -1715,7 +1715,7 @@ namespace eos
         return ObservableIterator(_imp->observables.end());
     }
 
-    typedef std::function<Constraint (const QualifiedName &, const Options & options)> ConstraintFactory;
+    using ConstraintFactory = std::function<Constraint (const QualifiedName &, const Options & options)>;
 
     template <typename Factory_>
     ConstraintFactory make_factory(const Factory_ & f)
@@ -1826,7 +1826,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Constraints::ConstraintIteratorTag>
     {
-        typedef std::map<QualifiedName, std::shared_ptr<const ConstraintEntry>>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::map<QualifiedName, std::shared_ptr<const ConstraintEntry>>::const_iterator;
     };
     template class WrappedForwardIterator<Constraints::ConstraintIteratorTag, const std::pair<const QualifiedName, std::shared_ptr<const ConstraintEntry>>>;
 

--- a/eos/constraint.hh
+++ b/eos/constraint.hh
@@ -62,7 +62,7 @@ namespace eos
             ///@name Iteration over Observables
             ///@{
             struct ObservableIteratorTag;
-            typedef WrappedForwardIterator<ObservableIteratorTag, ObservablePtr> ObservableIterator;
+            using ObservableIterator = WrappedForwardIterator<ObservableIteratorTag, ObservablePtr>;
 
             ObservableIterator begin_observables() const;
             ObservableIterator end_observables() const;
@@ -71,7 +71,7 @@ namespace eos
             ///@name Iteration over Blocks
             ///@{
             struct BlockIteratorTag;
-            typedef WrappedForwardIterator<BlockIteratorTag, LogLikelihoodBlockPtr> BlockIterator;
+            using BlockIterator = WrappedForwardIterator<BlockIteratorTag, LogLikelihoodBlockPtr>;
 
             BlockIterator begin_blocks() const;
             BlockIterator end_blocks() const;
@@ -117,7 +117,7 @@ namespace eos
             ///@name Iteration over our Observables
             ///@{
             struct ObservableNameIteratorTag;
-            typedef WrappedForwardIterator<ObservableNameIteratorTag, const QualifiedName> ObservableNameIterator;
+            using ObservableNameIterator = WrappedForwardIterator<ObservableNameIteratorTag, const QualifiedName>;
 
             virtual ObservableNameIterator begin_observable_names() const = 0;
             virtual ObservableNameIterator end_observable_names() const = 0;
@@ -153,7 +153,7 @@ namespace eos
         ///@name Iteration over known constraints
         ///@{
         struct ConstraintIteratorTag;
-        typedef WrappedForwardIterator<ConstraintIteratorTag, const std::pair<const QualifiedName, std::shared_ptr<const ConstraintEntry>>> ConstraintIterator;
+        using ConstraintIterator = WrappedForwardIterator<ConstraintIteratorTag, const std::pair<const QualifiedName, std::shared_ptr<const ConstraintEntry>>>;
 
         ConstraintIterator begin() const;
         ConstraintIterator end() const;

--- a/eos/form-factors/baryonic.cc
+++ b/eos/form-factors/baryonic.cc
@@ -141,8 +141,8 @@ namespace eos
     {
         std::shared_ptr<FormFactors<OneHalfPlusToOneHalfPlus>> result;
 
-        typedef QualifiedName KeyType;
-        typedef std::function<FormFactors<OneHalfPlusToOneHalfPlus> * (const Parameters &, const Options &)> ValueType;
+        using KeyType = QualifiedName;
+        using ValueType = std::function<FormFactors<OneHalfPlusToOneHalfPlus> * (const Parameters &, const Options &)>;
         static const std::map<KeyType, ValueType> form_factors
         {
             { KeyType("Lambda_b->Lambda::BFvD2014"),   &BFvD2014FormFactors::make                      },
@@ -185,8 +185,8 @@ namespace eos
     {
         std::shared_ptr<FormFactors<OneHalfPlusToOneHalfMinus>> result;
 
-        typedef std::tuple<std::string, std::string> KeyType;
-        typedef std::function<FormFactors<OneHalfPlusToOneHalfMinus> * (const Parameters &, unsigned)> ValueType;
+        using KeyType = std::tuple<std::string, std::string>;
+        using ValueType = std::function<FormFactors<OneHalfPlusToOneHalfMinus> * (const Parameters &, unsigned)>;
 
         static const std::map<KeyType, ValueType> form_factors
         {
@@ -252,8 +252,8 @@ namespace eos
     {
         std::shared_ptr<FormFactors<OneHalfPlusToThreeHalfMinus>> result;
 
-        typedef std::tuple<std::string, std::string> KeyType;
-        typedef std::function<FormFactors<OneHalfPlusToThreeHalfMinus> * (const Parameters &, unsigned)> ValueType;
+        using KeyType = std::tuple<std::string, std::string>;
+        using ValueType = std::function<FormFactors<OneHalfPlusToThreeHalfMinus> * (const Parameters &, unsigned)>;
 
         static const std::map<KeyType, ValueType> form_factors
         {

--- a/eos/form-factors/mesonic-impl.hh
+++ b/eos/form-factors/mesonic-impl.hh
@@ -749,7 +749,7 @@ namespace eos
     /* P -> P Processes */
 
     struct BToK {
-        typedef PToP Transition;
+        using Transition = PToP;
         static constexpr const char * label = "B->K";
         static constexpr const double m_B = 5.279;
         static constexpr const double m_P = 0.492;
@@ -761,7 +761,7 @@ namespace eos
     };
 
     struct BToPi {
-        typedef PToP Transition;
+        using Transition = PToP;
         static constexpr const char * label = "B->pi";
         static constexpr const double m_B = 5.279;
         static constexpr const double m_P = 0.135;
@@ -773,7 +773,7 @@ namespace eos
     };
 
     struct BsToK {
-        typedef PToP Transition;
+        using Transition = PToP;
         static constexpr const char * label = "B_s->K";
         static constexpr const double m_B = 5.366;
         static constexpr const double m_P = 0.494;
@@ -785,7 +785,7 @@ namespace eos
     };
 
     struct BToD {
-        typedef PToP Transition;
+        using Transition = PToP;
         static constexpr const char * label = "B->D";
         static constexpr const char * name_B = "mass::B_d";
         static constexpr const char * name_P = "mass::D_u";
@@ -801,7 +801,7 @@ namespace eos
     };
 
     struct BsToDs {
-        typedef PToP Transition;
+        using Transition = PToP;
         static constexpr const char * label = "B_s->D_s";
         static constexpr const char * name_B = "mass::B_s";
         static constexpr const char * name_P = "mass::D_s";
@@ -1277,7 +1277,7 @@ namespace eos
     /* P -> PP Processes */
 
     struct BToPiPi {
-        typedef PToPP Transition;
+        using Transition = PToPP;
         static constexpr const char * label = "B->pipi";
         static constexpr double mB  = 5.2795;
         static constexpr double mP1 = 0.13957;

--- a/eos/form-factors/mesonic.cc
+++ b/eos/form-factors/mesonic.cc
@@ -147,8 +147,8 @@ namespace eos
     {
         std::shared_ptr<FormFactors<PToV>> result;
 
-        typedef QualifiedName KeyType;
-        typedef std::function<FormFactors<PToV> * (const Parameters &, const Options &)> ValueType;
+        using KeyType = QualifiedName;
+        using ValueType = std::function<FormFactors<PToV> * (const Parameters &, const Options &)>;
         static const std::map<KeyType, ValueType> form_factors
         {
             { KeyType("B->rho::BSZ2015"),      &BSZ2015FormFactors<BToRho,    PToV>::make          },
@@ -325,8 +325,8 @@ namespace eos
     {
         std::shared_ptr<FormFactors<PToP>> result;
 
-        typedef QualifiedName KeyType;
-        typedef std::function<FormFactors<PToP> * (const Parameters &, const Options &)> ValueType;
+        using KeyType = QualifiedName;
+        using ValueType = std::function<FormFactors<PToP> * (const Parameters &, const Options &)>;
         static const std::map<KeyType, ValueType> form_factors
         {
             // parametrizations
@@ -391,8 +391,8 @@ namespace eos
     {
         std::shared_ptr<FormFactors<PToPP>> result;
 
-        typedef QualifiedName KeyType;
-        typedef std::function<FormFactors<PToPP> * (const Parameters &, const Options &)> ValueType;
+        using KeyType = QualifiedName;
+        using ValueType = std::function<FormFactors<PToPP> * (const Parameters &, const Options &)>;
         static const std::map<KeyType, ValueType> form_factors
         {
             // analytic computations
@@ -421,8 +421,8 @@ namespace eos
     {
         std::shared_ptr<FormFactors<VToP>> result;
 
-        typedef QualifiedName KeyType;
-        typedef std::function<FormFactors<VToP> * (const Parameters &, const Options &)> ValueType;
+        using KeyType = QualifiedName;
+        using ValueType = std::function<FormFactors<VToP> * (const Parameters &, const Options &)>;
         static const std::map<KeyType, ValueType> form_factors
         {
             // parametrizations
@@ -450,8 +450,8 @@ namespace eos
     {
         std::shared_ptr<FormFactors<VToV>> result;
 
-        typedef QualifiedName KeyType;
-        typedef std::function<FormFactors<VToV> * (const Parameters &, const Options &)> ValueType;
+        using KeyType = QualifiedName;
+        using ValueType = std::function<FormFactors<VToV> * (const Parameters &, const Options &)>;
         static const std::map<KeyType, ValueType> form_factors
         {
             // parametrizations

--- a/eos/observable.cc
+++ b/eos/observable.cc
@@ -107,7 +107,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<ObservableGroup::ObservableIteratorTag>
     {
-        typedef std::map<QualifiedName, ObservableEntryPtr>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::map<QualifiedName, ObservableEntryPtr>::const_iterator;
     };
     template class WrappedForwardIterator<ObservableGroup::ObservableIteratorTag, const std::pair<const QualifiedName, ObservableEntryPtr>>;
 
@@ -147,7 +147,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<ObservableSection::GroupIteratorTag>
     {
-        typedef std::vector<ObservableGroup>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ObservableGroup>::const_iterator;
     };
     template class WrappedForwardIterator<ObservableSection::GroupIteratorTag, const ObservableGroup &>;
 
@@ -187,14 +187,14 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Observables::ObservableIteratorTag>
     {
-        typedef std::map<QualifiedName, ObservableEntryPtr>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::map<QualifiedName, ObservableEntryPtr>::const_iterator;
     };
     template class WrappedForwardIterator<Observables::ObservableIteratorTag, const std::pair<const QualifiedName, ObservableEntryPtr>>;
 
     template <>
     struct WrappedForwardIteratorTraits<Observables::SectionIteratorTag>
     {
-        typedef std::vector<ObservableSection>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ObservableSection>::const_iterator;
     };
     template class WrappedForwardIterator<Observables::SectionIteratorTag, const ObservableSection &>;
 

--- a/eos/observable.hh
+++ b/eos/observable.hh
@@ -76,7 +76,7 @@ namespace eos
             ///@name Iteration over groups
             ///@{
             struct GroupIteratorTag;
-            typedef WrappedForwardIterator<GroupIteratorTag, const ObservableGroup &> GroupIterator;
+            using GroupIterator = WrappedForwardIterator<GroupIteratorTag, const ObservableGroup &>;
 
             GroupIterator begin() const;
             GroupIterator end() const;
@@ -106,7 +106,7 @@ namespace eos
             ///@name Iteration over observables
             ///@{
             struct ObservableIteratorTag;
-            typedef WrappedForwardIterator<ObservableIteratorTag, const std::pair<const QualifiedName, ObservableEntryPtr>> ObservableIterator;
+            using ObservableIterator = WrappedForwardIterator<ObservableIteratorTag, const std::pair<const QualifiedName, ObservableEntryPtr>>;
 
             ObservableIterator begin() const;
             ObservableIterator end() const;
@@ -182,7 +182,7 @@ namespace eos
             ///@name Iteration over observables
             ///@{
             struct ObservableIteratorTag;
-            typedef WrappedForwardIterator<ObservableIteratorTag, const std::pair<const QualifiedName, ObservableEntryPtr>> ObservableIterator;
+            using ObservableIterator = WrappedForwardIterator<ObservableIteratorTag, const std::pair<const QualifiedName, ObservableEntryPtr>>;
 
             ObservableIterator begin() const;
             ObservableIterator end() const;
@@ -191,7 +191,7 @@ namespace eos
             ///@name Iteration over groups of observables
             ///@{
             struct SectionIteratorTag;
-            typedef WrappedForwardIterator<SectionIteratorTag, const ObservableSection &> SectionIterator;
+            using SectionIterator = WrappedForwardIterator<SectionIteratorTag, const ObservableSection &>;
 
             SectionIterator begin_sections() const;
             SectionIterator end_sections() const;

--- a/eos/optimize/optimizer.hh
+++ b/eos/optimize/optimizer.hh
@@ -32,7 +32,7 @@ namespace eos
 {
     class Optimizer;
 
-    typedef std::shared_ptr<Optimizer> OptimizerPtr;
+    using OptimizerPtr = std::shared_ptr<Optimizer>;
 
     /*!
      * Optimizer takes a Density and modified its parameters such that the

--- a/eos/rare-b-decays/exclusive-b-to-dilepton.cc
+++ b/eos/rare-b-decays/exclusive-b-to-dilepton.cc
@@ -58,7 +58,7 @@ namespace eos
 
         std::function<complex<double> (const Model *)> lambda;
 
-        typedef std::array<complex<double>, 4> xi_t;
+        using xi_t = std::array<complex<double>, 4>;
 
         Implementation(const Parameters & p, const Options & o, ParameterUser & u) :
             model(Model::make(o.get("model", "SM"), p, o)),

--- a/eos/reference.hh
+++ b/eos/reference.hh
@@ -94,7 +94,7 @@ namespace eos
             ///@name Iteration over known constraints
             ///@{
             struct ReferenceIteratorTag;
-            typedef WrappedForwardIterator<ReferenceIteratorTag, const std::pair<const ReferenceName, ReferencePtr>> ReferenceIterator;
+            using ReferenceIterator = WrappedForwardIterator<ReferenceIteratorTag, const std::pair<const ReferenceName, ReferencePtr>>;
 
             ReferenceIterator begin() const;
             ReferenceIterator end() const;

--- a/eos/signal-pdf.cc
+++ b/eos/signal-pdf.cc
@@ -86,7 +86,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<SignalPDFEntry::KinematicRangeIteratorTag>
     {
-        typedef const KinematicRange * UnderlyingIterator;
+        using UnderlyingIterator = const KinematicRange *;
     };
     template class WrappedForwardIterator<SignalPDFEntry::KinematicRangeIteratorTag, const KinematicRange>;
 
@@ -458,7 +458,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<SignalPDFs::SignalPDFIteratorTag>
     {
-        typedef std::map<QualifiedName, const SignalPDFEntry *>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::map<QualifiedName, const SignalPDFEntry *>::iterator;
     };
     template class WrappedForwardIterator<SignalPDFs::SignalPDFIteratorTag, std::pair<const QualifiedName, const SignalPDFEntry *>>;
 

--- a/eos/signal-pdf.hh
+++ b/eos/signal-pdf.hh
@@ -50,7 +50,7 @@ namespace eos
 
     class SignalPDF;
 
-    typedef std::shared_ptr<SignalPDF> SignalPDFPtr;
+    using SignalPDFPtr = std::shared_ptr<SignalPDF>;
 
     class SignalPDF :
         public Density
@@ -100,7 +100,7 @@ namespace eos
             ///@name Iteration over our kinematic ranges
             ///@{
             struct KinematicRangeIteratorTag;
-            typedef WrappedForwardIterator<KinematicRangeIteratorTag, const KinematicRange> KinematicRangeIterator;
+            using KinematicRangeIterator = WrappedForwardIterator<KinematicRangeIteratorTag, const KinematicRange>;
 
             virtual KinematicRangeIterator begin_kinematic_ranges() const = 0;
             virtual KinematicRangeIterator end_kinematic_ranges() const = 0;
@@ -141,7 +141,7 @@ namespace eos
             ///@name Iteration over known constraints
             ///@{
             struct SignalPDFIteratorTag;
-            typedef WrappedForwardIterator<SignalPDFIteratorTag, std::pair<const QualifiedName, const SignalPDFEntry *>> SignalPDFIterator;
+            using SignalPDFIterator = WrappedForwardIterator<SignalPDFIteratorTag, std::pair<const QualifiedName, const SignalPDFEntry *>>;
 
             SignalPDFIterator begin() const;
             SignalPDFIterator end() const;

--- a/eos/statistics/chain-group.cc
+++ b/eos/statistics/chain-group.cc
@@ -212,14 +212,14 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<ChainGroup::IteratorTag>
     {
-        typedef std::vector<HistoryPtr>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<HistoryPtr>::iterator;
     };
     template class WrappedForwardIterator<ChainGroup::IteratorTag, HistoryPtr>;
 
     template <>
     struct WrappedForwardIteratorTraits<ChainGroup::IndexIteratorTag>
     {
-        typedef std::vector<unsigned>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<unsigned>::iterator;
     };
     template class WrappedForwardIterator<ChainGroup::IndexIteratorTag, unsigned>;
 }

--- a/eos/statistics/chain-group.hh
+++ b/eos/statistics/chain-group.hh
@@ -13,7 +13,7 @@ namespace eos
         public PrivateImplementationPattern<ChainGroup>
     {
         public:
-            typedef std::function<double (const std::vector<double> &, const std::vector<double> &, const unsigned &)> RValueFunction;
+            using RValueFunction = std::function<double (const std::vector<double> &, const std::vector<double> &, const unsigned &)>;
 
             /*!
              * Construct a cluster, which checks if two chains overlap by
@@ -64,12 +64,12 @@ namespace eos
             void parameter_indices(const std::vector<unsigned> & indices);
 
             struct IteratorTag;
-            typedef WrappedForwardIterator<IteratorTag, HistoryPtr> Iterator;
+            using Iterator = WrappedForwardIterator<IteratorTag, HistoryPtr>;
             Iterator begin() const;
             Iterator end() const;
 
             struct IndexIteratorTag;
-            typedef WrappedForwardIterator<IndexIteratorTag, unsigned> IndexIterator;
+            using IndexIterator = WrappedForwardIterator<IndexIteratorTag, unsigned>;
             IndexIterator begin_indices() const;
             IndexIterator end_indices() const;
     };

--- a/eos/statistics/chi-squared.hh
+++ b/eos/statistics/chi-squared.hh
@@ -32,7 +32,7 @@ namespace eos
          * Signature for Chi-Squared functions.
          */
 
-        typedef std::function<double (double, double, double, double, double, double)> Function;
+        using Function = std::function<double (double, double, double, double, double, double)>;
 
         /*
          * Chi-Squared function with theory offset.

--- a/eos/statistics/density-wrapper.cc
+++ b/eos/statistics/density-wrapper.cc
@@ -26,7 +26,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<SimpleParameters::IteratorTag>
     {
-        typedef std::vector<ParameterDescription>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ParameterDescription>::const_iterator;
     };
 
     DensityWrapper::DensityWrapper(const WrappedDensity & density) :

--- a/eos/statistics/density-wrapper.hh
+++ b/eos/statistics/density-wrapper.hh
@@ -40,8 +40,8 @@ namespace eos
         public Density
     {
         public:
-            typedef double (* RawDensity)(const std::vector<double> &);
-            typedef std::function< double (const std::vector<double> &)> WrappedDensity;
+            using RawDensity = double(*)(const std::vector<double> &);
+            using WrappedDensity = std::function< double (const std::vector<double> &)>;
 
             /// Initialize with a WrappedDensity, that could point for example to a member method
             DensityWrapper(const WrappedDensity &);

--- a/eos/statistics/goodness-of-fit.cc
+++ b/eos/statistics/goodness-of-fit.cc
@@ -84,7 +84,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<GoodnessOfFit::ChiSquareIteratorTag>
     {
-        typedef std::map<QualifiedName, test_statistics::ChiSquare>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::map<QualifiedName, test_statistics::ChiSquare>::const_iterator;
     };
     template class WrappedForwardIterator<GoodnessOfFit::ChiSquareIteratorTag, const std::pair<const QualifiedName, test_statistics::ChiSquare>>;
 

--- a/eos/statistics/goodness-of-fit.hh
+++ b/eos/statistics/goodness-of-fit.hh
@@ -40,7 +40,7 @@ namespace eos
             int total_degrees_of_freedom() const;
 
             struct ChiSquareIteratorTag;
-            typedef WrappedForwardIterator<ChiSquareIteratorTag, const std::pair<const QualifiedName, test_statistics::ChiSquare>> ChiSquareIterator;
+            using ChiSquareIterator = WrappedForwardIterator<ChiSquareIteratorTag, const std::pair<const QualifiedName, test_statistics::ChiSquare>>;
 
             ChiSquareIterator begin_chi_square() const;
             ChiSquareIterator end_chi_square() const;

--- a/eos/statistics/hierarchical-clustering.cc
+++ b/eos/statistics/hierarchical-clustering.cc
@@ -569,21 +569,21 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<HierarchicalClustering::InputIteratorTag>
     {
-        typedef HierarchicalClustering::MixtureDensity::iterator UnderlyingIterator;
+        using UnderlyingIterator = HierarchicalClustering::MixtureDensity::iterator;
     };
     template class WrappedForwardIterator<HierarchicalClustering::InputIteratorTag, HierarchicalClustering::Component>;
 
     template <>
     struct WrappedForwardIteratorTraits<HierarchicalClustering::OutputIteratorTag>
     {
-        typedef HierarchicalClustering::MixtureDensity::iterator UnderlyingIterator;
+        using UnderlyingIterator = HierarchicalClustering::MixtureDensity::iterator;
     };
     template class WrappedForwardIterator<HierarchicalClustering::OutputIteratorTag, HierarchicalClustering::Component>;
 
     template <>
     struct WrappedForwardIteratorTraits<HierarchicalClustering::MapIteratorTag>
     {
-        typedef std::vector<unsigned>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<unsigned>::iterator;
     };
     template class WrappedForwardIterator<HierarchicalClustering::MapIteratorTag, unsigned>;
 }

--- a/eos/statistics/hierarchical-clustering.hh
+++ b/eos/statistics/hierarchical-clustering.hh
@@ -41,7 +41,7 @@ namespace eos
         public:
             class Config;
             class Component;
-            typedef std::vector<HierarchicalClustering::Component> MixtureDensity;
+            using MixtureDensity = std::vector<HierarchicalClustering::Component>;
 
             ///@name Basic Functions
             ///@{
@@ -74,19 +74,19 @@ namespace eos
 
             /// Loop over input components
             struct InputIteratorTag;
-            typedef WrappedForwardIterator<InputIteratorTag, Component> InputIterator;
+            using InputIterator = WrappedForwardIterator<InputIteratorTag, Component>;
             InputIterator begin_input() const;
             InputIterator end_input() const;
 
             /// Loop over output components (determined during clustering).
             struct OutputIteratorTag;
-            typedef WrappedForwardIterator<OutputIteratorTag, Component> OutputIterator;
+            using OutputIterator = WrappedForwardIterator<OutputIteratorTag, Component>;
             OutputIterator begin_output() const;
             OutputIterator end_output() const;
 
             /// To which output is an input component mapped?
             struct MapIteratorTag;
-            typedef WrappedForwardIterator<MapIteratorTag, unsigned> MapIterator;
+            using MapIterator = WrappedForwardIterator<MapIteratorTag, unsigned>;
             MapIterator begin_map() const;
             MapIterator end_map() const;
     };

--- a/eos/statistics/histogram.cc
+++ b/eos/statistics/histogram.cc
@@ -36,7 +36,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Histogram<1>::ConstIteratorTag>
     {
-        typedef std::list<Histogram<1>::Bin>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<Histogram<1>::Bin>::const_iterator;
     };
 
     template <> struct Implementation<Histogram<1>>
@@ -169,13 +169,13 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Histogram<2>::IteratorTag>
     {
-        typedef std::vector<Histogram<2>::Bin>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<Histogram<2>::Bin>::iterator;
     };
 
     template <>
     struct WrappedForwardIteratorTraits<Histogram<2>::ConstIteratorTag>
     {
-        typedef std::vector<Histogram<2>::Bin>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<Histogram<2>::Bin>::const_iterator;
     };
 
     template <> struct Implementation<Histogram<2>>

--- a/eos/statistics/histogram.hh
+++ b/eos/statistics/histogram.hh
@@ -71,7 +71,7 @@ namespace eos
             ///@name Iteration
             ///@{
             struct ConstIteratorTag;
-            typedef WrappedForwardIterator<ConstIteratorTag, const Bin> ConstIterator;
+            using ConstIterator = WrappedForwardIterator<ConstIteratorTag, const Bin>;
 
             ConstIterator begin() const;
             ConstIterator end() const;
@@ -171,7 +171,7 @@ namespace eos
             ///@name Iteration
             ///@{
             struct IteratorTag;
-            typedef WrappedForwardIterator<IteratorTag, Bin> Iterator;
+            using Iterator = WrappedForwardIterator<IteratorTag, Bin>;
 
             Iterator begin();
             Iterator find(const std::array<double, 2> & coordinates);
@@ -181,7 +181,7 @@ namespace eos
             ///@name Constant Iteration
             ///@{
             struct ConstIteratorTag;
-            typedef WrappedForwardIterator<ConstIteratorTag, const Bin> ConstIterator;
+            using ConstIterator = WrappedForwardIterator<ConstIteratorTag, const Bin>;
 
             ConstIterator cbegin() const;
             ConstIterator cend() const;

--- a/eos/statistics/log-likelihood-fwd.hh
+++ b/eos/statistics/log-likelihood-fwd.hh
@@ -29,7 +29,7 @@ namespace eos
     // Forward declarations.
     class LogLikelihoodBlock;
 
-    typedef std::shared_ptr<LogLikelihoodBlock> LogLikelihoodBlockPtr;
+    using LogLikelihoodBlockPtr = std::shared_ptr<LogLikelihoodBlock>;
 }
 
 #endif

--- a/eos/statistics/log-likelihood.cc
+++ b/eos/statistics/log-likelihood.cc
@@ -1223,7 +1223,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<LogLikelihood::ConstraintIteratorTag>
     {
-        typedef std::vector<Constraint>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<Constraint>::iterator;
     };
     template class WrappedForwardIterator<LogLikelihood::ConstraintIteratorTag, Constraint>;
 

--- a/eos/statistics/log-likelihood.hh
+++ b/eos/statistics/log-likelihood.hh
@@ -349,7 +349,7 @@ namespace eos
             ///@name Iteration and Access
             ///@{
             struct ConstraintIteratorTag;
-            typedef WrappedForwardIterator<ConstraintIteratorTag, Constraint> ConstraintIterator;
+            using ConstraintIterator = WrappedForwardIterator<ConstraintIteratorTag, Constraint>;
 
             /// Iterator to the first constraint.
             ConstraintIterator begin() const;

--- a/eos/statistics/log-posterior-fwd.hh
+++ b/eos/statistics/log-posterior-fwd.hh
@@ -27,7 +27,7 @@ namespace eos
     // forward declaration
     class LogPosterior;
 
-    typedef std::shared_ptr<LogPosterior> LogPosteriorPtr;
+    using LogPosteriorPtr = std::shared_ptr<LogPosterior>;
 }
 
 #endif

--- a/eos/statistics/log-posterior.hh
+++ b/eos/statistics/log-posterior.hh
@@ -311,8 +311,8 @@ namespace eos
 
      struct LogPosterior::Output
      {
-         typedef hdf5::Composite<hdf5::Scalar<const char *>, hdf5::Scalar<double>, hdf5::Scalar<double>,
-                                 hdf5::Scalar<int>, hdf5::Scalar<const char *>> DescriptionType;
+         using  DescriptionType = hdf5::Composite<hdf5::Scalar<const char *>, hdf5::Scalar<double>, hdf5::Scalar<double>,
+                                                  hdf5::Scalar<int>, hdf5::Scalar<const char *>>;
          static DescriptionType description_type();
          static std::tuple<const char *, double, double, int, const char *> description_record();
      };

--- a/eos/statistics/log-prior-fwd.hh
+++ b/eos/statistics/log-prior-fwd.hh
@@ -27,7 +27,7 @@ namespace eos
     // forward declarations
     class LogPrior;
 
-    typedef std::shared_ptr<LogPrior> LogPriorPtr;
+    using LogPriorPtr = std::shared_ptr<LogPrior>;
 }
 
 #endif

--- a/eos/statistics/log-prior.cc
+++ b/eos/statistics/log-prior.cc
@@ -40,7 +40,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<LogPrior::IteratorTag>
     {
-        typedef std::vector<ParameterDescription>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ParameterDescription>::iterator;
     };
 
     namespace priors

--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -76,7 +76,7 @@ namespace eos
             ///@name Iteration over descriptions
             ///@{
             struct IteratorTag;
-            typedef WrappedForwardIterator<IteratorTag, ParameterDescription> Iterator;
+            using Iterator = WrappedForwardIterator<IteratorTag, ParameterDescription>;
 
             Iterator begin();
             Iterator end();

--- a/eos/statistics/markov-chain.cc
+++ b/eos/statistics/markov-chain.cc
@@ -81,7 +81,7 @@ namespace eos
         double welford_data_density;
 
         // Output data types
-        typedef hdf5::Array<1, double> SampleType;
+        using SampleType = hdf5::Array<1, double>;
         const SampleType sample_type;
 
         Implementation(const DensityPtr & density, unsigned long seed, const std::shared_ptr<MarkovChain::ProposalFunction> & proposal_function) :

--- a/eos/statistics/markov-chain.hh
+++ b/eos/statistics/markov-chain.hh
@@ -163,7 +163,7 @@ namespace eos
      */
     struct MarkovChain::State
     {
-        typedef std::vector<State>::const_iterator Iterator;
+        using Iterator = std::vector<State>::const_iterator;
 
         /// position in parameter space
         std::vector<double> point;
@@ -231,7 +231,7 @@ namespace eos
         double variance_of_log_density;
     };
 
-    typedef std::shared_ptr<MarkovChain::History> HistoryPtr;
+    using HistoryPtr = std::shared_ptr<MarkovChain::History>;
 
     /*!
      * Holds the entire history of a run of a MarkovChain
@@ -275,7 +275,7 @@ namespace eos
                                    std::vector<double> & mean, std::vector<double> & variance) const;
     };
 
-    typedef std::shared_ptr<MarkovChain::ProposalFunction> ProposalFunctionPtr;
+    using ProposalFunctionPtr = std::shared_ptr<MarkovChain::ProposalFunction>;
 
     /*!
      * Interface to proposal functions for a MarkovChain.

--- a/eos/statistics/population-monte-carlo-sampler.cc
+++ b/eos/statistics/population-monte-carlo-sampler.cc
@@ -147,7 +147,7 @@ namespace eos
             return value;
         }
 
-        typedef std::pair<unsigned, double> index_pair;
+        using index_pair = std::pair<unsigned, double>;
 
         /*
          * Find the minimal partition of N into K parts, such that the smallest
@@ -243,7 +243,7 @@ namespace eos
     template<>
     struct Implementation<PopulationMonteCarloSampler>
     {
-        typedef std::vector<unsigned> IndexList;
+        using IndexList = std::vector<unsigned>;
 
         // store reference, but don't own log-posterior
         DensityPtr density;

--- a/eos/statistics/population-monte-carlo-sampler.hh
+++ b/eos/statistics/population-monte-carlo-sampler.hh
@@ -324,11 +324,11 @@ namespace eos
      */
     struct PopulationMonteCarloSampler::Output
     {
-         typedef hdf5::Composite<hdf5::Scalar<double>, hdf5::Array<1, double>, hdf5::Array<1, double>> ComponentType;
-         typedef hdf5::Scalar<short> IgnoreType;
-         typedef hdf5::Array<1, double> SampleType;
-         typedef hdf5::Composite<hdf5::Scalar<double>, hdf5::Scalar<double>, hdf5::Scalar<double>> StatisticsType;
-         typedef hdf5::Composite<hdf5::Scalar<double>, hdf5::Scalar<double>> WeightType;
+         using ComponentType = hdf5::Composite<hdf5::Scalar<double>, hdf5::Array<1, double>, hdf5::Array<1, double>>;
+         using IgnoreType = hdf5::Scalar<short>;
+         using SampleType = hdf5::Array<1, double>;
+         using StatisticsType = hdf5::Composite<hdf5::Scalar<double>, hdf5::Scalar<double>, hdf5::Scalar<double>>;
+         using WeightType = hdf5::Composite<hdf5::Scalar<double>, hdf5::Scalar<double>>;
 
          static ComponentType component_type(const unsigned & dimension);
          static IgnoreType ignore_type();

--- a/eos/statistics/prior-sampler.cc
+++ b/eos/statistics/prior-sampler.cc
@@ -31,13 +31,13 @@ namespace eos
 {
     namespace
     {
-        typedef PriorSampler::SamplesList SamplesList;
+        using SamplesList = PriorSampler::SamplesList;
     }
 
     template<>
     struct Implementation<PriorSampler>
     {
-        typedef std::function<void (void)> Function;
+        using Function = std::function<void (void)>;
 
         struct Worker
         {

--- a/eos/statistics/prior-sampler.hh
+++ b/eos/statistics/prior-sampler.hh
@@ -41,8 +41,8 @@ namespace eos
         public:
             struct Config;
 
-            typedef hdf5::Array<1, double> ObservablesType;
-            typedef std::vector<std::vector<double>> SamplesList;
+            using ObservablesType = hdf5::Array<1, double>;
+            using SamplesList = std::vector<std::vector<double>>;
 
             static ObservablesType observables_type(const unsigned & dimension);
 

--- a/eos/statistics/proposal-functions.cc
+++ b/eos/statistics/proposal-functions.cc
@@ -273,7 +273,7 @@ namespace eos
                 }
         };
 
-        typedef std::function< ProposalFunctionPtr (hdf5::File &, const std::string & data_set_base_name, const unsigned & dimension)> ProposalFactory;
+        using ProposalFactory = std::function< ProposalFunctionPtr (hdf5::File &, const std::string & data_set_base_name, const unsigned & dimension)>;
 
         template <typename Factory_> ProposalFactory
         make_factory(const Factory_ &)

--- a/eos/statistics/proposal-functions.hh
+++ b/eos/statistics/proposal-functions.hh
@@ -48,10 +48,10 @@ namespace eos
         /*!
          * This data type descriptor is needed to identify the proposal function type
          */
-        typedef hdf5::Composite<hdf5::Scalar<const char *>, hdf5::Scalar<unsigned>> MetaType;
+        using MetaType = hdf5::Composite<hdf5::Scalar<const char *>, hdf5::Scalar<unsigned>>;
         MetaType meta_type();
 
-        typedef std::tuple<const char *, unsigned> MetaRecord;
+        using MetaRecord = std::tuple<const char *, unsigned>;
         MetaRecord meta_record();
 
         /*!
@@ -151,7 +151,7 @@ namespace eos
             public MarkovChain::ProposalFunction
         {
             public:
-                typedef hdf5::Array<1, double> CovarianceType;
+                using CovarianceType = hdf5::Array<1, double>;
                 static CovarianceType covariance_type(const unsigned & dimension);
 
             protected:
@@ -251,13 +251,13 @@ namespace eos
                 virtual void set_indices(const std::vector<unsigned> & index_list);
         };
 
-        typedef std::shared_ptr<Multivariate> MultivariateProposalPtr;
+        using MultivariateProposalPtr = std::shared_ptr<Multivariate>;
 
         class MultivariateGaussian :
             public Multivariate
         {
             public:
-                typedef hdf5::Composite<hdf5::Scalar<double>, hdf5::Scalar<double>, hdf5::Scalar<unsigned>> ScalarsType;
+                using ScalarsType = hdf5::Composite<hdf5::Scalar<double>, hdf5::Scalar<double>, hdf5::Scalar<unsigned>>;
                 static ScalarsType scalars_type();
 
             protected:
@@ -281,7 +281,7 @@ namespace eos
             public Multivariate
         {
             public:
-                typedef hdf5::Composite<hdf5::Scalar<double>, hdf5::Scalar<double>, hdf5::Scalar<unsigned>, hdf5::Scalar<double>> ScalarsType;
+                using ScalarsType = hdf5::Composite<hdf5::Scalar<double>, hdf5::Scalar<double>, hdf5::Scalar<unsigned>, hdf5::Scalar<double>>;
                 static ScalarsType scalars_type();
 
             protected:
@@ -315,7 +315,7 @@ namespace eos
             public MarkovChain::ProposalFunction
         {
             public:
-                typedef hdf5::Composite<hdf5::Scalar<const char *>> PriorsType;
+                using PriorsType = hdf5::Composite<hdf5::Scalar<const char *>>;
                 static PriorsType priors_type();
                 friend struct MultivariateAccess;
             private:

--- a/eos/statistics/simple-parameters.cc
+++ b/eos/statistics/simple-parameters.cc
@@ -30,7 +30,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<SimpleParameters::IteratorTag>
     {
-        typedef std::vector<ParameterDescription>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ParameterDescription>::const_iterator;
     };
 
     template <>

--- a/eos/statistics/simple-parameters.hh
+++ b/eos/statistics/simple-parameters.hh
@@ -40,7 +40,7 @@ namespace eos
             /*!
              * A unique number index of this parameter
              */
-            typedef size_t Index;
+            using Index = size_t;
 
             ///@name Basic Operations
             ///@{
@@ -106,7 +106,7 @@ namespace eos
             ///@name Iteration
             ///@{
             struct IteratorTag;
-            typedef WrappedForwardIterator<IteratorTag, const ParameterDescription> Iterator;
+            using Iterator = WrappedForwardIterator<IteratorTag, const ParameterDescription>;
 
             Iterator begin() const;
             Iterator end() const;

--- a/eos/statistics/test-statistic.hh
+++ b/eos/statistics/test-statistic.hh
@@ -34,7 +34,7 @@ namespace eos
         class ChiSquare;
     }
 
-    typedef OneOf<test_statistics::Empty, test_statistics::ChiSquare> TestStatistic;
+    using TestStatistic = OneOf<test_statistics::Empty, test_statistics::ChiSquare>;
 }
 
 #endif

--- a/eos/utils/cartesian-product.hh
+++ b/eos/utils/cartesian-product.hh
@@ -32,7 +32,7 @@ namespace eos
     template <typename T_> class CartesianProduct
     {
         private:
-            typedef std::vector<typename T_::const_iterator> IteratorState;
+            using IteratorState = std::vector<typename T_::const_iterator>;
 
             // All stored containers.
             std::vector<T_> _data;
@@ -43,13 +43,13 @@ namespace eos
             // The overall number of elements stored in CartesianProduct.
             size_t _size;
 
-            typedef std::vector<size_t> Sizes;
+            using Sizes = std::vector<size_t>;
             Sizes _sizes;
 
             template <typename U_> class _Iterator
             {
                 private:
-                    typedef std::vector<typename U_::const_iterator> IteratorState;
+                    using IteratorState = std::vector<typename U_::const_iterator>;
 
                     IteratorState _state;
                     Sizes _sizes;
@@ -137,7 +137,7 @@ namespace eos
             /*!
              * @brief This is a random access iterator for CartesianPoduct.
              */
-            typedef _Iterator<T_> Iterator;
+            using Iterator = _Iterator<T_>;
 
             /*!
              * Initializes an empty CartesianProduct.

--- a/eos/utils/density-fwd.hh
+++ b/eos/utils/density-fwd.hh
@@ -28,7 +28,7 @@ namespace eos
     // Forward declaration.
     class Density;
 
-    typedef std::shared_ptr<Density> DensityPtr;
+    using DensityPtr = std::shared_ptr<Density>;
 }
 
 #endif

--- a/eos/utils/density-impl.hh
+++ b/eos/utils/density-impl.hh
@@ -30,7 +30,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Density::IteratorTag>
     {
-        typedef std::vector<ParameterDescription>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ParameterDescription>::const_iterator;
     };
 }
 

--- a/eos/utils/density.hh
+++ b/eos/utils/density.hh
@@ -49,7 +49,7 @@ namespace eos
             /// Iterate over the parameters relevant to this density function.
             ///@{
             struct IteratorTag;
-            typedef WrappedForwardIterator<IteratorTag, const ParameterDescription> Iterator;
+            using Iterator = WrappedForwardIterator<IteratorTag, const ParameterDescription>;
 
             virtual Iterator begin() const = 0;
             virtual Iterator end() const = 0;
@@ -70,8 +70,8 @@ namespace eos
      */
     struct Density::Output
     {
-        typedef hdf5::Composite<hdf5::Scalar<const char *>, hdf5::Scalar<double>, hdf5::Scalar<double>,
-                                hdf5::Scalar<int>> DescriptionType;
+        using DescriptionType = hdf5::Composite<hdf5::Scalar<const char *>, hdf5::Scalar<double>,
+                                               hdf5::Scalar<double>, hdf5::Scalar<int>>;
         static DescriptionType description_type();
         static std::tuple<const char *, double, double, int> description_record();
     };

--- a/eos/utils/diagnostics.cc
+++ b/eos/utils/diagnostics.cc
@@ -28,7 +28,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Diagnostics::IteratorTag>
     {
-        typedef std::vector<Diagnostics::Entry>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<Diagnostics::Entry>::const_iterator;
     };
     template class WrappedForwardIterator<Diagnostics::IteratorTag, const Diagnostics::Entry>;
 

--- a/eos/utils/diagnostics.hh
+++ b/eos/utils/diagnostics.hh
@@ -53,7 +53,7 @@ namespace eos
 
             struct IteratorTag;
             /// Iterator over entries.
-            typedef WrappedForwardIterator<IteratorTag, const Entry> Iterator;
+            using Iterator = WrappedForwardIterator<IteratorTag, const Entry>;
 
             /// Returns Iterator pointing to the first entry.
             Iterator begin() const;

--- a/eos/utils/hdf5.hh
+++ b/eos/utils/hdf5.hh
@@ -104,7 +104,7 @@ namespace eos
             virtual void copy_from_hdf5(const void * src, void * dest) const = 0;
         };
 
-        typedef std::shared_ptr<Type> TypePtr;
+        using TypePtr = std::shared_ptr<Type>;
 
         /*!
          * Scalar represents a scalar built-in HDF5 data type.
@@ -118,7 +118,7 @@ namespace eos
                 std::string _name;
 
             public:
-                typedef T_ Type;
+                using Type = T_;
 
                 Scalar(const std::string & name) :
                     _type_id(hdf5::DataType<T_>::type_id()),
@@ -167,7 +167,7 @@ namespace eos
                 unsigned _elements;
 
             public:
-                typedef std::vector<T_> Type;
+                using Type = std::vector<T_>;
 
                 Array(const std::string & name, const std::initializer_list<hsize_t> & dimensions) :
                     _name(name)
@@ -293,7 +293,7 @@ namespace eos
                 }
 
             public:
-                typedef std::tuple<typename T_::Type ...> Type;
+                using Type = std::tuple<typename T_::Type ...>;
 
                 Composite(const std::string & name, const T_ & ... t) :
                     _type_id(_insert(H5Tcreate(H5T_COMPOUND, _compute_size(t ...)), 0, t ...)),
@@ -543,7 +543,7 @@ namespace eos
         template <typename T_> class DataSet
         {
             public:
-                typedef typename T_::Type RecordType;
+                using RecordType = typename T_::Type;
 
             private:
                 DataSetHandle _handle;
@@ -698,7 +698,7 @@ namespace eos
         template <typename T_> class Attribute
         {
             public:
-                typedef typename T_::Type RecordType;
+                using RecordType = typename T_::Type;
 
             private:
                 AttributeHandle _handle;

--- a/eos/utils/indirect-iterator.hh
+++ b/eos/utils/indirect-iterator.hh
@@ -34,37 +34,37 @@ namespace eos
     template <typename T_>
     struct IndirectIteratorValueType
     {
-        typedef typename std::iterator_traits<T_>::value_type Type;
+        using Type = typename std::iterator_traits<T_>::value_type;
     };
 
     template <typename T_>
     struct IndirectIteratorValueType<T_ *>
     {
-        typedef T_ Type;
+        using Type = T_;
     };
 
     template <typename T_>
     struct IndirectIteratorValueType<std::shared_ptr<T_> >
     {
-        typedef T_ Type;
+        using Type = T_;
     };
 
     template <typename T_>
     struct IndirectIteratorValueType<std::shared_ptr<const T_> >
     {
-        typedef const T_ Type;
+        using Type = const T_;
     };
 
     template <typename T_>
     struct IndirectIteratorValueType<const T_>
     {
-        typedef typename IndirectIteratorValueType<T_>::Type Type;
+        using Type = typename IndirectIteratorValueType<T_>::Type;
     };
 
     template <typename T_>
     struct IndirectIteratorValueType<T_ &>
     {
-        typedef typename IndirectIteratorValueType<T_>::Type Type;
+        using Type = typename IndirectIteratorValueType<T_>::Type;
     };
 
     /**
@@ -100,15 +100,15 @@ namespace eos
             typedef typename std::remove_reference<Value_>::type & value_type;
             typedef typename std::remove_reference<Value_>::type & reference;
             typedef typename std::remove_reference<Value_>::type * pointer;
-            typedef std::ptrdiff_t difference_type;
-            typedef std::forward_iterator_tag iterator_category;
+            using difference_type = std::ptrdiff_t;
+            using iterator_category = std::forward_iterator_tag;
 
             ///@}
 
             ///@name Additional typedefs
             ///@{
 
-            typedef Iter_ underlying_iterator_type;
+            using underlying_iterator_type = Iter_;
 
             ///@}
 

--- a/eos/utils/integrate.hh
+++ b/eos/utils/integrate.hh
@@ -26,7 +26,7 @@
 
 // TODO Didn't manage to forward declare C struct
 // struct gsl_integration_workspace;
-// typedef gsl_integration_workspace gsl_integration_workspace;
+// using gsl_integration_workspace = gsl_integration_workspace;
 // struct gsl_integration_workspace;
 #include <gsl/gsl_integration.h>
 

--- a/eos/utils/kinematic.cc
+++ b/eos/utils/kinematic.cc
@@ -30,7 +30,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Kinematics::KinematicVariableIteratorTag>
     {
-        typedef std::vector<KinematicVariable>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<KinematicVariable>::iterator;
     };
     template class WrappedForwardIterator<Kinematics::KinematicVariableIteratorTag, const KinematicVariable>;
 

--- a/eos/utils/kinematic.hh
+++ b/eos/utils/kinematic.hh
@@ -116,7 +116,7 @@ namespace eos
             ///@name Iteration over our kinematic variables
             ///@{
             struct KinematicVariableIteratorTag;
-            typedef WrappedForwardIterator<KinematicVariableIteratorTag, const KinematicVariable> KinematicVariableIterator;
+            using KinematicVariableIterator = WrappedForwardIterator<KinematicVariableIteratorTag, const KinematicVariable>;
 
             KinematicVariableIterator begin() const;
             KinematicVariableIterator end() const;

--- a/eos/utils/matrix_TEST.cc
+++ b/eos/utils/matrix_TEST.cc
@@ -178,8 +178,8 @@ class MatrixMultiplicationTest :
 
             // vector * matrix
             {
-                typedef array<array<double, 3>, 3> Matrix;
-                typedef array<double, 3> Vector;
+                using Matrix = array<array<double, 3>, 3>;
+                using Vector = array<double, 3>;
 
                 const Matrix A
                 {{
@@ -200,7 +200,7 @@ class MatrixMultiplicationTest :
 
             // scalar product
             {
-                typedef array<double, 3> Vector;
+                using Vector = array<double, 3>;
 
                 const Vector x {{1/2., 1/3., 1/4.}};
                 const Vector y {{43/12., 14/3., 23/4.}};
@@ -210,7 +210,7 @@ class MatrixMultiplicationTest :
 
             // vector - vector
             {
-                typedef array<double, 3> Vector;
+                using Vector = array<double, 3>;
 
                 const Vector x {{1 / 2., 1 / 3., 1 / 4.}};
                 const Vector y {{43 / 12., 14 / 3., 23 / 4.}};

--- a/eos/utils/memoise.hh
+++ b/eos/utils/memoise.hh
@@ -86,13 +86,13 @@ namespace eos
         template <typename Result_, typename Class_, typename ... Args_>
         struct ResultOf<Result_ (Class_::*) (Args_ ...)>
         {
-            typedef Result_ Type;
+            using Type = Result_;
         };
 
         template <typename Result_, typename ... Args_>
         struct ResultOf<Result_ (*) (Args_ ...)>
         {
-            typedef Result_ Type;
+            using Type = Result_;
         };
     }
 
@@ -119,8 +119,8 @@ namespace eos
         public InstantiationPolicy<Memoiser<Result_, Params_ ...>, Singleton>
     {
         public:
-            typedef Result_ (*FunctionType)(const Params_ & ...);
-            typedef std::tuple<FunctionType, Params_...> KeyType;
+            using FunctionType = Result_(*)(const Params_ & ...);
+            using KeyType = std::tuple<FunctionType, Params_...>;
 
         private:
             Mutex * const _mutex;

--- a/eos/utils/model.cc
+++ b/eos/utils/model.cc
@@ -33,7 +33,7 @@ namespace eos
     std::shared_ptr<Model>
     Model::make(const std::string & name, const Parameters & parameters, const Options & options)
     {
-        typedef std::function<std::shared_ptr<Model> (const Parameters &, const Options &)> ModelMaker;
+        using ModelMaker = std::function<std::shared_ptr<Model> (const Parameters &, const Options &)>;
         static const std::map<std::string, ModelMaker> model_makers
         {
             std::make_pair("CKMScan", &CKMScanModel::make),

--- a/eos/utils/mutable-fwd.hh
+++ b/eos/utils/mutable-fwd.hh
@@ -28,7 +28,7 @@ namespace eos
     // Forward Declaration
     class Mutable;
 
-    typedef std::shared_ptr<Mutable> MutablePtr;
+    using MutablePtr = std::shared_ptr<Mutable>;
 }
 
 #endif

--- a/eos/utils/mutable.hh
+++ b/eos/utils/mutable.hh
@@ -27,7 +27,7 @@
 
 namespace eos
 {
-    typedef std::shared_ptr<Mutable> MutablePtr;
+    using MutablePtr = std::shared_ptr<Mutable>;
 
     /// Base class for all mutable entities, e.g. a Parameter.
     class Mutable

--- a/eos/utils/named-value.hh
+++ b/eos/utils/named-value.hh
@@ -56,8 +56,8 @@ namespace eos
             V_ _value;
 
         public:
-            typedef K_ KeyType;
-            typedef V_ ValueType;
+            using KeyType = K_;
+            using ValueType = V_;
 
             template <typename T_>
             NamedValue(const NamedValue<K_, T_> & v) :

--- a/eos/utils/observable_cache.hh
+++ b/eos/utils/observable_cache.hh
@@ -47,7 +47,7 @@ namespace eos
 
             ///@name Access
             ///@{
-            typedef unsigned Id;
+            using Id = unsigned;
 
             /*!
              * Add a given observable to the cache and return its unique Id.

--- a/eos/utils/observable_set.cc
+++ b/eos/utils/observable_set.cc
@@ -100,7 +100,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<ObservableSet::IteratorTag>
     {
-        typedef std::vector<ObservablePtr>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ObservablePtr>::iterator;
     };
     template class WrappedForwardIterator<ObservableSet::IteratorTag, ObservablePtr>;
 

--- a/eos/utils/observable_set.hh
+++ b/eos/utils/observable_set.hh
@@ -47,7 +47,7 @@ namespace eos
             ///@name Iteration and Access
             ///@{
             struct IteratorTag;
-            typedef WrappedForwardIterator<IteratorTag, ObservablePtr> Iterator;
+            using Iterator = WrappedForwardIterator<IteratorTag, ObservablePtr>;
 
             /// Iterator to the first observable.
             Iterator begin() const;

--- a/eos/utils/one-of.hh
+++ b/eos/utils/one-of.hh
@@ -39,17 +39,17 @@ namespace eos
     template <typename Want_>
     struct SelectOneOfType<Want_>
     {
-        typedef UnknownTypeForOneOf Type;
+        using Type = UnknownTypeForOneOf;
     };
 
     template <typename Want_, typename Try_, typename ... Rest_>
     struct SelectOneOfType<Want_, Try_, Rest_ ...>
     {
-        typedef typename std::conditional<
+        using Type = typename std::conditional<
             std::is_same<Want_, Try_>::value,
             Try_,
             typename SelectOneOfType<Want_, Rest_ ...>::Type
-                >::type Type;
+                >::type;
     };
 
     /* OneOfVisitor */

--- a/eos/utils/one-of_TEST.cc
+++ b/eos/utils/one-of_TEST.cc
@@ -36,7 +36,7 @@ class OneOfTest :
 
         virtual void run() const
         {
-            typedef OneOf<int, std::string> Type;
+            using Type = OneOf<int, std::string>;
 
             Type x = 0;
             Type y = std::string("foo");
@@ -80,7 +80,7 @@ class OneOfVisitorReturningVoidTest :
 
         virtual void run() const
         {
-            typedef OneOf<Foo, Bar, Baz> Type;
+            using Type = OneOf<Foo, Bar, Baz>;
             std::array<Type, 5> items
             {{
                 Type{Foo()},
@@ -130,7 +130,7 @@ class OneOfVisitorReturningStringTest :
 
         virtual void run() const
         {
-            typedef OneOf<Foo, Bar, Baz> Type;
+            using Type = OneOf<Foo, Bar, Baz>;
             std::array<Type, 5> items
             {{
                 Type{Foo()},

--- a/eos/utils/options.cc
+++ b/eos/utils/options.cc
@@ -28,7 +28,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Options::OptionIteratorTag>
     {
-        typedef std::map<std::string, std::string>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::map<std::string, std::string>::const_iterator;
     };
     template class WrappedForwardIterator<Options::OptionIteratorTag, const std::pair<const std::string, std::string>>;
 

--- a/eos/utils/options.hh
+++ b/eos/utils/options.hh
@@ -109,7 +109,7 @@ namespace eos
             ///@name Iteration over our options
             ///@{
             struct OptionIteratorTag;
-            typedef WrappedForwardIterator<OptionIteratorTag, const std::pair<const std::string, std::string>> OptionIterator;
+            using OptionIterator = WrappedForwardIterator<OptionIteratorTag, const std::pair<const std::string, std::string>>;
 
             OptionIterator begin() const;
             OptionIterator end() const;

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -79,7 +79,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<ParameterGroup::ParameterIteratorTag>
     {
-        typedef std::vector<Parameter>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<Parameter>::const_iterator;
     };
     template class WrappedForwardIterator<ParameterGroup::ParameterIteratorTag, const Parameter>;
 
@@ -136,7 +136,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<ParameterSection::GroupIteratorTag>
     {
-        typedef std::vector<ParameterGroup>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ParameterGroup>::const_iterator;
     };
     template class WrappedForwardIterator<ParameterSection::GroupIteratorTag, const ParameterGroup &>;
 
@@ -203,14 +203,14 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<Parameters::IteratorTag>
     {
-        typedef std::vector<Parameter>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<Parameter>::iterator;
     };
     template class WrappedForwardIterator<Parameters::IteratorTag, Parameter>;
 
     template <>
     struct WrappedForwardIteratorTraits<Parameters::SectionIteratorTag>
     {
-        typedef std::vector<ParameterSection>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<ParameterSection>::const_iterator;
     };
     template class WrappedForwardIterator<Parameters::SectionIteratorTag, const ParameterSection &>;
 
@@ -731,7 +731,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<ParameterUser::ConstIteratorTag>
     {
-        typedef std::set<Parameter::Id>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::set<Parameter::Id>::const_iterator;
     };
     template class WrappedForwardIterator<ParameterUser::ConstIteratorTag, const Parameter::Id>;
 

--- a/eos/utils/parameters.hh
+++ b/eos/utils/parameters.hh
@@ -124,7 +124,7 @@ namespace eos
             ///@name Iteration over parameters
             ///@{
             struct IteratorTag;
-            typedef WrappedForwardIterator<IteratorTag, Parameter> Iterator;
+            using Iterator = WrappedForwardIterator<IteratorTag, Parameter>;
 
             Iterator begin() const;
             Iterator end() const;
@@ -133,7 +133,7 @@ namespace eos
             ///@name Iteration over parameter sections
             ///@{
             struct SectionIteratorTag;
-            typedef WrappedForwardIterator<SectionIteratorTag, const ParameterSection &> SectionIterator;
+            using SectionIterator = WrappedForwardIterator<SectionIteratorTag, const ParameterSection &>;
 
             SectionIterator begin_sections() const;
             SectionIterator end_sections() const;
@@ -219,7 +219,7 @@ namespace eos
             /*!
              * A unique number that identifies this parameter at run time.
              */
-            typedef unsigned Id;
+            using Id = unsigned;
 
             ///@name Basic Functions
             ///@{
@@ -295,7 +295,7 @@ namespace eos
             ///@name Iteration over groups
             ///@{
             struct GroupIteratorTag;
-            typedef WrappedForwardIterator<GroupIteratorTag, const ParameterGroup &> GroupIterator;
+            using GroupIterator = WrappedForwardIterator<GroupIteratorTag, const ParameterGroup &>;
 
             GroupIterator begin() const;
             GroupIterator end() const;
@@ -325,7 +325,7 @@ namespace eos
             ///@name Iteration over parameters
             ///@{
             struct ParameterIteratorTag;
-            typedef WrappedForwardIterator<ParameterIteratorTag, const Parameter> ParameterIterator;
+            using ParameterIterator = WrappedForwardIterator<ParameterIteratorTag, const Parameter>;
 
             ParameterIterator begin() const;
             ParameterIterator end() const;
@@ -351,7 +351,7 @@ namespace eos
             ///@name Iteration over ids
             ///@{
             struct ConstIteratorTag;
-            typedef WrappedForwardIterator<ConstIteratorTag, const Parameter::Id> ConstIterator;
+            using ConstIterator = WrappedForwardIterator<ConstIteratorTag, const Parameter::Id>;
 
             ConstIterator begin() const;
             ConstIterator end() const;

--- a/eos/utils/qcd.hh
+++ b/eos/utils/qcd.hh
@@ -28,10 +28,10 @@ namespace eos
     {
         public:
             /// The four leading coefficients of the \f$\alpha_s\f$ expansion of the quark mass' anomalous dimension \f$\gamma_m\f$.
-            typedef std::array<double, 4> AnomalousMassDimension;
+            using AnomalousMassDimension = std::array<double, 4>;
 
             /// The four leading coefficient of the \f$\alpha_s\f$ expansion of the beta function of QCD.
-            typedef std::array<double, 4> BetaFunction;
+            using BetaFunction = std::array<double, 4>;
 
             /*!
              * Calculate RGE running of strong coupling alpha_s from scale mu_0 down to scale mu in the MSbar scheme.

--- a/eos/utils/thread.hh
+++ b/eos/utils/thread.hh
@@ -43,7 +43,7 @@ namespace eos
     {
         public:
             /// Our function type.
-            typedef std::function<void ()> Function;
+            using Function = std::function<void ()>;
 
             /// \name Constructor and destructor
             /// \{

--- a/eos/utils/tuple-maker.hh
+++ b/eos/utils/tuple-maker.hh
@@ -28,7 +28,7 @@ namespace eos
 {
     namespace impl
     {
-        template <typename T_, typename U_> struct ConvertTo { typedef U_ Type; };
+        template <typename T_, typename U_> struct ConvertTo { using Type = U_; };
 
         template <unsigned n_> struct TupleMaker
         {

--- a/eos/utils/type-list.hh
+++ b/eos/utils/type-list.hh
@@ -34,38 +34,38 @@ namespace eos
     template <typename Item_, typename Tail_>
     struct TypeListEntry
     {
-        typedef Item_ Item;
-        typedef Tail_ Tail;
+        using Item = Item_;
+        using Tail = Tail_;
     };
 
     template <>
     struct MakeTypeList<>
     {
-        typedef TypeListTail Type;
+        using Type = TypeListTail;
     };
 
     template <typename H_, typename... T_>
     struct MakeTypeList<H_, T_...>
     {
-        typedef TypeListEntry<H_, typename MakeTypeList<T_...>::Type> Type;
+        using Type = TypeListEntry<H_, typename MakeTypeList<T_...>::Type>;
     };
 
     template <>
     struct MakeTypeListConstEntry<TypeListTail>
     {
-        typedef TypeListTail Type;
+        using Type = TypeListTail;
     };
 
     template <typename Item_, typename Tail_>
     struct MakeTypeListConstEntry<TypeListEntry<Item_, Tail_> >
     {
-        typedef TypeListEntry<const Item_, typename MakeTypeListConstEntry<Tail_>::Type> Type;
+        using Type = TypeListEntry<const Item_, typename MakeTypeListConstEntry<Tail_>::Type>;
     };
 
     template <typename TypeList_>
     struct MakeTypeListConst
     {
-        typedef typename MakeTypeListConstEntry<TypeList_>::Type Type;
+        using Type = typename MakeTypeListConstEntry<TypeList_>::Type;
     };
 
     template <typename Item_>

--- a/eos/utils/visitor.hh
+++ b/eos/utils/visitor.hh
@@ -36,7 +36,7 @@ namespace eos
             Visitor_ & _v;
 
         public:
-            typedef void result_type;
+            using result_type = void;
 
             /// @name Visitor operations
             /// @{
@@ -60,7 +60,7 @@ namespace eos
             Visitor_ & _v;
 
         public:
-            typedef Returning_ result_type;
+            using result_type = Returning_;
 
             /// @name Visitor operations
             /// @{
@@ -98,7 +98,7 @@ namespace eos
     template <typename T_, typename R_, typename A1_, typename... As_>
     struct ExtractFirstArgumentType<R_ (T_::*) (A1_, As_...) const>
     {
-        typedef A1_ Type;
+        using Type = A1_;
     };
 
     template <typename T_>
@@ -110,7 +110,7 @@ namespace eos
     template <typename T_, typename R_, typename... As_>
     struct ExtractResultType<R_ (T_::*) (As_...) const>
     {
-        typedef R_ Type;
+        using Type = R_;
     };
 
     template <typename T_>
@@ -308,8 +308,8 @@ namespace eos
             virtual void _real_accept_const(WrappedVisitorBase<typename MakeTypeListConst<VisitableTypeList_>::Type> &) const = 0;
 
         public:
-            typedef VisitableTypeList_ VisitableTypeList;
-            typedef BaseClass_ VisitableBaseClass;
+            using VisitableTypeList = VisitableTypeList_;
+            using VisitableBaseClass = BaseClass_;
 
             template <typename UnwrappedVisitor_>
             void accept(UnwrappedVisitor_ & v)

--- a/eos/utils/wilson-polynomial.hh
+++ b/eos/utils/wilson-polynomial.hh
@@ -38,7 +38,7 @@ namespace eos
 
     struct Cosine;
 
-    typedef OneOf<Constant, Sum, Product, Sine, Cosine, Parameter> WilsonPolynomial;
+    using WilsonPolynomial = OneOf<Constant, Sum, Product, Sine, Cosine, Parameter>;
 
     WilsonPolynomial make_polynomial(const ObservablePtr &, const std::list<std::string> &);
 

--- a/eos/utils/wilson_coefficients.cc
+++ b/eos/utils/wilson_coefficients.cc
@@ -44,7 +44,7 @@ namespace eos
             const double & alpha_s_0, const double & alpha_s, const double & nf, const QCD::BetaFunction & beta)
     {
         using std::array;
-        typedef array<array<complex<double>, 15>, 15> Matrix;
+        using Matrix = array<array<complex<double>, 15>, 15>;
 
         // diagonalisation matrix of gamma_qcd_0
         static const Matrix V

--- a/eos/utils/wrapped_forward_iterator.hh
+++ b/eos/utils/wrapped_forward_iterator.hh
@@ -42,7 +42,7 @@ namespace eos
              WrappedForwardIteratorUnderlyingIteratorHolder * _iter;
 
         public:
-            typedef Tag_ Tag;
+            using Tag = Tag_;
 
             ///@name Basic operations
             ///@{
@@ -61,11 +61,11 @@ namespace eos
             ///@name Standard library typedefs
             ///@{
 
-            typedef typename std::remove_reference<Value_>::type & value_type;
-            typedef typename std::remove_reference<Value_>::type & reference;
-            typedef typename std::remove_reference<Value_>::type * pointer;
-            typedef std::ptrdiff_t difference_type;
-            typedef std::forward_iterator_tag iterator_category;
+            using value_type = typename std::remove_reference<Value_>::type &;
+            using reference = typename std::remove_reference<Value_>::type &;
+            using pointer = typename std::remove_reference<Value_>::type *;
+            using difference_type = std::ptrdiff_t;
+            using iterator_category = std::forward_iterator_tag;
 
             ///@}
 

--- a/src/clients/cli_group.cc
+++ b/src/clients/cli_group.cc
@@ -44,7 +44,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<cli::Group::ConstIteratorTag>
     {
-        typedef std::list<cli::Option *>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<cli::Option *>::const_iterator;
     };
 
     namespace cli

--- a/src/clients/cli_group.hh
+++ b/src/clients/cli_group.hh
@@ -81,7 +81,7 @@ namespace eos
                 ///\{
 
                 struct ConstIteratorTag;
-                typedef WrappedForwardIterator<ConstIteratorTag, Option * const> ConstIterator;
+                using ConstIterator = WrappedForwardIterator<ConstIteratorTag, Option * const>;
 
                 ConstIterator begin() const;
                 ConstIterator end() const;

--- a/src/clients/cli_handler.cc
+++ b/src/clients/cli_handler.cc
@@ -68,49 +68,49 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<cli::Handler::SectionsConstIteratorTag>
     {
-        typedef IndirectIterator<std::list<cli::Section *>::const_iterator> UnderlyingIterator;
+        using UnderlyingIterator = IndirectIterator<std::list<cli::Section *>::const_iterator>;
     };
 
     template <>
     struct WrappedForwardIteratorTraits<cli::Handler::ParametersConstIteratorTag>
     {
-        typedef std::list<std::string>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<std::string>::const_iterator;
     };
 
     template <>
     struct WrappedForwardIteratorTraits<cli::Handler::NotesIteratorTag>
     {
-        typedef std::list<std::string>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<std::string>::const_iterator;
     };
 
     template <>
     struct WrappedForwardIteratorTraits<cli::Handler::DescriptionLineConstIteratorTag>
     {
-        typedef std::list<std::string>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<std::string>::const_iterator;
     };
 
     template <>
     struct WrappedForwardIteratorTraits<cli::Handler::ExamplesConstIteratorTag>
     {
-        typedef std::list<std::pair<std::string, std::string> >::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<std::pair<std::string, std::string> >::const_iterator;
     };
 
     template <>
     struct WrappedForwardIteratorTraits<cli::Handler::UsageLineConstIteratorTag>
     {
-        typedef std::list<std::string>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<std::string>::const_iterator;
     };
 
     template <>
     struct WrappedForwardIteratorTraits<cli::Handler::ArgsIteratorTag>
     {
-        typedef std::list<std::string>::iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<std::string>::iterator;
     };
 
     template <>
     struct WrappedForwardIteratorTraits<cli::Handler::SeeAlsoConstIteratorTag>
     {
-        typedef std::list<std::pair<std::string, int> >::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::list<std::pair<std::string, int> >::const_iterator;
     };
 
     namespace cli

--- a/src/clients/cli_handler.hh
+++ b/src/clients/cli_handler.hh
@@ -101,7 +101,7 @@ namespace eos
                 ///@{
 
                 struct ParametersConstIteratorTag;
-                typedef WrappedForwardIterator<ParametersConstIteratorTag, const std::string> ParametersConstIterator;
+                using ParametersConstIterator = WrappedForwardIterator<ParametersConstIteratorTag, const std::string>;
 
                 ParametersConstIterator begin_parameters() const;
                 ParametersConstIterator end_parameters() const;
@@ -155,7 +155,7 @@ namespace eos
                 ///@{
 
                 struct UsageLineConstIteratorTag;
-                typedef WrappedForwardIterator<UsageLineConstIteratorTag, const std::string> UsageLineConstIterator;
+                using UsageLineConstIterator = WrappedForwardIterator<UsageLineConstIteratorTag, const std::string>;
 
                 UsageLineConstIterator begin_usage_lines() const;
                 UsageLineConstIterator end_usage_lines() const;
@@ -170,8 +170,8 @@ namespace eos
                 ///@{
 
                 struct ExamplesConstIteratorTag;
-                typedef WrappedForwardIterator<ExamplesConstIteratorTag,
-                        const std::pair<std::string, std::string> > ExamplesConstIterator;
+                using ExamplesConstIterator = WrappedForwardIterator<ExamplesConstIteratorTag,
+                                                                     const std::pair<std::string, std::string> >;
 
                 ExamplesConstIterator begin_examples() const;
                 ExamplesConstIterator end_examples() const;
@@ -186,7 +186,7 @@ namespace eos
                 ///@{
 
                 struct SectionsConstIteratorTag;
-                typedef WrappedForwardIterator<SectionsConstIteratorTag, const Section> SectionsConstIterator;
+                using SectionsConstIterator = WrappedForwardIterator<SectionsConstIteratorTag, const Section>;
 
                 SectionsConstIterator begin_args_sections() const;
                 SectionsConstIterator end_args_sections() const;
@@ -208,7 +208,7 @@ namespace eos
                 ///@{
 
                 struct NotesIteratorTag;
-                typedef WrappedForwardIterator<NotesIteratorTag, const std::string > NotesIterator;
+                using NotesIterator = WrappedForwardIterator<NotesIteratorTag, const std::string >;
 
                 NotesIterator begin_notes() const;
                 NotesIterator end_notes() const;
@@ -223,7 +223,7 @@ namespace eos
                 ///@{
 
                 struct DescriptionLineConstIteratorTag;
-                typedef WrappedForwardIterator<DescriptionLineConstIteratorTag, const std::string> DescriptionLineConstIterator;
+                using DescriptionLineConstIterator = WrappedForwardIterator<DescriptionLineConstIteratorTag, const std::string>;
 
                 DescriptionLineConstIterator begin_description_lines() const;
                 DescriptionLineConstIterator end_description_lines() const;
@@ -239,7 +239,7 @@ namespace eos
                 ///@{
 
                 struct SeeAlsoConstIteratorTag;
-                typedef WrappedForwardIterator<SeeAlsoConstIteratorTag, const std::pair<std::string, int> > SeeAlsoConstIterator;
+                using SeeAlsoConstIterator = WrappedForwardIterator<SeeAlsoConstIteratorTag, const std::pair<std::string, int> >;
 
                 SeeAlsoConstIterator begin_see_alsos() const;
                 SeeAlsoConstIterator end_see_alsos() const;
@@ -254,7 +254,7 @@ namespace eos
                 ///@{
 
                 struct ArgsIteratorTag;
-                typedef WrappedForwardIterator<ArgsIteratorTag, std::string> ArgsIterator;
+                using ArgsIterator = WrappedForwardIterator<ArgsIteratorTag, std::string>;
 
                 ///@}
 

--- a/src/clients/cli_option.cc
+++ b/src/clients/cli_option.cc
@@ -75,7 +75,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<cli::EnumArg::AllowedArgConstIteratorTag>
     {
-        typedef std::vector<cli::AllowedEnumArg>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<cli::AllowedEnumArg>::const_iterator;
     };
 
     template class WrappedForwardIterator<cli::EnumArg::AllowedArgConstIteratorTag, const cli::AllowedEnumArg>;
@@ -89,7 +89,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<cli::StringListArg::ConstIteratorTag>
     {
-        typedef std::vector<std::string>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<std::string>::const_iterator;
     };
 
     template class WrappedForwardIterator<cli::StringListArg::ConstIteratorTag, const std::string>;
@@ -361,7 +361,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<cli::ParameterBudgetArg::ParameterBudgetArgConstIteratorTag>
     {
-        typedef std::vector<cli::ParameterBudgetArg::ParameterBudget>::const_iterator UnderlyingIterator;
+        using UnderlyingIterator = std::vector<cli::ParameterBudgetArg::ParameterBudget>::const_iterator;
     };
     template class WrappedForwardIterator<cli::ParameterBudgetArg::ParameterBudgetArgConstIteratorTag, const cli::ParameterBudgetArg::ParameterBudget>;
 

--- a/src/clients/cli_option.hh
+++ b/src/clients/cli_option.hh
@@ -40,9 +40,9 @@ namespace eos
 {
     namespace n
     {
-        typedef Name<struct name_description> description;
-        typedef Name<struct name_long_name> long_name;
-        typedef Name<struct name_short_name> short_name;
+        using description = Name<struct name_description>;
+        using long_name = Name<struct name_long_name>;
+        using short_name = Name<struct name_short_name>;
     }
 
     namespace cli
@@ -320,7 +320,7 @@ namespace eos
                  * Iterate over our args.
                  */
                 struct ConstIteratorTag;
-                typedef WrappedForwardIterator<ConstIteratorTag, const std::string> ConstIterator;
+                using ConstIterator = WrappedForwardIterator<ConstIteratorTag, const std::string>;
 
                 ConstIterator begin_args() const;
                 ConstIterator end_args() const;
@@ -504,8 +504,8 @@ namespace eos
                 ///@{
 
                 struct AllowedArgConstIteratorTag;
-                typedef WrappedForwardIterator<AllowedArgConstIteratorTag,
-                        const AllowedEnumArg> AllowedArgConstIterator;
+                using AllowedArgConstIterator = WrappedForwardIterator<AllowedArgConstIteratorTag,
+                                                                       const AllowedEnumArg>;
 
                 AllowedArgConstIterator begin_allowed_args() const;
 
@@ -601,8 +601,8 @@ namespace eos
                 ///@{
 
                 struct ParameterBudgetArgConstIteratorTag;
-                typedef WrappedForwardIterator<ParameterBudgetArgConstIteratorTag,
-                        const ParameterBudget> ParameterBudgetArgConstIterator;
+                using ParameterBudgetArgConstIterator = WrappedForwardIterator<ParameterBudgetArgConstIteratorTag,
+                                                                               const ParameterBudget>;
 
                 ParameterBudgetArgConstIterator begin_budgets() const;
 

--- a/src/clients/cli_section.cc
+++ b/src/clients/cli_section.cc
@@ -48,7 +48,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<cli::Section::GroupsConstIteratorTag>
     {
-        typedef IndirectIterator<std::list<cli::Group *>::const_iterator> UnderlyingIterator;
+        using UnderlyingIterator = IndirectIterator<std::list<cli::Group *>::const_iterator>;
     };
 
     template class WrappedForwardIterator<cli::Section::GroupsConstIteratorTag, const cli::Group>;

--- a/src/clients/cli_section.hh
+++ b/src/clients/cli_section.hh
@@ -46,7 +46,7 @@ namespace eos
                 ~Section();
 
                 struct GroupsConstIteratorTag;
-                typedef WrappedForwardIterator<GroupsConstIteratorTag, const cli::Group> GroupsConstIterator;
+                using GroupsConstIterator = WrappedForwardIterator<GroupsConstIteratorTag, const cli::Group>;
                 GroupsConstIterator begin() const;
                 GroupsConstIterator end() const;
 

--- a/src/clients/eos-scan-polynomial.cc
+++ b/src/clients/eos-scan-polynomial.cc
@@ -77,7 +77,7 @@ struct ObservableHTLikeRatioInput
     double min, central, max;
 };
 
-typedef OneOf<ObservableInput, ObservableRatioInput, ObservableHTLikeRatioInput> Input;
+using Input = OneOf<ObservableInput, ObservableRatioInput, ObservableHTLikeRatioInput>;
 
 struct ScanData
 {


### PR DESCRIPTION
Solves issue #243 by replacing all uses of typedef with using.
Typedefs are kept in eos/utils/integrate-cubature.cc/hh as this is external code.