### PR TITLE
[github] Add concurrency in the jobs

### DIFF
--- a/.github/workflows/macos-build+check.yaml
+++ b/.github/workflows/macos-build+check.yaml
@@ -6,6 +6,10 @@ on:
 
 name: Build/Check on MacOS
 
+concurrency:
+  group: MacOS, ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
     macos-build-check:
         name: Build on MacOS

--- a/.github/workflows/manylinux-build+check+deploy.yaml
+++ b/.github/workflows/manylinux-build+check+deploy.yaml
@@ -9,6 +9,10 @@ on:
 
 name: Build/Check/Deploy for PyPI
 
+concurrency:
+  group: manylinux, ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
     pypi-build:
         name: Build on manylinux2014

--- a/.github/workflows/ubuntu-build+check+deploy.yaml
+++ b/.github/workflows/ubuntu-build+check+deploy.yaml
@@ -9,6 +9,10 @@ on:
 
 name: Build/Check/Deploy on Ubuntu
 
+concurrency:
+  group: Ubuntu, ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
     ubuntu-build:
         strategy:


### PR DESCRIPTION
When a PR is forced push, the previous workflow is automatically cancelled. This will avoid having queued jobs due to anyway useless failing jobs.