### PR TITLE
Unify plot args

### DIFF
--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Danny van Dyk
+ * Copyright (c) 2021 Philip Lüghausen
  * Copyright (c) 2010 Christian Wacker
  *
  * This file is part of the EOS project. EOS is free software;
@@ -621,6 +622,16 @@ namespace eos
             throw UnknownParameterError(name);
 
         _imp->parameters_data->data[i->second].value = value;
+    }
+
+    bool
+    Parameters::has(const std::string & name)
+    {
+        auto i(_imp->parameters_map.find(name));
+
+        if (_imp->parameters_map.end() == i)
+            return false;
+        else return true;
     }
 
     Parameters::Iterator

--- a/eos/utils/parameters.hh
+++ b/eos/utils/parameters.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2010, 2011, 2012, 2013, 2019 Danny van Dyk
+ * Copyright (c) 2021 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -155,6 +156,13 @@ namespace eos
              * @param value The parameter's new numeric value.
              */
             void set(const std::string & name, const double & value);
+
+            /*!
+             * Verify if a parameter with a given name exists.
+             *
+             * @param name  The name to be checked against the known parameters.
+             */
+            bool has(const std::string & name);
 
             /*!
              * Retrieve a parameter's Parameter object by name.

--- a/eos/utils/parameters_TEST.cc
+++ b/eos/utils/parameters_TEST.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2011 Danny van Dyk
+ * Copyright (c) 2021 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -70,6 +71,14 @@ class ParametersTest :
                 m_c_original = 0.0;
                 TEST_CHECK_EQUAL(m_c_original(), 0.0);
                 TEST_CHECK_EQUAL(m_c_clone(), m_c_clone.central());
+            }
+
+            // Parameters::has
+            {
+                Parameters p = Parameters::Defaults();
+
+                TEST_CHECK_EQUAL(p.has("mass::tau"), true);
+                TEST_CHECK_EQUAL(p.has("mass::boing747"), false);
             }
         }
 } parameters_test;

--- a/examples/cli/btopilnu.plot
+++ b/examples/cli/btopilnu.plot
@@ -21,7 +21,7 @@ contents:
       type: 'observable'
       color: 'C1'
       observable: 'B->pilnu::dBR/dq2;l=mu,model=CKMScan'
-      kinematic: 'q2'
+      variable: 'q2'
       range: [0.01, 26.0]
       samples: 200
       parameters:

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -66,7 +66,10 @@ _eos_la_LIBADD = $(top_builddir)/eos/libeos.la $(top_builddir)/eos/utils/libeosu
 
 TESTS = \
 	eos_TEST.py \
-	eos/analysis_TEST.py
+	eos/analysis_TEST.py \
+	eos/observable_TEST.py \
+	eos/parameter_TEST.py \
+	eos/plot/plotter_TEST.py
 
 EXTRA_DIST += $(TESTS)
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -215,6 +215,7 @@ BOOST_PYTHON_MODULE(_eos)
         .def("declare", &Parameters::declare, return_value_policy<return_by_value>())
         .def("sections", range(&Parameters::begin_sections, &Parameters::end_sections))
         .def("set", &Parameters::set)
+        .def("has", &Parameters::has)
         .def("override_from_file", &Parameters::override_from_file)
         ;
 

--- a/python/eos/observable.py
+++ b/python/eos/observable.py
@@ -84,3 +84,12 @@ class Observables(_Observables):
         result += r'</table>'
 
         return(result)
+
+    @staticmethod
+    def _get_obs_entry(name):
+        obs = Observables()[name]
+        if obs is None:
+            raise ValueError("Observable with name '" + name + "' is not known")
+        else:
+            return obs
+

--- a/python/eos/observable_TEST.py
+++ b/python/eos/observable_TEST.py
@@ -1,0 +1,23 @@
+import unittest
+import eos
+
+class StaticMethodTests(unittest.TestCase):
+
+    def test_get_obs_entry_0(self):
+        "name is valid"
+
+        valid_name = 'B->Dlnu::dBR/dq2;l=e,q=d'
+        eos.Observables._get_obs_entry(valid_name)
+
+
+    def test_get_obs_entry_1(self):
+        "name is invalid"
+
+        invalid_name = 'prefix::Philipp'
+        with self.assertRaisesRegex(ValueError, "Observable with name 'prefix::Philipp' is not known"):
+            eos.Observables._get_obs_entry(invalid_name)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)
+

--- a/python/eos/parameter.py
+++ b/python/eos/parameter.py
@@ -128,3 +128,11 @@ class Parameters(_Parameters):
         return parameters
 
 
+    @staticmethod
+    def _assert_valid_name(name):
+        "Raise error if 'name' is not a valid EOS paramter name"
+
+        valid_names = [p.name() for p in Parameters()]
+        if name not in valid_names:
+            raise ValueError("Parameter name '" + name + "' is not known")
+

--- a/python/eos/parameter.py
+++ b/python/eos/parameter.py
@@ -127,12 +127,3 @@ class Parameters(_Parameters):
 
         return parameters
 
-
-    @staticmethod
-    def _assert_valid_name(name):
-        "Raise error if 'name' is not a valid EOS paramter name"
-
-        valid_names = [p.name() for p in Parameters()]
-        if name not in valid_names:
-            raise ValueError("Parameter name '" + name + "' is not known")
-

--- a/python/eos/parameter_TEST.py
+++ b/python/eos/parameter_TEST.py
@@ -1,0 +1,21 @@
+import unittest
+import eos
+
+class StaticMethodTests(unittest.TestCase):
+
+    def test_assert_valid_name_0(self):
+        "Value of 'name' is valid"
+
+        eos.Parameters._assert_valid_name('mass::mu')
+
+
+    def test_assert_valid_name_1(self):
+        "Value of 'name' is invalid (for small-scale physics)"
+
+        with self.assertRaisesRegex(ValueError, "Parameter name 'mass::your_mum' is not known"):
+            eos.Parameters._assert_valid_name('mass::your_mum')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)
+

--- a/python/eos/parameter_TEST.py
+++ b/python/eos/parameter_TEST.py
@@ -1,20 +1,7 @@
 import unittest
 import eos
 
-class StaticMethodTests(unittest.TestCase):
-
-    def test_assert_valid_name_0(self):
-        "Value of 'name' is valid"
-
-        eos.Parameters._assert_valid_name('mass::mu')
-
-
-    def test_assert_valid_name_1(self):
-        "Value of 'name' is invalid (for small-scale physics)"
-
-        with self.assertRaisesRegex(ValueError, "Parameter name 'mass::your_mum' is not known"):
-            eos.Parameters._assert_valid_name('mass::your_mum')
-
+# no tests yet
 
 if __name__ == '__main__':
     unittest.main(verbosity=5)

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2018 Frederik Beaujean
 # Copyright (c) 2017, 2018, 2021 Danny van Dyk
+# Copyright (c) 2021 Philip Lüghausen
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -332,16 +333,19 @@ class Plotter:
                         "also specified as a fix kinematic with value " + str(val))
 
             # Declare variable that is either parameter or kinematic
-            try:
-                eos.Parameters._assert_valid_name(item['variable'])
-                var = parameters.declare(item['variable'], np.nan)
-            except ValueError:
-                if item['variable'] not in valid_kin_vars:
-                    # variable is neither a valid parameter nor valid kinematic
-                    raise ValueError("Value of 'variable' for observable '" + oname +
-                        "' is neither a valid kinematic variable nor parameter: '" + item['variable'] + "'")
+            var = None
 
-                # variable must be valid kinematic
+            # is a valid parameter?
+            if parameters.has(item['variable']):
+                var = parameters.declare(item['variable'], np.nan)
+
+            # is neither a valid parameter nor valid kinematic?
+            elif item['variable'] not in valid_kin_vars:
+                raise ValueError("Value of 'variable' for observable '" + oname +
+                    "' is neither a valid kinematic variable nor parameter: '" + item['variable'] + "'")
+
+            # variable must be valid kinematic
+            else:
                 var = kinematics.declare(item['variable'], np.nan)
 
 

--- a/python/eos/plot/plotter_TEST.py
+++ b/python/eos/plot/plotter_TEST.py
@@ -1,0 +1,117 @@
+import unittest
+import copy
+import eos
+
+class PlotterObservableVariableTests(unittest.TestCase):
+    "Test handling of argument 'variable' in Plotter.Observable"
+
+    @classmethod
+    def setUpClass(cls):
+
+        cls.plot_args_prototype = {
+                'plot': {
+                    'x': { 'label': r'$q^2$', 'unit': r'$\textnormal{GeV}^2$', 'range': [0.0, 11.63] },
+                    'y': { 'label': r'$d\mathcal{B}/dq^2$',                    'range': [0.0,  5e-3] },
+                    'legend': { 'location': 'lower left' }
+                    },
+                'contents': [
+                    {
+                        'label': r'$\ell=e$',
+                        'type': 'observable',
+                        'observable': 'B->Dlnu::dBR/dq2;l=e,q=d',
+                        'variable': 'q2',
+                        'parameters': {
+                            'mass::mu': 1.0,
+                            'mass::tau': 1.0,
+                            },
+                        'color': 'black',
+                        'range': [0.02, 11.63],
+                        },
+                    ]
+                }
+
+        # All tests call Plotter.plot(), which relies on the presence of a
+        # LaTeX installation. The tests of this class should be skipped if
+        # that is not given.
+        try:
+            eos.plot.Plotter(cls.plot_args_prototype).plot()
+        except Exception as e:
+            msg = "Plotting fails: " + repr(e)
+            raise unittest.SkipTest(msg)
+
+
+    def setUp(self):
+        self.plot_args = copy.deepcopy(self.plot_args_prototype)
+
+
+    def test_variable_key_0(self):
+        "Check valid case: variable is kinematic"
+
+        eos.plot.Plotter(self.plot_args).plot()
+
+
+    def test_variable_key_1(self):
+        "Check valid case: variable is parameter"
+
+        self.plot_args['contents'][0]['variable'] = 'mass::tau'
+        self.plot_args['contents'][0]['parameters'].pop('mass::tau')
+        self.plot_args['contents'][0]['kinematics'] = {'q2': 0.1}
+        eos.plot.Plotter(self.plot_args).plot()
+
+
+    def test_variable_key_2(self):
+        "Handle 'variable' key not given"
+
+        self.plot_args['contents'][0].pop('variable')
+        with self.assertRaisesRegex(ValueError,
+            "Missing key for plot of observable 'B->Dlnu::dBR/dq2;l=e,q=d': 'variable'"):
+            eos.plot.Plotter(self.plot_args).plot()
+
+
+    def test_variable_key_3(self):
+        "Handle value of 'variable' not a kinematic var. nor a parameter"
+
+        self.plot_args['contents'][0]['variable'] = 'neitherKinNorPar'
+
+        with self.assertRaisesRegex(ValueError,
+            "Value of 'variable' for observable 'B->Dlnu::dBR/dq2;l=e,q=d' is neither " +
+            "a valid kinematic variable nor parameter: 'neitherKinNorPar'"):
+            eos.plot.Plotter(self.plot_args).plot()
+
+
+    def test_variable_key_4(self):
+        "Pass the variable key again as a fix kinematic"
+
+        self.plot_args['contents'][0]['kinematics'] = {'q2': 0.1}
+
+        with self.assertRaisesRegex(ValueError,
+            "Variable 'q2' of observable 'B->Dlnu::dBR/dq2;l=e,q=d' is also " +
+            "specified as a fix kinematic with value 0.1"):
+            eos.plot.Plotter(self.plot_args).plot()
+
+
+    def test_variable_key_5(self):
+        "Pass the variable key again as a fix parameter"
+
+        self.plot_args['contents'][0]['variable'] = 'mass::tau'
+
+        with self.assertRaisesRegex(ValueError,
+            "Variable 'mass::tau' of observable 'B->Dlnu::dBR/dq2;l=e,q=d' is also " +
+            "specified as a fix parameter with value 1.0"):
+            eos.plot.Plotter(self.plot_args).plot()
+
+
+    def test_kinematics_key_0(self):
+        "Handle invalid kinematics key"
+
+        self.plot_args['contents'][0]['kinematics'] = {'q3': 0.1}
+
+        with self.assertRaisesRegex(ValueError,
+            "Kinematic quantity 'q3' does not match known ones for observable " +
+            "'B->Dlnu::dBR/dq2;l=e,q=d': \['q2'\]"):
+            eos.plot.Plotter(self.plot_args).plot()
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)
+


### PR DESCRIPTION
Unify Plotter.Observable items 'kinematic' and 'parameter' to a single key 'variable' (which was also still implemented before as a proxy for 'kinematic'). This is a breaking change! We need to check and likely modify any documentation on this.

All changes are covered with unit tests, where test infrastructure was added where needed. Anticipated user errors are caught and reported with meaningful (expressive) error messages to improve the user experience.