### PR TITLE
Bump minimum Python version to >=3.7

### DIFF
--- a/.github/workflows/manylinux-build+check+deploy.yaml
+++ b/.github/workflows/manylinux-build+check+deploy.yaml
@@ -20,7 +20,6 @@ jobs:
         strategy:
             matrix:
                 cfg:
-                    - { pypath: cp36-cp36m,  pysuffix: cp36,  pyboostsuffix: 36  }
                     - { pypath: cp37-cp37m,  pysuffix: cp37,  pyboostsuffix: 37  }
                     - { pypath: cp38-cp38,   pysuffix: cp38,  pyboostsuffix: 38  }
                     - { pypath: cp39-cp39,   pysuffix: cp39,  pyboostsuffix: 39  }
@@ -90,7 +89,6 @@ jobs:
         strategy:
             matrix:
                 cfg:
-                    - { pypath: cp36-cp36m,  pysuffix: cp36,  pyboostsuffix: 36  }
                     - { pypath: cp37-cp37m,  pysuffix: cp37,  pyboostsuffix: 37  }
                     - { pypath: cp38-cp38,   pysuffix: cp38,  pyboostsuffix: 38  }
                     - { pypath: cp39-cp39,   pysuffix: cp39,  pyboostsuffix: 39  }
@@ -130,7 +128,6 @@ jobs:
         strategy:
             matrix:
                 cfg:
-                    - { pypath: cp36-cp36m,  pysuffix: cp36,  pyboostsuffix: 36  }
                     - { pypath: cp37-cp37m,  pysuffix: cp37,  pyboostsuffix: 37  }
                     - { pypath: cp38-cp38,   pysuffix: cp38,  pyboostsuffix: 38  }
                     - { pypath: cp39-cp39,   pysuffix: cp39,  pyboostsuffix: 39  }

--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,7 @@ AC_ARG_WITH([boost-python-suffix],
 dnl }}}
 dnl {{{ python checks (you can change the required python version below)
 if test "x$enable_python" == xyes ; then
-	AM_PATH_PYTHON([3.6])
+	AM_PATH_PYTHON([3.7])
 	PY_PREFIX=`$PYTHON -c 'import sys ; print(sys.prefix)'`
 	PYTHON_LIBS="`python$PYTHON_VERSION-config --libs`"
 	if python$PYTHON_VERSION-config --libs --embed 2>&1 > /dev/null ; then


### PR DESCRIPTION
Probably does not need a review. Commits have been extracted from PR #521. Applying them later, due to our main workstations still running Ubuntu 18.04 LTS / Python 3.6.