### PR TITLE
Fixes for Romy

### DIFF
--- a/eos/constraint.cc
+++ b/eos/constraint.cc
@@ -1834,7 +1834,7 @@ namespace eos
                 return _entries;
             }
 
-            void insert(const QualifiedName & key, std::shared_ptr<const ConstraintEntry> & value)
+            void insert(const QualifiedName & key, const std::shared_ptr<const ConstraintEntry> & value)
             {
                 _entries[key] = value;
             }

--- a/eos/observable.hh
+++ b/eos/observable.hh
@@ -215,6 +215,13 @@ namespace eos
             SectionIterator begin_sections() const;
             SectionIterator end_sections() const;
             ///@}
+
+            /*!
+            * Insert a new ObservableEntry.
+            * @param name  The name of the new ObservableEntry.
+            * @param entry The new ObservableEntry.
+            */
+            void insert(const QualifiedName & name, const ObservableEntry * entry) const;
     };
 
     extern template class WrappedForwardIterator<Observables::ObservableIteratorTag, const std::pair<const QualifiedName, ObservableEntryPtr>>;

--- a/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil.cc
+++ b/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil.cc
@@ -2712,7 +2712,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane using the LHC
         std::function<double (const double &)> f = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        return integrate<GSL::QNG>(f, s_min, s_max);
+        return integrate<GSL::QAGS>(f, s_min, s_max);
     }
 
     double
@@ -2721,7 +2721,7 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane using the LHC
         std::function<double (const double &)> f = std::bind(std::mem_fn(&BToKDilepton<LargeRecoil>::differential_branching_ratio),
                 this, std::placeholders::_1);
 
-        return integrate<GSL::QNG>(f, s_min, s_max);
+        return integrate<GSL::QAGS>(f, s_min, s_max);
     }
 
     double
@@ -2731,9 +2731,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane using the LHC
         std::function<double (const double &)> f = std::bind(&BToKDilepton<LargeRecoil>::differential_branching_ratio,
                 this, std::placeholders::_1);
 
-        double br = integrate<GSL::QNG>(f, s_min, s_max);
+        double br = integrate<GSL::QAGS>(f, s_min, s_max);
         _imp->cp_conjugate = true;
-        double br_bar = integrate<GSL::QNG>(f, s_min, s_max);
+        double br_bar = integrate<GSL::QAGS>(f, s_min, s_max);
 
         return (br + br_bar) / 2.0;
     }
@@ -2745,9 +2745,9 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane using the LHC
         std::function<double (const double &)> f = std::bind(&BToKDilepton<LargeRecoil>::differential_branching_ratio,
                 this, std::placeholders::_1);
 
-        double br = integrate<GSL::QNG>(f, s_min, s_max);
+        double br = integrate<GSL::QAGS>(f, s_min, s_max);
         _imp->cp_conjugate = true;
-        double br_bar = integrate<GSL::QNG>(f, s_min, s_max);
+        double br_bar = integrate<GSL::QAGS>(f, s_min, s_max);
 
         return (br - br_bar) / (br + br_bar);
     }
@@ -2760,8 +2760,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane using the LHC
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
-        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
+        double num_integrated = integrate<GSL::QAGS>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QAGS>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2775,13 +2775,13 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane using the LHC
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
-        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
+        double num_integrated = integrate<GSL::QAGS>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QAGS>(denom, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate<GSL::QNG>(num, s_min, s_max);
-        denom_integrated += integrate<GSL::QNG>(denom, s_min, s_max);
+        num_integrated += integrate<GSL::QAGS>(num, s_min, s_max);
+        denom_integrated += integrate<GSL::QAGS>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2795,8 +2795,8 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane using the LHC
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
-        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
+        double num_integrated = integrate<GSL::QAGS>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QAGS>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
     }
@@ -2810,40 +2810,15 @@ The azimuthal angle between the Kbar-pi plane and the l^+l^- plane using the LHC
         std::function<double (const double &)> denom = std::bind(std::mem_fn(&Implementation<BToKDilepton<LargeRecoil>>::unnormalized_decay_width),
                 _imp, std::placeholders::_1);
 
-        double num_integrated = integrate<GSL::QNG>(num, s_min, s_max);
-        double denom_integrated = integrate<GSL::QNG>(denom, s_min, s_max);
+        double num_integrated = integrate<GSL::QAGS>(num, s_min, s_max);
+        double denom_integrated = integrate<GSL::QAGS>(denom, s_min, s_max);
 
         _imp->cp_conjugate = true;
 
-        num_integrated += integrate<GSL::QNG>(num, s_min, s_max);
-        denom_integrated += integrate<GSL::QNG>(denom, s_min, s_max);
+        num_integrated += integrate<GSL::QAGS>(num, s_min, s_max);
+        denom_integrated += integrate<GSL::QAGS>(denom, s_min, s_max);
 
         return num_integrated / denom_integrated;
-    }
-
-    double
-    BToKDilepton<LargeRecoil>::integrated_ratio_muons_electrons(const double & s_min, const double & s_max) const
-    {
-        std::function<double (const double &)> integrand = std::bind(std::mem_fn(&BToKDilepton<LargeRecoil>::differential_branching_ratio),
-                this, std::placeholders::_1);
-
-        double br_electrons;
-        {
-            Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::e"]());
-            Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "e");
-            // br_electrons = integrate<GSL::QNG>(integrand, s_min, s_max);
-            br_electrons = integrate<GSL::QNG>(integrand, s_min, s_max);
-        }
-
-        double br_muons;
-        {
-            Save<Parameter, double> save_m_l(_imp->m_l, _imp->parameters["mass::mu"]());
-            Save<std::string> save_lepton_flavour(_imp->lepton_flavour, "mu");
-            br_muons = integrate<GSL::QNG>(integrand, s_min, s_max);
-        }
-
-        // cf. [BHP2007], Eq. (4.10), p. 6
-        return br_muons / br_electrons;
     }
 
     const std::string

--- a/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil.hh
+++ b/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil.hh
@@ -217,7 +217,6 @@ namespace eos
             double integrated_flat_term_cp_averaged(const double & s_min, const double & s_max) const;
             double integrated_forward_backward_asymmetry(const double & s_min, const double & s_max) const;
             double integrated_forward_backward_asymmetry_cp_averaged(const double & s_min, const double & s_max) const;
-            double integrated_ratio_muons_electrons(const double & s_min, const double & s_max) const;
 
             /*!
              * Descriptions of the process and its kinematics.

--- a/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil_TEST.cc
+++ b/eos/rare-b-decays/exclusive-b-to-s-dilepton-large-recoil_TEST.cc
@@ -274,7 +274,6 @@ class BToKDileptonLargeRecoilBobethCompatibilityTest :
                                       2.8855929e-19 * tau_over_hbar, eps);
             TEST_CHECK_RELATIVE_ERROR(d.integrated_forward_backward_asymmetry(1, 6), 0.1097985735, eps);
             TEST_CHECK_RELATIVE_ERROR(d.integrated_flat_term(1, 6), 0.2788261376, eps);
-            TEST_CHECK_RELATIVE_ERROR(d.integrated_ratio_muons_electrons(1, 6), 1.073039657, eps);
             TEST_CHECK_RELATIVE_ERROR(d.integrated_cp_asymmetry(1, 6), 0.00455162022, 5 * eps);
         }
 } b_to_k_dilepton_large_recoil_bobeth_compatibility_test;

--- a/eos/rare-b-decays/observables.cc
+++ b/eos/rare-b-decays/observables.cc
@@ -148,10 +148,6 @@ namespace eos
                         Options{ { "l", "e" } }
                         ),
 
-                make_observable("B->Kll::R_K@LargeRecoil",
-                        &BToKDilepton<LargeRecoil>::integrated_ratio_muons_electrons,
-                        std::make_tuple("q2_min", "q2_max")),
-
                 make_observable("B->Kll::a_l@LargeRecoil",
                         &BToKDilepton<LargeRecoil>::a_l,
                         std::make_tuple("q2")),


### PR DESCRIPTION
 - R_K has two implementation; remove the specific one and keep the general one
 - B->Kll observables use GSL::QNG, which fails to reach the needed precision in the q2 range 1.1 to 6.0 GeV^2; switch to GSL::QAGS