### PR TITLE
Remove Fred's dead email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Authors and Contributors
 The main authors are:
 
  * Danny van Dyk <danny.van.dyk@gmail.com>,
- * Frederik Beaujean <beaujean@mpp.mpg.de>,
+ * Frederik Beaujean,
  * Christoph Bobeth <christoph.bobeth@gmail.com>,
  * Nico Gubernari <nicogubernari@gmail.com>,
  * Meril Reboud <reboud@gmail.com>,


### PR DESCRIPTION
My old MPP account is not active anymore. I don't think a mail address is needed. We could use my github user name instead