### PR TITLE
[doc] Improve installation documentation

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -42,3 +42,29 @@ of your local computer's secure shell programm.
 Presently we do not support using EOS on Windows. We recommend that you install EOS on a
 remote Linux machine (e.g., one of your department's workstations) and connect remotely
 as discussed :ref:`above <... use EOS remotely?>`.
+
+.. _faq-check-installation:
+
+... check the installation?
+===========================
+
+You can test with a single command that EOS is available as a python module:
+
+.. code-block:: bash
+
+    python3 -c "import eos; print(eos.__doc__)"
+
+Please verify that the command prints a description of the EOS module:
+
+.. code-block:: none
+
+    EOS is a software package that addresses several use cases in the field of high-energy flavor physics (HEP). [...]
+
+If you built and installed from the source code
+and the import fails, i.e. you see ``ModuleNotFoundError: No module named 'eos'``,
+the module was either not installed with ``make install`` or the ``PYTHONPATH`` is not configured correctly.
+
+If you installed via `pip`
+and the output description is incorrect or ``None``,
+you have another module installed that is also named `eos`.
+Mind that the package name for the ``pip3 install`` command is ``eoshep``.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -18,18 +18,12 @@ This is the recommended installation method using the 'package installer for Pyt
 
   pip3 install --user eoshep
 
-This way, you will install the latest regular release of EOS.
-You can now use the EOS Python module via ``import eos``. In addition, some command line scripts have become available.
-To update EOS, run ``pip3 install --user --upgrade eoshep``.
+You can now use the EOS Python module via ``import eos``. In addition, some command-line scripts have become available.
 
-This installs the most recent development version of EOS:
-
-::
-
-  pip3 install --user --pre eoshep
-
-The development version corresponds to the most recent commit in the Github EOS repository.
-To update, run ``pip3 install --user --pre --upgrade eoshep``.
+| To **update** EOS, add the flag ``--upgrade`` to the above command.
+| To install the **development version**, add the flag ``--pre``.
+  This version is automatically up-to-date with the master branch in the Github EOS repository.
+| You can **test** and debug the installation of the python module as described :ref:`here <faq-check-installation>`.
 
 
 Installation with `apt` (Ubuntu, Debian and Siblings)
@@ -323,3 +317,5 @@ You can determine the correct value by running the following command:
 ::
 
   python3 -c "import sys; print('python{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))"
+
+You can test and debug the installation of the python module as described :ref:`here <faq-check-installation>`.


### PR DESCRIPTION
Apart from the FAQ, I also noticed that the `pip` installation description can be shorter. Since this is our 'hero' installation method, I'd keep it as easy to grasp as possible.

I built the html doc to check the links and rendering.

---

 - Add FAQ entry to troubleshoot problems with the module installation
 - Shorten description of the pip3 installation

 Solves #323