### PR TITLE
Corner plot and storing nested sampling results

### DIFF
--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -460,6 +460,65 @@ def sample_nested(analysis_file:str, posterior:str, base_directory:str='./', bou
     eos.data.DynestyResults.create(os.path.join(base_directory, posterior, 'dynesty_results'), analysis.varied_parameters, results)
 
 
+# Corner plot
+@task('corner-plot', '{posterior}/plots')
+def corner_plot(analysis_file:str, posterior:str, base_directory:str='./'):
+    """
+    Generates a corner plot of the 1-D and 2-D marginalized posteriors.
+
+    The input files are expected in EOS_BASE_DIRECTORY/POSTERIOR/samples.
+    The output files will be stored in EOS_BASE_DIRECTORY/POSTERIOR/plots.
+
+    :param analysis_file: The name of the analysis file that describes the named posterior, or an object of class `eos.AnalysisFile`.
+    :type analysis_file: str or `eos.AnalysisFile`
+    :param posterior: The name of the posterior.
+    :type posterior: str
+    :param base_directory: The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.
+    :type base_directory: str, optional
+    """
+    analysis = analysis_file.analysis(posterior)
+    p = analysis.varied_parameters
+    f = eos.data.ImportanceSamples(os.path.join(base_directory, posterior, 'samples'))
+    size = f.samples.shape[-1]
+    fig, axes = plt.subplots(size, size, figsize=(3.0 * size, 3.0 * size), dpi=100)
+
+    for i in range(size):
+        # diagonal
+        ax = axes[i, i]
+        samples = f.samples[:, i]
+        xmin = np.min(samples)
+        xmax = np.max(samples)
+        ax.set_xlim((xmin, xmax))
+
+        ax.set_xlabel(p[i].latex())
+        ax.set_ylabel(p[i].latex())
+
+        ax.hist(samples, weights=f.weights, alpha=0.5, bins=100, density=True, stacked=True, color='C1')
+        ax.set_aspect(np.diff((xmin, xmax))[0] / np.diff(ax.get_ylim())[0])
+
+        for j in range(0, size):
+            if j < i:
+                axes[i, j].set_axis_off()
+
+            if j <= i:
+                continue
+
+            ax = axes[i, j]
+            xsamples = f.samples[:, j]
+            ysamples = f.samples[:, i]
+            xmin = np.min(xsamples)
+            xmax = np.max(xsamples)
+            ymin = np.min(ysamples)
+            ymax = np.max(ysamples)
+            ax.set_xlim((xmin, xmax))
+            ax.set_ylim((ymin, ymax))
+            ax.set_aspect(np.diff((xmin, xmax))[0] / np.diff((ymin, ymax))[0])
+            ax.hist2d(xsamples, ysamples, weights=weights, alpha=1.0, bins=100, cmap='Greys')
+
+    fig.tight_layout()
+    fig.savefig(os.path.join(base_directory, posterior, 'plots', 'corner-plot.pdf'))
+
+
 class Executor:
     _factory_methods = {}
 

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -455,9 +455,10 @@ def sample_nested(analysis_file:str, posterior:str, base_directory:str='./', bou
     """
     analysis = analysis_file.analysis(posterior)
     results = analysis.sample_nested(bound=bound, nlive=nlive, dlogz=dlogz, maxiter=maxiter)
-    #samples = map(analysis._x_to_par, results.samples)
-    #weights = _np.exp(results.logwt - results.logz[-1])
+    samples = np.array(list(map(analysis._x_to_par, results.samples)))
+    weights = _np.exp(results.logwt - results.logz[-1])
     eos.data.DynestyResults.create(os.path.join(base_directory, posterior, 'dynesty_results'), analysis.varied_parameters, results)
+    eos.data.ImportanceSamples.create(os.path.join(base_directory, posterior, 'samples'), analysis.varied_parameters, samples, weights)
 
 
 # Corner plot

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -421,6 +421,28 @@ The output files will be stored in EOS_BASE_DIRECTORY/POSTERIOR/pred-PREDICTION.
     parser_predict_observables.set_defaults(cmd = cmd_predict_observables)
 
 
+    # corner-plot
+    parser_corner_plot = subparsers.add_parser('corner_plot',
+        parents = [common_subparser],
+        description =
+'''
+Generate a corner plot of the 1-D and 2-D marginalized posteriors.
+
+The input files are expected in EOS_BASE_DIRECTORY/POSTERIOR/samples.
+The output files will be stored in EOS_BASE_DIRECTORY/POSTERIOR/plots.
+''',
+        help = 'Generate a corner plot of the 1-D and 2-D marginalized posteriors.'
+    )
+    parser_corner_plot.add_argument('posterior', metavar = 'POSTERIOR',
+        help = 'The name of the posterior PDF from which the samples were drawn.'
+    )
+    parser_corner_plot.add_argument('-b', '--base-directory',
+        help = 'The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.',
+        dest = 'base_directory', action = 'store', default = get_from_env('EOS_BASE_DIRECTORY', './')
+    )
+    parser_corner_plot.set_defaults(cmd = cmd_corner_plot)
+
+
     # run
     parser_run = subparsers.add_parser('run',
         parents = [common_subparser],
@@ -567,6 +589,11 @@ def cmd_sample_pmc(args):
 # Nested sampling
 def cmd_sample_nested(args):
     return eos.sample_nested(**args_to_dict(args))
+
+
+# Corner plot
+def cmd_corner_plot(args):
+    return eos.corner_plot(**args_to_dict(args))
 
 
 # Cartesian product


### PR DESCRIPTION
The option to visualize marginalized posteriors using a corner plot as an `eos task` was added. A mistake from the previous implementation of the sample-nested task was corrected, namely the calculation of the samples so that they can be stored using `eos.data.ImportanceSamples`.