### PR TITLE
Provide a systematic framework to run analysis steps in a reproducible way

### DIFF
--- a/.github/workflows/macos-build+check.yaml
+++ b/.github/workflows/macos-build+check.yaml
@@ -41,7 +41,7 @@ jobs:
                 brew outdated boost-python3 || brew upgrade boost-python3 || true
                 brew install autoconf automake boost-python3 gsl libtool pkg-config yaml-cpp
                 brew link --overwrite --force python@3.9
-                $PYTHON -m pip install -U cython h5py matplotlib numpy "pypmc>=1.2" PyYAML scipy wilson
+                $PYTHON -m pip install -U cython h5py matplotlib networkx numpy "pypmc>=1.2" PyYAML scipy wilson
 
             - name: Create build directory
               shell: bash

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ dnl }}}
 
 dnl {{{ check for compiler requirements
 dnl {{{ check for -std=c++17
-AC_MSG_CHECKING([for C++14 support])
+AC_MSG_CHECKING([for C++17 support])
 CHECK_CXXFLAG([-std=c++17])
 dnl }}}
 dnl {{{ check for braced initializers

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -65,7 +65,7 @@ You might need to install the ``curl`` program first, if not already installed. 
 
 ::
 
-  pip3 install --user --upgrade h5py matplotlib numpy pypmc pyyaml scipy
+  pip3 install --user --upgrade h5py matplotlib networkx numpy pypmc pyyaml scipy
 
 
 *******
@@ -154,17 +154,20 @@ h5py
 matplotlib
   the Python plotting library in version 2.0 or higher;
 
+networkx
+  the Python graph library (needed for some functionality);
+
 scipy
   the Python scientific library;
 
 pypmc
-  the Python library for adaptive importance sampling with Markov Chain and Population Monte Carlo methods;
+  the Python library for adaptive importance sampling with Markov Chain and Population Monte Carlo methods (needed for some functionality);
 
 PyYAML
   the Python YAML parser and emitter library;
 
 wilson
-  the Python library for matching, translating, and running Wilson coefficients in the Weak Effective Theory and the Standard Model Effective Theory.
+  the Python library for matching, translating, and running Wilson coefficients in the Weak Effective Theory and the Standard Model Effective Theory (needed for some functionality).
 
 We recommend you install the above packages via your system's software management system.
 
@@ -186,7 +189,7 @@ by running the following commands:
   # for the 'System Software'
   sudo apt-get install g++ autoconf automake libtool pkg-config libboost-filesystem-dev libboost-system-dev libyaml-cpp-dev
   # for the 'Python Software'
-  sudo apt-get install python3-dev libboost-python-dev python3-h5py python3-matplotlib python3-scipy python3-yaml
+  sudo apt-get install python3-dev libboost-python-dev python3-h5py python3-matplotlib python3-networkx python3-scipy python3-yaml
   # for the 'Scientific Software'
   sudo apt-get install libgsl0-dev
 

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -155,44 +155,134 @@ class AnalysisFile:
             for k, v in params.items()
         }
 
-    def run(self):
+    def steps(self, base_directory=None):
         """Runs predefined analysis steps recorded in the analysis file."""
-        import inspect
-        command_map = {
-            'find-clusters':       eos.find_clusters,
-            'predict-observables': eos.predict_observables,
-            'sample-mcmc':         eos.sample_mcmc,
-            'sample-pmc':          eos.sample_pmc,
-        }
+        from .tasks import _tasks
+        from collections import ChainMap
+        from inspect import signature
+        from itertools import chain, product
+        import networkx as nx
 
-        for idx, step in enumerate(self._steps):
-            if type(step) is not dict:
-                raise ValueError("Step #{} is not a key/value map.")
+        def _expand_arguments(step_name, task, arguments):
+            task_sig = signature(_tasks[task])
 
-            if 'command' not in step:
-                raise ValueError("Step #{} contains no command.")
-
-            command  = step['command']
-            func     = command_map[command]
-            params   = step['parameters'] if 'parameters' in step else {}
-            params   = { params_map[(command, k)]: v for k, v in params.items() }
-            paramstr = ','.join(['{k}={v}'.format(k=k,v=v) for k, v in params])
-
-            func_sig = inspect.signature(func)
-            func_required_args = {}
-            for n, p in func_sig.parameters.items():
-                if p.default() != p.empty():
+            task_required_args = set()
+            for n, p in task_sig.parameters.items():
+                if p.default != p.empty:
                     continue
-                func_required_args += { n }
-            for n in func_required_args:
-                if n in params.keys():
+                task_required_args.add(n)
+            for n in task_required_args:
+                if n in arguments.keys():
                     continue
-                eos.error('Mandatory argument \'{}\' not provided'.format(n))
-                return
+                raise ValueError(f'Task "{task}" in step "{step_name}" requires mandatory argument \'{n}\', which is not provided')
 
-            eos.info('Beginning step #{i}: {cmd}({params})'.format(i=i,cmd=cmd, params=paramstr))
-            func(**params)
-            eos.info('Step #{i} complete'.format(i=i))
+            outer_list = []
+            for key, value in arguments.items():
+                if key not in task_sig.parameters:
+                    eos.warn(f'Task "{task}" in step "{step_name}" does not expect argument "{key}", possibly misspelled?')
+                    continue
+
+                param_type = task_sig.parameters[key].annotation
+
+                # handle special cases
+                if param_type is int:
+                    # integer range?
+                    if type(value) is str:
+                        values = list(chain.from_iterable(range(int(v.split("-")[0]),int(v.split("-")[-1])+1) for v in value.split(",")))
+                        outer_list.append([{key: v} for v in values])
+                    else:
+                        # append
+                        outer_list.append([{key: value}])
+                # otherwise append w/o modification
+                else:
+                    # append
+                    outer_list.append([{key: value}])
+
+            result = []
+            for r in list(product(*outer_list)):
+                _arguments = {}
+                for d in r:
+                    _arguments.update(d)
+
+                # replace format strings
+                arguments = {}
+                for key, value in _arguments.items():
+                    if type(value) is str:
+                        arguments.update({key: value.format(**_arguments)})
+                    else:
+                        arguments.update({key: value})
+
+                result.append(arguments)
+
+            return result
+
+        def _handle_single_step(step_desc, step_arguments):
+            step_name = step_desc['name']
+            tasks     = step_desc['tasks']
+
+            for task_desc in tasks:
+                task = task_desc['task']
+                if task not in _tasks.keys():
+                    raise ValueError(f'Unknown task \"{task}\" encountered in step {step_name}')
+
+                arguments = { 'analysis_file': self }
+                for key, value in step_arguments.items():
+                    if key in _tasks.keys():
+                        continue
+
+                    arguments[key] = value
+
+                if 'arguments' in task_desc:
+                    arguments.update(task_desc['arguments'])
+
+                if task in step_arguments:
+                    arguments.update(step_arguments[task])
+
+                if base_directory:
+                    arguments.update({ 'base_directory': base_directory })
+
+                return [(step_name, step_desc, task, a) for a in _expand_arguments(step_name, task, arguments)]
+
+        # main part starts here
+
+        # check inputs
+        for step_idx, step_desc in enumerate(self._steps):
+            if type(step_desc) is not dict:
+                raise ValueError(f'Description of step #{step_idx} is not a key/value map')
+
+            if 'name' not in step_desc:
+                raise ValueError(f'Description of step #{step_idx} requires a name')
+
+            if 'tasks' not in step_desc:
+                raise ValueError('Description of step #{step_idx} ({step["name"]}) requires a list of tasks')
+
+            if 'iterations' in step_desc:
+                if type(step_desc['iterations']) is not list:
+                    raise ValueError(f'Description of step #{step_idx} ({step["name"]} expects a list of iterations')
+
+        # resolve dependencies
+        graph = nx.MultiDiGraph()
+        graph.add_nodes_from([step['name'] for step in self._steps])
+        for step in self._steps:
+            if not 'depends-on' in step:
+                continue
+
+            for dep in step['depends-on']:
+                graph.add_edge(dep, step['name'])
+        steps = list(nx.topological_sort(graph))
+
+        # return steps and theirs tasks in the order imposed by the dependency graph
+        result = []
+        for step in steps:
+            step_desc = { sd['name']: sd for sd in self._steps }[step]
+            iterations = [{}]
+            if 'iterations' in step_desc:
+                iterations = step_desc['iterations']
+
+            for iteration_arguments in iterations:
+                result.extend(_handle_single_step(step_desc, iteration_arguments))
+
+        return result
 
 
     @property

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -85,7 +85,7 @@ def task(name, output, mode=lambda **kwargs: 'w'):
 
 
 @task('find-mode', '{posterior}/mode-{label}')
-def find_mode(analysis_file, posterior, base_directory='./', optimizations=3, start_point=None, chain=None, seed=None, label='default'):
+def find_mode(analysis_file:str, posterior:str, base_directory:str='./', optimizations:int=3, start_point:list=None, chain:int=None, seed:int=None, label:str='default'):
     '''
     Finds the mode of the named posterior.
 
@@ -184,7 +184,7 @@ def find_mode(analysis_file, posterior, base_directory='./', optimizations=3, st
 
 
 @task('sample-mcmc', '{posterior}/mcmc-{chain:04}')
-def sample_mcmc(analysis_file, posterior, chain, base_directory='./', pre_N=150, preruns=3, N=1000, stride=5, cov_scale=0.1, start_point=None):
+def sample_mcmc(analysis_file:str, posterior:str, chain:int, base_directory:str='./', pre_N:int=150, preruns:int=3, N:int=1000, stride:int=5, cov_scale:float=0.1, start_point:list=None):
     """
     Samples from a named posterior PDF using Markov Chain Monte Carlo (MCMC) methods.
 
@@ -228,7 +228,7 @@ def sample_mcmc(analysis_file, posterior, chain, base_directory='./', pre_N=150,
 
 
 @task('find-clusters', '{posterior}/clusters')
-def find_clusters(posterior, base_directory='./', threshold=2.0, K_g=1, analysis_file=None):
+def find_clusters(posterior:str, base_directory:str='./', threshold:float=2.0, K_g:int=1, analysis_file:str=None):
     """
     Finds clusters among posterior MCMC samples, grouped by Gelman-Rubin R value, and creates a Gaussian mixture density.
 
@@ -263,7 +263,7 @@ def find_clusters(posterior, base_directory='./', threshold=2.0, K_g=1, analysis
 
 
 @task('mixture-product', '{posterior}/product')
-def mixture_product(posterior, posteriors, base_directory='./', analysis_file=None):
+def mixture_product(posterior:str, posteriors:list, base_directory:str='./', analysis_file:str=None):
     """
     Compute the cartesian product of the densities listed in posteriors. Note that this product is not commutative.
 
@@ -285,9 +285,9 @@ def mixture_product(posterior, posteriors, base_directory='./', analysis_file=No
 
 # Sample PMC
 @task('sample-pmc', '{posterior}/pmc', mode=lambda initial_proposal, **kwargs: 'a' if initial_proposal != 'clusters' else 'a')
-def sample_pmc(analysis_file, posterior, base_directory='./', step_N=500, steps=10, final_N=5000,
-               perplexity_threshold=1.0, weight_threshold=1e-10, sigma_test_stat=None, initial_proposal='clusters',
-               pmc_iterations=1, pmc_rel_tol=1e-10, pmc_abs_tol=1e-05, pmc_lookback=1):
+def sample_pmc(analysis_file:str, posterior:str, base_directory:str='./', step_N:int=500, steps:int=10, final_N:int=5000,
+               perplexity_threshold:float=1.0, weight_threshold:float=1e-10, sigma_test_stat:list=None, initial_proposal:str='clusters',
+               pmc_iterations:int=1, pmc_rel_tol:float=1e-10, pmc_abs_tol:float=1e-05, pmc_lookback:int=1):
     """
     Samples from a named posterior using the Population Monte Carlo (PMC) methods.
 
@@ -359,7 +359,7 @@ def sample_pmc(analysis_file, posterior, base_directory='./', step_N=500, steps=
 
 # Predict observables
 @task('predict-observables', '{posterior}/pred-{prediction}')
-def predict_observables(analysis_file, posterior, prediction, base_directory='./', begin=0, end=-1):
+def predict_observables(analysis_file:str, posterior:str, prediction:str, base_directory:str='./', begin:int=0, end:int=-1):
     '''
     Predicts a set of observables based on previously obtained importance samples.
 
@@ -412,7 +412,7 @@ def predict_observables(analysis_file, posterior, prediction, base_directory='./
 
 # Run analysis steps
 @task('run-steps', '')
-def run_steps(analysis_file, base_directory='./'):
+def run_steps(analysis_file:str, base_directory:str='./'):
     """
     Runs a list of predefined steps recorded in the analysis file.
 

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -389,13 +389,17 @@ The output files will be stored in EOS_BASE_DIRECTORY/POSTERIOR/pred-PREDICTION.
         parents = [common_subparser],
         description =
 '''
-Runs a list of subcommands.
+Runs a list of subcommands based on the pre-recorded steps defined within an analysis.
 ''',
         help = 'Runs a list of subcommands.'
     )
     parser_run.add_argument('-b', '--base-directory',
         help = 'The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.',
         dest = 'base_directory', action = 'store', default = get_from_env('EOS_BASE_DIRECTORY', './')
+    )
+    parser_run.add_argument('-d', '--dry-run',
+        help = 'Perform a dry run only. Outputs the list of subcommands that would be run instead of running them.',
+        dest = 'dry_run', action = 'store_true', default = False
     )
     parser_run.set_defaults(cmd = cmd_run)
 
@@ -534,7 +538,7 @@ def cmd_predict_observables(args):
 
 # Run steps
 def cmd_run(args):
-    return eos.run_steps(**args_to_dict(args))
+    return eos.run(**args_to_dict(args))
 
 
 # List priors

--- a/src/scripts/eos-analysis_TEST
+++ b/src/scripts/eos-analysis_TEST
@@ -9,6 +9,16 @@ export EOS_BASE_DIRECTORY=$(mktemp -d)
 echo using PYTHON=${PYTHON} >&2
 echo using PYTHONPATH=${PYTHONPATH} >&2
 
+###########################################
+## Run the Analysis's steps automaticall ##
+###########################################
+echo running analysis steps test ... >&2
+$PYTHON ${SOURCE_DIR}/eos-analysis \
+    run \
+    -f ${SOURCE_DIR}/eos-analysis_TEST.d/analysis.yaml
+echo ... success >&2
+
+
 ###########################
 ## Analysis optimization ##
 ###########################

--- a/src/scripts/eos-analysis_TEST.d/analysis.yaml
+++ b/src/scripts/eos-analysis_TEST.d/analysis.yaml
@@ -79,3 +79,28 @@ predictions:
       - name: B->pilnu::P(q2_min,q2_max)
         kinematics: { 'q2_min': 0.01, 'q2_max': 2.00 }
       - name: B_u->lnu::BR
+
+steps:
+  - name: optimize
+    iterations:
+      - posterior: CKM+FF
+        seed: 123
+    tasks:
+      - task: find-mode
+        arguments:
+          label: 'seed-{seed}'
+
+  - name: sample
+    iterations:
+      - { posterior: CKM+FF }
+    tasks:
+      - task: sample-mcmc
+        arguments:
+          chain: '0,1-2,3'
+          pre_N: 500
+
+      - task: find-clusters
+
+      - task: sample-pmc
+        arguments:
+          step_N: 1000


### PR DESCRIPTION
(addresses discussion #432)

Each ``step`` requires a name, and a list of task descriptions. Optionally, it can provide a list of ``iterations``.
Similar to Github Action's ``strategy.matrix``, a step is run for each element of ``iterations``. In the example below,
the ``sample`` step is run twice: once for the posterior ``CKM-pi``, and once for the posterior ``CKM-rho``.

The example is correctly parsed and interpreted. It currently does not run the tasks. Instead, it prints the equivalent
``eos-analysis`` commands.

```yaml
steps:
  - name: optimize
    iterations:
      - { posterior: CKM-all                                                         }
    tasks:
      - task: sample-mcmc
        arguments:
          posterior: 'CKM-all'
          pre_N: 1000

      - task: find-mode
        arguments:
          posterior: 'CKM-all'


  - name: sample
    iterations:
      - { posterior: CKM-pi                                                          }
      - { posterior: CKM-rho, 'sample-mcmc': { pre_N: 1500, starting_point: 'mode' } }
    tasks:
      - task: sample-mcmc
        arguments:
          chain: 0-1,2
          pre_N: 1000 # overriden for 'CKM-rho' to use 'pre_N': 1500

      - task: find-clusters
```