### PR TITLE
Small python changes

### DIFF
--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -434,6 +434,14 @@ class Analysis:
         generating_components.append(origins)
         samples = np.apply_along_axis(self._x_to_par, 1, sampler.samples[:])  # Rescale the parameters back to their original bounds
         weights = sampler.weights[:][:, 0]
+        # rescale proposal components back to their physical bounds
+        for component in sampler.proposal.components:
+            rescaled_mu = self._x_to_par(component.mu)
+            rescaled_sigma = np.array([[
+                component.sigma[i, j] * (bj[1] - bj[0]) * (bi[1] - bi[0]) / 4 for j, bj in enumerate(self.bounds)
+                ] for i, bi in enumerate(self.bounds)])
+            component.update(rescaled_mu, rescaled_sigma)
+
         perplexity = self._perplexity(np.copy(weights))
         eos.info('Perplexity after final samples: {}'.format(perplexity))
 

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -48,7 +48,7 @@ class Plotter:
         self.plot_types = {
             'band':                  Plotter.Band,
             'constraint':            Plotter.Constraint,
-            'constraint2D':         Plotter.Constraint2D,
+            'constraint2D':          Plotter.Constraint2D,
             'constraint-overview':   Plotter.ConstraintOverview,
             'contours2D':            Plotter.Contours2D,
             'expression':            Plotter.Expression,
@@ -267,9 +267,12 @@ class Plotter:
             self.plotter.ax.add_patch(rect)
 
         def handles_labels(self):
-            handle = plt.Rectangle((0,0),1,1, color=self.color)
-            label  = self.label
-            return ([handle], [label])
+            if self.label:
+                handle = plt.Rectangle((0,0),1,1, color=self.color)
+                label  = self.label
+                return ([handle], [label])
+            else:
+                return ([], [])
 
 
     """ Plots a single EOS observable w/o uncertainties as a function of one kinemtic variable or one parameter. """
@@ -850,9 +853,12 @@ class Plotter:
 
 
         def handles_labels(self):
-            handle = plt.Rectangle((0,0),1,1, color=self.color, alpha=self.alpha)
-            label  = self.label
-            return ([handle], [label])
+            if self.label:
+                handle = plt.Rectangle((0,0),1,1, color=self.color, alpha=self.alpha)
+                label  = self.label
+                return ([handle], [label])
+            else:
+                return ([], [])
 
 
     """ Plots overview of several constraints from the EOS library of experimental and theoretical likelihoods. """
@@ -1175,13 +1181,16 @@ class Plotter:
                 plt.clabel(CS, inline=1, fmt=fmt, fontsize=10)
 
         def handles_labels(self):
-            handle = None
-            if 'areas' in self.contours:
-                handle = plt.Rectangle((0,0),1,1, color=self.color)
-            else:
-                handle = plt.Line2D((0,1),(0.5,0.), color=self.color, linestyle=self.style[0])
+            if self.label:
+                handle = None
+                if 'areas' in self.contours:
+                    handle = plt.Rectangle((0,0),1,1, color=self.color)
+                else:
+                    handle = plt.Line2D((0,1),(0.5,0.), color=self.color, linestyle=self.style[0])
 
-            return ([handle], [self.label])
+                return ([handle], [self.label])
+            else:
+                return ([], [])
 
 
     """ Plots a 1D histogram of pre-existing random samples. """


### PR DESCRIPTION
This PR:
  - Fixes a small bug in the labels of plotter.py
  - Scales the sampler proposal back to the initial parameter space in pmc-sample
  - Allows to fix a perplexity threshold to stop PMC adaptations
  - Allows to return final step samples only in pmc-sample