### PR TITLE
[github] Switch to Python 3.9 for builds on MacOS

### DIFF
--- a/.github/workflows/macos-build+check.yaml
+++ b/.github/workflows/macos-build+check.yaml
@@ -27,16 +27,16 @@ jobs:
             - name: Prepare VM
               shell: bash
               env:
-                PYTHON: /usr/local/bin/python3.8
+                PYTHON: /usr/local/bin/python3.9
               run: |
                 export HOMEBREW_LOGS=/tmp
                 brew tap eos/eos
-                brew outdated python@3.8 || brew upgrade python@3.8 || true
+                brew outdated python@3.9 || brew upgrade python@3.9 || true
                 rm -Rf '/usr/local/lib/python2.7/site-packages/numpy/'
                 brew outdated boost || brew upgrade boost || true
                 brew outdated boost-python3 || brew upgrade boost-python3 || true
                 brew install autoconf automake boost-python3 gsl hdf5 libtool minuit2 pkg-config yaml-cpp
-                brew link --overwrite python@3.8
+                brew link --overwrite --force python@3.9
                 $PYTHON -m pip install -U cython h5py matplotlib numpy PyYAML scipy
                 curl -L -O https://github.com/fredRos/pypmc/archive/v1.1.4.tar.gz
                 tar zxf v1.1.4.tar.gz
@@ -50,14 +50,14 @@ jobs:
               shell: bash
               env:
                 CXXFLAGS: "-O2 -g -march=x86-64"
-                PYTHON: /usr/local/bin/python3.8
+                PYTHON: /usr/local/bin/python3.9
               run: |
                 echo ===
                 ls -ld /usr/local/Cellar/python*
                 echo ===
-                ls -ld /usr/local/Cellar/python@3.8/
+                ls -ld /usr/local/Cellar/python@3.9/
                 echo ===
-                find /usr/local/Cellar/python@3.8 -name "python3*"
+                find /usr/local/Cellar/python@3.9 -name "python3*"
                 echo ===
                 SUFFIX=$($PYTHON -c "import sys; print('{0}{1}'.format(sys.version_info[0], sys.version_info[1]))")
                 echo using boost-python suffix ${SUFFIX}
@@ -95,5 +95,5 @@ jobs:
                 export PYTHONPATH+=":$(make print-pythondir)"
                 popd
                 pushd _src
-                make -C manual/examples examples
+                make -C examples/cli examples
                 popd

--- a/examples/cli/Makefile
+++ b/examples/cli/Makefile
@@ -17,8 +17,7 @@ MACOSX_EXAMPLES = \
     btopilnu-find-mode.bash \
     btopilnu-find-clusters.bash \
     btopilnu-sample-pmc.bash \
-    btopilnu-predict-observables.bash \
-    btopilnu-plot.bash
+    btopilnu-predict-observables.bash
 
 ifeq ($(shell uname),Darwin)
     EXAMPLES=$(MACOSX_EXAMPLES)


### PR DESCRIPTION
Homebrew upgraded ```boost-python3``` to use Python version 3.9 now.