### PR TITLE
Fix issue #313

### DIFF
--- a/eos/b-decays/b-to-d-l-nu_TEST.cc
+++ b/eos/b-decays/b-to-d-l-nu_TEST.cc
@@ -168,6 +168,7 @@ class BToDLeptonNeutrinoTest :
                 p["mass::B_d"]             =  5.279;
                 p["mass::D_d"]             =  1.870;
                 // by default, all other couplings are zero in eos
+                p["CKM::abs(V_cb)"]      =  0.041996951916414726;
                 p["cbmunumu::Re{cVL}"]   =  1.0066;  // include Sirlin correction
                 p["cbtaunutau::Re{cVL}"] =  1.0066;  // include Sirlin correction
 
@@ -220,6 +221,8 @@ class BToDLeptonNeutrinoTest :
                 p["mu"]                    =  4.18;
                 p["mass::b(MSbar)"]        =  4.18;
                 p["mass::c"]               =  1.275;
+                // CKM
+                p["CKM::abs(V_cb)"]        =  0.041996951916414726;
                 // mu mode
                 p["cbmunumu::Re{cVL}"]         = +1.0 * etaEW;
                 p["cbmunumu::Im{cVL}"]         = -2.0 * etaEW;

--- a/eos/b-decays/b-to-dstar-l-nu_TEST.cc
+++ b/eos/b-decays/b-to-dstar-l-nu_TEST.cc
@@ -211,7 +211,7 @@ class BToVectorLeptonNeutrinoTest :
                 p["B(*)->D(*)::l_6(1)@HQET"].set(1.95851);
                 p["B(*)->D(*)::l_6'(1)@HQET"].set(1.22043);
 
-                p["CKM::abs(V_cb)"].set(1.0);
+                p["CKM::abs(V_cb)"]            =  0.041996951916414726;
                 p["mass::e"].set(0.00000000000001);
                 p["B(*)->D(*)::a@HQET"].set(1.000);
                 p["mass::B_d"].set(5.27942);
@@ -291,6 +291,7 @@ class BToVectorLeptonNeutrinoTest :
                 p1["mass::B_d"]                   = +5.279;
                 p1["mass::D_d^*"]                 = +2.0103;
                 // by default, all other couplings are zero in eos
+                p1["CKM::abs(V_cb)"]            =  0.041996951916414726;
                 p1["cbmunumu::Re{cVL}"]         = +1.0066;  // include Sirlin correction
                 p1["cbtaunutau::Re{cVL}"]       = +1.0066;  // include Sirlin correction
 
@@ -362,6 +363,8 @@ class BToVectorLeptonNeutrinoTest :
                 p3["mass::b(MSbar)"]              = +4.18;
                 // mc(mc)
                 p3["mass::c"]                     = +1.275;
+                // CKM
+                p3["CKM::abs(V_cb)"]              =  0.041996951916414726;
                 // mu mode
                 p3["cbmunumu::Re{cVL}"]         = +1.0 * etaEW;
                 p3["cbmunumu::Im{cVL}"]         = -2.0 * etaEW;

--- a/eos/b-decays/bs-to-kstar-l-nu_TEST.cc
+++ b/eos/b-decays/bs-to-kstar-l-nu_TEST.cc
@@ -45,6 +45,10 @@ class BsToKstarLeptonNeutrinoTest :
                 p["CKM::lambda"] = 0.22535;
                 p["CKM::rhobar"] = 0.132;
                 p["CKM::etabar"] = 0.340;
+                // CKM matrix elements corresponding to the above Wolfenstein parameters
+                p["CKM::abs(V_ub)"] =  0.003540609803917236;
+                p["CKM::arg(V_ub)"] = -1.2010727175261147;
+
                 // Kaon mass
                 p["mass::K_u^*"] = 0.89166;
                 // B mass

--- a/eos/b-decays/lambdab-to-lambdac-l-nu_TEST.cc
+++ b/eos/b-decays/lambdab-to-lambdac-l-nu_TEST.cc
@@ -52,6 +52,7 @@ class LambdaBToLambdaCLeptonNeutrinoTest :
                 p["Lambda_c::alpha"]       = -0.78;
                 p["mass::Lambda_b"]        = 5.6194;
                 p["mass::Lambda_c"]        = 2.2865;
+                p["CKM::abs(V_cb)"]        =  0.041996951916414726;
 
                 // the parameters are fixed as EOS default values
 
@@ -79,6 +80,7 @@ class LambdaBToLambdaCLeptonNeutrinoTest :
                 p["Lambda_c::alpha"]       = -0.78;
                 p["mass::Lambda_b"]        = 5.6194;
                 p["mass::Lambda_c"]        = 2.2865;
+                p["CKM::abs(V_cb)"]        =  0.041996951916414726;
 
                 // the parameters are fixed as EOS default values
 
@@ -104,6 +106,7 @@ class LambdaBToLambdaCLeptonNeutrinoTest :
             {
                 Parameters p = Parameters::Defaults();
                 // the rest of input is fixed to default EOS values
+                p["CKM::abs(V_cb)"]      =  0.041996951916414726;
                 p["cbmunumu::Re{cVL}"]   =  1.0;
                 p["cbmunumu::Im{cVL}"]   = -1.0;
                 p["cbmunumu::Re{cVR}"]   =  2.0;
@@ -142,6 +145,7 @@ class LambdaBToLambdaCLeptonNeutrinoTest :
             {
                 Parameters p = Parameters::Defaults();
                 // the rest of input is fixed to default EOS values
+                p["CKM::abs(V_cb)"]      =  0.041996951916414726;
                 p["cbmunumu::Re{cVL}"]   =  1.0;
                 p["cbmunumu::Im{cVL}"]   = -1.0;
                 p["cbmunumu::Re{cVR}"]   =  2.0;

--- a/eos/rare-b-decays/b-to-k-charmonium_TEST.cc
+++ b/eos/rare-b-decays/b-to-k-charmonium_TEST.cc
@@ -18,6 +18,10 @@ class BToKCharmoniumGvDV2020Test :
         {
 
             Parameters p = Parameters::Defaults();
+            p["CKM::abs(V_cb)"]                          =  0.041996951916414726;
+            p["CKM::arg(V_cb)"]                          =  0.0;
+            p["CKM::abs(V_cs)"]                          =  0.9734061815416853;
+            p["CKM::arg(V_cs)"]                          = -3.304199362533668e-05;
             p["mass::B_d"]                               = 5.27942;
             p["mass::K_d"]                               = 0.49761;
             p["mass::J/psi"]                             = 3.0969;
@@ -61,6 +65,10 @@ class BToKCharmoniumGRvDV2021Test :
         {
 
             Parameters p = Parameters::Defaults();
+            p["CKM::abs(V_cb)"]                           =  0.041996951916414726;
+            p["CKM::arg(V_cb)"]                           =  0.0;
+            p["CKM::abs(V_cs)"]                           =  0.9734061815416853;
+            p["CKM::arg(V_cs)"]                           = -3.304199362533668e-05;
             p["mass::B_d"]                                = 5.27942;
             p["mass::K_d"]                                = 0.49761;
             p["mass::J/psi"]                              = 3.0969;

--- a/eos/rare-b-decays/b-to-k-ll-bfs2004_TEST.cc
+++ b/eos/rare-b-decays/b-to-k-ll-bfs2004_TEST.cc
@@ -50,6 +50,18 @@ class BToKDileptonBFS2004BobethCompatibilityTest :
             // Christoph uses \Delta C instead of C for C9, C10
             // important to agree on alpha_s, can change values by 1%
             Parameters p = Parameters::Defaults();
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
             p["b->s::c1"] = -0.3231323312;
             p["b->s::c2"] = 1.009301831;
             p["b->s::c3"] = -0.005233499106;

--- a/eos/rare-b-decays/b-to-k-ll-gp2004_TEST.cc
+++ b/eos/rare-b-decays/b-to-k-ll-gp2004_TEST.cc
@@ -62,10 +62,22 @@ class BToKDileptonLowRecoilTest :
                 p["b->smumu::Re{c9}"] = 4.27;
                 p["b->smumu::Re{c10}"] = -4.17;
                 // PDG 2008 CKM parameters
-                p["CKM::A"] = 0.814;
-                p["CKM::lambda"] = 0.2257;
-                p["CKM::rhobar"] = 0.135;
-                p["CKM::etabar"] = 0.349;
+                p["CKM::A"]         = 0.814;
+                p["CKM::lambda"]    = 0.2257;
+                p["CKM::rhobar"]    = 0.135;
+                p["CKM::etabar"]    = 0.349;
+                p["CKM::abs(V_ub)"] =  0.00359255775926898;
+                p["CKM::arg(V_ub)"] = -1.2023040533144056;
+                p["CKM::abs(V_cb)"] =  0.04146529127297828;
+                p["CKM::arg(V_cb)"] =  0.0;
+                p["CKM::abs(V_tb)"] =  0.9991334809397352;
+                p["CKM::arg(V_tb)"] =  0.0;
+                p["CKM::abs(V_us)"] =  0.22569854350471902;
+                p["CKM::arg(V_us)"] =  0.0;
+                p["CKM::abs(V_cs)"] =  0.973346862850555;
+                p["CKM::arg(V_cs)"] = -3.222382085887583e-05;
+                p["CKM::abs(V_ts)"] =  0.040694467854567457;
+                p["CKM::arg(V_ts)"] = -3.1230200317017145;
                 // Kaon mass
                 p["mass::K_d"] = 0.49761;
                 // B mass
@@ -106,10 +118,22 @@ class BToKDileptonLowRecoilTest :
                 Parameters p = Parameters::Defaults();
                 p["life_time::B_d"] = 1.530e-12;
                 // PDG 2008 CKM parameters
-                p["CKM::A"] = 0.814;
-                p["CKM::lambda"] = 0.2257;
-                p["CKM::rhobar"] = 0.135;
-                p["CKM::etabar"] = 0.349;
+                p["CKM::A"]         = 0.814;
+                p["CKM::lambda"]    = 0.2257;
+                p["CKM::rhobar"]    = 0.135;
+                p["CKM::etabar"]    = 0.349;
+                p["CKM::abs(V_ub)"] =  0.00359255775926898;
+                p["CKM::arg(V_ub)"] = -1.2023040533144056;
+                p["CKM::abs(V_cb)"] =  0.04146529127297828;
+                p["CKM::arg(V_cb)"] =  0.0;
+                p["CKM::abs(V_tb)"] =  0.9991334809397352;
+                p["CKM::arg(V_tb)"] =  0.0;
+                p["CKM::abs(V_us)"] =  0.22569854350471902;
+                p["CKM::arg(V_us)"] =  0.0;
+                p["CKM::abs(V_cs)"] =  0.973346862850555;
+                p["CKM::arg(V_cs)"] = -3.222382085887583e-05;
+                p["CKM::abs(V_ts)"] =  0.040694467854567457;
+                p["CKM::arg(V_ts)"] = -3.1230200317017145;
                 // B mass
                 p["mass::B_d"] = 5.27953;
                 // Kaon mass
@@ -173,6 +197,18 @@ class BToKDileptonLowRecoilBobethCompatibilityTest :
             Parameters p = Parameters::Defaults();
             // old test data generated for K^+ mass set to K0 mass
             p["mass::K_u"] = 0.497614;
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
             Options o;
             o.set("model", "WilsonScan");
             o.set("tag", "GP2004");

--- a/eos/rare-b-decays/b-to-kstar-charmonium_TEST.cc
+++ b/eos/rare-b-decays/b-to-kstar-charmonium_TEST.cc
@@ -64,6 +64,19 @@ class BToKstarCharmoniumGvDV2020Test :
             p["B->K^*ccbar::Re{alpha_2^long}@GvDV2020"]  = 18.0;
             p["B->K^*ccbar::Im{alpha_2^long}@GvDV2020"]  = 19.0;
 
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
+
             Options oo;
             oo.set("model",               "WilsonScan");
             oo.set("q",                   "d");
@@ -126,6 +139,19 @@ class BToKstarCharmoniumGRvDV2021Test :
             p["B->K^*ccbar::Im{alpha_1^long}@GRvDV2021"]  = 17.0;
             p["B->K^*ccbar::Re{alpha_2^long}@GRvDV2021"]  = 18.0;
             p["B->K^*ccbar::Im{alpha_2^long}@GRvDV2021"]  = 19.0;
+
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
 
             Options oo;
             oo.set("model",               "WilsonScan");

--- a/eos/rare-b-decays/b-to-kstar-gamma-bfs2004_TEST.cc
+++ b/eos/rare-b-decays/b-to-kstar-gamma-bfs2004_TEST.cc
@@ -63,10 +63,24 @@ class BToKstarGammaTest :
                 p["b->s::Re{c7'}"] = -0.00659; // m_s(m_b) / m_b(m_b) * Abs{c7} = 85 / 4200 * Abs{c7}
                 p["b->s::c8"] = -0.181;
                 // PDG 2010 CKM parameters
-                p["CKM::A"] = 0.812;
-                p["CKM::lambda"] = 0.22543;
-                p["CKM::rhobar"] = 0.144;
-                p["CKM::etabar"] = 0.342;
+                p["CKM::A"]         =  0.812;
+                p["CKM::lambda"]    =  0.22543;
+                p["CKM::rhobar"]    =  0.144;
+                p["CKM::etabar"]    =  0.342;
+                p["CKM::abs(V_ub)"] =  0.003540950873054711;
+                p["CKM::arg(V_ub)"] = -1.1728563751359748;
+                p["CKM::abs(V_cb)"] =  0.04126451344307112;
+                p["CKM::arg(V_cb)"] =  0.0;
+                p["CKM::abs(V_tb)"] =  0.9991419776905534;
+                p["CKM::arg(V_tb)"] =  0.0;
+                p["CKM::abs(V_td)"] =  0.008576901910577167;
+                p["CKM::arg(V_td)"] = -0.37951557931964897;
+                p["CKM::abs(V_us)"] =  0.22542858674178629;
+                p["CKM::arg(V_us)"] =  0.0;
+                p["CKM::abs(V_cs)"] =  0.9734167680132911;
+                p["CKM::arg(V_cs)"] = -3.119448393424795e-05;
+                p["CKM::abs(V_ts)"] =  0.04051834255894421;
+                p["CKM::arg(V_ts)"] = -3.123445879630718;
                 p["decay-constant::B_d"] = 0.200;
                 p["mass::b(MSbar)"] = 4.2;
                 p["mass::c"] = 1.27;
@@ -108,10 +122,24 @@ class BToKstarGammaTest :
                 p["b->s::Im{c7'}"] = -0.00659; // m_s(m_b) / m_b(m_b) * Abs{c7} = 85 / 4200 * Abs{c7}
                 p["b->s::c8"] = -0.181;
                 // PDG 2010 CKM parameters
-                p["CKM::A"] = 0.812;
-                p["CKM::lambda"] = 0.22543;
-                p["CKM::rhobar"] = 0.144;
-                p["CKM::etabar"] = 0.342;
+                p["CKM::A"]         =  0.812;
+                p["CKM::lambda"]    =  0.22543;
+                p["CKM::rhobar"]    =  0.144;
+                p["CKM::etabar"]    =  0.342;
+                p["CKM::abs(V_ub)"] =  0.003540950873054711;
+                p["CKM::arg(V_ub)"] = -1.1728563751359748;
+                p["CKM::abs(V_cb)"] =  0.04126451344307112;
+                p["CKM::arg(V_cb)"] =  0.0;
+                p["CKM::abs(V_tb)"] =  0.9991419776905534;
+                p["CKM::arg(V_tb)"] =  0.0;
+                p["CKM::abs(V_td)"] =  0.008576901910577167;
+                p["CKM::arg(V_td)"] = -0.37951557931964897;
+                p["CKM::abs(V_us)"] =  0.22542858674178629;
+                p["CKM::arg(V_us)"] =  0.0;
+                p["CKM::abs(V_cs)"] =  0.9734167680132911;
+                p["CKM::arg(V_cs)"] = -3.119448393424795e-05;
+                p["CKM::abs(V_ts)"] =  0.04051834255894421;
+                p["CKM::arg(V_ts)"] = -3.123445879630718;
                 p["decay-constant::B_d"] = 0.200;
                 p["mass::b(MSbar)"] = 4.2;
                 p["mass::B_d"] = 5.27958;
@@ -156,6 +184,20 @@ class BToKstarGammaBobethCompatibilityTest :
             };
 
             Parameters p = Parameters::Defaults();
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951915501936;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111398988599;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424454577;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061890640963;
+            p["CKM::arg(V_cs)"] = -0.0000330419933699906;
+            p["CKM::abs(V_ts)"] =  0.04121211253368258;
+            p["CKM::arg(V_ts)"] = -3.1230250245535283;
+            p["CKM::abs(V_td)"] =  0.008859566045351227;
+            p["CKM::arg(V_td)"] = -0.38266;
             p["decay-constant::B_d"] = 0.1906;
             p["mass::B_d"] = 5.27958;
             p["mass::K_d^*"] = 0.89594;

--- a/eos/rare-b-decays/b-to-kstar-ll-bfs2004_TEST.cc
+++ b/eos/rare-b-decays/b-to-kstar-ll-bfs2004_TEST.cc
@@ -45,7 +45,18 @@ class BToKstarDileptonBFS2004BobethCompatibilityTest :
     {
         {
             Parameters p = Parameters::Defaults();
-
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
             p["b->s::c1"]      = -0.3231323312;
             p["b->s::c2"]      = 1.009301831;
             p["b->s::c3"]      = -0.005233499106;
@@ -98,6 +109,18 @@ class BToKstarDileptonBFS2004BobethCompatibilityTest :
        {
             // important to agree on alpha_s, can change values by 1%
             Parameters p = Parameters::Defaults();
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
             p["b->s::c1"]      = -0.3231323312;
             p["b->s::c2"]      = 1.009301831;
             p["b->s::c3"]      = -0.005233499106;

--- a/eos/rare-b-decays/b-to-kstar-ll-gp2004_TEST.cc
+++ b/eos/rare-b-decays/b-to-kstar-ll-gp2004_TEST.cc
@@ -63,10 +63,22 @@ class BToKstarDileptonLowRecoilTest :
                 p["b->smumu::Re{c9}"] = +4.27;
                 p["b->smumu::Re{c10}"] = -4.173;
                 // PDG 2008 CKM parameters
-                p["CKM::A"] = 0.814;
-                p["CKM::lambda"] = 0.2257;
-                p["CKM::rhobar"] = 0.135;
-                p["CKM::etabar"] = 0.349;
+                p["CKM::A"]         =  0.814;
+                p["CKM::lambda"]    =  0.2257;
+                p["CKM::rhobar"]    =  0.135;
+                p["CKM::etabar"]    =  0.349;
+                p["CKM::abs(V_ub)"] =  0.00359255775926898;
+                p["CKM::arg(V_ub)"] = -1.2023040533144056;
+                p["CKM::abs(V_cb)"] =  0.04146529127297828;
+                p["CKM::arg(V_cb)"] =  0.0;
+                p["CKM::abs(V_tb)"] =  0.9991334809397352;
+                p["CKM::arg(V_tb)"] =  0.0;
+                p["CKM::abs(V_us)"] =  0.22569854350471902;
+                p["CKM::arg(V_us)"] =  0.0;
+                p["CKM::abs(V_cs)"] =  0.973346862850555;
+                p["CKM::arg(V_cs)"] = -3.222382085887583e-05;
+                p["CKM::abs(V_ts)"] =  0.040694467854567457;
+                p["CKM::arg(V_ts)"] = -3.1230200317017145;
                 // Kaon mass
                 p["mass::K_d^*"] = 0.896;
                 // B mass
@@ -168,10 +180,22 @@ class BToKstarDileptonLowRecoilTest :
                 p["b->smumu::Re{c10}"] = 0.0;
                 p["b->smumu::Im{c10}"] = -4.2;
                 // PDG 2008 CKM parameters
-                p["CKM::A"] = 0.814;
-                p["CKM::lambda"] = 0.2257;
-                p["CKM::rhobar"] = 0.135;
-                p["CKM::etabar"] = 0.349;
+                p["CKM::A"]         = 0.814;
+                p["CKM::lambda"]    = 0.2257;
+                p["CKM::rhobar"]    = 0.135;
+                p["CKM::etabar"]    = 0.349;
+                p["CKM::abs(V_ub)"] =  0.00359255775926898;
+                p["CKM::arg(V_ub)"] = -1.2023040533144056;
+                p["CKM::abs(V_cb)"] =  0.04146529127297828;
+                p["CKM::arg(V_cb)"] =  0.0;
+                p["CKM::abs(V_tb)"] =  0.9991334809397352;
+                p["CKM::arg(V_tb)"] =  0.0;
+                p["CKM::abs(V_us)"] =  0.22569854350471902;
+                p["CKM::arg(V_us)"] =  0.0;
+                p["CKM::abs(V_cs)"] =  0.973346862850555;
+                p["CKM::arg(V_cs)"] = -3.222382085887583e-05;
+                p["CKM::abs(V_ts)"] =  0.040694467854567457;
+                p["CKM::arg(V_ts)"] = -3.1230200317017145;
                 // Kaon mass
                 p["mass::K_d^*"] = 0.896;
                 // B mass
@@ -239,10 +263,22 @@ class BToKstarDileptonLowRecoilTest :
                 p["b->smumu::Re{c9}"] = 0.0;
                 p["b->smumu::Re{c10}"] = 0.0;
                 // PDG 2008 CKM parameters
-                p["CKM::A"] = 0.814;
-                p["CKM::lambda"] = 0.2257;
-                p["CKM::rhobar"] = 0.135;
-                p["CKM::etabar"] = 0.349;
+                p["CKM::A"]         = 0.814;
+                p["CKM::lambda"]    = 0.2257;
+                p["CKM::rhobar"]    = 0.135;
+                p["CKM::etabar"]    = 0.349;
+                p["CKM::abs(V_ub)"] =  0.00359255775926898;
+                p["CKM::arg(V_ub)"] = -1.2023040533144056;
+                p["CKM::abs(V_cb)"] =  0.04146529127297828;
+                p["CKM::arg(V_cb)"] =  0.0;
+                p["CKM::abs(V_tb)"] =  0.9991334809397352;
+                p["CKM::arg(V_tb)"] =  0.0;
+                p["CKM::abs(V_us)"] =  0.22569854350471902;
+                p["CKM::arg(V_us)"] =  0.0;
+                p["CKM::abs(V_cs)"] =  0.973346862850555;
+                p["CKM::arg(V_cs)"] = -3.222382085887583e-05;
+                p["CKM::abs(V_ts)"] =  0.040694467854567457;
+                p["CKM::arg(V_ts)"] = -3.1230200317017145;
                 // Kaon mass
                 p["mass::K_d^*"] = 0.896;
                 // B mass
@@ -336,6 +372,18 @@ class BToKstarDileptonLowRecoilPolynomialTest :
                 };
 
                 Parameters parameters = Parameters::Defaults();
+                parameters["CKM::abs(V_ub)"] =  0.003631275231633653;
+                parameters["CKM::arg(V_ub)"] = -1.210765774253535;
+                parameters["CKM::abs(V_cb)"] =  0.041996951916414726;
+                parameters["CKM::arg(V_cb)"] =  0.0;
+                parameters["CKM::abs(V_tb)"] =  0.9991111344469873;
+                parameters["CKM::arg(V_tb)"] =  0.0;
+                parameters["CKM::abs(V_us)"] =  0.22534851424944366;
+                parameters["CKM::arg(V_us)"] =  0.0;
+                parameters["CKM::abs(V_cs)"] =  0.9734061815416853;
+                parameters["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+                parameters["CKM::abs(V_ts)"] =  0.04121212396309175;
+                parameters["CKM::arg(V_ts)"] = -3.1230250224697222;
                 Kinematics kinematics
                 {
                     { "q2_min", 14.18 },
@@ -478,6 +526,18 @@ class BToKstarDileptonLowRecoilBobethCompatibilityTest :
             p["mass::mu"] = 1e-5;
             p["mass::B_d"] = 5.27958;
             p["mass::K_d^*"] = 0.89594;
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
 
             Options o;
             o.set("model", "WilsonScan");
@@ -584,6 +644,18 @@ class BToKstarDileptonTensorLowRecoilBobethCompatibilityTest :
             // Christoph uses \Delta C instead of C for C9, C10
             // important to agree to alpha_s, can change values by 1%
             Parameters p = Parameters::Defaults();
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
             p["b->s::c1"] = -0.3231323312;
             p["b->s::c2"] = 1.009301831;
             p["b->s::c3"] = -0.005233499106;

--- a/eos/rare-b-decays/b-to-kstar-ll-gvdv2020_TEST.cc
+++ b/eos/rare-b-decays/b-to-kstar-ll-gvdv2020_TEST.cc
@@ -67,6 +67,18 @@ class BToKstarDileptonGvDV2020Test :
             p["B->K^*ccbar::Re{alpha_2^long}@GvDV2020"]  = 0.0018;
             p["B->K^*ccbar::Im{alpha_2^long}@GvDV2020"]  = 0.0019;
 
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
             p["b->s::Re{c7}"] = -0.3370422989 + 0.1;
             p["b->s::Im{c7}"] = 0.2;
             p["b->s::Re{c7'}"] = 0.3;

--- a/eos/rare-b-decays/bs-to-phi-charmonium_TEST.cc
+++ b/eos/rare-b-decays/bs-to-phi-charmonium_TEST.cc
@@ -63,6 +63,18 @@ class BsToPhiCharmoniumGvDV2020Test :
             p["B_s->phiccbar::Re{alpha_2^long}@GvDV2020"]  = 18.0;
             p["B_s->phiccbar::Im{alpha_2^long}@GvDV2020"]  = 19.0;
 
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
 
             Options oo;
             oo.set("model",               "WilsonScan");
@@ -117,6 +129,19 @@ class BsToPhiCharmoniumGRvDV2021Test :
             p["B_s->phiccbar::Im{alpha_1^long}@GRvDV2021"]  = 17.0;
             p["B_s->phiccbar::Re{alpha_2^long}@GRvDV2021"]  = 18.0;
             p["B_s->phiccbar::Im{alpha_2^long}@GRvDV2021"]  = 19.0;
+
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
 
             Options oo;
             oo.set("model",               "WilsonScan");

--- a/eos/rare-b-decays/bs-to-phi-ll-gvdv2020_TEST.cc
+++ b/eos/rare-b-decays/bs-to-phi-ll-gvdv2020_TEST.cc
@@ -67,6 +67,18 @@ class BsToPhiDileptonGvDV2020Test :
             p["B_s->phiccbar::Re{alpha_2^long}@GvDV2020"]  = 0.0018;
             p["B_s->phiccbar::Im{alpha_2^long}@GvDV2020"]  = 0.0019;
 
+            p["CKM::abs(V_ub)"] =  0.003631275231633653;
+            p["CKM::arg(V_ub)"] = -1.210765774253535;
+            p["CKM::abs(V_cb)"] =  0.041996951916414726;
+            p["CKM::arg(V_cb)"] =  0.0;
+            p["CKM::abs(V_tb)"] =  0.9991111344469873;
+            p["CKM::arg(V_tb)"] =  0.0;
+            p["CKM::abs(V_us)"] =  0.22534851424944366;
+            p["CKM::arg(V_us)"] =  0.0;
+            p["CKM::abs(V_cs)"] =  0.9734061815416853;
+            p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+            p["CKM::abs(V_ts)"] =  0.04121212396309175;
+            p["CKM::arg(V_ts)"] = -3.1230250224697222;
             p["b->s::Re{c7}"] = -0.3370422989 + 0.1;
             p["b->s::Im{c7}"] = 0.2;
             p["b->s::Re{c7'}"] = 0.3;

--- a/eos/rare-b-decays/exclusive-b-to-dilepton_TEST.cc
+++ b/eos/rare-b-decays/exclusive-b-to-dilepton_TEST.cc
@@ -52,10 +52,25 @@ class BToDileptonTest :
                 p["b->smumu::Re{c10}"] = -4.150;
                 p["b->smumu::Re{c10'}"] = 0.000;
                 // PDG 2010 CKM parameters
-                p["CKM::A"] = 0.812;
-                p["CKM::lambda"] = 0.22543;
-                p["CKM::rhobar"] = 0.144;
-                p["CKM::etabar"] = 0.342;
+                p["CKM::A"]             =  0.812;
+                p["CKM::lambda"]        =  0.22543;
+                p["CKM::rhobar"]        =  0.144;
+                p["CKM::etabar"]        =  0.342;
+                p["CKM::abs(V_ub)"]     =  0.003540950873054711;
+                p["CKM::arg(V_ub)"]     = -1.1728563751359748;
+                p["CKM::abs(V_cb)"]     =  0.04126451344307112;
+                p["CKM::arg(V_cb)"]     =  0.0;
+                p["CKM::abs(V_tb)"]     =  0.9991419776905534;
+                p["CKM::arg(V_tb)"]     =  0.0;
+                p["CKM::abs(V_td)"]     =  0.008576901910577167;
+                p["CKM::arg(V_td)"]     = -0.37951557931964897;
+                p["CKM::abs(V_us)"]     =  0.22542858674178629;
+                p["CKM::arg(V_us)"]     =  0.0;
+                p["CKM::abs(V_cs)"]     =  0.9734167680132911;
+                p["CKM::arg(V_cs)"]     = -3.119448393424795e-05;
+                p["CKM::abs(V_ts)"]     =  0.04051834255894421;
+                p["CKM::arg(V_ts)"]     = -3.123445879630718;
+
                 p["decay-constant::B_s"] = 0.2276;
                 p["decay-constant::B_d"] = 0.256;
                 p["mass::B_d"] = 5.2795;
@@ -141,10 +156,23 @@ class BToDileptonTest :
                 p["b->smumu::Im{cP'}"] = 1.3;
 
                 // 2013 default values
-                p["CKM::A"] = +0.827;
-                p["CKM::lambda"] = 0.22535;
-                p["CKM::rhobar"] = 0.132;
-                p["CKM::etabar"] = 0.350;
+                p["CKM::A"]          = +0.827;
+                p["CKM::lambda"]     =  0.22535;
+                p["CKM::rhobar"]     =  0.132;
+                p["CKM::etabar"]     =  0.350;
+                p["CKM::abs(V_ub)"]  =  0.003631275231633653;
+                p["CKM::arg(V_ub)"]  = -1.210765774253535;
+                p["CKM::abs(V_cb)"]  =  0.041996951916414726;
+                p["CKM::arg(V_cb)"]  =  0.0;
+                p["CKM::abs(V_tb)"]  =  0.9991111344469873;
+                p["CKM::arg(V_tb)"]  =  0.0;
+                p["CKM::abs(V_us)"]  =  0.22534851424944366;
+                p["CKM::arg(V_us)"]  =  0.0;
+                p["CKM::abs(V_cs)"]  =  0.9734061815416853;
+                p["CKM::arg(V_cs)"]  = -3.304199362533668e-05;
+                p["CKM::abs(V_ts)"]  =  0.04121212396309175;
+                p["CKM::arg(V_ts)"]  = -3.1230250224697222;
+
                 p["mass::B_d"] = 5.27958;
                 p["mass::B_s"] = 5.36677;
                 p["life_time::B_d"] = 1.519e-12;

--- a/eos/rare-b-decays/inclusive-b-to-s-dilepton_TEST.cc
+++ b/eos/rare-b-decays/inclusive-b-to-s-dilepton_TEST.cc
@@ -54,8 +54,20 @@ class BToXsDileptonLargeRecoilTest :
                 p["b->s::c6"] = +0.00105859;
                 p["b->s::Re{c7}"] = -0.331;
                 p["b->s::c8"] = -0.181;
-                p["b->smumu::Re{c9}"] = +4.27;
+                p["b->smumu::Re{c9}"]  = +4.27;
                 p["b->smumu::Re{c10}"] = -4.173;
+                p["CKM::abs(V_ub)"]    =  0.003631275231633653;
+                p["CKM::arg(V_ub)"]    = -1.210765774253535;
+                p["CKM::abs(V_cb)"]    =  0.041996951916414726;
+                p["CKM::arg(V_cb)"]    =  0.0;
+                p["CKM::abs(V_tb)"]    =  0.9991111344469873;
+                p["CKM::arg(V_tb)"]    =  0.0;
+                p["CKM::abs(V_us)"]    =  0.22534851424944366;
+                p["CKM::arg(V_us)"]    =  0.0;
+                p["CKM::abs(V_cs)"]    =  0.9734061815416853;
+                p["CKM::arg(V_cs)"]    = -3.304199362533668e-05;
+                p["CKM::abs(V_ts)"]    =  0.04121212396309175;
+                p["CKM::arg(V_ts)"]    = -3.1230250224697222;
 
                 // quark masses
                 p["mass::b(MSbar)"] = 4.2;
@@ -100,10 +112,22 @@ class BToXsDileptonLargeRecoilTest :
                 p["b->s::Re{c7}"]  = 0.0;
                 p["b->s::Re{c7'}"] = -0.331;
                 p["b->s::c8"] = -0.181;
-                p["b->smumu::Re{c9}"]  = 0.0;
-                p["b->smumu::Re{c9'}"] = +4.27;
+                p["b->smumu::Re{c9}"]   = 0.0;
+                p["b->smumu::Re{c9'}"]  = +4.27;
                 p["b->smumu::Re{c10}"]  = 0.0;
                 p["b->smumu::Re{c10'}"] = -4.173;
+                p["CKM::abs(V_ub)"]     =  0.003631275231633653;
+                p["CKM::arg(V_ub)"]     = -1.210765774253535;
+                p["CKM::abs(V_cb)"]     =  0.041996951916414726;
+                p["CKM::arg(V_cb)"]     =  0.0;
+                p["CKM::abs(V_tb)"]     =  0.9991111344469873;
+                p["CKM::arg(V_tb)"]     =  0.0;
+                p["CKM::abs(V_us)"]     =  0.22534851424944366;
+                p["CKM::arg(V_us)"]     =  0.0;
+                p["CKM::abs(V_cs)"]     =  0.9734061815416853;
+                p["CKM::arg(V_cs)"]     = -3.304199362533668e-05;
+                p["CKM::abs(V_ts)"]     =  0.04121212396309175;
+                p["CKM::arg(V_ts)"]     = -3.1230250224697222;
 
                 // quark masses
                 p["mass::b(MSbar)"] = 4.2;
@@ -188,6 +212,18 @@ class BToXsDileptonLargeRecoilPolynomialTest :
             };
 
             Parameters parameters = Parameters::Defaults();
+            parameters["CKM::abs(V_ub)"]     =  0.003631275231633653;
+            parameters["CKM::arg(V_ub)"]     = -1.210765774253535;
+            parameters["CKM::abs(V_cb)"]     =  0.041996951916414726;
+            parameters["CKM::arg(V_cb)"]     =  0.0;
+            parameters["CKM::abs(V_tb)"]     =  0.9991111344469873;
+            parameters["CKM::arg(V_tb)"]     =  0.0;
+            parameters["CKM::abs(V_us)"]     =  0.22534851424944366;
+            parameters["CKM::arg(V_us)"]     =  0.0;
+            parameters["CKM::abs(V_cs)"]     =  0.9734061815416853;
+            parameters["CKM::arg(V_cs)"]     = -3.304199362533668e-05;
+            parameters["CKM::abs(V_ts)"]     =  0.04121212396309175;
+            parameters["CKM::arg(V_ts)"]     = -3.1230250224697222;
             Kinematics kinematics
             {
                 { "q2_min", 1.0 },

--- a/eos/rare-b-decays/inclusive-b-to-s-gamma_TEST.cc
+++ b/eos/rare-b-decays/inclusive-b-to-s-gamma_TEST.cc
@@ -53,11 +53,23 @@ class BToXsGammaNLOTest :
                 p["b->s::Re{c7}"] = -0.32372;
                 p["b->s::c8"] = -0.159167;
                 p["b->s::mu_b"] = 5.0;
-                // PDG 2010 CKM parameters
-                p["CKM::A"] = 0.812;
-                p["CKM::lambda"] = 0.2243;
-                p["CKM::rhobar"] = 0.144;
-                p["CKM::etabar"] = 0.342;
+                // PDG 2010 CKM parameters w/ typo in CKM::lambda (should be 0.22543)
+                p["CKM::A"]             = 0.812;
+                p["CKM::lambda"]        = 0.2243;
+                p["CKM::rhobar"]        = 0.144;
+                p["CKM::etabar"]        = 0.342;
+                p["CKM::abs(V_ub)"]     =  0.0034870776047445035;
+                p["CKM::arg(V_ub)"]     = -1.1728447805386266;
+                p["CKM::abs(V_cb)"]     =  0.040851869505042326;
+                p["CKM::arg(V_cb)"]     =  0.0;
+                p["CKM::abs(V_tb)"]     =  0.99915912422571;
+                p["CKM::arg(V_tb)"]     =  0.0;
+                p["CKM::abs(V_us)"]     =  0.22429863628849864;
+                p["CKM::arg(V_us)"]     =  0.0;
+                p["CKM::abs(V_cs)"]     =  0.9736942292982523;
+                p["CKM::arg(V_cs)"]     = -3.0251458252370057e-05;
+                p["CKM::abs(V_ts)"]     =  0.04012054599802285;
+                p["CKM::arg(V_ts)"]     = -3.123635053579304;
                 // QED coupling as used in [CMM1996], Sec 5.(iii), p. 11
                 p["QED::alpha_e(m_b)"] = 1/130.3;
                 // b quark mass

--- a/eos/rare-b-decays/lambda-b-to-lambda-dilepton_TEST.cc
+++ b/eos/rare-b-decays/lambda-b-to-lambda-dilepton_TEST.cc
@@ -50,9 +50,20 @@ class LambdaBToLambdaDileptonLowRecoilTest :
                     oo.set("production-polarisation", "unpolarised");
 
                     Parameters p = Parameters::Defaults();
-                    p["mass::Lambda_b"] = 5.6194;
+                    p["mass::Lambda_b"] =  5.6194;
+                    p["CKM::abs(V_ub)"] =  0.003631275231633653;
+                    p["CKM::arg(V_ub)"] = -1.210765774253535;
+                    p["CKM::abs(V_cb)"] =  0.041996951916414726;
+                    p["CKM::arg(V_cb)"] =  0.0;
+                    p["CKM::abs(V_tb)"] =  0.9991111344469873;
+                    p["CKM::arg(V_tb)"] =  0.0;
+                    p["CKM::abs(V_us)"] =  0.22534851424944366;
+                    p["CKM::arg(V_us)"] =  0.0;
+                    p["CKM::abs(V_cs)"] =  0.9734061815416853;
+                    p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+                    p["CKM::abs(V_ts)"] =  0.04121212396309175;
+                    p["CKM::arg(V_ts)"] = -3.1230250224697222;
 
-		    
                     LambdaBToLambdaDilepton<LowRecoil> d(p, oo);
 
                     TEST_CHECK_RELATIVE_ERROR(8.250965481e-08, d.differential_branching_ratio(16.0), eps);
@@ -103,7 +114,19 @@ class LambdaBToLambdaDileptonLowRecoilTest :
                     oo.set("production-polarisation", "LHCb");
 
                     Parameters p = Parameters::Defaults();
-                    p["mass::Lambda_b"] = 5.6194;
+                    p["mass::Lambda_b"] =  5.6194;
+                    p["CKM::abs(V_ub)"] =  0.003631275231633653;
+                    p["CKM::arg(V_ub)"] = -1.210765774253535;
+                    p["CKM::abs(V_cb)"] =  0.041996951916414726;
+                    p["CKM::arg(V_cb)"] =  0.0;
+                    p["CKM::abs(V_tb)"] =  0.9991111344469873;
+                    p["CKM::arg(V_tb)"] =  0.0;
+                    p["CKM::abs(V_us)"] =  0.22534851424944366;
+                    p["CKM::arg(V_us)"] =  0.0;
+                    p["CKM::abs(V_cs)"] =  0.9734061815416853;
+                    p["CKM::arg(V_cs)"] = -3.304199362533668e-05;
+                    p["CKM::abs(V_ts)"] =  0.04121212396309175;
+                    p["CKM::arg(V_ts)"] = -3.1230250224697222;
 
                     LambdaBToLambdaDilepton<LowRecoil> d(p, oo);
 
@@ -156,7 +179,19 @@ class LambdaBToLambdaDileptonLowRecoilTest :
                     Parameters p = Parameters::Defaults();
                     p["b->smumu::Re{c9}"]  = +3.2734;
                     p["b->smumu::Re{c9'}"] = +1.0000;
-                    p["mass::Lambda_b"] = 5.6194;
+                    p["mass::Lambda_b"]    =  5.6194;
+                    p["CKM::abs(V_ub)"]    =  0.003631275231633653;
+                    p["CKM::arg(V_ub)"]    = -1.210765774253535;
+                    p["CKM::abs(V_cb)"]    =  0.041996951916414726;
+                    p["CKM::arg(V_cb)"]    =  0.0;
+                    p["CKM::abs(V_tb)"]    =  0.9991111344469873;
+                    p["CKM::arg(V_tb)"]    =  0.0;
+                    p["CKM::abs(V_us)"]    =  0.22534851424944366;
+                    p["CKM::arg(V_us)"]    =  0.0;
+                    p["CKM::abs(V_cs)"]    =  0.9734061815416853;
+                    p["CKM::arg(V_cs)"]    = -3.304199362533668e-05;
+                    p["CKM::abs(V_ts)"]    =  0.04121212396309175;
+                    p["CKM::arg(V_ts)"]    = -3.1230250224697222;
 
                     LambdaBToLambdaDilepton<LowRecoil> d(p, oo);
 
@@ -209,9 +244,21 @@ class LambdaBToLambdaDileptonLowRecoilTest :
                     oo.set("production-polarisation", "LHCb");
 
                     Parameters p = Parameters::Defaults();
-                    p["mass::Lambda_b"] = 5.6194;
                     p["b->smumu::Re{c9}"]  = +3.2734;
                     p["b->smumu::Re{c9'}"] = +1.0000;
+                    p["mass::Lambda_b"]    =  5.6194;
+                    p["CKM::abs(V_ub)"]    =  0.003631275231633653;
+                    p["CKM::arg(V_ub)"]    = -1.210765774253535;
+                    p["CKM::abs(V_cb)"]    =  0.041996951916414726;
+                    p["CKM::arg(V_cb)"]    =  0.0;
+                    p["CKM::abs(V_tb)"]    =  0.9991111344469873;
+                    p["CKM::arg(V_tb)"]    =  0.0;
+                    p["CKM::abs(V_us)"]    =  0.22534851424944366;
+                    p["CKM::arg(V_us)"]    =  0.0;
+                    p["CKM::abs(V_cs)"]    =  0.9734061815416853;
+                    p["CKM::arg(V_cs)"]    = -3.304199362533668e-05;
+                    p["CKM::abs(V_ts)"]    =  0.04121212396309175;
+                    p["CKM::arg(V_ts)"]    = -3.1230250224697222;
 
                     LambdaBToLambdaDilepton<LowRecoil> d(p, oo);
 

--- a/eos/utils/wilson_scan_model.cc
+++ b/eos/utils/wilson_scan_model.cc
@@ -496,7 +496,7 @@ namespace eos
     }
 
     WilsonScanModel::WilsonScanModel(const Parameters & parameters, const Options & options) :
-        SMComponent<components::CKM>(parameters, *this),
+        CKMScanComponent(parameters, options, *this),
         SMComponent<components::QCD>(parameters, *this),
         WilsonScanComponent<components::DeltaB2>(parameters, options, *this),
         WilsonScanComponent<components::DeltaBS1>(parameters, options, *this),
@@ -516,7 +516,7 @@ namespace eos
     }
 
     ConstrainedWilsonScanModel::ConstrainedWilsonScanModel(const Parameters & parameters, const Options & options) :
-        SMComponent<components::CKM>(parameters, *this),
+        CKMScanComponent(parameters, options, *this),
         SMComponent<components::QCD>(parameters, *this),
         WilsonScanComponent<components::DeltaB2>(parameters, options, *this),
         ConstrainedWilsonScanComponent(parameters, options, *this),

--- a/eos/utils/wilson_scan_model.hh
+++ b/eos/utils/wilson_scan_model.hh
@@ -23,6 +23,7 @@
 #ifndef EOS_GUARD_SRC_UTILS_WILSON_SCAN_MODEL_HH
 #define EOS_GUARD_SRC_UTILS_WILSON_SCAN_MODEL_HH 1
 
+#include <eos/utils/ckm_scan_model.hh>
 #include <eos/utils/model.hh>
 #include <eos/utils/standard-model.hh>
 
@@ -254,7 +255,7 @@ namespace eos
      */
     class WilsonScanModel :
         public Model,
-        public SMComponent<components::CKM>,
+        public CKMScanComponent,
         public SMComponent<components::QCD>,
         public WilsonScanComponent<components::DeltaB2>,
         public WilsonScanComponent<components::DeltaBS1>,
@@ -284,7 +285,7 @@ namespace eos
      */
     class ConstrainedWilsonScanModel :
         public Model,
-        public SMComponent<components::CKM>,
+        public CKMScanComponent,
         public SMComponent<components::QCD>,
         public WilsonScanComponent<components::DeltaB2>,
         public ConstrainedWilsonScanComponent,


### PR DESCRIPTION
This commit fixes #313 by

 - [x] replacing the ``SMComponent<components::CKM>`` with ``CKMScanComponent`` in both ``WilsonScanModel`` and ``ConstrainedWilsonScanModel``
 - [x] setting the required CKM matrix elements (abs and arg) in ``b-decays`` to either the values based on the current default Wolfeinstein params or based on the Wolfenstein params provided in the test case
 - [x] repeating the above for ``rare-b-decays``. However, one test case is stubborn, should use default Wolfenstein values but still fails: ``b-to-kstar-gamma-bfs2004_TEST.cc``, the Bobeth compatibility test

The order of commits is such that the CKM matrix element are fixed first.