### PR TITLE
Fix various warnings

### DIFF
--- a/eos/utils/gsl-hacks.cc
+++ b/eos/utils/gsl-hacks.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010 Danny van Dyk
+ * Copyright (c) 2010, 2022 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -68,7 +68,7 @@ namespace eos
 
         void gsl_error_handler_hack()
         {
-            gsl_error_handler_t * previous_gsl_error_handler = gsl_set_error_handler(&gsl_error_handler);
+            gsl_error_handler_t * previous_gsl_error_handler __attribute__ ((unused)) = gsl_set_error_handler(&gsl_error_handler);
         }
     }
 }

--- a/eos/utils/log.cc
+++ b/eos/utils/log.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011 Danny van Dyk
+ * Copyright (c) 2011-2022 Danny van Dyk
  *
  * Based upon 'paludis/util/log.cc', which is
  *
@@ -259,7 +259,7 @@ namespace eos
 
     LogMessageHandler::~LogMessageHandler()
     {
-        if ((! std::uncaught_exception()) && (! _message.empty()))
+        if ((0 == std::uncaught_exceptions()) && (! _message.empty()))
         {
             _log->_message(_id, _log_level, _message);
         }

--- a/eos/utils/memoise.hh
+++ b/eos/utils/memoise.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2013 Danny van Dyk
+ * Copyright (c) 2010, 2011, 2013, 2022 Danny van Dyk
  * Copyright (c) 2010 Christian Wacker
  *
  * This file is part of the EOS project. EOS is free software;
@@ -43,9 +43,9 @@ namespace std
         {
             return *reinterpret_cast<const uint64_t *>(&u);
         }
-        else if (sizeof(U_) == sizeof(uint32_t))
+        else if (sizeof(U_) == sizeof(int32_t))
         {
-            return static_cast<const uint64_t>(*reinterpret_cast<const uint32_t *>(&u));
+            return static_cast<uint64_t>(*reinterpret_cast<const uint32_t *>(&u));
         }
     }
 

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2020 Danny van Dyk
+# Copyright (c) 2020-2022 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -448,24 +448,25 @@ def main():
     parser = _parser()
     args = parser.parse_args()
 
-    if args.verbose > 3:
-        args.verbose = 3
-
-    levels = {
-        0: logging.ERROR,
-        1: logging.WARNING,
-        2: logging.INFO,
-        3: logging.DEBUG
-    }
-
-    logging.basicConfig(level=levels[args.verbose])
-
     if not 'cmd' in args:
         parser.print_help()
     elif not callable(args.cmd):
         parser.print_help()
     else:
+        if args.verbose > 3:
+            args.verbose = 3
+
+        levels = {
+            0: logging.ERROR,
+            1: logging.WARNING,
+            2: logging.INFO,
+            3: logging.DEBUG
+        }
+
+        logging.basicConfig(level=levels[args.verbose])
+
         args.cmd(args)
+
 
 
 def make_analysis_file(args):


### PR DESCRIPTION
 - remove an unnecessary `const` type qualifier
 - replace `std::uncaught_exception` with `std::uncaught_exceptions`
 - mark an unused variable as unused in the GSL hacks
 - only check verbosity in `eos-analysis` if a subcommand is invoked