### PR TITLE
[utils] Include <cstddef> in cartesian-product.hh

### DIFF
--- a/eos/utils/cartesian-product.hh
+++ b/eos/utils/cartesian-product.hh
@@ -22,6 +22,7 @@
 #define EOS_GUARD_SRC_UTILS_CARTESIAN_PRODUCT_HH 1
 
 #include <vector>
+#include <cstddef>
 
 namespace eos
 {


### PR DESCRIPTION
Including `<cstddef>` in the header of `utils/cartesian-product.hh` fixes a compiler error stating that `„size_t” was not declared`.