### PR TITLE
[python] Fix the table representation of PDFs

### DIFF
--- a/python/eos/signal_pdf.py
+++ b/python/eos/signal_pdf.py
@@ -167,10 +167,11 @@ class SignalPDFs(_SignalPDFs):
         return True
 
     def _repr_html_(self):
-        result = '<table>\n'
+        result = '<table>'
         for qn, entry in self:
             if not self.filter_entry(qn):
                 continue
             result += r'      <tr><th><tt style="color:grey">{qn}</tt></th><td style="text-align:left">{desc}</td></tr>'.format(qn=qn,desc=entry.description())
+        result += '</table>'
 
         return result


### PR DESCRIPTION
Although the tables were correctly rendered in a Jupyter notebook, exporting this notebook in PDF or displaying it in GitHub caused a rendering bugs with mixed cells.