### PR TITLE
Another set of changes before v1.0

### DIFF
--- a/doc/api/python.rst.jinja
+++ b/doc/api/python.rst.jinja
@@ -131,7 +131,7 @@ expressed in terms of independent plot items.
 In the above, ``FILENAME`` is an optional argument naming the file into which the plot shall be placed.
 The format is automatically determined based on the file name extension.
 
-Plot layouting
+Plot Layouting
 --------------
 
 By default plots lack any axis labels and units, and any legend.
@@ -176,7 +176,7 @@ An example illustrating plot layouting follows:
        ]
    }
 
-Plot contents
+Plot Contents
 -------------
 
 Each item in a plot's contents is represented by a dictionary.
@@ -190,130 +190,33 @@ Each features the mandatory ``type`` key and more type-specific (mandatory or op
 
       * - value
         - description
-      {% for key, value in plot_type_descs.items() %}
+      {% for key, value in plot_types.items() %}
       * - ``{{ key }}``
-        - {{ value }}
+        - {{ value.oneline }}
       {% endfor %}
 
-   You can find examples for the following types:
-
-    - ``observable`` -- See `Plotting observables`_
-    - ``constraints`` -- See `Plotting constraints`_
-    - ``point`` -- See `Plotting points`_
-
- * ``name`` (*str*, optional) -- The name of the plot item, for convenience when reporting warnings and errors.
 
 All item types recognize the following optional keys:
+
+ * ``name`` (*str*, optional) -- The name of the plot item, for convenience when reporting warnings and errors.
 
  * ``alpha`` (*float*, between 0.0 and 1.0) -- The opacity of the plot item expressed as an alpha value. 0.0 means completely transparent,
    1.0 means completely opaque.
 
  * ``color`` (*str*, containing any valid Matplotlib color specification) -- The color of the plot item.
    Defaults to one of the colors in the Matplotlib default color cycler.
+
  * ``label`` (*str*, may contain LaTeX commands) -- The label that appears in the plot's legend for this plot item.
 
-Plotting observables
---------------------
-
-Contents items of type ``observable`` are used to display one of the built-in `observables <../observables.html>`_.
-The following keys are mandatory:
-
- * ``observable`` (:class:`QualifiedName <eos.QualifiedName>`) -- The name of the observable that will be plotted.
-   Must identify one of the observables known to EOS; see `the complete list of observables <../observables.html>`_.
- * ``range`` (*list* or *tuple* of two *float*) --The tuple of [minimal, maximal] values of the specified kinematic variable
-   for which the observable will be evaluated.
-
-Exactly one of the following keys is mandatory, to specify either a kinematic variable or a parameter to which the x coordinate
-will be mapped:
-
- * ``variable`` (*str*) -- The name of the kinematic variable to which the x axis will be mapped.
- * ``kinematic`` (*str*) -- Alias for ``variable``.
- * ``parameter`` (*str*) -- The name of the parameter to which the x axis will be mapped;
-   see `the complete list of parameters <../parameters.html>`_.
-
-Example:
-
-.. code-block::
-
-   plot_args = {
-       'plot': { ... },
-       'contents': [
-           {
-               'label': r'$\ell=\mu$',
-               'type': 'observable',
-               'observable': 'B->Dlnu::dBR/dq2;l=mu',
-               'variable': 'q2',
-               'range': [0.02, 11.60],
-           },
-       ]
-   }
-
-Plotting constraints
---------------------
-
-Contents items of type ``constraints`` are used to display one of the built-in `experimental or theoretical constraints <../constraints.html>`_.
-The following keys are mandatory:
-
- * ``constraints`` (:class:`QualifiedName <eos.QualifiedName>` or iterable thereof) -- The name or the list of names of the constraints
-   that will be plotted. Must identify at least one of the constraints known to EOS; see `the complete list of constraints <../constraints.html>`_.
- * ``variable`` (*str*) -- The name of the kinematic variable to which the x axis will be mapped.
-
-When plotting multivariate constraints, the following key is also mandatory:
-
- * ``observable`` (:class:`QualifiedName <eos.QualifiedName>`) -- The name of the observable whose constraints will be plotted.
-   Must identify one of the observables known to EOS; see `the complete list of observables <../observables.html>`_.
-   This is only mandatory in multivariate constraints, since these can constrain more than one observable simultaneously.
-
-Example:
-
-.. code-block::
-
-   plot_args = {
-       'plot': { ... },
-       'contents': [
-           {
-               'label': r'Belle 2015 $\ell=e,\, q=d$',
-               'type': 'constraint',
-               'color': 'C0',
-               'constraints': 'B^0->D^+e^-nu::BRs@Belle-2015A',
-               'observable': 'B->Dlnu::BR',
-               'variable': 'q2',
-               'rescale-by-width': False
-           }
-       ]
-   }
+ * ``style`` (*str*, containing any valid Matplotlib styale specification) -- The style of the plot item.
 
 
-Plotting points
----------------
+{% for key, value in plot_types.items() %}
+{% if value.content | length %}
+.. _{{ key }}:
 
-Content items of type ``point`` are used to display a single data point manually.
-The following keys are mandatory:
+{{ value.content }}
 
- * ``x`` (*number*) -- The point's x coordinate.
- * ``y`` (*number*) -- The point's y coordinate.
+{% endif %}
+{% endfor %}
 
-Beside the common set of optional keys, this item type recognizes the following optional
-keys:
-
- * ``marker`` (*str*, a valid Matplotlib marker style) -- The point's marker style.
- * ``markersize`` (*number*, a valid Matplotlib marker size) -- The point's marker size in pts.
-
-Example:
-
-.. code-block::
-
-   plot_args = {
-       'plot': { ... },
-       'contents': [
-           {
-               'label': r'LCSR (Bharucha 2012)',
-               'type': 'point',
-               'color': 'C0',
-               'x': 0,
-               'y': 0.261,
-               'marker': 'o',
-               'markersize': 12
-           }
-       ]
-   }

--- a/doc/api/python.rst.py
+++ b/doc/api/python.rst.py
@@ -1,16 +1,19 @@
 import eos
 from jinja_util import print_template
 
-plot_types_attrs = eos.plot.Plotter.plot_types
-
 # get docstrings from classes
-plot_type_descs = dict()
-for key in plot_types_attrs:
-    PlotterClass = plot_types_attrs[key]
-    desc = PlotterClass.__doc__.split('\n')[0]
-    plot_type_descs.update({key: desc})
+plot_types = {}
+for key, PlotterClass in eos.plot.Plotter.plot_types.items():
+    oneline = PlotterClass.__doc__.split('\n')[0]
+    content = PlotterClass._api_doc if '_api_doc' in dir(PlotterClass) else ''
+    plot_types.update({
+        key: {
+            'oneline': oneline,
+            'content': content
+        }
+    })
 
 print_template(__file__,
-    plot_type_descs = plot_type_descs
+    plot_types = plot_types
 )
 

--- a/doc/basics.rst
+++ b/doc/basics.rst
@@ -56,7 +56,7 @@ for the muon mass:
    * - current value
      - 0.105658
    * - default value
-     - 0.1050658
+     - 0.105658
 
 
 

--- a/eos/b-decays/observables.cc
+++ b/eos/b-decays/observables.cc
@@ -1910,6 +1910,9 @@ namespace eos
                 make_bs_to_kstar_l_nu_group(),
                 make_bs_to_dsstar_l_nu_group(),
 
+                // B_{u,d} -> P P l^- nubar
+                make_b_to_pi_pi_l_nu_group(),
+
                 // B_{u,d} -> P nu nubar
                 make_b_to_k_nu_nu_group(),
 

--- a/eos/rare-b-decays/inclusive-b-to-s-gamma.cc
+++ b/eos/rare-b-decays/inclusive-b-to-s-gamma.cc
@@ -439,13 +439,16 @@ namespace eos
             A += 4.0 * a_s * std::real(wc.c2() * std::conj(wc.c7()) * fij.f27);
             A += 4.0 * a_s * std::real(wc.c2() * std::conj(wc.c8()) * fij.f28);
             A += 4.0 * a_s * std::norm(wc.c7()) * std::real(fij.f77);
-            A += 4.0 * a_s * std::norm(wc.c7prime()) * std::real(fij.f77);
             A += 4.0 * a_s * std::real(wc.c7() * std::conj(wc.c8()) * fij.f78);
             A += 4.0 * a_s * std::norm(wc.c8()) * std::real(fij.f88);
+            A += 4.0 * a_s * std::norm(wc.c7prime()) * std::real(fij.f77);
+            A += 4.0 * a_s * std::norm(wc.c8prime()) * std::real(fij.f88);
+            A += 4.0 * a_s * std::real(wc.c7prime() * std::conj(wc.c8prime()) * fij.f78);
 
             return A;
         }
 
+        // ToDo: this function is only used in Diagnostics
         double ratio_quark(const double & z, const double & delta, const double & ckm, const double & alpha_s, const double & mu) const
         {
             // Constants
@@ -453,7 +456,7 @@ namespace eos
             static const complex<double> iu(0.0, 1.0);
 
             // masses
-            double m_b_pole = 4.8;
+            double m_b_pole = 4.8;                  // ToDo: check whether hardcoded numerical value could be removed
             double lnmu = std::log(m_b_pole / mu);
 
             WilsonCoefficients<BToS> wc = model->wilson_coefficients_b_to_s(mu, "mu" /* fake lepton flavor */);

--- a/examples/inference.ipynb
+++ b/examples/inference.ipynb
@@ -845,7 +845,7 @@
     "    'contents': [\n",
     "        {\n",
     "            'type': 'kde2D', 'color': 'C1', 'label': 'posterior',\n",
-    "            'range': [40e-3, 45e-3], 'levels': [68, 95], 'bandwidth': 3,\n",
+    "            'levels': [68, 95], 'contours': ['lines','areas'], 'bandwidth':3,\n",
     "            'data': { 'samples': parameter_samples[:, (0,1)] }\n",
     "        }\n",
     "    ]\n",

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -88,7 +88,9 @@ class AnalysisFile:
         global_options = posterior['global_options'] if 'global_options' in posterior else {}
         fixed_parameters = posterior['fixed_parameters'] if 'fixed_parameters' in posterior else {}
 
-        return eos.Analysis(prior, likelihood, global_options, manual_constraints=manual_constraints)
+        return eos.Analysis(prior, likelihood, global_options,
+                            manual_constraints=manual_constraints,
+                            fixed_parameters=fixed_parameters)
 
 
     def observables(self, _prediction, parameters):

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -82,6 +82,14 @@ class AnalysisFile:
         likelihood = []
         manual_constraints = {}
         for lh in posterior['likelihood']:
+            LH_ALLOWED_KEYS = { 'name', 'constraints', 'manual_constraints' }
+            for key in self._likelihoods[lh]:
+                if key not in LH_ALLOWED_KEYS:
+                    raise KeyError(f"Unsupported key in 'likelihoods['{lh}']': {key}")
+
+            if 'constraints' not in self._likelihoods[lh] and 'manual_constraints' not in self._likelihoods[lh]:
+                raise KeyError(f'Missing entry in \'likelihoods[\'{lh}\']\': neither \'constraints\' nor \'manual_constraints\' is provided')
+
             likelihood.extend(self._likelihoods[lh]['constraints'] if 'constraints' in self._likelihoods[lh] else [])
             manual_constraints.update(self._likelihoods[lh]['manual_constraints'] if 'manual_constraints' in self._likelihoods[lh] else {})
 

--- a/python/eos/data/pypmc.py
+++ b/python/eos/data/pypmc.py
@@ -179,8 +179,8 @@ class PMCSampler:
         self.type = 'PMCSampler'
         self.varied_parameters = description['parameters']
         self.lookup_table = { item['name']: idx for idx, item in enumerate(self.varied_parameters) }
-        self.components = _np.array([pypmc.density.gauss.Gauss(_np.array(c['mu']), _np.array(c['sigma'])) for c in description['proposal']['components']])
-        self.weights    = _np.array(description['proposal']['weights'])
+        self.components        = _np.array([pypmc.density.gauss.Gauss(_np.array(c['mu']), _np.array(c['sigma'])) for c in description['proposal']['components']])
+        self.component_weights = _np.array(description['proposal']['weights'])
 
         f = os.path.join(path, 'samples.npy')
         if not os.path.exists(f) or not os.path.isfile(f):

--- a/python/eos/data/pypmc.py
+++ b/python/eos/data/pypmc.py
@@ -42,6 +42,7 @@ class MarkovChain:
 
         self.type = 'MarkovChain'
         self.varied_parameters = description['parameters']
+        self.lookup_table = { item['name']: idx for idx, item in enumerate(self.varied_parameters) }
 
         f = os.path.join(path, 'samples.npy')
         if not os.path.exists(f) or not os.path.isfile(f):
@@ -177,6 +178,7 @@ class PMCSampler:
 
         self.type = 'PMCSampler'
         self.varied_parameters = description['parameters']
+        self.lookup_table = { item['name']: idx for idx, item in enumerate(self.varied_parameters) }
         self.components = _np.array([pypmc.density.gauss.Gauss(_np.array(c['mu']), _np.array(c['sigma'])) for c in description['proposal']['components']])
         self.weights    = _np.array(description['proposal']['weights'])
 

--- a/python/eos/data/pypmc.py
+++ b/python/eos/data/pypmc.py
@@ -193,6 +193,11 @@ class PMCSampler:
         self.weights = _np.load(f)
 
 
+    def density(self):
+        """ Return a pypmc.density.MixtureDensity. """
+        return pypmc.density.mixture.MixtureDensity(self.components, self.component_weights)
+
+
     @staticmethod
     def _evaluate_mixture_pdf(components, weights, x):
         """ Internal function that evaluate the PDF of the mixture density at point x."""

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -1411,6 +1411,43 @@ class Plotter:
 
     class Histogram1D(BasePlot):
         """Plots a 1D histogram of pre-existing random samples"""
+
+        _api_doc = inspect.cleandoc("""\
+        Plotting Histograms
+        -------------------
+
+        Contents items of type ``histogram`` are used to display samples of a probability density, be it a prior, a posterior, or a signal PDF.
+        The following key is mandatory:
+
+         * ``data`` (*dict*, see below) -- The data on probability density that will be histogramed.
+
+        Within the data object, the following keys are understood.
+
+         * ``samples`` (*list* of *float*) -- The samples that will be histogramed. Mandatory.
+         * ``weights`` or ``log_weights`` (*list* of *float*, optional) -- The weights of the samples, on a linear or logarithmic scale.
+           Defaults to uniform weights.
+
+        Example:
+
+        .. code-block::
+
+           analysis = ... # eos.Analysis object as discussed in the example notebook `inference.ipynb`
+           parameter_samples, _, = analysis.sample(N=5000, pre_N=1000)
+           plot_args = {
+               'plot': {
+                   'x': { 'label': r'$|V_{cb}|$' },
+                   'y': { 'label': r'$d\mathcal{B}/dq^2$' }
+               },
+               'contents': [
+                   {
+                       'type': 'histogram',
+                       'data': { 'samples': parameter_samples[:, 0] },
+                   },
+               ]
+           }
+
+        """)
+
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -1291,7 +1291,9 @@ class Plotter:
             if self.level:
                 plevelf = lambda x, pdf, P: pdf[pdf > x * pdf_norm].sum() - P * pdf_norm
                 plevel = scipy.optimize.brentq(plevelf, 0., 1., args=(pdf, self.level / 100.0 ))
-                self.plotter.ax.fill_between(x[pdf >= plevel * pdf_norm], pdf[pdf >= plevel * pdf_norm], facecolor=self.color, alpha=self.alpha)
+                self.plotter.ax.fill_between(np.ma.masked_array(x, mask=pdf < plevel * pdf_norm),
+                                             np.ma.masked_array(pdf, mask=pdf < plevel * pdf_norm, fill_value=np.nan),
+                                             facecolor=self.color, alpha=self.alpha)
 
             plt.plot(x, pdf, color=self.color, label=self.label)
 

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -1187,6 +1187,51 @@ class Plotter:
 
     class KernelDensityEstimate1D(BasePlot):
         """Plots a 1D Kernel Density Estimate (KDE) of pre-existing random samples"""
+
+        _api_doc = inspect.cleandoc("""\
+        Plotting Kernel Density Estimates
+        ---------------------------------
+
+        Contents items of type ``kde`` are used to display a kernel density estimate (a smooth histogram) of samples of a probability density,
+        be it a prior, a posterior, or a signal PDF.
+
+        The following key is mandatory:
+
+         * ``data`` (*dict*, see below) -- The data on the probability density that will be histogramed.
+
+           Within the data object, the following keys are understood.
+
+            * ``samples`` (*list* of *float*) -- The samples that will be histogramed. Mandatory.
+            * ``weights`` or ``log_weights`` (*list* of *float*, optional) -- The weights of the samples, on a linear or logarithmic scale.
+              Defaults to uniform weights.
+
+
+        The following keys are optional:
+
+         * ``bandwidth`` (*float*) -- The factor by which the automatically determined kernel bandwidth is scaled. See the SciPy documentation
+           for ``gaussian_kde``, ``bw_method='silverman'``. Defaults to 1.
+         * ``range`` (*tuple* of two *float*) -- The minimum and maximum value of the x coordinate for which the smooth histogram is plotted.
+
+        Example:
+
+        .. code-block::
+
+           analysis = ... # eos.Analysis object as discussed in the example notebook `inference.ipynb`
+           parameter_samples, _, = analysis.sample(N=5000, pre_N=1000)
+           plot_args = {
+               'plot': {
+                   'x': { 'label': r'$|V_{cb}|$', 'range':[38e-3, 45e-3] }
+               },
+               'contents': [
+                   {
+                       'type': 'kde', 'color': C0, 'label': 'posterior', 'bandwidth': 1,
+                       'range': [40e-3, 45e-3],
+                       'data': { 'samples': parameter_samples[:, 0] }
+                   }
+               ]
+           }
+
+        """)
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -16,6 +16,7 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 import eos
+import inspect
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -161,6 +162,7 @@ class Plotter:
 
     class BasePlot:
         """Base class for any of the plots supported by Plotter"""
+
         def __init__(self, plotter, item):
             self.plotter = plotter
             self.item    = item
@@ -183,6 +185,43 @@ class Plotter:
 
     class Point(BasePlot):
         """Plots a single point"""
+        
+        _api_doc = inspect.cleandoc("""\
+        Plotting Points
+        ---------------
+
+        Content items of type ``point`` are used to display a single data point manually.
+        The following keys are mandatory:
+
+         * ``x`` (*number*) -- The point's x coordinate.
+         * ``y`` (*number*) -- The point's y coordinate.
+
+        Beside the common set of optional keys, this item type recognizes the following optional
+        keys:
+
+         * ``marker`` (*str*, a valid Matplotlib marker style) -- The point's marker style.
+         * ``markersize`` (*number*, a valid Matplotlib marker size) -- The point's marker size in pts.
+
+        Example:
+
+        .. code-block::
+
+           plot_args = {
+               'plot': { ... },
+               'contents': [
+                   {
+                       'label': r'LCSR (Bharucha 2012)',
+                       'type': 'point',
+                       'color': 'C0',
+                       'x': 0,
+                       'y': 0.261,
+                       'marker': 'o',
+                       'markersize': 12
+                   }
+               ]
+           }
+        """)
+
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 
@@ -257,6 +296,45 @@ class Plotter:
 
     class Observable(BasePlot):
         """Plots a single EOS observable w/o uncertainties as a function of one kinemtic variable or one parameter"""
+
+        _api_doc = inspect.cleandoc("""\
+        Plotting Observables
+        --------------------
+
+        Contents items of type ``observable`` are used to display one of the built-in `observables <../observables.html>`_.
+        The following keys are mandatory:
+
+         * ``observable`` (:class:`QualifiedName <eos.QualifiedName>`) -- The name of the observable that will be plotted.
+           Must identify one of the observables known to EOS; see `the complete list of observables <../observables.html>`_.
+         * ``range`` (*list* or *tuple* of two *float*) --The tuple of [minimal, maximal] values of the specified kinematic variable
+           for which the observable will be evaluated.
+
+        Exactly one of the following keys is mandatory, to specify either a kinematic variable or a parameter to which the x coordinate
+        will be mapped:
+
+         * ``variable`` (*str*) -- The name of the kinematic variable to which the x axis will be mapped.
+         * ``kinematic`` (*str*) -- Alias for ``variable``.
+         * ``parameter`` (*str*) -- The name of the parameter to which the x axis will be mapped;
+           see `the complete list of parameters <../parameters.html>`_.
+
+        Example:
+
+        .. code-block::
+
+           plot_args = {
+               'plot': { ... },
+               'contents': [
+                   {
+                       'label': r'$\ell=\mu$',
+                       'type': 'observable',
+                       'observable': 'B->Dlnu::dBR/dq2;l=mu',
+                       'variable': 'q2',
+                       'range': [0.02, 11.60],
+                   },
+               ]
+           }
+        """)
+
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 
@@ -340,7 +418,7 @@ class Plotter:
     class Uncertainty(BasePlot):
         """Plots an uncertainty band as a function of one kinematic variable
 
-This routine expects the uncertainty propagation to have produces an HDF5 file"""
+        This routine expects the uncertainty propagation to have produced an HDF5 file"""
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 
@@ -425,7 +503,7 @@ This routine expects the uncertainty propagation to have produces an HDF5 file""
     class UncertaintyBinned(BasePlot):
         """Plots one or more uncertainty band integrated over one kinematic variable
 
-This routine expects the uncertainty propagation to have produces an HDF5 file"""
+        This routine expects the uncertainty propagation to have produces an HDF5 file"""
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 
@@ -513,7 +591,7 @@ This routine expects the uncertainty propagation to have produces an HDF5 file""
     class UncertaintyOverview(BasePlot):
         """Plots an overview of uncertainty estimates
 
-This routine expects the uncertainty propagation to have produced an HDF5 file"""
+        This routine expects the uncertainty propagation to have produced an HDF5 file"""
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 
@@ -551,6 +629,45 @@ This routine expects the uncertainty propagation to have produced an HDF5 file""
 
     class Constraint(BasePlot):
         """Plots constraints from the EOS library of experimental and theoretical likelihoods"""
+
+        _api_doc = inspect.cleandoc("""\
+        Plotting Constraints
+        --------------------
+
+        Contents items of type ``constraints`` are used to display one of the built-in `experimental or theoretical constraints <../constraints.html>`_.
+        The following keys are mandatory:
+
+         * ``constraints`` (:class:`QualifiedName <eos.QualifiedName>` or iterable thereof) -- The name or the list of names of the constraints
+           that will be plotted. Must identify at least one of the constraints known to EOS; see `the complete list of constraints <../constraints.html>`_.
+         * ``variable`` (*str*) -- The name of the kinematic variable to which the x axis will be mapped.
+
+        When plotting multivariate constraints, the following key is also mandatory:
+
+         * ``observable`` (:class:`QualifiedName <eos.QualifiedName>`) -- The name of the observable whose constraints will be plotted.
+           Must identify one of the observables known to EOS; see `the complete list of observables <../observables.html>`_.
+           This is only mandatory in multivariate constraints, since these can constrain more than one observable simultaneously.
+
+        Example:
+
+        .. code-block::
+
+           plot_args = {
+               'plot': { ... },
+               'contents': [
+                   {
+                       'label': r'Belle 2015 $\ell=e,\, q=d$',
+                       'type': 'constraint',
+                       'color': 'C0',
+                       'constraints': 'B^0->D^+e^-nu::BRs@Belle:2015A',
+                       'observable': 'B->Dlnu::BR',
+                       'variable': 'q2',
+                       'rescale-by-width': False
+                   }
+               ]
+           }
+
+        """)
+
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -419,6 +419,55 @@ class Plotter:
         """Plots an uncertainty band as a function of one kinematic variable
 
         This routine expects the uncertainty propagation to have produced an HDF5 file"""
+
+        _api_doc = inspect.cleandoc("""\
+        Plotting Uncertainty Bands
+        --------------------------
+
+        Contents items of type ``uncertainty`` are used to display uncertainty bands at 68% probability
+        for one of the built-in `observables <../observables.html>`_. This item type requires that either
+        a predictive distribution of the observables has been previously produced.
+
+        Exactly one of the following keys is mandatory:
+
+         * ``data`` (*dict*, see below) -- The data on predictive distribution of the observable whose uncertainty band will be plotted.
+
+         * ``data-file`` (*str*, path to an existing data file of type *eos.data.Prediction*) -- The path to
+           a data file that was generated with the ``eos-analysis`` command-line client.
+
+        For ``data`` object, the following keys are mandatory:
+
+         * ``xvalues`` (*tuple* of *float*) -- The values on the x axis at which the observable has been evaluated.
+         * ``samples`` (*list* of tuples of *float*) -- The list of samples of the predictive distribution. Each tuple of samples
+           corresponds to an evaluation of the observables at the kinematic configuration corresponding to the ``xvalues``
+           entry with the same index.
+
+        Example:
+
+        .. code-block::
+
+           analysis = ... # eos.Analysis object as discussed in the example notebook `predictions.ipynb`
+           mu_q2values = numpy.unique(numpy.concatenate((numpy.linspace(0.02,1.00,20), numpy.linspace(1.00,11.60,20))))
+           mu_obs      = [eos.Observable.make('B->Dlnu::dBR/dq2', prior.parameters,
+                                              eos.Kinematics(q2=q2), eos.Options({'form-factors':'BSZ2015','l':'mu'}))
+                          for q2 in mu_q2values]
+           _, _, mu_samples = analysis.sample(N=5000, pre_N=1000, observables=mu_obs)
+           plot_args = {
+               'plot': {
+                   'x': { 'label': r'$q^2$' },
+                   'y': { 'label': r'$d\mathcal{B}/dq^2$' }
+               },
+               'contents': [
+                   {
+                       'label': r'$\ell=\mu$',
+                       'type': 'uncertainty',
+                       'data': { 'samples': mu_samples, 'xvalues': mu_q2values },
+                       'range': [0.02, 11.60],
+                   },
+               ]
+           }
+        """)
+
         def __init__(self, plotter, item):
             super().__init__(plotter, item)
 

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -123,7 +123,7 @@ def sample_pmc(analysis_file, posterior, base_directory='./', step_N=500, steps=
     """
 
     output_path = os.path.join(base_directory, posterior, 'pmc')
-    _set_log_file(output_path, 'log')
+    _set_log_file(output_path, 'log', mode='a' if continue_sampling else 'w')
     _analysis_file = eos.AnalysisFile(analysis_file)
     analysis = _analysis_file.analysis(posterior)
     rng = _np.random.mtrand.RandomState(1701)

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -97,7 +97,7 @@ def find_clusters(analysis_file, posterior, base_directory='./', threshold=2.0, 
 
 
 # Sample PMC
-def sample_pmc(analysis_file, posterior, base_directory='./', step_N=500, steps=10, final_N=5000):
+def sample_pmc(analysis_file, posterior, base_directory='./', step_N=500, steps=10, final_N=5000, perplexity_threshold=1.0):
     """
     Samples from a named posterior using the Population Monte Carlo (PMC) methods.
 
@@ -116,6 +116,8 @@ def sample_pmc(analysis_file, posterior, base_directory='./', step_N=500, steps=
     :type steps: int > 0, optional
     :param final_N: The number of samples to be stored in the output file. Defaults to 5000,
     :type final_N: int > 0, optional
+    :param perplexity_threshold: The threshold for the perplexity in the last step after which further adaptation steps are to be skipped. Defaults to 1.0.
+    :type perplexity_threshold: 0.0 < float <= 1.0, optional
     """
 
     output_path = os.path.join(base_directory, posterior, 'pmc')
@@ -124,7 +126,8 @@ def sample_pmc(analysis_file, posterior, base_directory='./', step_N=500, steps=
     analysis = _analysis_file.analysis(posterior)
     rng = _np.random.mtrand.RandomState(1701)
     initial_proposal = eos.data.MixtureDensity(os.path.join(base_directory, posterior, 'clusters')).density()
-    samples, weights, proposal = analysis.sample_pmc(initial_proposal, step_N=step_N, steps=steps, final_N=final_N, rng=rng)
+    samples, weights, proposal = analysis.sample_pmc(initial_proposal, step_N=step_N, steps=steps, final_N=final_N,
+                                                     rng=rng, final_perplexity_threshold=perplexity_threshold)
     eos.data.PMCSampler.create(output_path, analysis.varied_parameters, samples, weights, proposal)
 
 

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -118,12 +118,13 @@ def sample_pmc(analysis_file, posterior, base_directory='./', step_N=500, steps=
     :type final_N: int > 0, optional
     """
 
+    output_path = os.path.join(base_directory, posterior, 'pmc')
+    _set_log_file(output_path, 'log')
     _analysis_file = eos.AnalysisFile(analysis_file)
     analysis = _analysis_file.analysis(posterior)
     rng = _np.random.mtrand.RandomState(1701)
     initial_proposal = eos.data.MixtureDensity(os.path.join(base_directory, posterior, 'clusters')).density()
     samples, weights, proposal = analysis.sample_pmc(initial_proposal, step_N=step_N, steps=steps, final_N=final_N, rng=rng)
-    output_path = os.path.join(base_directory, posterior, 'pmc')
     eos.data.PMCSampler.create(output_path, analysis.varied_parameters, samples, weights, proposal)
 
 

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -210,9 +210,9 @@ def run_steps(analysis_file, base_directory='./'):
     _analysis_file.run()
 
 
-def _set_log_file(path, name='log'):
+def _set_log_file(path, name='log', mode='w'):
     os.makedirs(path, exist_ok=True)
     formatter = logging.Formatter('%(asctime)-15s %(name)-5s %(levelname)-8s %(message)s')
-    handler = logging.FileHandler(os.path.join(path, name), mode='w')
+    handler = logging.FileHandler(os.path.join(path, name), mode=mode)
     handler.setFormatter(formatter)
     eos.logger.addHandler(handler)

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -152,6 +152,10 @@ The output file will be stored in EOS_BASE_DIRECTORY/POSTERIOR/pmc.
         help = 'The number of samples to be stored in the output file.',
         dest = 'final_N', action = 'store', type = int, default = 5000
     )
+    parser_sample_pmc.add_argument('-c', '--continue-sampling',
+        help = 'Whether to continue sampling from the previous `sample-pmc` results, or start fresh from the proposal obtained using `find-clusters`.',
+        dest = 'continue_sampling', action = 'store_true', default = False
+    )
     parser_sample_pmc.add_argument('-b', '--base-directory',
         help = 'The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.',
         dest = 'base_directory', action = 'store', default = get_from_env('EOS_BASE_DIRECTORY', './')

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -144,6 +144,10 @@ The output file will be stored in EOS_BASE_DIRECTORY/POSTERIOR/pmc.
         help = 'The number of adaptation steps, which ared used to adapt the PMC proposal to the posterior.',
         dest = 'steps', action = 'store', type = int, default = 10
     )
+    parser_sample_pmc.add_argument('-t', '--perplexity-threshold',
+        help = 'The threshold for the perplexity in the last step after which further adaptation steps are to be skipped.',
+        dest = 'perplexity_threshold', action = 'store', type = float, default = 1.0
+    )
     parser_sample_pmc.add_argument('-N', '--number-of-final-samples',
         help = 'The number of samples to be stored in the output file.',
         dest = 'final_N', action = 'store', type = int, default = 5000


### PR DESCRIPTION
 - tracks @cBobeth's commit from #423, fixing #236 
 - fixes #424 
 - documents all plot types used in the paper except for `histogram2D` and `kde2D`
 - enables the perplexity threshold in the CLI script
 - add means to continue a PMC sampling step, including further adaptations, from an existing `eos.data.PMCSampler` object
