### PR TITLE
B_q <-> Bbar_q mixing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -468,14 +468,15 @@ AC_OUTPUT(
 	debian/control-xenial
 	debian/Makefile
 	eos/Makefile
+	eos/b-decays/Makefile
 	eos/constraints/Makefile
 	eos/form-factors/Makefile
-	eos/rare-b-decays/Makefile
-	eos/b-decays/Makefile
-	eos/parameters/Makefile
-	eos/utils/Makefile
+	eos/meson-mixing/Makefile
 	eos/optimize/Makefile
+	eos/parameters/Makefile
+	eos/rare-b-decays/Makefile
 	eos/statistics/Makefile
+	eos/utils/Makefile
 	manual/Makefile
 	manual/appendices/Makefile
 	manual/figures/Makefile

--- a/eos/Makefile.am
+++ b/eos/Makefile.am
@@ -3,7 +3,17 @@ CLEANFILES = \
 	references_TEST
 MAINTAINERCLEANFILES = Makefile.in
 
-SUBDIRS = constraints parameters utils optimize statistics form-factors rare-b-decays b-decays .
+SUBDIRS = \
+	constraints \
+	parameters \
+	utils \
+	optimize \
+	statistics \
+	form-factors \
+	rare-b-decays \
+	b-decays \
+	meson-mixing \
+	.
 
 AM_CXXFLAGS = @AM_CXXFLAGS@
 
@@ -24,7 +34,8 @@ libeos_la_LIBADD = \
 	$(top_builddir)/eos/statistics/libeosstatistics.la \
 	$(top_builddir)/eos/form-factors/libeosformfactors.la \
 	$(top_builddir)/eos/b-decays/libeosbdecays.la \
-	$(top_builddir)/eos/rare-b-decays/libeosrarebdecays.la
+	$(top_builddir)/eos/rare-b-decays/libeosrarebdecays.la \
+	$(top_builddir)/eos/meson-mixing/libeosmesonmixing.la
 
 include_eosdir = $(includedir)/eos
 include_eos_HEADERS = \

--- a/eos/meson-mixing/Makefile.am
+++ b/eos/meson-mixing/Makefile.am
@@ -1,0 +1,37 @@
+CLEANFILES = *~
+MAINTAINERCLEANFILES = Makefile.in
+
+AM_CXXFLAGS = @AM_CXXFLAGS@
+
+lib_LTLIBRARIES = libeosmesonmixing.la
+libeosmesonmixing_la_SOURCES = \
+    bq-mixing.cc bq-mixing.hh \
+	observables.cc observables.hh
+libeosmesonmixing_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
+libeosmesonmixing_la_LDFLAGS = $(GSL_LDFLAGS)
+libeosmesonmixing_la_LIBADD = \
+	$(top_builddir)/eos/utils/libeosutils.la \
+	-lgslcblas \
+	-lgsl
+
+include_eos_mesonmixingdir = $(includedir)/eos/meson-mixing
+include_eos_mesonmixing_HEADERS = \
+	bq-mixing.hh \
+	observables.hh
+
+EXTRA_DIST =
+
+AM_TESTS_ENVIRONMENT = \
+	export EOS_TESTS_PARAMETERS="$(top_srcdir)/eos/parameters";
+
+TESTS = \
+    bq-mixing_TEST
+
+LDADD = \
+	$(top_builddir)/test/libeostest.a \
+	libeosmesonmixing.la \
+	$(top_builddir)/eos/utils/libeosutils.la \
+	$(top_builddir)/eos/libeos.la
+
+check_PROGRAMS = $(TESTS)
+bq_mixing_TEST_SOURCES = bq-mixing_TEST.cc

--- a/eos/meson-mixing/bq-mixing.cc
+++ b/eos/meson-mixing/bq-mixing.cc
@@ -1,0 +1,121 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2021 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <eos/meson-mixing/bq-mixing.hh>
+#include <eos/utils/destringify.hh>
+#include <eos/utils/model.hh>
+#include <eos/utils/power_of.hh>
+#include <eos/utils/private_implementation_pattern-impl.hh>
+#include <eos/utils/options-impl.hh>
+
+namespace eos
+{
+    using std::norm;
+
+    template <>
+    struct Implementation<BMixing>
+    {
+        std::shared_ptr<Model> model;
+
+        UsedParameter hbar;
+
+        UsedParameter g_fermi;
+
+        SwitchOption opt_q;
+
+        UsedParameter m_B;
+
+        UsedParameter f_B;
+
+        UsedParameter tau_B;
+
+        UsedParameter R_1;
+        UsedParameter R_2;
+        UsedParameter R_3;
+        UsedParameter R_4;
+        UsedParameter R_5;
+
+        Implementation(const Parameters & p, const Options & o, ParameterUser & u) :
+            model(Model::make(o.get("model", "SM"), p, o)),
+            hbar(p["QM::hbar"], u),
+            g_fermi(p["WET::G_Fermi"], u),
+            opt_q(o, "q", {"s"}),
+            m_B(p["mass::B_" + opt_q.value()], u),
+            f_B(p["decay-constant::B_" + opt_q.value()], u),
+            tau_B(p["life_time::B_" + opt_q.value()], u),
+            R_1(p["B_s<->Bbar_s::R^1"], u),
+            R_2(p["B_s<->Bbar_s::R^2"], u),
+            R_3(p["B_s<->Bbar_s::R^3"], u),
+            R_4(p["B_s<->Bbar_s::R^4"], u),
+            R_5(p["B_s<->Bbar_s::R^5"], u)
+        {
+            u.uses(*model);
+        }
+
+        complex<double> M_12() const
+        {
+            const double mu = 4.2;
+            const auto wc = model->wilson_coefficients_sbsb(mu);
+
+            // cf. [DDHLMSW:2019A]
+            const std::array<complex<double>, 8> contributions{{
+                wc.c1()  * R_1(),
+                wc.c2()  * R_2(),
+                wc.c3()  * R_3(),
+                wc.c4()  * R_4(),
+                wc.c5()  * R_5(),
+                wc.c1p() * R_1(), // primed operators share the hadronic matrix elements of their unprimed partners
+                wc.c2p() * R_2(),
+                wc.c3p() * R_3(),
+            }};
+
+            complex<double> result = 0.0;
+            for (auto & c : contributions)
+            {
+                result += c;
+            }
+
+            // cf. [BBL:1995A], eq. (XVIII.17), p. 153
+            return 4.0 * g_fermi / std::sqrt(2.0) * power_of<2>(model->ckm_tb() * std::conj(model->ckm_ts()))
+                * f_B() * f_B() * m_B() / 2.0 * result;
+
+        }
+    };
+
+    BMixing::BMixing(const Parameters & parameters, const Options & options) :
+        PrivateImplementationPattern<BMixing>(new Implementation<BMixing>(parameters, options, *this))
+    {
+    }
+
+    BMixing::~BMixing()
+    {
+    }
+
+    double
+    BMixing::delta_m() const
+    {
+        // cf. [BBL:1995A], eq. (XVIII.16), p. 153
+        return 2.0 * std::abs(_imp->M_12()) / _imp->hbar();
+    }
+
+    const std::set<ReferenceName>
+    BMixing::references
+    {
+    };
+}

--- a/eos/meson-mixing/bq-mixing.hh
+++ b/eos/meson-mixing/bq-mixing.hh
@@ -1,0 +1,49 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2021 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_MESON_MIXING_BQ_MIXING_HH
+#define EOS_GUARD_EOS_MESON_MIXING_BQ_MIXING_HH 1
+
+#include <eos/utils/complex.hh>
+#include <eos/utils/options.hh>
+#include <eos/utils/parameters.hh>
+#include <eos/utils/private_implementation_pattern.hh>
+#include <eos/utils/reference-name.hh>
+
+namespace eos
+{
+    class BMixing :
+        public ParameterUser,
+        public PrivateImplementationPattern<BMixing>
+    {
+        public:
+            BMixing(const Parameters & parameters, const Options & options);
+            ~BMixing();
+
+            // Observables
+            double delta_m() const;
+
+            /*!
+             * References used in the computation of our observables.
+             */
+            static const std::set<ReferenceName> references;
+    };
+}
+
+#endif

--- a/eos/meson-mixing/bq-mixing_TEST.cc
+++ b/eos/meson-mixing/bq-mixing_TEST.cc
@@ -1,0 +1,65 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2021 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <test/test.hh>
+#include <eos/observable.hh>
+#include <eos/meson-mixing/bq-mixing.hh>
+
+using namespace test;
+using namespace eos;
+
+class BsMixingTest :
+    public TestCase
+{
+    public:
+        BsMixingTest() :
+            TestCase("b_s_mixing_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            {
+                Parameters p = Parameters::Defaults();
+                p["CKM::lambda"]           =  0.22535;
+                p["CKM::A"]                =  0.827;
+                p["CKM::rhobar"]           =  0.132;
+                p["CKM::etabar"]           =  0.350;
+                // Using [DDHLMSW:2019A] inputs for the reduced matrix elements.
+                p["B_s<->Bbar_s::R^1"]     =  0.54200;
+                p["B_s<->Bbar_s::R^2"]     = -0.54500;
+                p["B_s<->Bbar_s::R^3"]     =  0.10900;
+                p["B_s<->Bbar_s::R^4"]     =  0.91250;
+                p["B_s<->Bbar_s::R^5"]     =  0.48625;
+
+                Options oo
+                {
+                    { "model",        "SM"         },
+                    { "q",            "s"          },
+                };
+
+                BMixing process(p, oo);
+
+                const double eps = 1.0e-5;
+
+                // pico seconds
+                TEST_CHECK_RELATIVE_ERROR(17.26529e+12, process.delta_m(), eps);
+            }
+        }
+} b_s_mixing_test;

--- a/eos/meson-mixing/observables.cc
+++ b/eos/meson-mixing/observables.cc
@@ -1,0 +1,61 @@
+/* vim: set sw=4 sts=4 et tw=150 foldmethod=marker : */
+
+/*
+ * Copyright (c) 2021 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <eos/observable-impl.hh>
+#include <eos/meson-mixing/bq-mixing.hh>
+#include <eos/utils/concrete-cacheable-observable.hh>
+#include <eos/utils/concrete_observable.hh>
+
+namespace eos
+{
+    // B_q-Bbar_q mixing
+    // {{{
+    ObservableGroup
+    make_bs_mixing_group()
+    {
+        auto imp = new Implementation<ObservableGroup>(
+            R"(Observables in $B_s$--$\bar{B}_s$ mixing)",
+            R"()",
+            {
+                make_observable("B_s<->Bbar_s::DeltaM", R"(\Delta M_s(B_s\leftrightarrow \bar{B}_s))",
+                        &BMixing::delta_m,
+                        std::make_tuple(),
+                        Options{ { "q", "s" } }),
+            }
+        );
+
+        return ObservableGroup(imp);
+    }
+    // }}}
+
+    ObservableSection
+    make_meson_mixing_section()
+    {
+        auto imp = new Implementation<ObservableSection>(
+            "Observables in neutral meson mixing",
+            "",
+            {
+                // B_s <-> Bbar_s
+                make_bs_mixing_group(),
+            }
+        );
+
+        return ObservableSection(imp);
+    }
+}

--- a/eos/meson-mixing/observables.hh
+++ b/eos/meson-mixing/observables.hh
@@ -1,0 +1,30 @@
+/* vim: set sw=4 sts=4 et tw=150 foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2021 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_MESON_MIXING_OBSERVABLES_HH
+#define EOS_GUARD_EOS_MESON_MIXING_OBSERVABLES_HH 1
+
+#include <eos/observable-fwd.hh>
+
+namespace eos
+{
+    ObservableSection make_meson_mixing_section();
+}
+
+#endif

--- a/eos/observable.cc
+++ b/eos/observable.cc
@@ -24,6 +24,7 @@
 #include <eos/b-decays/observables.hh>
 #include <eos/rare-b-decays/observables.hh>
 #include <eos/form-factors/observables.hh>
+#include <eos/meson-mixing/observables.hh>
 //#include <eos/utils/concrete_observable.hh>
 #include <eos/utils/instantiation_policy-impl.hh>
 #include <eos/utils/private_implementation_pattern-impl.hh>
@@ -42,7 +43,8 @@ namespace eos
         return std::vector<ObservableSection>({
             make_b_decays_section(),
             make_rare_b_decays_section(),
-            make_form_factors_section()
+            make_form_factors_section(),
+            make_meson_mixing_section(),
         });
     }
 

--- a/eos/parameters/hadronic-matrix-elements.yaml
+++ b/eos/parameters/hadronic-matrix-elements.yaml
@@ -2,6 +2,41 @@
 title: 'Hadronic Matrix Element Parameters'
 description: ''
 groups:
+# Parameters in B_q <-> Bbar_q Meson Mixing
+  # {{{
+  - title: 'Parameters in $B_q \leftrightarrow \bar{B}_q$ Meson Mixing'
+    description: ''
+    parameters:
+      # R^n taken from table V of [DDHLMSW:2019A], p. 5, and divided by 4
+      # to match the L x L structure rather than a (V-A)x(V-A) structure;
+      # for the definition, see eq. (B1), idem.
+      'B_s<->Bbar_s::R^1' :
+          central: +0.542
+          min:     +0.51875
+          max:     +0.56525
+          latex:    'R_1^{B_s\leftrightarrow \bar{B}_s}'
+      'B_s<->Bbar_s::R^2' :
+          central: -0.545
+          min:     -0.57
+          max:     -0.52
+          latex:    'R_2^{B_s\leftrightarrow \bar{B}_s}'
+      'B_s<->Bbar_s::R^3' :
+          central: +0.109
+          min:     +0.10175
+          max:     +0.11625
+          latex:    'R_3^{B_s\leftrightarrow \bar{B}_s}'
+      'B_s<->Bbar_s::R^4' :
+          central: +0.9125
+          min:     +0.875
+          max:     +0.95
+          latex:    'R_4^{B_s\leftrightarrow \bar{B}_s}'
+      'B_s<->Bbar_s::R^5' :
+          central: +0.48625
+          min:     +0.46725
+          max:     +0.50525
+          latex:    'R_5^{B_s\leftrightarrow \bar{B}_s}'
+  # }}}
+
   # Parameters in B -> P Form Factor Parametrizations
   # {{{
   - title: 'Parameters in $B\to P$ Form Factor Parametrizations'

--- a/eos/parameters/sm-and-eft.yaml
+++ b/eos/parameters/sm-and-eft.yaml
@@ -292,6 +292,24 @@ groups:
           latex:   '$\arg{V_{tb}}$'
   # }}}
 
+  # sbsb WET Parameters
+  # {{{
+  - title: '$\bar{s}b\bar{s}b$ WET Parameters'
+    description: >
+        The list of parameters describing the $\bar{s}b\bar{s}b$ Wilson coefficients.
+        See the EOS manual for their physical definitions.
+    wcxf-relevant: true
+    parameters:
+      # SM matching scale
+      'sbsb::mu_0' :
+          central: +120.0
+          max:     +160.0
+          min:      +80.0
+          latex:    '$\mu^{\bar{s}b\bar{s}b}_0$'
+          comments: ''
+          unit:     'GeV'
+  # }}}
+
   # b -> s {qqbar, gamma, l^+l^-} WET Parameters
   # {{{
   - title: '$b\to s\left\lbrace \bar{q}q,\, \gamma,\, \ell^+\ell^-\right\rbrace$ WET Parameters'

--- a/eos/parameters/sm-and-eft.yaml
+++ b/eos/parameters/sm-and-eft.yaml
@@ -308,6 +308,89 @@ groups:
           latex:    '$\mu^{\bar{s}b\bar{s}b}_0$'
           comments: ''
           unit:     'GeV'
+
+      # Wilson coefficients at the low scale mu = 4.2 GeV to NLL accuracy as calculated in the SM by EOS' StandardModel class.
+      # For the calculations, cf. [BBL:1995A].
+      'sbsb::Re{c1}' :
+          central: +0.001313228
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Re}\,C_{1}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Im{c1}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Im}\,C_{1}^{\bar{s}b\bar{s}b}$'
+      "sbsb::Re{c1'}" :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Re}\,C_{1^\prime}^{\bar{s}b\bar{s}b}$'
+      "sbsb::Im{c1'}" :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Im}\,C_{1^\prime}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Re{c2}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Re}\,C_{2}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Im{c2}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Im}\,C_{2}^{\bar{s}b\bar{s}b}$'
+      "sbsb::Re{c2'}" :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Re}\,C_{2^\prime}^{\bar{s}b\bar{s}b}$'
+      "sbsb::Im{c2'}" :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Im}\,C_{2^\prime}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Re{c3}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Re}\,C_{3}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Im{c3}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Im}\,C_{3}^{\bar{s}b\bar{s}b}$'
+      "sbsb::Re{c3'}" :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Re}\,C_{3^\prime}^{\bar{s}b\bar{s}b}$'
+      "sbsb::Im{c3'}" :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Im}\,C_{3^\prime}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Re{c4}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Re}\,C_{4}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Im{c4}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Im}\,C_{4}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Re{c5}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Re}\,C_{5}^{\bar{s}b\bar{s}b}$'
+      'sbsb::Im{c5}' :
+          central: +0.0
+          max:     +0.0
+          min:     +0.0
+          latex:    '$\textrm{Im}\,C_{5}^{\bar{s}b\bar{s}b}$'
   # }}}
 
   # b -> s {qqbar, gamma, l^+l^-} WET Parameters

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -613,6 +613,14 @@ DBG:2013A:
     id: oai:arXiv.org:1307.6653
   inspire-id: Dutta:2013qaa
   title: 'Effective theory approach to new physics in $b \to u$ and $b \to c$ leptonic and semileptonic decays'
+DDHLMSW:2019A:
+  authors: Dowdall, R.J. and Davies, C.T.H. and Horgan, R.R. and Lepage, G.P. and Monahan, C.J. and Shigemitsu, J. and Wingate, M.
+  collaboration: HPQCD
+  eprint:
+    archive: arXiv
+    id: oai:arXiv.org:1907.01025
+  inspire-id: Dowdall:2019bea
+  title: Neutral B-meson mixing from full lattice QCD at the physical point
 DDS:2014A:
   authors: Datta, A. and Duraisamy, M. and Sharma, P
   eprint:

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -613,6 +613,13 @@ DDS:2014A:
     id: oai:arXiv.org:1405.3719
   inpire-id: Duraisamy:2014sna
   title: Azimuthal $B \to D^{*} \tau^{-} \bar{\nu_\tau}$ angular distribution with tensor operators
+DLKLR:2019A:
+  authors: Di Luzio, L. and Kirk, M. and Lenz, A. and Rauh, Th.
+  eprint:
+    archive: arXiv
+    id: oai:arXiv.org:1909.11087
+  inspire-id: DiLuzio:2019jyq
+  title: '$\Delta M_s$ theory precision confronts flavour anomalies'
 DKMMO:2008A:
   authors: Duplancic, G. and Khodjamirian, A. and Mannel, Th. and Melic, B. and Offen,
     N.

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -38,6 +38,13 @@ AEMSS:2002A:
   inspire-id: Ahmady:2002qg
   title: Renormalization group improvement of effective actions beyond summation of
     leading logarithms
+AFGV:2017A:
+  authors: Aebischer, J. and Fael, M. and Greub, Ch. and Virto, J.
+  eprint:
+    archive: arXiv
+    id: oai:arXiv.org:1704.06639
+  inspire-id: Aebischer:2017gaw
+  title: 'B physics Beyond the Standard Model at One Loop: Complete Renormalization Group Evolution below the Electroweak Scale'
 ALGH:2001A:
   authors: Ali, A. and Lunghi, E. and Greub, C. and Hiller, G.
   eprint:

--- a/eos/utils/ckm_scan_model.cc
+++ b/eos/utils/ckm_scan_model.cc
@@ -111,6 +111,7 @@ namespace eos
     CKMScanModel::CKMScanModel(const Parameters & parameters, const Options & options) :
         CKMScanComponent(parameters, options, *this),
         SMComponent<components::QCD>(parameters, *this),
+        SMComponent<components::DeltaB2>(parameters, *this),
         SMComponent<components::DeltaBS1>(parameters, *this),
         SMComponent<components::DeltaBU1>(parameters, *this),
         SMComponent<components::DeltaBC1>(parameters, *this)

--- a/eos/utils/ckm_scan_model.hh
+++ b/eos/utils/ckm_scan_model.hh
@@ -76,6 +76,7 @@ namespace eos
         public Model,
         public CKMScanComponent,
         public SMComponent<components::QCD>,
+        public SMComponent<components::DeltaB2>,
         public SMComponent<components::DeltaBS1>,
         public SMComponent<components::DeltaBU1>,
         public SMComponent<components::DeltaBC1>

--- a/eos/utils/model.hh
+++ b/eos/utils/model.hh
@@ -141,6 +141,7 @@ namespace eos
         public ParameterUser,
         public virtual ModelComponent<components::CKM>,
         public virtual ModelComponent<components::QCD>,
+        public virtual ModelComponent<components::DeltaB2>,
         public virtual ModelComponent<components::DeltaBS1>,
         public virtual ModelComponent<components::DeltaBU1>,
         public virtual ModelComponent<components::DeltaBC1>

--- a/eos/utils/model.hh
+++ b/eos/utils/model.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2012, 2013, 2014, 2015 Danny van Dyk
+ * Copyright (c) 2010-2015, 2021 Danny van Dyk
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018 Christoph Bobeth
  *
@@ -41,6 +41,7 @@ namespace eos
         ///@{
         struct CKM;
         struct QCD;
+        struct DeltaB2;
         struct DeltaBS1;
         struct DeltaBU1;
         struct DeltaBC1;
@@ -101,6 +102,16 @@ namespace eos
         public:
             /* b->s Wilson coefficients */
             virtual WilsonCoefficients<BToS> wilson_coefficients_b_to_s(const double & mu, const std::string & lepton_flavour, const bool & cp_conjugate = false) const = 0;
+    };
+
+    /*!
+     * Base class for the Delta B = 2 = -Delta S FCNC component of models.
+     */
+    template <> class ModelComponent<components::DeltaB2>
+    {
+        public:
+            /* sbar b sbar b Wilson coefficients */
+            virtual WilsonCoefficients<wc::SBSB> wilson_coefficients_sbsb(const double & mu) const = 0;
     };
 
     /*!

--- a/eos/utils/qualified-name.cc
+++ b/eos/utils/qualified-name.cc
@@ -32,12 +32,12 @@ namespace eos
                 throw QualifiedNameSyntaxError("A qualified name's prefix part must not be empty");
             }
 
-            // PREFIX := ['a'-'z', 'A'-'Z', '0'-'9', '>', '^', '_', '*', '+', '-']
+            // PREFIX := ['a'-'z', 'A'-'Z', '0'-'9', '<', '>', '^', '_', '*', '+', '-', '(', ')']
             static const char * valid_prefix_characters =
                     "abcdefghijklmnopqrstuvwxyz"
                     "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
                     "0123456789"
-                    ">^_*+-()";
+                    "<>^_*+-()";
 
             auto pos = prefix.find_first_not_of(valid_prefix_characters);
 

--- a/eos/utils/standard-model.hh
+++ b/eos/utils/standard-model.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2012, 2013, 2014, 2015 Danny van Dyk
+ * Copyright (c) 2010-2015, 2021 Danny van Dyk
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018 Christoph Bobeth
  *
@@ -123,6 +123,37 @@ namespace eos
             virtual WilsonCoefficients<BToS> wilson_coefficients_b_to_s(const double & mu, const std::string & lepton_flavour, const bool & cp_conjugate) const;
     };
 
+    template <> class SMComponent<components::DeltaB2> :
+        public virtual ModelComponent<components::DeltaB2>
+    {
+        private:
+            /* Weak decay parameters */
+            UsedParameter _G_Fermi__deltabs2;
+
+            /* QCD parameters */
+            UsedParameter _alpha_s_Z__deltabs2;
+            UsedParameter _mu_t__deltabs2;
+            UsedParameter _mu_b__deltabs2;
+            UsedParameter _mu_c__deltabs2;
+
+            /* GSW parameters */
+            UsedParameter _sw2__deltabs2;
+
+            /* Masses */
+            UsedParameter _m_t_pole__deltabs2;
+            UsedParameter _m_W__deltabs2;
+            UsedParameter _m_Z__deltabs2;
+
+            /* Matching scales */
+            UsedParameter _mu_0__deltabs2;
+
+        public:
+            SMComponent(const Parameters &, ParameterUser &);
+
+            /* sbar b sbar b Wilson coefficients */
+            virtual WilsonCoefficients<wc::SBSB> wilson_coefficients_sbsb(const double & mu) const;
+    };
+
     template <> class SMComponent<components::DeltaBU1> :
         public virtual ModelComponent<components::DeltaBU1>
     {
@@ -147,6 +178,7 @@ namespace eos
         public Model,
         public SMComponent<components::CKM>,
         public SMComponent<components::QCD>,
+        public SMComponent<components::DeltaB2>,
         public SMComponent<components::DeltaBS1>,
         public SMComponent<components::DeltaBU1>,
         public SMComponent<components::DeltaBC1>

--- a/eos/utils/standard_model_TEST.cc
+++ b/eos/utils/standard_model_TEST.cc
@@ -441,3 +441,43 @@ class WilsonCoefficientsBToSTest :
             }
         }
 } wilson_coefficients_b_to_s_test;
+
+class WilsonCoefficientsSBSBTest :
+    public TestCase
+{
+    public:
+        WilsonCoefficientsSBSBTest() :
+            TestCase("wilson_coefficients_sbsb_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            /* Test for 5 active flavors, evolving from mu_0 = 120 GeV to mu = 4.2 GeV */
+            {
+                static const double eps = 1e-8;
+                static const double mu = 4.2;
+
+                Parameters parameters = reference_parameters();
+                StandardModel model(parameters);
+
+                WilsonCoefficients<wc::SBSB> wc = model.wilson_coefficients_sbsb(mu);
+                TEST_CHECK_NEARLY_EQUAL(+0.001313228, real(wc.c1()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c1()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c2()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c2()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c3()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c3()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c4()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c4()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c5()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c5()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c1p()), eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c1p()), eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c2p()), eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c2p()), eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c3p()), eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c3p()), eps);
+            }
+        }
+} wilson_coefficients_sbsb_test;

--- a/eos/utils/wilson_coefficients.cc
+++ b/eos/utils/wilson_coefficients.cc
@@ -247,4 +247,9 @@ namespace eos
 
         return result;
     }
+
+    WilsonCoefficients<wc::SBSB>::WilsonCoefficients()
+    {
+        _coefficients.fill(0.0);
+    }
 }

--- a/eos/utils/wilson_coefficients.hh
+++ b/eos/utils/wilson_coefficients.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2013, 2015 Danny van Dyk
+ * Copyright (c) 2010, 2011, 2013, 2015, 2021 Danny van Dyk
  * Copyright (c) 2014 Frederik Beaujean
  * Copyright (c) 2014 Christoph Bobeth
  *
@@ -122,6 +122,43 @@ namespace eos
             const std::array<complex<double>, 15> & wc_qcd_2,
             const double & alpha_s_0, const double & alpha_s,
             const double & nf, const QCD::BetaFunction & beta);
+
+    namespace wc
+    {
+        struct SBSB {};
+    }
+
+    /* Wilson coefficients for |Delta B| = |Delta S| = 2 operators */
+    template <> struct WilsonCoefficients<wc::SBSB>
+    {
+        /*
+         * The eight operators are defined as in [AFGV:2017A], eq. (2.4), p. 6
+         *
+         * C++ idx -> operator
+         * 0       -> O_1
+         * 1       -> O_2
+         * 2       -> O_3
+         * 3       -> O_4
+         * 4       -> O_5
+         * 5       -> O_1'
+         * 6       -> O_2'
+         * 7       -> O_3'
+         */
+        std::array<complex<double>, 8> _coefficients;
+
+        /*! Default ctor */
+        WilsonCoefficients();
+
+        // AFGV basis
+        inline complex<double> c1()   const { return _coefficients[0]; }
+        inline complex<double> c2()   const { return _coefficients[1]; }
+        inline complex<double> c3()   const { return _coefficients[2]; }
+        inline complex<double> c4()   const { return _coefficients[3]; }
+        inline complex<double> c5()   const { return _coefficients[4]; }
+        inline complex<double> c1p()  const { return _coefficients[5]; }
+        inline complex<double> c2p()  const { return _coefficients[6]; }
+        inline complex<double> c3p()  const { return _coefficients[7]; }
+    };
 }
 
 #endif

--- a/eos/utils/wilson_scan_model.cc
+++ b/eos/utils/wilson_scan_model.cc
@@ -43,6 +43,46 @@ namespace eos
         complex<double> zero() { return complex<double>(0.0, 0.0); }
     }
 
+    /* sbar b sbar b Wilson coefficients */
+    WilsonScanComponent<components::DeltaB2>::WilsonScanComponent(const Parameters & p, const Options &, ParameterUser & u) :
+        _re_sbsb_c1__deltab2(p["sbsb::Re{c1}"], u),
+        _im_sbsb_c1__deltab2(p["sbsb::Im{c1}"], u),
+        _re_sbsb_c2__deltab2(p["sbsb::Re{c2}"], u),
+        _im_sbsb_c2__deltab2(p["sbsb::Im{c2}"], u),
+        _re_sbsb_c3__deltab2(p["sbsb::Re{c3}"], u),
+        _im_sbsb_c3__deltab2(p["sbsb::Im{c3}"], u),
+        _re_sbsb_c4__deltab2(p["sbsb::Re{c4}"], u),
+        _im_sbsb_c4__deltab2(p["sbsb::Im{c4}"], u),
+        _re_sbsb_c5__deltab2(p["sbsb::Re{c5}"], u),
+        _im_sbsb_c5__deltab2(p["sbsb::Im{c5}"], u),
+        _re_sbsb_c1p__deltab2(p["sbsb::Re{c1'}"], u),
+        _im_sbsb_c1p__deltab2(p["sbsb::Im{c1'}"], u),
+        _re_sbsb_c2p__deltab2(p["sbsb::Re{c2'}"], u),
+        _im_sbsb_c2p__deltab2(p["sbsb::Im{c2'}"], u),
+        _re_sbsb_c3p__deltab2(p["sbsb::Re{c3'}"], u),
+        _im_sbsb_c3p__deltab2(p["sbsb::Im{c3'}"], u)
+    {
+    }
+
+    WilsonCoefficients<wc::SBSB>
+    WilsonScanComponent<components::DeltaB2>::wilson_coefficients_sbsb(const double & mu) const
+    {
+        WilsonCoefficients<wc::SBSB> result;
+
+        result._coefficients = std::array<complex<double>, 8>{{
+            complex<double>(_re_sbsb_c1__deltab2(),  _im_sbsb_c1__deltab2()),
+            complex<double>(_re_sbsb_c2__deltab2(),  _im_sbsb_c2__deltab2()),
+            complex<double>(_re_sbsb_c3__deltab2(),  _im_sbsb_c3__deltab2()),
+            complex<double>(_re_sbsb_c4__deltab2(),  _im_sbsb_c4__deltab2()),
+            complex<double>(_re_sbsb_c5__deltab2(),  _im_sbsb_c5__deltab2()),
+            complex<double>(_re_sbsb_c1p__deltab2(), _im_sbsb_c1p__deltab2()),
+            complex<double>(_re_sbsb_c2p__deltab2(), _im_sbsb_c2p__deltab2()),
+            complex<double>(_re_sbsb_c3p__deltab2(), _im_sbsb_c3p__deltab2())
+        }};
+
+        return result;
+    }
+
     /* b->s Wilson coefficients */
     WilsonScanComponent<components::DeltaBS1>::WilsonScanComponent(const Parameters & p, const Options &, ParameterUser & u) :
         _alpha_s_Z__deltabs1(p["QCD::alpha_s(MZ)"], u),
@@ -458,6 +498,7 @@ namespace eos
     WilsonScanModel::WilsonScanModel(const Parameters & parameters, const Options & options) :
         SMComponent<components::CKM>(parameters, *this),
         SMComponent<components::QCD>(parameters, *this),
+        WilsonScanComponent<components::DeltaB2>(parameters, options, *this),
         WilsonScanComponent<components::DeltaBS1>(parameters, options, *this),
         WilsonScanComponent<components::DeltaBU1>(parameters, options, *this),
         WilsonScanComponent<components::DeltaBC1>(parameters, options, *this)
@@ -477,6 +518,7 @@ namespace eos
     ConstrainedWilsonScanModel::ConstrainedWilsonScanModel(const Parameters & parameters, const Options & options) :
         SMComponent<components::CKM>(parameters, *this),
         SMComponent<components::QCD>(parameters, *this),
+        WilsonScanComponent<components::DeltaB2>(parameters, options, *this),
         ConstrainedWilsonScanComponent(parameters, options, *this),
         WilsonScanComponent<components::DeltaBU1>(parameters, options, *this),
         WilsonScanComponent<components::DeltaBC1>(parameters, options, *this)

--- a/eos/utils/wilson_scan_model.hh
+++ b/eos/utils/wilson_scan_model.hh
@@ -115,6 +115,36 @@ namespace eos
     };
 
     template <>
+    class WilsonScanComponent<components::DeltaB2> :
+        public virtual ModelComponent<components::DeltaB2>
+    {
+        protected:
+            /* b->s Wilson coefficients */
+            UsedParameter _re_sbsb_c1__deltab2;
+            UsedParameter _im_sbsb_c1__deltab2;
+            UsedParameter _re_sbsb_c2__deltab2;
+            UsedParameter _im_sbsb_c2__deltab2;
+            UsedParameter _re_sbsb_c3__deltab2;
+            UsedParameter _im_sbsb_c3__deltab2;
+            UsedParameter _re_sbsb_c4__deltab2;
+            UsedParameter _im_sbsb_c4__deltab2;
+            UsedParameter _re_sbsb_c5__deltab2;
+            UsedParameter _im_sbsb_c5__deltab2;
+            UsedParameter _re_sbsb_c1p__deltab2;
+            UsedParameter _im_sbsb_c1p__deltab2;
+            UsedParameter _re_sbsb_c2p__deltab2;
+            UsedParameter _im_sbsb_c2p__deltab2;
+            UsedParameter _re_sbsb_c3p__deltab2;
+            UsedParameter _im_sbsb_c3p__deltab2;
+
+        public:
+            WilsonScanComponent(const Parameters &, const Options &, ParameterUser &);
+
+            /*! sbar b sbar b Wilson coefficients */
+            virtual WilsonCoefficients<wc::SBSB> wilson_coefficients_sbsb(const double & mu) const;
+    };
+
+    template <>
     class WilsonScanComponent<components::DeltaBU1> :
         public virtual ModelComponent<components::DeltaBU1>
     {
@@ -226,6 +256,7 @@ namespace eos
         public Model,
         public SMComponent<components::CKM>,
         public SMComponent<components::QCD>,
+        public WilsonScanComponent<components::DeltaB2>,
         public WilsonScanComponent<components::DeltaBS1>,
         public WilsonScanComponent<components::DeltaBU1>,
         public WilsonScanComponent<components::DeltaBC1>
@@ -255,6 +286,7 @@ namespace eos
         public Model,
         public SMComponent<components::CKM>,
         public SMComponent<components::QCD>,
+        public WilsonScanComponent<components::DeltaB2>,
         public ConstrainedWilsonScanComponent,
         public WilsonScanComponent<components::DeltaBU1>,
         public WilsonScanComponent<components::DeltaBC1>

--- a/eos/utils/wilson_scan_model_TEST.cc
+++ b/eos/utils/wilson_scan_model_TEST.cc
@@ -207,6 +207,65 @@ class WilsonCoefficientsBToSTest :
         }
 } wilson_coefficients_b_to_s_test;
 
+class WilsonCoefficientsSBSBTest :
+    public TestCase
+{
+    public:
+        WilsonCoefficientsSBSBTest() :
+            TestCase("wilson_coefficients_sbsb_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            /* Test passing of WC via cartesian parametrisations */
+            {
+                static const double eps = 1e-6;
+                static const double mu = 4.2; // approximate m_b(m_b) MSbar mass
+
+                Parameters p = Parameters::Defaults();
+                p["sbsb::Re{c1}" ] =  0.123456;
+                p["sbsb::Im{c1}" ] = -0.234567;
+                p["sbsb::Re{c1'}"] = -0.345678;
+                p["sbsb::Im{c1'}"] =  0.456789;
+                p["sbsb::Re{c2}" ] =  0.567890;
+                p["sbsb::Im{c2}" ] = -0.678901;
+                p["sbsb::Re{c2'}"] = -0.789012;
+                p["sbsb::Im{c2'}"] =  0.890123;
+                p["sbsb::Re{c3}" ] =  0.901234;
+                p["sbsb::Im{c3}" ] = -0.012345;
+                p["sbsb::Re{c3'}"] = -0.123456;
+                p["sbsb::Im{c3'}"] =  0.234567;
+                p["sbsb::Re{c4}" ] =  0.345678;
+                p["sbsb::Im{c4}" ] = -0.456789;
+                p["sbsb::Re{c5}" ] = -0.567890;
+                p["sbsb::Im{c5}" ] =  0.678901;
+
+                Options o{};
+
+                WilsonScanModel model(p, o);
+
+                const auto wc = model.wilson_coefficients_sbsb(mu);
+                TEST_CHECK_NEARLY_EQUAL( 0.123456, real(wc.c1()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.234567, imag(wc.c1()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.345678, real(wc.c1p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.456789, imag(wc.c1p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.567890, real(wc.c2()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.678901, imag(wc.c2()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.789012, real(wc.c2p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.890123, imag(wc.c2p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.901234, real(wc.c3()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.012345, imag(wc.c3()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.123456, real(wc.c3p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.234567, imag(wc.c3p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.345678, real(wc.c4()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.456789, imag(wc.c4()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.567890, real(wc.c5()),  eps);
+                TEST_CHECK_NEARLY_EQUAL( 0.678901, imag(wc.c5()),  eps);
+            }
+        }
+} wilson_coefficients_sbsbs_test;
+
 class ConstrainedWilsonScanModelTest:
     public TestCase
 {

--- a/src/clients/Makefile.am
+++ b/src/clients/Makefile.am
@@ -35,6 +35,7 @@ LDADD = \
 	$(top_builddir)/eos/form-factors/libeosformfactors.la \
 	$(top_builddir)/eos/b-decays/libeosbdecays.la \
 	$(top_builddir)/eos/rare-b-decays/libeosrarebdecays.la \
+	$(top_builddir)/eos/meson-mixing/libeosmesonmixing.la \
 	$(top_builddir)/eos/libeos.la \
 	libcli.a \
 	-lboost_filesystem -lboost_system \


### PR DESCRIPTION
Available only for q=s at the moment, but readily extensible.

TODOs:
 - [x] test case for SM component
 - [x] test case for WilsonScan component
 - [x] test case for DeltaM_s