### PR TITLE
[github] Fix missing library in PyPI wheel

### DIFF
--- a/.github/workflows/manylinux-build+check+deploy.yaml
+++ b/.github/workflows/manylinux-build+check+deploy.yaml
@@ -161,7 +161,7 @@ jobs:
                 pushd _pypi
                 export PATH="$PYTHON_PATH:$PATH"
                 cp ../_build/python/.libs/_eos.so ./
-                LIBRARIES='libboost|libeos|libgfortran|libgsl|libquadmath|libyaml|libz'
+                LIBRARIES='libboost|libeos|libgfortran|libgsl|libquadmath|libsatlas|libyaml|libz'
                 for f in $(ldd _eos.so | grep '=>' | grep -E "$LIBRARIES" | awk '{print $3}') ; do
                     cp $f ./
                 done


### PR DESCRIPTION
libsatlas.so is a dependency of libgslcblas.so on the manylinux build image.
Re-add this library to the wheel.