### PR TITLE
[b-decays] Fix sign error in [KKvDZ:2022A] and allow for tauon flavour

### DIFF
--- a/eos/b-decays/b-to-3l-nu.cc
+++ b/eos/b-decays/b-to-3l-nu.cc
@@ -130,21 +130,21 @@ namespace eos
             / (9. * k2 * m_B_sq);
             const double f12 = (128 * (2 * power_of<2>(k2) - k2 * m_l_sq - m_l_4) * M_PI * q2
             * (k2 - m_B_sq + q2) * (2 * m_lprime_sq + q2)) / (3. * k2 * m_B_sq);
-            const double f15 = (256 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (- ((k2 - m_l_sq)
+            const double f15 = -(256 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (- ((k2 - m_l_sq)
             * (2 * k2 - m_B_sq + m_l_sq + q2) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2)
             - 2 * k2 * (m_B_sq + q2))) + 2 * k2 * (k2 - m_B_sq) * (k2 - m_B_sq + 2 * m_l_sq + q2)
             * std::atanh(((k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2
             * (m_B_sq + q2)))/(power_of<2>(k2) + m_l_sq * (- m_B_sq + q2) - k2
             * (m_B_sq - m_l_sq + q2))))) / (3. * m_B * (k2 - m_l_sq) * sqrt(power_of<2>(k2)
             + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2)));
-            const double f25 = (- 256 * m_l_sq * M_PI * q2 * (2 * m_lprime_sq + q2)
+            const double f25 = -(- 256 * m_l_sq * M_PI * q2 * (2 * m_lprime_sq + q2)
             * (3 * (k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2
             * (m_B_sq + q2)) + (- 4 * power_of<2>(k2) + 6 * k2 * m_B_sq - 4 * k2 * m_l_sq
             + 2 * m_l_4) * std::atanh(((k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2)
             - 2 * k2 * (m_B_sq + q2)))/(power_of<2>(k2) + m_l_sq * (- m_B_sq + q2) - k2 * (m_B_sq
             - m_l_sq + q2))))) / (3. * m_B * (k2 - m_l_sq) * sqrt(power_of<2>(k2)
             + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2)));
-            const double f35 = (- 128 * m_l_sq * M_PI * q2 * (2 * m_lprime_sq + q2)
+            const double f35 = -(- 128 * m_l_sq * M_PI * q2 * (2 * m_lprime_sq + q2)
             * (- ((k2 - m_l_sq) * (power_of<2>(k2) + k2 * (3 * m_B_sq - 3 * m_l_sq - q2)
             + m_l_sq * (- m_B_sq + q2)) * sqrt(power_of<2>(k2)
             + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2))) + 4 * k2 * (k2 - m_B_sq)
@@ -153,7 +153,7 @@ namespace eos
             * (- m_B_sq + q2) - k2 * (m_B_sq - m_l_sq + q2))))) / (3. * k2 * m_B * (k2 - m_B_sq)
             * (k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2)
             - 2 * k2 * (m_B_sq + q2)));
-            const double f45 = (- 256 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (- ((k2 - m_l_sq)
+            const double f45 = -(- 256 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (- ((k2 - m_l_sq)
             * (k2 - m_B_sq + q2) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2
             * (m_B_sq + q2))) + 2 * k2 * (power_of<2>(k2) + m_B_4 - m_B_sq * q2 + 2 * m_l_sq
             * q2 - k2 * (2 * m_B_sq + q2)) * std::atanh(((k2 - m_l_sq) * sqrt(power_of<2>(k2)
@@ -317,25 +317,25 @@ namespace eos
             + k2 * (4 * m_lprime_sq * (1 + z_w_sq + z_gamma_sq * (1 - 3 * z_w_sq)) + q2 * (3
             - z_w_sq + z_gamma_sq * (- 1 + 3 * z_w_sq))) - (k2 - m_l_sq) * (4 * m_lprime_sq - q2)
             * (- 1 + z_gamma_sq) * (- 1 + z_w_sq) * cos(2 * phi)))) / (std::pow(k2,1.5) * m_B_sq);
-            const double f3c1Re =(- 4 * m_l_sq * (k2 - m_l_sq) * sqrt(q2) * sqrt(k4
+            const double f3c1Re =(4 * m_l_sq * (k2 - m_l_sq) * sqrt(q2) * sqrt(k4
             + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * (2 * sqrt(k2) * sqrt(q2)
             * (- 4 * m_lprime_sq * z_gamma_sq + q2 * (- 1 + z_gamma_sq)) * z_w - (4 * m_lprime_sq
             - q2) * (k2 - m_B_sq + q2) * z_gamma * sqrt(1 - z_gamma_sq)
             * sqrt(1 - z_w_sq) * cos(phi))) / (std::pow(k2,1.5) * m_B_sq);
-            const double f4c1Re = (- 4 * (k2 - m_l_sq) * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            const double f4c1Re = (4 * (k2 - m_l_sq) * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
             * (m_B_sq + q2)) * ((k2 - m_B_sq + q2) * (- 4 * m_lprime_sq * (- 1 + z_gamma_sq) + q2
             * (1 + z_gamma_sq)) * z_w + 2 * sqrt(k2) * sqrt(q2) * (- 4 * m_lprime_sq + q2) * z_gamma
             * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * cos(phi))) / m_B_sq;
-            const double f3c2Re = (- 4 * m_l_sq * (k2 - m_l_sq) * q2 * sqrt(k4 + m_B_sq_q2_diff2
+            const double f3c2Re = (4 * m_l_sq * (k2 - m_l_sq) * q2 * sqrt(k4 + m_B_sq_q2_diff2
             - 2 * k2 * (m_B_sq + q2)) * ((k2 - m_B_sq + q2) * (- 4 * m_lprime_sq * z_gamma_sq + q2
             * (- 1 + z_gamma_sq)) * z_w + 2 * sqrt(k2) * sqrt(q2) * (- 4 * m_lprime_sq + q2)
             * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * cos(phi))) / (k4 * m_B_sq);
-            const double f4c2Re = (- 4 * (k2 - m_l_sq) * sqrt(q2) * sqrt(k4 + m_B_sq_q2_diff2
+            const double f4c2Re = (4 * (k2 - m_l_sq) * sqrt(q2) * sqrt(k4 + m_B_sq_q2_diff2
             - 2 * k2 * (m_B_sq + q2)) * (2 * sqrt(k2) * sqrt(q2) * (- 4 * m_lprime_sq
             * (- 1 + z_gamma_sq) + q2 * (1 + z_gamma_sq)) * z_w - (4 * m_lprime_sq - q2) * (k2
             - m_B_sq + q2) * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * cos(phi)))
             / (sqrt(k2) * m_B_sq);
-            const double f2c1Im = (- 4.0 * (k2 - m_l_sq) * sqrt(q2) * (- 4 * m_lprime_sq + q2) * (k4
+            const double f2c1Im = (4.0 * (k2 - m_l_sq) * sqrt(q2) * (- 4 * m_lprime_sq + q2) * (k4
             + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma * sqrt(1 - z_gamma_sq)
             * sqrt(1 - z_w_sq) * sin(phi)) / (sqrt(k2) * m_B_sq);
             const double f4c1Im = (- 4.0 * m_l_sq_k2_diff2 * (- 4 * m_lprime_sq + q2) * sqrt(k4
@@ -347,161 +347,155 @@ namespace eos
             * sqrt(1 - z_w_sq) * ((k2 - m_B_sq + q2) * z_gamma * z_w + 2 * sqrt(k2) * sqrt(q2)
             * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * cos(phi)) * sin(phi)) / (std::pow(k2,1.5)
             * m_B_sq);
-            const double f4c3Im =(- 4.0 * m_l_sq * (- k2 + m_l_sq) * sqrt(q2) * (- 4 * m_lprime_sq
+            const double f4c3Im =(4.0 * m_l_sq * (- k2 + m_l_sq) * sqrt(q2) * (- 4 * m_lprime_sq
             + q2) * (k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma * sqrt(1 - z_gamma_sq)
             * sqrt(1 - z_w_sq) * sin(phi)) / (std::pow(k2,1.5) * m_B_sq);
-            const double f51Re = (- 8 * m_l_sq * (- k2 + m_l_sq) * (sqrt(q2) * (- 4 * m_lprime_sq
-            + q2) * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * (7 * k6 * z_w - m_l_sq
-            * (m_B_sq - q2) * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - m_B_sq * z_w
-            + q2 * z_w) + k4 * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - 6 * m_B_sq
-            * z_w - 7 * m_l_sq * z_w + 2 * q2 * z_w) - k2 * (- (m_l_sq * sqrt(k4 + m_B_sq_q2_diff2
-            - 2 * k2 * (m_B_sq + q2))) + q2 * sqrt(k4 + m_B_sq_q2_diff2
-            - 2 * k2 * (m_B_sq + q2)) + m_B_4 * z_w + 2 * m_l_sq * q2 * z_w +
-            q4 * z_w + m_B_sq * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - 6 * m_l_sq
-            * z_w - 2 * q2 * z_w))) * cos(phi) + sqrt(k2) * (- 4 * m_B_6 * m_lprime_sq + 4 * m_B_4
-            * m_l_sq * m_lprime_sq - m_B_6 * q2 + m_B_4 * m_l_sq * q2 + 8 * m_B_4 * m_lprime_sq * q2
-             - 4 * m_B_sq * m_l_sq * m_lprime_sq * q2 + 2 * m_B_4 * q4 - m_B_sq * m_l_sq * q4 - 4
-             * m_B_sq * m_lprime_sq * q4 - m_B_sq * q6 + 4 * m_B_6 * m_lprime_sq * z_gamma_sq
-            - 4 * m_B_4 * m_l_sq * m_lprime_sq * z_gamma_sq - m_B_6 * q2 * z_gamma_sq + m_B_4
-            * m_l_sq * q2 * z_gamma_sq - 8 * m_B_4 * m_lprime_sq * q2 * z_gamma_sq + 4 * m_B_sq
-            * m_l_sq * m_lprime_sq * q2 * z_gamma_sq + 2 * m_B_4 * q4 * z_gamma_sq -  m_B_sq
-            * m_l_sq * q4 * z_gamma_sq + 4 * m_B_sq * m_lprime_sq * q4 * z_gamma_sq - m_B_sq * q6
-            * z_gamma_sq + 4 * m_B_4 * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w + m_B_4 * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w - 4 * m_B_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2
-            - 2 * k2 * (m_B_sq + q2)) * z_w - m_B_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w - 2 * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_w - 4 * m_B_4 * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_gamma_sq * z_w + m_B_4 * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_gamma_sq * z_w + 4 * m_B_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2
-            - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 8 * m_l_sq * m_lprime_sq * q2
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - m_B_sq * q4
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * m_l_sq
-            * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 4
-            * m_B_4 * m_l_sq * m_lprime_sq * z_w_sq - m_B_4 * m_l_sq * q2 * z_w_sq + 4 * m_B_sq
-            * m_l_sq * m_lprime_sq * q2 * z_w_sq + 3 * m_B_sq * m_l_sq * q4 * z_w_sq - 2 * m_l_sq
-            * q6 * z_w_sq + 4 * m_B_4 * m_l_sq * m_lprime_sq * z_gamma_sq * z_w_sq - m_B_4 * m_l_sq
-            * q2 * z_gamma_sq * z_w_sq + 4 * m_B_sq * m_l_sq * m_lprime_sq * q2 * z_gamma_sq
-            * z_w_sq - m_B_sq * m_l_sq * q4 * z_gamma_sq * z_w_sq - 8 * m_l_sq * m_lprime_sq * q4
-            * z_gamma_sq * z_w_sq + 2 * m_l_sq * q6 * z_gamma_sq * z_w_sq + k6 * (- 4 * m_lprime_sq
-            * (- 1 + z_gamma_sq) + q2 * (1 + z_gamma_sq)) * z_w_sq + k4 * (4 * m_lprime_sq * q2 + 5
-            * q4 + 12 * m_lprime_sq * q2 * z_gamma_sq - 3 * q4 * z_gamma_sq + 4 * m_lprime_sq
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - 4 * m_lprime_sq * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + q2
+            const double f51Re = (8 * m_l_sq * (-k2 + m_l_sq) * (-(sqrt(q2) * (-4 * m_lprime_sq
+            + q2) * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * (-7 * k6 * z_w + k4
+            * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + 6 * m_B_sq * z_w + 7 * m_l_sq
+            * z_w - 2 * q2 * z_w) - m_l_sq * (m_B_sq - q2) * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) + m_B_sq * z_w - q2 * z_w) + k2 * (m_l_sq * sqrt(k4 + m_B_sq_q2_diff2
+            - 2 * k2 * (m_B_sq + q2)) - q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            + m_B_4 * z_w + 2 * m_l_sq * q2 * z_w + q4 * z_w - m_B_sq * (sqrt(k4 + m_B_sq_q2_diff2
+            - 2 * k2 * (m_B_sq + q2)) + 6 * m_l_sq * z_w + 2 * q2 * z_w))) * cos(phi)) + sqrt(k2)
+            * (-4 * m_B_6 * m_lprime_sq + 4 * m_B_4 * m_l_sq * m_lprime_sq - m_B_6 * q2 + m_B_4
+            * m_l_sq * q2 + 8 * m_B_4 * m_lprime_sq * q2 - 4 * m_B_sq * m_l_sq * m_lprime_sq * q2
+            + 2 * m_B_4 * q4 - m_B_sq * m_l_sq * q4 - 4 * m_B_sq * m_lprime_sq * q4 - m_B_sq * q6 +
+            4 * m_B_6 * m_lprime_sq * z_gamma_sq - 4 * m_B_4 * m_l_sq * m_lprime_sq * z_gamma_sq
+            - m_B_6 * q2 * z_gamma_sq + m_B_4 * m_l_sq * q2 * z_gamma_sq - 8 * m_B_4 * m_lprime_sq
+            * q2 * z_gamma_sq + 4 * m_B_sq * m_l_sq * m_lprime_sq * q2 * z_gamma_sq + 2 * m_B_4
+            * q4 * z_gamma_sq - m_B_sq * m_l_sq * q4 * z_gamma_sq + 4 * m_B_sq * m_lprime_sq * q4
+            * z_gamma_sq - m_B_sq * q6 * z_gamma_sq - 4 * m_B_4 * m_lprime_sq
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - m_B_4 * q2 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 4 * m_B_sq * m_lprime_sq * q2
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + m_B_sq * q4
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 2 * m_l_sq * q4
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 4 * m_B_4 * m_lprime_sq
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - m_B_4 * q2
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 4 * m_B_sq
+            * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq
+            * z_w + 8 * m_l_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_gamma_sq * z_w + m_B_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_gamma_sq * z_w - 2 * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w - 4 * m_B_4 * m_l_sq * m_lprime_sq * z_w_sq - m_B_4
+            * m_l_sq * q2 * z_w_sq + 4 * m_B_sq * m_l_sq * m_lprime_sq * q2 * z_w_sq + 3 * m_B_sq
+            * m_l_sq * q4 * z_w_sq - 2 * m_l_sq * q6 * z_w_sq + 4 * m_B_4 * m_l_sq * m_lprime_sq
+            * z_gamma_sq * z_w_sq - m_B_4 * m_l_sq * q2 * z_gamma_sq * z_w_sq + 4 * m_B_sq * m_l_sq
+            * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - m_B_sq * m_l_sq * q4 * z_gamma_sq * z_w_sq -
+            8 * m_l_sq * m_lprime_sq * q4 * z_gamma_sq * z_w_sq + 2 * m_l_sq * q6 * z_gamma_sq
+            * z_w_sq + k6 * (-4 * m_lprime_sq * (-1 + z_gamma_sq) + q2 * (1 + z_gamma_sq)) * z_w_sq
+            + k4 * (4 * m_lprime_sq * q2 + 5 * q4 + 12 * m_lprime_sq * q2 * z_gamma_sq - 3 * q4
+            * z_gamma_sq - 4 * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_w - q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 4 * m_lprime_sq
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - q2
             * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 4
             * m_lprime_sq * q2 * z_w_sq - 5 * q4 * z_w_sq - 28 * m_lprime_sq * q2 * z_gamma_sq
-            * z_w_sq + 7 * q4 * z_gamma_sq * z_w_sq + m_l_sq * (4 * m_lprime_sq * (- 1 + z_gamma_sq)
-            - q2 * (1 + z_gamma_sq)) * (- 1 + z_w_sq) + m_B_sq * (4 * m_lprime_sq * (- 1
-            + z_gamma_sq) - q2 * (1 + z_gamma_sq)) * (1 + 2 * z_w_sq)) + k2 * (- (m_B_4 * (4
-            * m_lprime_sq * (- 1 + z_gamma_sq) - q2 * (1 + z_gamma_sq)) * (2 + z_w_sq)) - m_B_sq
-            * (12 * m_lprime_sq * q2 + 7 * q4 + 4 * m_lprime_sq * q2 * z_gamma_sq - q4 * z_gamma_sq
-            + 8 * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 2 * q2
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - 8 * m_lprime_sq * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 4 * m_lprime_sq * q2
-            * z_w_sq + 3 * q4 * z_w_sq + 4 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - q4
-            * z_gamma_sq * z_w_sq + 2 * m_l_sq * (4 * m_lprime_sq * (- 1 + z_gamma_sq) - q2
-            * (1 + z_gamma_sq)) * (- 1 + z_w_sq)) + q2 * (4 * m_lprime_sq * q2 + q4 - 4
-            * m_lprime_sq * q2 * z_gamma_sq + q4 * z_gamma_sq + 4 * m_lprime_sq
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 3 * q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 4 * m_lprime_sq * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * q4 * z_w_sq + 8
-            * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - 2 * q4 * z_gamma_sq * z_w_sq + m_l_sq
-            * (q2 * (1 + 5 * z_w_sq + z_gamma_sq * (1 - 7 * z_w_sq)) + 4 * m_lprime_sq
-            * (1 - z_w_sq + z_gamma_sq * (- 1 + 7 * z_w_sq))))) - (k2 - m_B_sq) * (k2 - m_l_sq)
-            * (4 * m_lprime_sq - q2) * (k2 - m_B_sq + q2) * (- 1 + z_gamma_sq) * (- 1 + z_w_sq)
-            * cos(2 * phi)))) / (sqrt(k2) * m_B * (k2 - m_B_sq) * (k4 + m_l_sq * (- m_B_sq + q2
-            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) - k2 * (m_B_sq - m_l_sq
-            + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
-            const double f52Re = (8 * m_l_sq * (- k2 + m_l_sq) * sqrt(q2) * (sqrt(k2)
-            * (4 * m_lprime_sq - q2) * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * (m_B_4
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - m_B_sq * q2 * sqrt(k4
+            * z_w_sq + 7 * q4 * z_gamma_sq * z_w_sq + m_l_sq * (4 * m_lprime_sq * (-1 + z_gamma_sq)
+            - q2 * (1 + z_gamma_sq)) * (-1 + z_w_sq) + m_B_sq * (4 * m_lprime_sq * (-1 + z_gamma_sq)
+            - q2 * (1 + z_gamma_sq)) * (1 + 2 * z_w_sq)) + k2 * (-(m_B_4 * (4 * m_lprime_sq
+            * (-1 + z_gamma_sq) - q2 * (1 + z_gamma_sq)) * (2 + z_w_sq)) + m_B_sq * (-2 * m_l_sq
+            * (4 * m_lprime_sq * (-1 + z_gamma_sq) - q2 * (1 + z_gamma_sq)) * (-1 + z_w_sq) +
+            q2 * (2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * (1 + z_gamma_sq) * z_w
+            + q2 * (-7 - 3 * z_w_sq + z_gamma_sq * (1 + z_w_sq))) - 4 * m_lprime_sq * (2 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * (-1 + z_gamma_sq) * z_w + q2 * (3 + z_w_sq
+            + z_gamma_sq * (1 + z_w_sq)))) + q2 * (4 * m_lprime_sq * q2 + q4 - 4 * m_lprime_sq * q2
+            * z_gamma_sq + q4 * z_gamma_sq - 4 * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_w - 3 * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_w - 4 * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_gamma_sq * z_w + q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_gamma_sq * z_w + 2 * q4 * z_w_sq + 8 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - 2
+            * q4 * z_gamma_sq * z_w_sq + m_l_sq * (q2 * (1 + 5 * z_w_sq + z_gamma_sq * (1 - 7
+            * z_w_sq)) + 4 * m_lprime_sq * (1 - z_w_sq + z_gamma_sq * (-1 + 7 * z_w_sq))))) - (k2
+            - m_B_sq) * (k2 - m_l_sq) * (4 * m_lprime_sq - q2) * (k2 - m_B_sq + q2) * (-1
+            + z_gamma_sq) * (-1 + z_w_sq) * cos(2 * phi))))/(sqrt(k2) * m_B * (k2 - m_B_sq)
+            * (k4 - m_l_sq * (m_B_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_w) + k2 * (-m_B_sq + m_l_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_w)));
+            const double f52Re = (-8 * m_l_sq * (-k2 + m_l_sq) * sqrt(q2) * (sqrt(k2) * (-4
+            * m_lprime_sq + q2) * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) *
+            (m_B_4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - m_B_sq * q2 * sqrt(k4
             + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + 2 * m_l_sq * q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + 2 * k6 * z_w - 2 * m_B_4 * m_l_sq * z_w
-            + 2 * m_l_sq * q4 * z_w + k4 * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            - 4 * m_B_sq * z_w - 2 * m_l_sq * z_w + 8 * q2 * z_w) - k2 * (- 2 * m_B_4 * z_w + 2
-            * m_B_sq * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - 2 * m_l_sq * z_w) + q2
-            * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + 8 * m_l_sq * z_w + 2 * q2
-            * z_w))) * cos(phi) + sqrt(q2) * (m_l_sq * (m_B_sq - q2) * (- 4 * m_lprime_sq
-            * z_gamma_sq + q2 * (- 1 + z_gamma_sq)) * z_w * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) - m_B_sq * z_w + q2 * z_w) + k6 * (q2 * (- 2 + z_w_sq + z_gamma_sq
-            * (2 - 5 * z_w_sq)) + 4 * m_lprime_sq * (- 2 * z_w_sq + z_gamma_sq * (- 2 + 5
-            * z_w_sq))) - k4 * (8 * m_l_sq * m_lprime_sq + 2 * m_l_sq * q2 + 8 * m_lprime_sq * q2
-            + 4 * q4 - 8 * m_l_sq * m_lprime_sq * z_gamma_sq + 2 * m_l_sq * q2 * z_gamma_sq + 8
-            * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 3 * q2
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - 2 * k6 * z_w + 2 * m_B_4 * m_l_sq * z_w
+            - 2 * m_l_sq * q4 * z_w + k4 * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            + 4 * m_B_sq * z_w + 2 * m_l_sq * z_w - 8 * q2 * z_w) - k2 * (2 * m_B_4 * z_w + 2
+            * m_B_sq * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + 2 * m_l_sq * z_w) +
+            q2 * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - 8 * m_l_sq * z_w - 2 * q2
+            * z_w))) * cos(phi) + sqrt(q2) * (-(m_l_sq * (m_B_sq - q2) * (-4 * m_lprime_sq
+            * z_gamma_sq + q2 * (-1 + z_gamma_sq)) * z_w * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) + m_B_sq * z_w - q2 * z_w)) + k6 * (q2 * (-2 + z_w_sq + z_gamma_sq
+            * (2 - 5 * z_w_sq)) + 4 * m_lprime_sq * (-2 * z_w_sq + z_gamma_sq * (-2 + 5 * z_w_sq)))
+            + k4 * (-8 * m_l_sq * m_lprime_sq - 2 * m_l_sq * q2 - 8 * m_lprime_sq * q2 - 4 * q4 + 8
+            * m_l_sq * m_lprime_sq * z_gamma_sq - 2 * m_l_sq * q2 * z_gamma_sq +
+            8 * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 3 * q2
             * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - 4 * m_lprime_sq * sqrt(k4
             + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 8 * m_l_sq
-            * m_lprime_sq * z_w_sq + m_l_sq * q2 * z_w_sq - 2 * q4 * z_w_sq
-            + 20 * m_l_sq * m_lprime_sq * z_gamma_sq * z_w_sq - 5 * m_l_sq * q2 * z_gamma_sq
-            * z_w_sq - 8 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq + 2 * q4 * z_gamma_sq * z_w_sq
-            + 2 * m_B_sq * (q2 * (- 3 + z_gamma_sq * (1 - 2 * z_w_sq)) + m_lprime_sq * (- 4 * (1
-            + z_w_sq) + z_gamma_sq * (- 4 + 8 * z_w_sq)))) + k2 * ((- 4 * m_lprime_sq * z_gamma_sq
-            + q2 * (- 1 + z_gamma_sq)) * z_w * (- (m_l_sq * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) - 2 * q2 * z_w)) + q2 * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) + q2 * z_w)) - m_B_4 * (4 * m_lprime_sq * (2 + z_gamma_sq * z_w_sq) + q2 * (4
-            - (- 1 + z_gamma_sq) * z_w_sq)) + m_B_sq * (8 * m_lprime_sq * q2 + 4 * q4 + 8
-            * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 3 * q2
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - 4 * m_lprime_sq * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * q4 * z_w_sq + 8
-            * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - 2 * q4 * z_gamma_sq * z_w_sq + 2 * m_l_sq
-            * (q2 + q2 * z_gamma_sq * (1 - 2 * z_w_sq) + m_lprime_sq * (4 - 4 * z_w_sq + z_gamma_sq
-            * (- 4 + 8 * z_w_sq))))) + 2 * k2 * (k2 - m_B_sq) * (k2 - m_l_sq) * (4 * m_lprime_sq
-            - q2) * (- 1 + z_gamma_sq) * (- 1 + z_w_sq) * cos(2 * phi)))) / (k2 * m_B * (k2
-            - m_B_sq) * (k4 + m_l_sq * (- m_B_sq + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w) - k2 * (m_B_sq - m_l_sq + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2
-            * k2 * (m_B_sq + q2)) * z_w)));
-            const double f53Re = (- 8 * m_l_sq * (- k2 + m_l_sq) * sqrt(q2) * (- (sqrt(q2)
-            * (- 4 * m_lprime_sq * z_gamma_sq + q2 * (- 1 + z_gamma_sq)) * (k6 - m_l_sq
-            * (m_B_sq - q2) * (m_B_sq - q2 - sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_w) - k4 * (2 * m_B_sq + m_l_sq + 2 * q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w) + k2 * (m_B_4 + 2 * m_l_sq * q2 + q4 + 3 * m_l_sq * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + m_B_sq * (2 * m_l_sq - 2 * q2 - 3
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)))) + sqrt(k2) * (k2
-            - m_B_sq) * (k2 + m_B_sq - 2 * m_l_sq - q2) * (- 4 * m_lprime_sq + q2) * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1
-            - z_w_sq) * cos(phi))) / (k2 * m_B * (k2 - m_B_sq) * (k4 + m_l_sq * (- m_B_sq + q2
-            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) - k2 * (m_B_sq - m_l_sq
-            + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
-            const double f54Re = (8 * m_l_sq * (- k2 + m_l_sq) * ((4 * m_lprime_sq * (- 1
-            + z_gamma_sq) - q2 * (1 + z_gamma_sq)) * (k4 + (m_B_sq - q2) * (m_B_sq - q2 - sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) + k2 * (- 2 * m_B_sq - 2 * q2
-            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)) - 2 * sqrt(k2) * sqrt(q2)
-            * (- 4 * m_lprime_sq + q2) * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * cos(phi))) / (m_B * (- k4 + m_l_sq
-            * (m_B_sq - q2 - sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)
-            + k2 * (m_B_sq - m_l_sq + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 8 * m_l_sq
+            * m_lprime_sq * z_w_sq - m_l_sq * q2 * z_w_sq + 2 * q4 * z_w_sq - 20 * m_l_sq
+            * m_lprime_sq * z_gamma_sq * z_w_sq + 5 * m_l_sq * q2 * z_gamma_sq * z_w_sq + 8
+            * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - 2 * q4 * z_gamma_sq * z_w_sq + m_B_sq * (8
+            * m_lprime_sq * (1 + z_w_sq + z_gamma_sq * (1 - 2 * z_w_sq)) + 2 * q2 * (3 + z_gamma_sq
+            * (-1 + 2 * z_w_sq)))) - k2 * (-((-4 * m_lprime_sq * z_gamma_sq + q2 * (-1
+            + z_gamma_sq)) * z_w * (q2 * (-sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + q2
+            * z_w) + m_l_sq * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + 2 * q2 * z_w)))
+            + m_B_4 * (4 * m_lprime_sq * (2 + z_gamma_sq * z_w_sq) + q2 * (4 - (-1 + z_gamma_sq)
+            * z_w_sq)) + m_B_sq * (-8 * m_lprime_sq * q2 - 4 * q4 + 8 * m_lprime_sq * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 3 * q2 * sqrt(k4 + m_B_sq_q2_diff2
+            - 2 * k2 * (m_B_sq + q2)) * z_w - 4 * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w + q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_gamma_sq * z_w - 2 * q4 * z_w_sq - 8 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq
+            + 2 * q4 * z_gamma_sq * z_w_sq - 2 * m_l_sq * (q2 + q2 * z_gamma_sq * (1 - 2 * z_w_sq)
+            + m_lprime_sq * (4 - 4 * z_w_sq + z_gamma_sq * (-4 + 8 * z_w_sq))))) + 2 * k2 * (k2
+            - m_B_sq) * (k2 - m_l_sq) * (4 * m_lprime_sq - q2) * (-1 + z_gamma_sq) * (-1 + z_w_sq)
+            * cos(2 * phi))))/(k2 * m_B * (k2 - m_B_sq) * (k4 - m_l_sq * (m_B_sq - q2 + sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) + k2 * (-m_B_sq + m_l_sq - q2
+            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
+            const double f53Re = (8 * m_l_sq * (-k2 + m_l_sq) * sqrt(q2) * (-(sqrt(q2) * (-4
+            * m_lprime_sq * z_gamma_sq + q2 * (-1 + z_gamma_sq)) * (k6 - k4 * (2 * m_B_sq + m_l_sq
+            + 2 * q2 - sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) -
+            m_l_sq * (m_B_sq - q2) * (m_B_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_w) + k2 * (m_B_4 + 2 * m_l_sq * q2 + q4 - 3 * m_l_sq * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2
+            * k2 * (m_B_sq + q2)) * z_w + m_B_sq * (2 * m_l_sq - 2 * q2 + 3 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)))) - sqrt(k2) * (k2 - m_B_sq)
+            * (k2 + m_B_sq - 2 * m_l_sq - q2) * (-4 * m_lprime_sq + q2) * sqrt(k4 + m_B_sq_q2_diff2
+            - 2 * k2 * (m_B_sq + q2)) * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq)
+            * cos(phi)))/(k2 * m_B * (k2 - m_B_sq) * (k4 - m_l_sq * (m_B_sq - q2 + sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) + k2 * (-m_B_sq + m_l_sq - q2
+            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
+            const double f54Re = (-8 * m_l_sq * (-k2 + m_l_sq) * ((4 * m_lprime_sq * (-1
+            + z_gamma_sq) - q2 * (1 + z_gamma_sq)) * (k4 + (m_B_sq - q2) * (m_B_sq - q2 + sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) - k2 * (2 * m_B_sq + 2 * q2
+            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)) + 2 * sqrt(k2) * sqrt(q2)
+            * (-4 * m_lprime_sq + q2) * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_gamma * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * cos(phi)))/(m_B * (-k4 + k2
+            * (m_B_sq - m_l_sq + q2 - sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) +
+            m_l_sq * (m_B_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
+            const double f52Im = (-8.0 * m_l_sq * (k2 - m_l_sq) * sqrt(q2) * (-4 * m_lprime_sq + q2)
+            * (k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma * sqrt(1 - z_gamma_sq)
+            * sqrt(1 - z_w_sq) * sin(phi))/(sqrt(k2) * m_B * (k4 - m_l_sq * (m_B_sq - q2 + sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) + k2 * (-m_B_sq + m_l_sq - q2
+            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
+            const double f53Im = (-8.0 * m_l_sq * (-k2 + m_l_sq) * sqrt(q2) * (-4
+            * m_lprime_sq + q2) * (k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma
+            * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * sin(phi))/(sqrt(k2) * m_B * (k4 - m_l_sq
+            * (m_B_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) + k2
+            * (-m_B_sq + m_l_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
+            const double f54Im = (8.0 * m_l_sq * m_l_sq_k2_diff2 * (-4 * m_lprime_sq + q2) * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) *
+            (sqrt(q2) * z_gamma * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + 3 * k2
+            * z_w + m_B_sq * z_w - q2 * z_w) + 2 * sqrt(k2) * (k2 - m_B_sq) * sqrt(1 - z_gamma_sq)
+            * sqrt(1 - z_w_sq) * cos(phi)) * sin(phi))/(sqrt(k2) * m_B * (k2 - m_B_sq) * (k4
+            - m_l_sq * (m_B_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)
+            + k2 * (-m_B_sq + m_l_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
             * z_w)));
-            const double f52Im  = (- 8.0 * m_l_sq * (k2 - m_l_sq) * sqrt(q2) * (- 4 * m_lprime_sq
-            + q2) * (k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma * sqrt(1 - z_gamma_sq)
-            * sqrt(1 - z_w_sq) * sin(phi)) / (sqrt(k2) * m_B * (k4 + m_l_sq * (- m_B_sq + q2
-            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) - k2 * (m_B_sq - m_l_sq
-            + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
-            const double f53Im = (- 8.0 * m_l_sq * (- k2 + m_l_sq) * sqrt(q2) * (- 4 * m_lprime_sq
-            + q2) * (k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma * sqrt(1 - z_gamma_sq)
-            * sqrt(1 - z_w_sq) * sin(phi)) / (sqrt(k2) * m_B * (k4 + m_l_sq * (- m_B_sq + q2
-            + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w) - k2 * (m_B_sq - m_l_sq
-            + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
-            const double f54Im = (8.0 * m_l_sq * m_l_sq_k2_diff2 * (- 4 * m_lprime_sq + q2)
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * sqrt(1 - z_gamma_sq)
-            * sqrt(1 - z_w_sq) * (sqrt(q2) * z_gamma * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) - 3 * k2 * z_w - m_B_sq * z_w + q2 * z_w) - 2 * sqrt(k2) * (k2 - m_B_sq)
-            * sqrt(1 - z_gamma_sq) * sqrt(1 - z_w_sq) * cos(phi)) * sin(phi)) / (sqrt(k2) * m_B
-            * (k2 - m_B_sq) * (k4 + m_l_sq * (- m_B_sq + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w) - k2 * (m_B_sq - m_l_sq + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2
-            * k2 * (m_B_sq + q2)) * z_w)));
             const double f55 = (8 * m_l_sq * (k2 - m_l_sq) * (4 * k10 * m_lprime_sq - 8 * k8
-            * m_B_sq * m_lprime_sq + 8 * k6 * m_B_4 * m_lprime_sq - 8 * k4 * m_B_6 * m_lprime_sq + 4
-            * k2 * m_B_8 * m_lprime_sq - 4 * k8 * m_l_sq * m_lprime_sq - 8 * k6 * m_B_sq * m_l_sq
+            * m_B_sq * m_lprime_sq + 8 * k6 * m_B_4 * m_lprime_sq - 8 * k4 * m_B_6 * m_lprime_sq +
+            4 * k2 * m_B_8 * m_lprime_sq - 4 * k8 * m_l_sq * m_lprime_sq - 8 * k6 * m_B_sq * m_l_sq
             * m_lprime_sq + 32 * k4 * m_B_4 * m_l_sq * m_lprime_sq - 24 * k2 * m_B_6 * m_l_sq
-            * m_lprime_sq + 4 * m_B_8 * m_l_sq * m_lprime_sq + 8 * k6 * m_l_4 * m_lprime_sq
-            - 16 * k4 * m_B_sq * m_l_4 * m_lprime_sq + 8 * k2 * m_B_4 * m_l_4 * m_lprime_sq + k10
-            * q2 - 2 * k8 * m_B_sq * q2 + 2 * k6 * m_B_4 * q2 - 2 * k4 * m_B_6 * q2 + k2 * m_B_8
-            * q2 - k8 * m_l_sq * q2 - 2 * k6 * m_B_sq * m_l_sq * q2 + 8 * k4 * m_B_4 * m_l_sq * q2
+            * m_lprime_sq + 4 * m_B_8 * m_l_sq * m_lprime_sq + 8 * k6 * m_l_4 * m_lprime_sq - 16
+            * k4 * m_B_sq * m_l_4 * m_lprime_sq + 8 * k2 * m_B_4 * m_l_4 * m_lprime_sq + k10 * q2
+            - 2 * k8 * m_B_sq * q2 + 2 * k6 * m_B_4 * q2 - 2 * k4 * m_B_6 * q2 + k2 * m_B_8 * q2
+            - k8 * m_l_sq * q2 - 2 * k6 * m_B_sq * m_l_sq * q2 + 8 * k4 * m_B_4 * m_l_sq * q2
             - 6 * k2 * m_B_6 * m_l_sq * q2 + m_B_8 * m_l_sq * q2 + 2 * k6 * m_l_4 * q2 - 4 * k4
             * m_B_sq * m_l_4 * q2 + 2 * k2 * m_B_4 * m_l_4 * q2 - 8 * k8 * m_lprime_sq * q2 + 8 * k6
             * m_B_sq * m_lprime_sq * q2 + 8 * k4 * m_B_4 * m_lprime_sq * q2 - 8 * k2 * m_B_6
@@ -514,182 +508,184 @@ namespace eos
             * m_lprime_sq * q4 + 4 * k4 * m_l_sq * m_lprime_sq * q4 - 8 * k2 * m_B_sq * m_l_sq
             * m_lprime_sq * q4 + 4 * m_B_4 * m_l_sq * m_lprime_sq * q4 - k6 * q6 - 4 * k4 * m_B_sq
             * q6 + k2 * m_B_4 * q6 + 5 * k4 * m_l_sq * q6 + 2 * k2 * m_B_sq * m_l_sq * q6 + m_B_4
-            * m_l_sq * q6 - 2 * k2 * m_l_4 * q6 - 2 * m_B_sq * m_l_4 * q6 + k4 * q8
-            - 2 * k2 * m_l_sq * q8 + m_l_4 * q8 - 4 * k10 * m_lprime_sq * z_gamma_sq + 8 * k8
-            * m_B_sq * m_lprime_sq * z_gamma_sq - 8 * k6 * m_B_4 * m_lprime_sq * z_gamma_sq + 8 * k4
-            * m_B_6 * m_lprime_sq * z_gamma_sq - 4 * k2 * m_B_8 * m_lprime_sq * z_gamma_sq + 4 * k8
-            * m_l_sq * m_lprime_sq * z_gamma_sq + 8 * k6 * m_B_sq * m_l_sq * m_lprime_sq
+            * m_l_sq * q6 - 2 * k2 * m_l_4 * q6 - 2 * m_B_sq * m_l_4 * q6 + k4 * q8 - 2 * k2
+            * m_l_sq * q8 + m_l_4 * q8 - 4 * k10 * m_lprime_sq * z_gamma_sq + 8 * k8 * m_B_sq
+            * m_lprime_sq * z_gamma_sq - 8 * k6 * m_B_4 * m_lprime_sq * z_gamma_sq +
+            8 * k4 * m_B_6 * m_lprime_sq * z_gamma_sq - 4 * k2 * m_B_8 * m_lprime_sq * z_gamma_sq
+            + 4 * k8 * m_l_sq * m_lprime_sq * z_gamma_sq + 8 * k6 * m_B_sq * m_l_sq * m_lprime_sq
             * z_gamma_sq - 32 * k4 * m_B_4 * m_l_sq * m_lprime_sq * z_gamma_sq + 24 * k2 * m_B_6
             * m_l_sq * m_lprime_sq * z_gamma_sq - 4 * m_B_8 * m_l_sq * m_lprime_sq * z_gamma_sq
             - 8 * k6 * m_l_4 * m_lprime_sq * z_gamma_sq + 16 * k4 * m_B_sq * m_l_4 * m_lprime_sq
             * z_gamma_sq - 8 * k2 * m_B_4 * m_l_4 * m_lprime_sq * z_gamma_sq + k10 * q2 * z_gamma_sq
             - 2 * k8 * m_B_sq * q2 * z_gamma_sq + 2 * k6 * m_B_4 * q2 * z_gamma_sq - 2 * k4 * m_B_6
             * q2 * z_gamma_sq + k2 * m_B_8 * q2 * z_gamma_sq - k8 * m_l_sq * q2 * z_gamma_sq - 2
-            * k6 * m_B_sq * m_l_sq * q2 * z_gamma_sq + 8 * k4 * m_B_4 * m_l_sq * q2 * z_gamma_sq - 6
-            * k2 * m_B_6 * m_l_sq * q2 * z_gamma_sq + m_B_8 * m_l_sq * q2 * z_gamma_sq + 2 * k6
-            * m_l_4 * q2 * z_gamma_sq - 4 * k4 * m_B_sq * m_l_4 * q2 * z_gamma_sq + 2 * k2 * m_B_4
-            * m_l_4 * q2 * z_gamma_sq + 12 * k8 * m_lprime_sq * q2 * z_gamma_sq - 16 * k6 * m_B_sq
-            * m_lprime_sq * q2 * z_gamma_sq - 4 * k4 * m_B_4 * m_lprime_sq * q2 * z_gamma_sq + 8
-            * k2 * m_B_6 * m_lprime_sq * q2 * z_gamma_sq + 8 * k4 * m_B_sq * m_l_sq * m_lprime_sq
-            * q2 * z_gamma_sq - 16 * k2 * m_B_4 * m_l_sq * m_lprime_sq * q2 * z_gamma_sq + 8 * m_B_6
-            * m_l_sq * m_lprime_sq * q2 * z_gamma_sq + 4 * k4 * m_l_4 * m_lprime_sq * q2
-            * z_gamma_sq - 8 * k2 * m_B_sq * m_l_4 * m_lprime_sq * q2 * z_gamma_sq + 4 * m_B_4
-            * m_l_4 * m_lprime_sq * q2 * z_gamma_sq - 3 * k8 * q4 * z_gamma_sq + 4 * k6 * m_B_sq
-            * q4 * z_gamma_sq + k4 * m_B_4 * q4 * z_gamma_sq - 2 * k2 * m_B_6 * q4 * z_gamma_sq - 2
-            * k4 * m_B_sq * m_l_sq * q4 * z_gamma_sq + 4 * k2 * m_B_4 * m_l_sq * q4 * z_gamma_sq - 2
-            * m_B_6 * m_l_sq * q4 * z_gamma_sq - k4 * m_l_4 * q4 * z_gamma_sq + 2 * k2 * m_B_sq
-            * m_l_4 * q4 * z_gamma_sq - m_B_4 * m_l_4 * q4 * z_gamma_sq - 12 * k6 * m_lprime_sq * q4
-            * z_gamma_sq - 4 * k2 * m_B_4 * m_lprime_sq * q4 * z_gamma_sq + 12 * k4 * m_l_sq
-            * m_lprime_sq * q4 * z_gamma_sq + 24 * k2 * m_B_sq * m_l_sq * m_lprime_sq * q4
-            * z_gamma_sq - 4 * m_B_4 * m_l_sq * m_lprime_sq * q4 * z_gamma_sq - 8 * k2 * m_l_4
-            * m_lprime_sq * q4 * z_gamma_sq - 8 * m_B_sq * m_l_4 * m_lprime_sq * q4 * z_gamma_sq + 3
-            * k6 * q6 * z_gamma_sq + k2 * m_B_4 * q6 * z_gamma_sq - 3 * k4 * m_l_sq * q6
-            * z_gamma_sq - 6 * k2 * m_B_sq * m_l_sq * q6 * z_gamma_sq + m_B_4 * m_l_sq * q6
-            * z_gamma_sq + 2 * k2 * m_l_4 * q6 * z_gamma_sq + 2 * m_B_sq * m_l_4 * q6 * z_gamma_sq
-            + 4 * k4 * m_lprime_sq * q6 * z_gamma_sq - 8 * k2 * m_l_sq * m_lprime_sq * q6
-            * z_gamma_sq + 4 * m_l_4 * m_lprime_sq * q6 * z_gamma_sq - k4 * q8 * z_gamma_sq
-            + 2 * k2 * m_l_sq * q8 * z_gamma_sq - m_l_4 * q8 * z_gamma_sq + 8 * k6 * m_l_sq
-            * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - 24 * k4
-            * m_B_sq * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_w + 24 * k2 * m_B_4 * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w - 8 * m_B_6 * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2
-            - 2 * k2 * (m_B_sq + q2)) * z_w + 2 * k6 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2
-            - 2 * k2 * (m_B_sq + q2)) * z_w - 6 * k4 * m_B_sq * m_l_sq * q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 6 * k2 * m_B_4 * m_l_sq * q2
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - 2 * m_B_6 * m_l_sq * q2
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 8 * k4 * m_l_sq
-            * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - 16 * k2
-            * m_B_sq * m_l_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_w + 8 * m_B_4 * m_l_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2
-            * k2 * (m_B_sq + q2)) * z_w - 2 * k6 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_w - 6 * k4 * m_B_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_w + 10 * k4 * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_w + 4 * k2 * m_B_sq * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w + 2 * m_B_4 * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w - 6 * k2 * m_l_4 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w - 2 * m_B_sq * m_l_4 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_w + 2 * k4 * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_w - 4 * k2 * m_l_sq * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_w + 2 * m_l_4 * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_w - 8 * k6 * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2)) * z_gamma_sq * z_w + 24 * k4 * m_B_sq * m_l_sq * m_lprime_sq * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 24 * k2 * m_B_4
-            * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_gamma_sq * z_w + 8 * m_B_6 * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2
-            * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * k6 * m_l_sq * q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 6 * k4 * m_B_sq
-            * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w
-            + 6 * k2 * m_B_4 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_gamma_sq * z_w - 2 * m_B_6 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_gamma_sq * z_w - 8 * k6 * m_lprime_sq * q2 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 24 * k4 * m_B_sq
+            * k6 * m_B_sq * m_l_sq * q2 * z_gamma_sq + 8 * k4 * m_B_4 * m_l_sq * q2 * z_gamma_sq -
+            6 * k2 * m_B_6 * m_l_sq * q2 * z_gamma_sq + m_B_8 * m_l_sq * q2 * z_gamma_sq + 2 * k6
+            * m_l_4 * q2 * z_gamma_sq - 4 * k4 * m_B_sq * m_l_4 * q2 * z_gamma_sq +
+            2 * k2 * m_B_4 * m_l_4 * q2 * z_gamma_sq + 12 * k8 * m_lprime_sq * q2 * z_gamma_sq - 16
+            * k6 * m_B_sq * m_lprime_sq * q2 * z_gamma_sq - 4 * k4 * m_B_4 * m_lprime_sq * q2
+            * z_gamma_sq + 8 * k2 * m_B_6 * m_lprime_sq * q2 * z_gamma_sq + 8 * k4 * m_B_sq * m_l_sq
+            * m_lprime_sq * q2 * z_gamma_sq - 16 * k2 * m_B_4 * m_l_sq * m_lprime_sq * q2
+            * z_gamma_sq + 8 * m_B_6 * m_l_sq * m_lprime_sq * q2 * z_gamma_sq + 4 * k4 * m_l_4
+            * m_lprime_sq * q2 * z_gamma_sq - 8 * k2 * m_B_sq * m_l_4 * m_lprime_sq * q2
+            * z_gamma_sq + 4 * m_B_4 * m_l_4 * m_lprime_sq * q2 * z_gamma_sq - 3 * k8 * q4
+            * z_gamma_sq + 4 * k6 * m_B_sq * q4 * z_gamma_sq + k4 * m_B_4 * q4 * z_gamma_sq -
+            2 * k2 * m_B_6 * q4 * z_gamma_sq - 2 * k4 * m_B_sq * m_l_sq * q4 * z_gamma_sq + 4 * k2
+            * m_B_4 * m_l_sq * q4 * z_gamma_sq - 2 * m_B_6 * m_l_sq * q4 * z_gamma_sq -
+            k4 * m_l_4 * q4 * z_gamma_sq + 2 * k2 * m_B_sq * m_l_4 * q4 * z_gamma_sq - m_B_4 * m_l_4
+            * q4 * z_gamma_sq - 12 * k6 * m_lprime_sq * q4 * z_gamma_sq - 4 * k2 * m_B_4
+            * m_lprime_sq * q4 * z_gamma_sq + 12 * k4 * m_l_sq * m_lprime_sq * q4 * z_gamma_sq + 24
+            * k2 * m_B_sq * m_l_sq * m_lprime_sq * q4 * z_gamma_sq - 4 * m_B_4 * m_l_sq
+            * m_lprime_sq * q4 * z_gamma_sq - 8 * k2 * m_l_4 * m_lprime_sq * q4 * z_gamma_sq - 8
+            * m_B_sq * m_l_4 * m_lprime_sq * q4 * z_gamma_sq + 3 * k6 * q6 * z_gamma_sq + k2 * m_B_4
+            * q6 * z_gamma_sq - 3 * k4 * m_l_sq * q6 * z_gamma_sq - 6 * k2 * m_B_sq * m_l_sq * q6
+            * z_gamma_sq + m_B_4 * m_l_sq * q6 * z_gamma_sq + 2 * k2 * m_l_4 * q6 * z_gamma_sq + 2
+            * m_B_sq * m_l_4 * q6 * z_gamma_sq + 4 * k4 * m_lprime_sq * q6 * z_gamma_sq - 8 * k2
+            * m_l_sq * m_lprime_sq * q6 * z_gamma_sq + 4 * m_l_4 * m_lprime_sq * q6 * z_gamma_sq
+            - k4 * q8 * z_gamma_sq + 2 * k2 * m_l_sq * q8 * z_gamma_sq - m_l_4 * q8 * z_gamma_sq
+            - 8 * k6 * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_w + 24 * k4 * m_B_sq * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_w - 24 * k2 * m_B_4 * m_l_sq * m_lprime_sq * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 8 * m_B_6 * m_l_sq * m_lprime_sq
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w -
+            2 * k6 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w +
+            6 * k4 * m_B_sq * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_w - 6 * k2 * m_B_4 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_w + 2 * m_B_6 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_w - 8 * k4 * m_l_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_w + 16 * k2 * m_B_sq * m_l_sq * m_lprime_sq * q2 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w - 8 * m_B_4 * m_l_sq * m_lprime_sq
+            * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w +
+            2 * k6 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w +
+            6 * k4 * m_B_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w -
+            10 * k4 * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w -
+            4 * k2 * m_B_sq * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_w - 2 * m_B_4 * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_w + 6 * k2 * m_l_4 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w
+            + 2 * m_B_sq * m_l_4 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w -
+            2 * k4 * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w + 4 * k2
+            * m_l_sq * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w -
+            2 * m_l_4 * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w +
+            8 * k6 * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_gamma_sq * z_w - 24 * k4 * m_B_sq * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2
+            - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 24 * k2 * m_B_4 * m_l_sq * m_lprime_sq
+            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w -
+            8 * m_B_6 * m_l_sq * m_lprime_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_gamma_sq * z_w - 2 * k6 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w + 6 * k4 * m_B_sq * m_l_sq * q2 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w -
+            6 * k2 * m_B_4 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_gamma_sq * z_w + 2 * m_B_6 * m_l_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w + 8 * k6 * m_lprime_sq * q2 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w +
+            24 * k4 * m_B_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_gamma_sq * z_w - 24 * k4 * m_l_sq * m_lprime_sq * q2 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w -
+            48 * k2 * m_B_sq * m_l_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w + 8 * m_B_4 * m_l_sq * m_lprime_sq * q2 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 24 * k2 * m_l_4
             * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq
-            * z_w + 24 * k4 * m_l_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_gamma_sq * z_w + 48 * k2 * m_B_sq * m_l_sq * m_lprime_sq * q2
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 8 * m_B_4
-            * m_l_sq * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_gamma_sq * z_w - 24 * k2 * m_l_4 * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2
-            * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 8 * m_B_sq * m_l_4 * m_lprime_sq * q2
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * k6 * q4
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 6 * k4
-            * m_B_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w
-            - 6 * k4 * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_gamma_sq * z_w - 12 * k2 * m_B_sq * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
-            * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * m_B_4 * m_l_sq * q4 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 6 * k2 * m_l_4 * q4
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * m_B_sq
-            * m_l_4 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w
-            + 8 * k4 * m_lprime_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_gamma_sq * z_w - 16 * k2 * m_l_sq * m_lprime_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2
-            - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 8 * m_l_4 * m_lprime_sq * q4 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 2 * k4 * q6 * sqrt(k4
-            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 4 * k2 * m_l_sq * q6
-            * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 2 * m_l_4
-            * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 4 * k10
-            * m_lprime_sq * z_w_sq + 8 * k8 * m_B_sq * m_lprime_sq * z_w_sq - 8 * k6 * m_B_4
-            * m_lprime_sq * z_w_sq + 8 * k4 * m_B_6 * m_lprime_sq * z_w_sq - 4 * k2 * m_B_8
-            * m_lprime_sq * z_w_sq + 12 * k8 * m_l_sq * m_lprime_sq * z_w_sq - 24 * k6 * m_B_sq
-            * m_l_sq * m_lprime_sq * z_w_sq + 16 * k4 * m_B_4 * m_l_sq * m_lprime_sq * z_w_sq - 8
-            * k2 * m_B_6 * m_l_sq * m_lprime_sq * z_w_sq + 4 * m_B_8 * m_l_sq * m_lprime_sq * z_w_sq
-            - 8 * k6 * m_l_4 * m_lprime_sq * z_w_sq + 16 * k4 * m_B_sq * m_l_4 * m_lprime_sq
-            * z_w_sq - 8 * k2 * m_B_4 * m_l_4 * m_lprime_sq * z_w_sq - k10 * q2 * z_w_sq + 2 * k8
-            * m_B_sq * q2 * z_w_sq - 2 * k6 * m_B_4 * q2 * z_w_sq + 2 * k4 * m_B_6 * q2 * z_w_sq
-            - k2 * m_B_8 * q2 * z_w_sq + 3 * k8 * m_l_sq * q2 * z_w_sq - 6 * k6 * m_B_sq * m_l_sq
-            * q2 * z_w_sq + 4 * k4 * m_B_4 * m_l_sq * q2 * z_w_sq - 2 * k2 * m_B_6 * m_l_sq * q2
-            * z_w_sq + m_B_8 * m_l_sq * q2 * z_w_sq - 2 * k6 * m_l_4 * q2 * z_w_sq + 4 * k4 * m_B_sq
-            * m_l_4 * q2 * z_w_sq - 2 * k2 * m_B_4 * m_l_4 * q2 * z_w_sq + 8 * k8 * m_lprime_sq
-            * q2 * z_w_sq - 8 * k6 * m_B_sq * m_lprime_sq * q2 * z_w_sq - 8 * k4 * m_B_4
-            * m_lprime_sq * q2 * z_w_sq + 8 * k2 * m_B_6 * m_lprime_sq * q2 * z_w_sq - 8 * k6
-            * m_l_sq * m_lprime_sq * q2 * z_w_sq + 8 * k4 * m_B_sq * m_l_sq * m_lprime_sq * q2
-            * z_w_sq + 8 * k2 * m_B_4 * m_l_sq * m_lprime_sq * q2 * z_w_sq - 8 * m_B_6 * m_l_sq
-            * m_lprime_sq * q2 * z_w_sq + 3 * k8 * q4 * z_w_sq + 4 * k6 * m_B_sq * q4 * z_w_sq + 7
-            * k4 * m_B_4 * q4 * z_w_sq + 2 * k2 * m_B_6 * q4 * z_w_sq - 12 * k6 * m_l_sq * q4
-            * z_w_sq - 10 * k4 * m_B_sq * m_l_sq * q4 * z_w_sq - 8 * k2 * m_B_4 * m_l_sq * q4
-            * z_w_sq - 2 * m_B_6 * m_l_sq * q4 * z_w_sq + 9 * k4 * m_l_4 * q4 * z_w_sq + 6 * k2
-            * m_B_sq * m_l_4 * q4 * z_w_sq + m_B_4 * m_l_4 * q4 * z_w_sq - 4 * k6 * m_lprime_sq * q4
-            * z_w_sq + 8 * k4 * m_B_sq * m_lprime_sq * q4 * z_w_sq - 4 * k2 * m_B_4 * m_lprime_sq
-            * q4 * z_w_sq + 4 * k4 * m_l_sq * m_lprime_sq * q4 * z_w_sq - 8 * k2 * m_B_sq * m_l_sq
-            * m_lprime_sq * q4 * z_w_sq + 4 * m_B_4 * m_l_sq * m_lprime_sq * q4 * z_w_sq - 3 * k6
-            * q6 * z_w_sq - 4 * k4 * m_B_sq * q6 * z_w_sq - k2 * m_B_4 * q6 * z_w_sq + 9 * k4
-            * m_l_sq * q6 * z_w_sq + 6 * k2 * m_B_sq * m_l_sq * q6 * z_w_sq + m_B_4 * m_l_sq * q6
-            * z_w_sq - 6 * k2 * m_l_4 * q6 * z_w_sq - 2 * m_B_sq * m_l_4 * q6 * z_w_sq + k4 * q8
-            * z_w_sq - 2 * k2 * m_l_sq * q8 * z_w_sq + m_l_4 * q8 * z_w_sq + 4 * k10 * m_lprime_sq
-            * z_gamma_sq * z_w_sq - 8 * k8 * m_B_sq * m_lprime_sq * z_gamma_sq * z_w_sq + 8 * k6
-            * m_B_4 * m_lprime_sq * z_gamma_sq * z_w_sq - 8 * k4 * m_B_6 * m_lprime_sq * z_gamma_sq
-            * z_w_sq + 4 * k2 * m_B_8 * m_lprime_sq * z_gamma_sq * z_w_sq - 12 * k8 * m_l_sq
-            * m_lprime_sq * z_gamma_sq * z_w_sq + 24 * k6 * m_B_sq * m_l_sq * m_lprime_sq
-            * z_gamma_sq * z_w_sq - 16 * k4 * m_B_4 * m_l_sq * m_lprime_sq * z_gamma_sq * z_w_sq + 8
-            * k2 * m_B_6 * m_l_sq * m_lprime_sq * z_gamma_sq * z_w_sq - 4 * m_B_8 * m_l_sq
-            * m_lprime_sq * z_gamma_sq * z_w_sq + 8 * k6 * m_l_4 * m_lprime_sq * z_gamma_sq * z_w_sq
-            - 16 * k4 * m_B_sq * m_l_4 * m_lprime_sq * z_gamma_sq * z_w_sq + 8 * k2 * m_B_4 * m_l_4
-            * m_lprime_sq * z_gamma_sq * z_w_sq - k10 * q2 * z_gamma_sq * z_w_sq + 2 * k8 * m_B_sq
-            * q2 * z_gamma_sq * z_w_sq - 2 * k6 * m_B_4 * q2 * z_gamma_sq * z_w_sq + 2 * k4 * m_B_6
-            * q2 * z_gamma_sq * z_w_sq - k2 * m_B_8 * q2 * z_gamma_sq * z_w_sq + 3 * k8 * m_l_sq
-            * q2 * z_gamma_sq * z_w_sq - 6 * k6 * m_B_sq * m_l_sq * q2 * z_gamma_sq * z_w_sq + 4
-            * k4 * m_B_4 * m_l_sq * q2 * z_gamma_sq * z_w_sq - 2 * k2 * m_B_6 * m_l_sq * q2
-            * z_gamma_sq * z_w_sq + m_B_8 * m_l_sq * q2 * z_gamma_sq * z_w_sq - 2 * k6 * m_l_4 * q2
-            * z_gamma_sq * z_w_sq + 4 * k4 * m_B_sq * m_l_4 * q2 * z_gamma_sq * z_w_sq - 2 * k2
-            * m_B_4 * m_l_4 * q2 * z_gamma_sq * z_w_sq - 4 * k8 * m_lprime_sq * q2 * z_gamma_sq
-            * z_w_sq + 32 * k6 * m_B_sq * m_lprime_sq * q2 * z_gamma_sq * z_w_sq + 44 * k4 * m_B_4
+            * z_w + 8 * m_B_sq * m_l_4 * m_lprime_sq * q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w - 2 * k6 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w - 6 * k4 * m_B_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2
+            - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 6 * k4 * m_l_sq * q4 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 12 * k2 * m_B_sq
+            * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w -
+            2 * m_B_4 * m_l_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            * z_gamma_sq * z_w - 6 * k2 * m_l_4 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_gamma_sq * z_w - 2 * m_B_sq * m_l_4 * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w - 8 * k4 * m_lprime_sq * q4 * sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w + 16 * k2 * m_l_sq
+            * m_lprime_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_gamma_sq
+            * z_w - 8 * m_l_4 * m_lprime_sq * q4 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_gamma_sq * z_w + 2 * k4 * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
+            + q2)) * z_gamma_sq * z_w - 4 * k2 * m_l_sq * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) * z_gamma_sq * z_w + 2 * m_l_4 * q6 * sqrt(k4 + m_B_sq_q2_diff2 - 2
+            * k2 * (m_B_sq + q2)) * z_gamma_sq * z_w - 4 * k10 * m_lprime_sq * z_w_sq + 8 * k8
+            * m_B_sq * m_lprime_sq * z_w_sq - 8 * k6 * m_B_4 * m_lprime_sq * z_w_sq + 8 * k4 * m_B_6
+            * m_lprime_sq * z_w_sq - 4 * k2 * m_B_8 * m_lprime_sq * z_w_sq + 12 * k8 * m_l_sq
+            * m_lprime_sq * z_w_sq - 24 * k6 * m_B_sq * m_l_sq * m_lprime_sq * z_w_sq + 16 * k4
+            * m_B_4 * m_l_sq * m_lprime_sq * z_w_sq - 8 * k2 * m_B_6 * m_l_sq * m_lprime_sq * z_w_sq
+            + 4 * m_B_8 * m_l_sq * m_lprime_sq * z_w_sq - 8 * k6 * m_l_4 * m_lprime_sq * z_w_sq + 16
+            * k4 * m_B_sq * m_l_4 * m_lprime_sq * z_w_sq - 8 * k2 * m_B_4 * m_l_4 * m_lprime_sq
+            * z_w_sq - k10 * q2 * z_w_sq + 2 * k8 * m_B_sq * q2 * z_w_sq - 2 * k6 * m_B_4 * q2
+            * z_w_sq + 2 * k4 * m_B_6 * q2 * z_w_sq - k2 * m_B_8 * q2 * z_w_sq + 3 * k8 * m_l_sq
+            * q2 * z_w_sq - 6 * k6 * m_B_sq * m_l_sq * q2 * z_w_sq + 4 * k4 * m_B_4 * m_l_sq * q2
+            * z_w_sq - 2 * k2 * m_B_6 * m_l_sq * q2 * z_w_sq + m_B_8 * m_l_sq * q2 * z_w_sq - 2 * k6
+            * m_l_4 * q2 * z_w_sq + 4 * k4 * m_B_sq * m_l_4 * q2 * z_w_sq - 2 * k2 * m_B_4 * m_l_4
+            * q2 * z_w_sq + 8 * k8 * m_lprime_sq * q2 * z_w_sq - 8 * k6 * m_B_sq * m_lprime_sq * q2
+            * z_w_sq - 8 * k4 * m_B_4 * m_lprime_sq * q2 * z_w_sq + 8 * k2 * m_B_6 * m_lprime_sq
+            * q2 * z_w_sq - 8 * k6 * m_l_sq * m_lprime_sq * q2 * z_w_sq + 8 * k4 * m_B_sq * m_l_sq
+            * m_lprime_sq * q2 * z_w_sq + 8 * k2 * m_B_4 * m_l_sq * m_lprime_sq * q2 * z_w_sq - 8
+            * m_B_6 * m_l_sq * m_lprime_sq * q2 * z_w_sq + 3 * k8 * q4 * z_w_sq + 4 * k6 * m_B_sq
+            * q4 * z_w_sq + 7 * k4 * m_B_4 * q4 * z_w_sq + 2 * k2 * m_B_6 * q4 * z_w_sq - 12 * k6
+            * m_l_sq * q4 * z_w_sq - 10 * k4 * m_B_sq * m_l_sq * q4 * z_w_sq -
+            8 * k2 * m_B_4 * m_l_sq * q4 * z_w_sq - 2 * m_B_6 * m_l_sq * q4 * z_w_sq + 9 * k4
+            * m_l_4 * q4 * z_w_sq + 6 * k2 * m_B_sq * m_l_4 * q4 * z_w_sq + m_B_4 * m_l_4 * q4
+            * z_w_sq - 4 * k6 * m_lprime_sq * q4 * z_w_sq + 8 * k4 * m_B_sq * m_lprime_sq * q4
+            * z_w_sq - 4 * k2 * m_B_4 * m_lprime_sq * q4 * z_w_sq + 4 * k4 * m_l_sq * m_lprime_sq
+            * q4 * z_w_sq - 8 * k2 * m_B_sq * m_l_sq * m_lprime_sq * q4 * z_w_sq +
+            4 * m_B_4 * m_l_sq * m_lprime_sq * q4 * z_w_sq - 3 * k6 * q6 * z_w_sq - 4 * k4 * m_B_sq
+            * q6 * z_w_sq - k2 * m_B_4 * q6 * z_w_sq + 9 * k4 * m_l_sq * q6 * z_w_sq + 6 * k2
+            * m_B_sq * m_l_sq * q6 * z_w_sq + m_B_4 * m_l_sq * q6 * z_w_sq - 6 * k2 * m_l_4 * q6
+            * z_w_sq - 2 * m_B_sq * m_l_4 * q6 * z_w_sq + k4 * q8 * z_w_sq - 2 * k2 * m_l_sq * q8
+            * z_w_sq + m_l_4 * q8 * z_w_sq + 4 * k10 * m_lprime_sq * z_gamma_sq * z_w_sq - 8 * k8
+            * m_B_sq * m_lprime_sq * z_gamma_sq * z_w_sq + 8 * k6 * m_B_4 * m_lprime_sq * z_gamma_sq
+            * z_w_sq - 8 * k4 * m_B_6 * m_lprime_sq * z_gamma_sq * z_w_sq + 4 * k2 * m_B_8
+            * m_lprime_sq * z_gamma_sq * z_w_sq - 12 * k8 * m_l_sq * m_lprime_sq * z_gamma_sq
+            * z_w_sq + 24 * k6 * m_B_sq * m_l_sq * m_lprime_sq * z_gamma_sq * z_w_sq - 16 * k4
+            * m_B_4 * m_l_sq * m_lprime_sq * z_gamma_sq * z_w_sq + 8 * k2 * m_B_6 * m_l_sq
+            * m_lprime_sq * z_gamma_sq * z_w_sq - 4 * m_B_8 * m_l_sq * m_lprime_sq * z_gamma_sq
+            * z_w_sq + 8 * k6 * m_l_4 * m_lprime_sq * z_gamma_sq * z_w_sq - 16 * k4 * m_B_sq
+            * m_l_4 * m_lprime_sq * z_gamma_sq * z_w_sq + 8 * k2 * m_B_4 * m_l_4 * m_lprime_sq
+            * z_gamma_sq * z_w_sq - k10 * q2 * z_gamma_sq * z_w_sq + 2 * k8 * m_B_sq * q2
+            * z_gamma_sq * z_w_sq - 2 * k6 * m_B_4 * q2 * z_gamma_sq * z_w_sq + 2 * k4 * m_B_6 * q2
+            * z_gamma_sq * z_w_sq - k2 * m_B_8 * q2 * z_gamma_sq * z_w_sq + 3 * k8 * m_l_sq * q2
+            * z_gamma_sq * z_w_sq - 6 * k6 * m_B_sq * m_l_sq * q2 * z_gamma_sq * z_w_sq + 4 * k4
+            * m_B_4 * m_l_sq * q2 * z_gamma_sq * z_w_sq - 2 * k2 * m_B_6 * m_l_sq * q2 * z_gamma_sq
+            * z_w_sq + m_B_8 * m_l_sq * q2 * z_gamma_sq * z_w_sq - 2 * k6 * m_l_4 * q2 * z_gamma_sq
+            * z_w_sq + 4 * k4 * m_B_sq * m_l_4 * q2 * z_gamma_sq * z_w_sq - 2 * k2 * m_B_4 * m_l_4
+            * q2 * z_gamma_sq * z_w_sq - 4 * k8 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq +
+            32 * k6 * m_B_sq * m_lprime_sq * q2 * z_gamma_sq * z_w_sq + 44 * k4 * m_B_4
             * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - 8 * k2 * m_B_6 * m_lprime_sq * q2
             * z_gamma_sq * z_w_sq - 32 * k6 * m_l_sq * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - 56
             * k4 * m_B_sq * m_l_sq * m_lprime_sq * q2 * z_gamma_sq * z_w_sq - 48 * k2 * m_B_4
             * m_l_sq * m_lprime_sq * q2 * z_gamma_sq * z_w_sq + 8 * m_B_6 * m_l_sq * m_lprime_sq
-            * q2 * z_gamma_sq * z_w_sq + 36 * k4 * m_l_4 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq
-            + 24 * k2 * m_B_sq * m_l_4 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq + 4 * m_B_4 * m_l_4
-            * m_lprime_sq * q2 * z_gamma_sq * z_w_sq + k8 * q4 * z_gamma_sq * z_w_sq - 8 * k6
-            * m_B_sq * q4 * z_gamma_sq * z_w_sq - 11 * k4 * m_B_4 * q4 * z_gamma_sq * z_w_sq + 2
-            * k2 * m_B_6 * q4 * z_gamma_sq * z_w_sq + 8 * k6 * m_l_sq * q4 * z_gamma_sq * z_w_sq
+            * q2 * z_gamma_sq * z_w_sq + 36 * k4 * m_l_4 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq +
+            24 * k2 * m_B_sq * m_l_4 * m_lprime_sq * q2 * z_gamma_sq * z_w_sq + 4 * m_B_4 * m_l_4
+            * m_lprime_sq * q2 * z_gamma_sq * z_w_sq + k8 * q4 * z_gamma_sq * z_w_sq -
+            8 * k6 * m_B_sq * q4 * z_gamma_sq * z_w_sq - 11 * k4 * m_B_4 * q4 * z_gamma_sq * z_w_sq
+            + 2 * k2 * m_B_6 * q4 * z_gamma_sq * z_w_sq + 8 * k6 * m_l_sq * q4 * z_gamma_sq * z_w_sq
             + 14 * k4 * m_B_sq * m_l_sq * q4 * z_gamma_sq * z_w_sq + 12 * k2 * m_B_4 * m_l_sq * q4
             * z_gamma_sq * z_w_sq - 2 * m_B_6 * m_l_sq * q4 * z_gamma_sq * z_w_sq - 9 * k4 * m_l_4
-            * q4 * z_gamma_sq * z_w_sq - 6 * k2 * m_B_sq * m_l_4 * q4 * z_gamma_sq * z_w_sq - m_B_4
-            * m_l_4 * q4 * z_gamma_sq * z_w_sq - 4 * k6 * m_lprime_sq * q4 * z_gamma_sq * z_w_sq
-            - 32 * k4 * m_B_sq * m_lprime_sq * q4 * z_gamma_sq * z_w_sq + 4 * k2 * m_B_4
+            * q4 * z_gamma_sq * z_w_sq - 6 * k2 * m_B_sq * m_l_4 * q4 * z_gamma_sq * z_w_sq -
+            m_B_4 * m_l_4 * q4 * z_gamma_sq * z_w_sq - 4 * k6 * m_lprime_sq * q4 * z_gamma_sq
+            * z_w_sq - 32 * k4 * m_B_sq * m_lprime_sq * q4 * z_gamma_sq * z_w_sq + 4 * k2 * m_B_4
             * m_lprime_sq * q4 * z_gamma_sq * z_w_sq + 28 * k4 * m_l_sq * m_lprime_sq * q4
             * z_gamma_sq * z_w_sq + 40 * k2 * m_B_sq * m_l_sq * m_lprime_sq * q4 * z_gamma_sq
-            * z_w_sq - 4 * m_B_4 * m_l_sq * m_lprime_sq * q4 * z_gamma_sq * z_w_sq - 24 * k2
-            * m_l_4 * m_lprime_sq * q4 * z_gamma_sq * z_w_sq - 8 * m_B_sq * m_l_4 * m_lprime_sq * q4
+            * z_w_sq - 4 * m_B_4 * m_l_sq * m_lprime_sq * q4 * z_gamma_sq * z_w_sq - 24 * k2 * m_l_4
+            * m_lprime_sq * q4 * z_gamma_sq * z_w_sq - 8 * m_B_sq * m_l_4 * m_lprime_sq * q4
             * z_gamma_sq * z_w_sq + k6 * q6 * z_gamma_sq * z_w_sq + 8 * k4 * m_B_sq * q6
             * z_gamma_sq * z_w_sq - k2 * m_B_4 * q6 * z_gamma_sq * z_w_sq - 7 * k4 * m_l_sq * q6
             * z_gamma_sq * z_w_sq - 10 * k2 * m_B_sq * m_l_sq * q6 * z_gamma_sq * z_w_sq + m_B_4
-            * m_l_sq * q6 * z_gamma_sq * z_w_sq + 6 * k2 * m_l_4 * q6 * z_gamma_sq * z_w_sq + 2
-            * m_B_sq * m_l_4 * q6 * z_gamma_sq * z_w_sq + 4 * k4 * m_lprime_sq * q6 * z_gamma_sq
+            * m_l_sq * q6 * z_gamma_sq * z_w_sq + 6 * k2 * m_l_4 * q6 * z_gamma_sq * z_w_sq +
+            2 * m_B_sq * m_l_4 * q6 * z_gamma_sq * z_w_sq + 4 * k4 * m_lprime_sq * q6 * z_gamma_sq
             * z_w_sq - 8 * k2 * m_l_sq * m_lprime_sq * q6 * z_gamma_sq * z_w_sq + 4 * m_l_4
             * m_lprime_sq * q6 * z_gamma_sq * z_w_sq - k4 * q8 * z_gamma_sq * z_w_sq + 2 * k2
-            * m_l_sq * q8 * z_gamma_sq * z_w_sq - m_l_4 * q8 * z_gamma_sq * z_w_sq + 2 * sqrt(k2)
-            * (k2 - m_B_sq) * sqrt(q2) * (- 4 * m_lprime_sq + q2) * z_gamma * sqrt(1 - z_gamma_sq)
-            * sqrt(1 - z_w_sq) * (- (k6 * z_w) - m_l_sq * (- 3 * m_B_sq + 2 * m_l_sq + q2)
-            * (- sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + m_B_sq * z_w - q2 * z_w) + k4
-            * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - 4 * m_B_sq * z_w + 7 * m_l_sq
-            * z_w + 2 * q2 * z_w) + k2 * (- (m_l_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq
-            + q2))) - q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - 3 * m_B_4 * z_w - 6
-            * m_l_4 * z_w - 4 * m_l_sq * q2 * z_w - q4 * z_w + m_B_sq * (sqrt(k4 + m_B_sq_q2_diff2
-            - 2 * k2 * (m_B_sq + q2)) + 6 * m_l_sq * z_w + 4 * q2 * z_w))) * cos(phi) + 2 * k2
-            * m_B_sq_k2_diff2 * (k2 - m_l_sq) * (m_B_sq - m_l_sq) * (4 * m_lprime_sq - q2) * (- 1
-            + z_gamma_sq) * (- 1 + z_w_sq) * cos(2 * phi))) / (m_B_sq_k2_diff2 * power_of<2>(k4
-            + m_l_sq * (- m_B_sq + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)
-            - k2 * (m_B_sq - m_l_sq + q2 + sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
-            * z_w)));
+            * m_l_sq * q8 * z_gamma_sq * z_w_sq - m_l_4 * q8 * z_gamma_sq * z_w_sq - 2 * sqrt(k2)
+            * (k2 - m_B_sq) * sqrt(q2) * (-4 * m_lprime_sq + q2) * z_gamma * sqrt(1 - z_gamma_sq)
+            * sqrt(1 - z_w_sq) * (k6 * z_w + k4 * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2)) + 4 * m_B_sq * z_w - 7 * m_l_sq * z_w - 2 * q2 * z_w) + m_l_sq * (-3
+            * m_B_sq + 2 * m_l_sq + q2) * (sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2))
+            + m_B_sq * z_w - q2 * z_w) + k2 * (-(m_l_sq * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2
+            * (m_B_sq + q2))) - q2 * sqrt(k4 + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) + 3
+            * m_B_4 * z_w + 6 * m_l_4 * z_w + 4 * m_l_sq * q2 * z_w + q4 * z_w + m_B_sq * (sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) - 6 * m_l_sq * z_w - 4 * q2 * z_w)))
+            * cos(phi) + 2 * k2 * m_B_sq_k2_diff2 * (k2 - m_l_sq) * (m_B_sq - m_l_sq) * (4
+            * m_lprime_sq - q2) * (-1 + z_gamma_sq) * (-1 + z_w_sq) * cos(2 * phi)))
+            /(m_B_sq_k2_diff2 * power_of<2>(k4 - m_l_sq * (m_B_sq - q2 + sqrt(k4 + m_B_sq_q2_diff2
+            - 2 * k2 * (m_B_sq + q2)) * z_w) + k2 * (-m_B_sq + m_l_sq - q2 + sqrt(k4
+            + m_B_sq_q2_diff2 - 2 * k2 * (m_B_sq + q2)) * z_w)));
 
             return prefactor * (f11 * norm(F_1) + f22 * norm(F_2) + f33 * norm(F_3)
                 + f44 * norm(F_4) + f2c1Re * real(conj(F_2) * F_1) + f3c1Re * real(conj(F_3) * F_1)
@@ -771,26 +767,26 @@ namespace eos
             * q2 + q4)) / (3. * k4 * m_B_sq);
             const double g24 = (- 128 * (k2 - m_l_sq) * M_PI * q2 * (2 * m_lprime_sq + q2) * sqrt(k4
             - 2 * k2 * m_B_sq + m_B_4 - 2 * k2 * q2 - 2 * m_B_sq * q2 + q4)) / (3. * m_B_sq);
-            const double g15 = (64 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (2 * m_l_sq_k2_diff2
+            const double g15 = -(64 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (2 * m_l_sq_k2_diff2
             * sqrt(k4 - 2 * k2 * m_B_sq + m_B_4 - 2 * k2 * q2 - 2 * m_B_sq * q2 + q4) - (4 * k2
             * power_of<2>(- k2 + m_B_sq) * (- k2 + m_B_sq - 2 * m_l_sq - q2) * log((4 * k2
             * power_of<2>(- k2 + m_B_sq) * m_l_sq + 4 * k2 * (k2 - m_l_sq) * (m_B_sq - m_l_sq) * q2)
             / power_of<2>((k2 + m_l_sq) * (- k2 + m_B_sq - q2) + 2 * k2 * q2))) / sqrt(k4 - 2 * k2
             * m_B_sq + m_B_4 - 2 * k2 * q2 - 2 * m_B_sq * q2 + q4))) / (3. * m_B * (- k2 + m_B_sq)
             * (k2 - m_l_sq));
-            const double g25 = (64 * m_l_sq * M_PI * q2 * (2 * m_lprime_sq + q2) * (m_l_sq_k2_diff2
+            const double g25 = -(64 * m_l_sq * M_PI * q2 * (2 * m_lprime_sq + q2) * (m_l_sq_k2_diff2
             * sqrt(k4 - 2 * k2 * m_B_sq + m_B_4 - 2 * k2 * q2 - 2 * m_B_sq * q2 + q4) + (4 * k2
             * (- k2 + m_B_sq) * (3 * k2 * (- k2 + m_B_sq) + m_l_sq_k2_diff2) * log((4 * k2
             * power_of<2>(- k2 + m_B_sq) * m_l_sq + 4 * k2 * (k2 - m_l_sq) * (m_B_sq - m_l_sq) * q2)
             / power_of<2>((k2 + m_l_sq) * (- k2 + m_B_sq - q2) + 2 * k2 * q2))) / sqrt(k4 - 2 * k2
             * m_B_sq + m_B_4 - 2 * k2 * q2 - 2 * m_B_sq * q2 + q4))) / (3. * k2 * m_B
             * (- k2 + m_B_sq) * (k2 - m_l_sq));
-            const double g35 = (256 * m_l_sq * (k2 * (- k2 + m_B_sq) + (k2 - m_l_sq)
+            const double g35 = -(256 * m_l_sq * (k2 * (- k2 + m_B_sq) + (k2 - m_l_sq)
             * (k2 + m_l_sq)) * M_PI * q2 * (2 * m_lprime_sq + q2) * log((4 * k2 * power_of<2>(- k2
             + m_B_sq) * m_l_sq + 4 * k2 * (k2 - m_l_sq) * (m_B_sq - m_l_sq) * q2) / power_of<2>((k2
             + m_l_sq) * (- k2 + m_B_sq - q2) + 2 * k2 * q2))) / (3. * m_B * (k2 - m_l_sq) * sqrt(k4
             - 2 * k2 * m_B_sq + m_B_4 - 2 * k2 * q2 - 2 * m_B_sq * q2 + q4));
-            const double g45 = (256 * k2 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * ((- k2 + m_B_sq)
+            const double g45 = -(256 * k2 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * ((- k2 + m_B_sq)
             * (- k2 + m_B_sq - q2) - 2 * (k2 - m_l_sq) * q2) * log((4 * k2 * power_of<2>(- k2
             + m_B_sq) * m_l_sq + 4 * k2 * (k2 - m_l_sq) * (m_B_sq - m_l_sq) * q2) / power_of<2>((k2
             + m_l_sq) * (- k2 + m_B_sq - q2) + 2 * k2 * q2))) / (3. * m_B * (k2 - m_l_sq) * sqrt(k4
@@ -833,7 +829,7 @@ namespace eos
             std::array<double, 2> x_max{ q2_max, k2_max };
 
             return integrate(integrand, x_min, x_max, config_cubature)
-                / ((hbar/tau_B)* integrated_branching_ratio(q2_min, q2_max, k2_min, k2_max));
+                / ((hbar/tau_B) * integrated_branching_ratio(q2_min, q2_max, k2_min, k2_max));
         }
     };
 
@@ -887,7 +883,6 @@ namespace eos
     {
         return _imp->integrated_forward_backward_asymmetry(q2_min, q2_max, k2_min, k2_max);
     }
-
 
     const std::string
     BToThreeLeptonsNeutrino::description = "\

--- a/eos/b-decays/b-to-3l-nu.cc
+++ b/eos/b-decays/b-to-3l-nu.cc
@@ -133,31 +133,31 @@ namespace eos
             const double f15 = (256 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (- ((k2 - m_l_sq)
             * (2 * k2 - m_B_sq + m_l_sq + q2) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2)
             - 2 * k2 * (m_B_sq + q2))) + 2 * k2 * (k2 - m_B_sq) * (k2 - m_B_sq + 2 * m_l_sq + q2)
-            * atan2(((k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2
-            * (m_B_sq + q2))),(power_of<2>(k2) + m_l_sq * (- m_B_sq + q2) - k2
+            * std::atanh(((k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2
+            * (m_B_sq + q2)))/(power_of<2>(k2) + m_l_sq * (- m_B_sq + q2) - k2
             * (m_B_sq - m_l_sq + q2))))) / (3. * m_B * (k2 - m_l_sq) * sqrt(power_of<2>(k2)
             + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2)));
             const double f25 = (- 256 * m_l_sq * M_PI * q2 * (2 * m_lprime_sq + q2)
             * (3 * (k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2
             * (m_B_sq + q2)) + (- 4 * power_of<2>(k2) + 6 * k2 * m_B_sq - 4 * k2 * m_l_sq
-            + 2 * m_l_4) * atan2(((k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2)
-            - 2 * k2 * (m_B_sq + q2))),(power_of<2>(k2) + m_l_sq * (- m_B_sq + q2) - k2 * (m_B_sq
+            + 2 * m_l_4) * std::atanh(((k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2)
+            - 2 * k2 * (m_B_sq + q2)))/(power_of<2>(k2) + m_l_sq * (- m_B_sq + q2) - k2 * (m_B_sq
             - m_l_sq + q2))))) / (3. * m_B * (k2 - m_l_sq) * sqrt(power_of<2>(k2)
             + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2)));
             const double f35 = (- 128 * m_l_sq * M_PI * q2 * (2 * m_lprime_sq + q2)
             * (- ((k2 - m_l_sq) * (power_of<2>(k2) + k2 * (3 * m_B_sq - 3 * m_l_sq - q2)
             + m_l_sq * (- m_B_sq + q2)) * sqrt(power_of<2>(k2)
             + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2))) + 4 * k2 * (k2 - m_B_sq)
-            * (k2 * m_B_sq - m_l_4) * atan2(((k2 - m_l_sq) * sqrt(power_of<2>(k2)
-            + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2))),(power_of<2>(k2) + m_l_sq
+            * (k2 * m_B_sq - m_l_4) * std::atanh(((k2 - m_l_sq) * sqrt(power_of<2>(k2)
+            + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2)))/(power_of<2>(k2) + m_l_sq
             * (- m_B_sq + q2) - k2 * (m_B_sq - m_l_sq + q2))))) / (3. * k2 * m_B * (k2 - m_B_sq)
             * (k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2)
             - 2 * k2 * (m_B_sq + q2)));
             const double f45 = (- 256 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (- ((k2 - m_l_sq)
             * (k2 - m_B_sq + q2) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2
             * (m_B_sq + q2))) + 2 * k2 * (power_of<2>(k2) + m_B_4 - m_B_sq * q2 + 2 * m_l_sq
-            * q2 - k2 * (2 * m_B_sq + q2)) * atan2(((k2 - m_l_sq) * sqrt(power_of<2>(k2)
-            + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2))),(power_of<2>(k2) + m_l_sq
+            * q2 - k2 * (2 * m_B_sq + q2)) * std::atanh(((k2 - m_l_sq) * sqrt(power_of<2>(k2)
+            + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2)))/(power_of<2>(k2) + m_l_sq
             * (- m_B_sq + q2) - k2 * (m_B_sq - m_l_sq + q2))))) / (3. * m_B * (k2 - m_l_sq)
             * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2)));
             const double f55 = (128 * m_l_sq * M_PI * (2 * m_lprime_sq + q2) * (- ((k2 - m_l_sq)
@@ -176,8 +176,8 @@ namespace eos
             * (4 * m_l_6 - 2 * m_l_4 * q2) + m_B_4 * (- 6 * m_l_4 - 2 * m_l_sq * q2
             + power_of<2>(q2))) + m_l_sq * (m_B_8 + 2 * m_B_6 * m_l_sq - 2 * m_l_6 * q2 + m_B_sq
             * m_l_sq * q2 * (4 * m_l_sq + q2) - m_B_4 * (2 * m_l_4 + m_l_sq * q2
-            + power_of<2>(q2)))) * atan2(((k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq
-            - q2) - 2 * k2 * (m_B_sq + q2))),(power_of<2>(k2) + m_l_sq * (- m_B_sq + q2) - k2
+            + power_of<2>(q2)))) * std::atanh(((k2 - m_l_sq) * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq
+            - q2) - 2 * k2 * (m_B_sq + q2)))/(power_of<2>(k2) + m_l_sq * (- m_B_sq + q2) - k2
             * (m_B_sq - m_l_sq + q2))))) / (3. * power_of<2>(k2 - m_B_sq) * (k2 - m_l_sq)
             * sqrt(power_of<2>(k2) + power_of<2>(m_B_sq - q2) - 2 * k2 * (m_B_sq + q2))
             * (power_of<2>(k2) * m_l_sq - k2 * m_l_sq * q2 + k2 * m_B_sq * (- 2 * m_l_sq + q2)

--- a/eos/b-decays/b-to-3l-nu.cc
+++ b/eos/b-decays/b-to-3l-nu.cc
@@ -88,7 +88,7 @@ namespace eos
             }
             if (opt_l.str() == opt_lprime.str())
             {
-                throw InvalidOptionValueError("opt_lprime", opt_l.str(), "e, mu if it is not the value of l_prime");
+                throw InvalidOptionValueError("opt_lprime", opt_l.str(), "e, mu, tau if it is not the value of l_prime");
             }
         }
 
@@ -886,7 +886,7 @@ namespace eos
 
     const std::string
     BToThreeLeptonsNeutrino::description = "\
-The decayB^- -> l^- nubar l_prime^+ l_prime^-, where l is either e or mu and l_prime the other flavor";
+The decayB^- -> l^- nubar l_prime^+ l_prime^-, where l is either e, mu or tau and l_prime is either e or mu";
 
     const std::string
     BToThreeLeptonsNeutrino::kinematics_description_q2 = "\

--- a/eos/b-decays/b-to-3l-nu.cc
+++ b/eos/b-decays/b-to-3l-nu.cc
@@ -712,7 +712,7 @@ namespace eos
         double quintuple_differential_branching_ratio(const double & q2, const double & k2,
                 const double & z_gamma, const double & z_w, const double & phi) const
         {
-            return abs(quintuple_differential_decay_width(q2, k2, z_gamma, z_w, phi)) * tau_B / hbar;
+            return quintuple_differential_decay_width(q2, k2, z_gamma, z_w, phi) * tau_B / hbar;
         }
 
         /*!

--- a/eos/b-decays/b-to-3l-nu_TEST.cc
+++ b/eos/b-decays/b-to-3l-nu_TEST.cc
@@ -43,14 +43,14 @@ class BToThreeLeptonsNeutrinoTest :
                 BToThreeLeptonsNeutrino three_lnu(p, Options{ { "l", "mu" }, { "lprime", "e" } });
 
                 // Tested against an IPython/Jupyter notebook implementation of Stephan Kürten
-                TEST_CHECK_NEARLY_EQUAL(4.39594668126115e-11  , three_lnu.double_differential_branching_ratio(1.2, 0.6), 1e-24);
-                TEST_CHECK_NEARLY_EQUAL(4.470741659137669e-11 , three_lnu.double_differential_branching_ratio(1.2, 0.9), 1e-24);
-                TEST_CHECK_NEARLY_EQUAL(1.950546024128868e-11 , three_lnu.double_differential_branching_ratio(1.5, 0.6), 1e-24);
-                TEST_CHECK_NEARLY_EQUAL(1.9810430065283566e-11, three_lnu.double_differential_branching_ratio(1.5, 0.9), 1e-24);
-                TEST_CHECK_NEARLY_EQUAL(7.984365465773253e-09 , three_lnu.double_differential_branching_ratio(0.6, 1.2), 1e-22);
-                TEST_CHECK_NEARLY_EQUAL(1.6702367962034642e-10, three_lnu.double_differential_branching_ratio(0.9, 1.2), 1e-23);
-                TEST_CHECK_NEARLY_EQUAL(8.177374478468938e-09 , three_lnu.double_differential_branching_ratio(0.6, 1.5), 1e-22);
-                TEST_CHECK_NEARLY_EQUAL(1.7009605852663074e-10, three_lnu.double_differential_branching_ratio(0.9, 1.5), 1e-23);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_branching_ratio(1.2, 0.6), 4.39594668126115e-11  , 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_branching_ratio(1.2, 0.9), 4.470741659137669e-11 , 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_branching_ratio(1.5, 0.6), 1.950546024128868e-11 , 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_branching_ratio(1.5, 0.9), 1.9810430065283566e-11, 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_branching_ratio(0.6, 1.2), 7.984365465773253e-09 , 1e-22);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_branching_ratio(0.9, 1.2), 1.6702367962034642e-10, 1e-23);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_branching_ratio(0.6, 1.5), 8.177374478468938e-09 , 1e-22);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_branching_ratio(0.9, 1.5), 1.7009605852663074e-10, 1e-23);
                 /*
                  * differential decay width of 5 kinematic variables
                  * quintuple_differential_decay_width(q2, k2, z_gamma, z_w, phi)
@@ -60,70 +60,70 @@ class BToThreeLeptonsNeutrinoTest :
                  * z_w is the angle between the charged lepton l and the positive z-axis
                  * phi is the angle between the q2 plane and the k2 plane
                  */
-                TEST_CHECK_NEARLY_EQUAL(1.4012775797795022e-11, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.0, 0.0, 0.0), 1e-24);
-                TEST_CHECK_NEARLY_EQUAL(5.1287437263386674e-14, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0,-1.0, 3.1), 1e-27);
-                TEST_CHECK_NEARLY_EQUAL(5.1287437263386674e-14, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0,-1.0,-3.1), 1e-27);
-                TEST_CHECK_NEARLY_EQUAL(5.1287437263386674e-14, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5,-1.0,-1.0,-3.1), 1e-27);
-                TEST_CHECK_NEARLY_EQUAL(3.085696796294097e-12 , three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0, 1.0, 3.1), 1e-25);
-                TEST_CHECK_NEARLY_EQUAL(1.1160400109072714e-11, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.6, 0.4, 3.1), 1e-24);
-                TEST_CHECK_NEARLY_EQUAL(6.643678742005261e-12 , three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.4, 0.6, 0.3), 1e-25);
-                TEST_CHECK_NEARLY_EQUAL(6.644934752365039e-12 , three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.4, 0.6,-0.3), 1e-25);
-                TEST_CHECK_NEARLY_EQUAL(3.1035668687398013e-10, three_lnu.quintuple_differential_branching_ratio(0.6, 1.2, 0.4, 0.6,-0.3), 1e-23);
-                TEST_CHECK_NEARLY_EQUAL(1.9082580462960103e-12, three_lnu.quintuple_differential_branching_ratio(1.2, 0.6, 0.4, 0.6,-0.3), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.0, 0.0, 0.0), 1.4012775797795022e-11, 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0,-1.0, 3.1), 5.1287437263386674e-14, 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0,-1.0,-3.1), 5.1287437263386674e-14, 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.9, 1.5,-1.0,-1.0,-3.1), 5.1287437263386674e-14, 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0, 1.0, 3.1), 3.085696796294097e-12 , 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.6, 0.4, 3.1), 1.1160400109072714e-11, 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.4, 0.6, 0.3), 6.643678742005261e-12 , 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.4, 0.6,-0.3), 6.644934752365039e-12 , 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(0.6, 1.2, 0.4, 0.6,-0.3), 3.1035668687398013e-10, 1e-23);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.quintuple_differential_branching_ratio(1.2, 0.6, 0.4, 0.6,-0.3), 1.9082580462960103e-12, 1e-25);
 
-                TEST_CHECK_NEARLY_EQUAL(-0.19978703404850154, three_lnu.double_differential_forward_backward_asymmetry(1.0, 4.7), 1e-13);
-                TEST_CHECK_NEARLY_EQUAL(-0.1900337624486565 , three_lnu.double_differential_forward_backward_asymmetry(0.6, 3.2), 1e-13);
-                TEST_CHECK_NEARLY_EQUAL(-0.15573648794445794, three_lnu.double_differential_forward_backward_asymmetry(0.9, 3.2), 1e-13);
-                TEST_CHECK_NEARLY_EQUAL(-0.1703444419281766 , three_lnu.double_differential_forward_backward_asymmetry(1.5, 4.7), 1e-13);
-                TEST_CHECK_NEARLY_EQUAL(-0.18574472584759466, three_lnu.double_differential_forward_backward_asymmetry(1.2, 4.7), 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_forward_backward_asymmetry(1.0, 4.7), -0.19978703404850154, 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_forward_backward_asymmetry(0.6, 3.2), -0.1900337624486565 , 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_forward_backward_asymmetry(0.9, 3.2), -0.15573648794445794, 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_forward_backward_asymmetry(1.5, 4.7), -0.1703444419281766 , 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.double_differential_forward_backward_asymmetry(1.2, 4.7), -0.18574472584759466, 1e-13);
 
-                TEST_CHECK_NEARLY_EQUAL(1.11942599097845e-10  , three_lnu.integrated_branching_ratio(1.0, 4.0, 1.0, 4.0), 1e-14);
-                TEST_CHECK_NEARLY_EQUAL(1.8054715753057808e-12, three_lnu.integrated_branching_ratio(4.0, 5.0, 3.0, 5.0), 1e-16);
-                TEST_CHECK_NEARLY_EQUAL(1.0192934595042032e-10, three_lnu.integrated_branching_ratio(1.2, 3.0, 0.2, 5.0), 1e-14);
-                TEST_CHECK_NEARLY_EQUAL(6.514881129640035e-11 , three_lnu.integrated_branching_ratio(1.2, 3.5, 2.2, 5.0), 1e-15);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.integrated_branching_ratio(1.0, 4.0, 1.0, 4.0), 1.11942599097845e-10  , 1e-14);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.integrated_branching_ratio(4.0, 5.0, 3.0, 5.0), 1.8054715753057808e-12, 1e-16);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.integrated_branching_ratio(1.2, 3.0, 0.2, 5.0), 1.0192934595042032e-10, 1e-14);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.integrated_branching_ratio(1.2, 3.5, 2.2, 5.0), 6.514881129640035e-11 , 1e-15);
 
-                TEST_CHECK_NEARLY_EQUAL(-0.10720983486749855, three_lnu.integrated_forward_backward_asymmetry(1.0, 4.0, 1.0, 4.0), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.09841640103003944, three_lnu.integrated_forward_backward_asymmetry(4.0, 5.0, 3.0, 5.0), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.10745200783863061, three_lnu.integrated_forward_backward_asymmetry(1.2, 3.0, 0.2, 5.0), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.1334186883151141 , three_lnu.integrated_forward_backward_asymmetry(1.2, 3.5, 2.2, 5.0), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.integrated_forward_backward_asymmetry(1.0, 4.0, 1.0, 4.0), -0.10720983486749855, 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.integrated_forward_backward_asymmetry(4.0, 5.0, 3.0, 5.0), -0.09841640103003944, 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.integrated_forward_backward_asymmetry(1.2, 3.0, 0.2, 5.0), -0.10745200783863061, 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu.integrated_forward_backward_asymmetry(1.2, 3.5, 2.2, 5.0), -0.1334186883151141 , 1e-5);
 
                 BToThreeLeptonsNeutrino three_lnu_with_tau(p, Options{ { "l", "tau" }, { "lprime", "mu" } });
 
-                TEST_CHECK_NEARLY_EQUAL(2.2656835615631178e-14, three_lnu_with_tau.double_differential_branching_ratio(1.2, 3.2), 1e-27);
-                TEST_CHECK_NEARLY_EQUAL(9.77022421527314e-15  , three_lnu_with_tau.double_differential_branching_ratio(1.5, 3.2), 1e-28);
-                TEST_CHECK_NEARLY_EQUAL(1.1407883572580513e-12, three_lnu_with_tau.double_differential_branching_ratio(1.2, 3.5), 1e-25);
-                TEST_CHECK_NEARLY_EQUAL(4.900016933078733e-13 , three_lnu_with_tau.double_differential_branching_ratio(1.5, 3.5), 1e-26);
-                TEST_CHECK_NEARLY_EQUAL(1.1431202742303967e-09, three_lnu_with_tau.double_differential_branching_ratio(0.6, 4.1), 1e-22);
-                TEST_CHECK_NEARLY_EQUAL(2.1967778054652107e-11, three_lnu_with_tau.double_differential_branching_ratio(0.9, 4.1), 1e-24);
-                TEST_CHECK_NEARLY_EQUAL(9.798358180136963e-09 , three_lnu_with_tau.double_differential_branching_ratio(0.6,15.0), 1e-22);
-                TEST_CHECK_NEARLY_EQUAL(1.4812669954450616e-10, three_lnu_with_tau.double_differential_branching_ratio(0.9,15.0), 1e-23);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_branching_ratio(1.2, 3.2), 2.2656835615631178e-14, 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_branching_ratio(1.5, 3.2), 9.77022421527314e-15  , 1e-28);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_branching_ratio(1.2, 3.5), 1.1407883572580513e-12, 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_branching_ratio(1.5, 3.5), 4.900016933078733e-13 , 1e-26);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_branching_ratio(0.6, 4.1), 1.1431202742303967e-09, 1e-22);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_branching_ratio(0.9, 4.1), 2.1967778054652107e-11, 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_branching_ratio(0.6,15.0), 9.798358180136963e-09 , 1e-22);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_branching_ratio(0.9,15.0), 1.4812669954450616e-10, 1e-23);
 
-                TEST_CHECK_NEARLY_EQUAL(2.031669886855895e-12 , three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.0, 0.0, 0.0), 1e-25);
-                TEST_CHECK_NEARLY_EQUAL(1.7424121078854753e-14, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0,-1.0, 3.1), 1e-27);
-                TEST_CHECK_NEARLY_EQUAL(1.7424121078854753e-14, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0,-1.0,-3.1), 1e-27);
-                TEST_CHECK_NEARLY_EQUAL(1.7424121078854753e-14, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5,-1.0,-1.0,-3.1), 1e-27);
-                TEST_CHECK_NEARLY_EQUAL(7.81354285945554e-13  , three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0, 1.0, 3.1), 1e-26);
-                TEST_CHECK_NEARLY_EQUAL(1.952956580972857e-12 , three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.6, 0.4, 3.1), 1e-25);
-                TEST_CHECK_NEARLY_EQUAL(2.5081122681564525e-12, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.4, 0.6, 0.3), 1e-25);
-                TEST_CHECK_NEARLY_EQUAL(2.5075950200134066e-12, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.4, 0.6,-0.3), 1e-25);
-                TEST_CHECK_NEARLY_EQUAL(9.292842351120294e-11 , three_lnu_with_tau.quintuple_differential_branching_ratio(0.6, 4.2, 0.4, 0.6,-0.3), 1e-24);
-                TEST_CHECK_NEARLY_EQUAL(1.500147195568813e-12 , three_lnu_with_tau.quintuple_differential_branching_ratio(1.2,14.6, 0.4, 0.6,-0.3), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.0, 0.0, 0.0), 2.031669886855895e-12 , 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0,-1.0, 3.1), 1.7424121078854753e-14, 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0,-1.0,-3.1), 1.7424121078854753e-14, 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5,-1.0,-1.0,-3.1), 1.7424121078854753e-14, 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0, 1.0, 3.1), 7.81354285945554e-13  , 1e-26);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.6, 0.4, 3.1), 1.952956580972857e-12 , 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.4, 0.6, 0.3), 2.5081122681564525e-12, 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.4, 0.6,-0.3), 2.5075950200134066e-12, 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(0.6, 4.2, 0.4, 0.6,-0.3), 9.292842351120294e-11 , 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.quintuple_differential_branching_ratio(1.2,14.6, 0.4, 0.6,-0.3), 1.500147195568813e-12 , 1e-25);
 
-                TEST_CHECK_NEARLY_EQUAL(-0.43890105637843724, three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.0, 4.7), 1e-10);
-                TEST_CHECK_NEARLY_EQUAL(-0.49813547368786776, three_lnu_with_tau.double_differential_forward_backward_asymmetry(0.6, 3.2), 1e-10);
-                TEST_CHECK_NEARLY_EQUAL(-0.4958929059233193 , three_lnu_with_tau.double_differential_forward_backward_asymmetry(0.9, 3.2), 1e-10);
-                TEST_CHECK_NEARLY_EQUAL(-0.41899237708674814, three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.5, 4.7), 1e-10);
-                TEST_CHECK_NEARLY_EQUAL(-0.4307210623669162 , three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.2, 4.7), 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.0, 4.7), -0.43890105637843724, 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_forward_backward_asymmetry(0.6, 3.2), -0.49813547368786776, 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_forward_backward_asymmetry(0.9, 3.2), -0.4958929059233193 , 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.5, 4.7), -0.41899237708674814, 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.2, 4.7), -0.4307210623669162 , 1e-10);
 
-                TEST_CHECK_NEARLY_EQUAL(1.0814431951945232e-12, three_lnu_with_tau.integrated_branching_ratio(1.0, 4.0, 3.5, 4.0), 1e-16);
-                TEST_CHECK_NEARLY_EQUAL(1.2892379916914902e-13, three_lnu_with_tau.integrated_branching_ratio(4.0, 5.0, 3.2, 5.0), 1e-17);
-                TEST_CHECK_NEARLY_EQUAL(4.327260506854218e-12 , three_lnu_with_tau.integrated_branching_ratio(1.2, 3.0, 3.5, 5.0), 1e-16);
-                TEST_CHECK_NEARLY_EQUAL(4.568873862504263e-12 , three_lnu_with_tau.integrated_branching_ratio(1.2, 3.5, 3.2, 5.0), 1e-16);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.integrated_branching_ratio(1.0, 4.0, 3.5, 4.0), 1.0814431951945232e-12, 1e-16);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.integrated_branching_ratio(4.0, 5.0, 3.2, 5.0), 1.2892379916914902e-13, 1e-17);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.integrated_branching_ratio(1.2, 3.0, 3.5, 5.0), 4.327260506854218e-12 , 1e-16);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.integrated_branching_ratio(1.2, 3.5, 3.2, 5.0), 4.568873862504263e-12 , 1e-16);
 
-                TEST_CHECK_NEARLY_EQUAL(-0.4580920453975816 , three_lnu_with_tau.integrated_forward_backward_asymmetry(1.0, 4.0, 3.5, 4.0), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.3173962670686166 , three_lnu_with_tau.integrated_forward_backward_asymmetry(4.0, 5.0, 3.2, 5.0), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.42333712608602736, three_lnu_with_tau.integrated_forward_backward_asymmetry(1.2, 3.0, 3.5, 5.0), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.4218080496815521 , three_lnu_with_tau.integrated_forward_backward_asymmetry(1.2, 3.5, 3.2, 5.0), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.integrated_forward_backward_asymmetry(1.0, 4.0, 3.5, 4.0), -0.4580920453975816 , 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.integrated_forward_backward_asymmetry(4.0, 5.0, 3.2, 5.0), -0.3173962670686166 , 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.integrated_forward_backward_asymmetry(1.2, 3.0, 3.5, 5.0), -0.42333712608602736, 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(three_lnu_with_tau.integrated_forward_backward_asymmetry(1.2, 3.5, 3.2, 5.0), -0.4218080496815521 , 1e-5);
             }
         }
 } b_to_3l_nu_test;

--- a/eos/b-decays/b-to-3l-nu_TEST.cc
+++ b/eos/b-decays/b-to-3l-nu_TEST.cc
@@ -40,18 +40,17 @@ class BToThreeLeptonsNeutrinoTest :
 
             {
 
-                BToThreeLeptonsNeutrino three_lnu(p, Options{ });
+                BToThreeLeptonsNeutrino three_lnu(p, Options{ { "l", "mu" }, { "lprime", "e" } });
 
                 // Tested against an IPython/Jupyter notebook implementation of Stephan Kürten
-                //TODO: do these tests for the branching ratio instead of decay width since I dont export decay widths anymore
-                TEST_CHECK_NEARLY_EQUAL(4.4169722387470174e-11, three_lnu.double_differential_branching_ratio(1.2, 0.6), 1e-15);
-                TEST_CHECK_NEARLY_EQUAL(4.4899433542534617e-11, three_lnu.double_differential_branching_ratio(1.2, 0.9), 1e-15);
-                TEST_CHECK_NEARLY_EQUAL(1.9615874219144387e-11, three_lnu.double_differential_branching_ratio(1.5, 0.6), 1e-15);
-                TEST_CHECK_NEARLY_EQUAL(1.991304494545849e-11 , three_lnu.double_differential_branching_ratio(1.5, 0.9), 1e-15);
-                TEST_CHECK_NEARLY_EQUAL(7.978355662846529e-09 , three_lnu.double_differential_branching_ratio(0.6, 1.2), 1e-13);
-                TEST_CHECK_NEARLY_EQUAL(1.6747424093160892e-10, three_lnu.double_differential_branching_ratio(0.9, 1.2), 1e-14);
-                TEST_CHECK_NEARLY_EQUAL(8.170238677828805e-09 , three_lnu.double_differential_branching_ratio(0.6, 1.5), 1e-13);
-                TEST_CHECK_NEARLY_EQUAL(1.7053307009828605e-10, three_lnu.double_differential_branching_ratio(0.9, 1.5), 1e-14);
+                TEST_CHECK_NEARLY_EQUAL(4.39594668126115e-11  , three_lnu.double_differential_branching_ratio(1.2, 0.6), 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(4.470741659137669e-11 , three_lnu.double_differential_branching_ratio(1.2, 0.9), 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(1.950546024128868e-11 , three_lnu.double_differential_branching_ratio(1.5, 0.6), 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(1.9810430065283566e-11, three_lnu.double_differential_branching_ratio(1.5, 0.9), 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(7.984365465773253e-09 , three_lnu.double_differential_branching_ratio(0.6, 1.2), 1e-22);
+                TEST_CHECK_NEARLY_EQUAL(1.6702367962034642e-10, three_lnu.double_differential_branching_ratio(0.9, 1.2), 1e-23);
+                TEST_CHECK_NEARLY_EQUAL(8.177374478468938e-09 , three_lnu.double_differential_branching_ratio(0.6, 1.5), 1e-22);
+                TEST_CHECK_NEARLY_EQUAL(1.7009605852663074e-10, three_lnu.double_differential_branching_ratio(0.9, 1.5), 1e-23);
                 /*
                  * differential decay width of 5 kinematic variables
                  * quintuple_differential_decay_width(q2, k2, z_gamma, z_w, phi)
@@ -61,24 +60,70 @@ class BToThreeLeptonsNeutrinoTest :
                  * z_w is the angle between the charged lepton l and the positive z-axis
                  * phi is the angle between the q2 plane and the k2 plane
                  */
-                TEST_CHECK_NEARLY_EQUAL(1.690117135105216e-12, three_lnu.quintuple_differential_branching_ratio(1.5, 0.9, 0.0, 0.0, 0.0), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(1.992595975584582e-13, three_lnu.quintuple_differential_branching_ratio(1.5, 0.9, 1.0,-1.0, 3.1), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(1.317143949587225e-14, three_lnu.quintuple_differential_branching_ratio(1.5, 0.9,-1.0, 1.0,-3.1), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(1.992595975584582e-13, three_lnu.quintuple_differential_branching_ratio(1.5, 0.9,-1.0,-1.0,-3.1), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(1.317143949587225e-14, three_lnu.quintuple_differential_branching_ratio(1.5, 0.9, 1.0, 1.0, 3.1), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(8.840457847366234e-13, three_lnu.quintuple_differential_branching_ratio(1.5, 0.9, 0.6, 0.4, 3.1), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(9.06242765770747e-13 , three_lnu.quintuple_differential_branching_ratio(1.5, 0.9, 0.4, 0.6, 0.3), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(9.062269295937419e-13, three_lnu.quintuple_differential_branching_ratio(1.5, 0.9, 0.4, 0.6,-0.3), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(2.050375005253621e-12, three_lnu.quintuple_differential_branching_ratio(1.2, 0.6, 0.4, 0.6,-0.3), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(3.576321002331276e-10, three_lnu.quintuple_differential_branching_ratio(0.6, 1.2, 0.4, 0.6,-0.3), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(2.543292200904078e-14, three_lnu.quintuple_differential_branching_ratio(5.0, 0.1, 0.4, 0.6,-0.3), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(4.357725963221514e-12, three_lnu.quintuple_differential_branching_ratio(0.1, 5.0, 0.4, 0.6,-0.3), 1e-18);
-                TEST_CHECK_NEARLY_EQUAL(4.687779112550517e-14, three_lnu.quintuple_differential_branching_ratio(4.0, 1.0, 0.4, 0.6,-0.3), 1e-18);
+                TEST_CHECK_NEARLY_EQUAL(1.4012775797795022e-11, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.0, 0.0, 0.0), 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(5.1287437263386674e-14, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0,-1.0, 3.1), 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(5.1287437263386674e-14, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0,-1.0,-3.1), 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(5.1287437263386674e-14, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5,-1.0,-1.0,-3.1), 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(3.085696796294097e-12 , three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 1.0, 1.0, 3.1), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(1.1160400109072714e-11, three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.6, 0.4, 3.1), 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(6.643678742005261e-12 , three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.4, 0.6, 0.3), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(6.644934752365039e-12 , three_lnu.quintuple_differential_branching_ratio(0.9, 1.5, 0.4, 0.6,-0.3), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(3.1035668687398013e-10, three_lnu.quintuple_differential_branching_ratio(0.6, 1.2, 0.4, 0.6,-0.3), 1e-23);
+                TEST_CHECK_NEARLY_EQUAL(1.9082580462960103e-12, three_lnu.quintuple_differential_branching_ratio(1.2, 0.6, 0.4, 0.6,-0.3), 1e-25);
 
-                TEST_CHECK_NEARLY_EQUAL(-0.03752014033347991, three_lnu.integrated_forward_backward_asymmetry(0.05, 4.2, 0.001, 1.0), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.01182330324675401, three_lnu.integrated_forward_backward_asymmetry(1.0 , 4.7, 0.001, 0.5), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.09288173467575606, three_lnu.integrated_forward_backward_asymmetry(0.1 , 3.7, 1.2  , 1.5), 1e-5);
-                TEST_CHECK_NEARLY_EQUAL(-0.04209717482075583, three_lnu.integrated_forward_backward_asymmetry(0.45, 2.0, 0.001, 1.2), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(-0.19978703404850154, three_lnu.double_differential_forward_backward_asymmetry(1.0, 4.7), 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(-0.1900337624486565 , three_lnu.double_differential_forward_backward_asymmetry(0.6, 3.2), 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(-0.15573648794445794, three_lnu.double_differential_forward_backward_asymmetry(0.9, 3.2), 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(-0.1703444419281766 , three_lnu.double_differential_forward_backward_asymmetry(1.5, 4.7), 1e-13);
+                TEST_CHECK_NEARLY_EQUAL(-0.18574472584759466, three_lnu.double_differential_forward_backward_asymmetry(1.2, 4.7), 1e-13);
+
+                TEST_CHECK_NEARLY_EQUAL(1.11942599097845e-10  , three_lnu.integrated_branching_ratio(1.0, 4.0, 1.0, 4.0), 1e-14);
+                TEST_CHECK_NEARLY_EQUAL(1.8054715753057808e-12, three_lnu.integrated_branching_ratio(4.0, 5.0, 3.0, 5.0), 1e-16);
+                TEST_CHECK_NEARLY_EQUAL(1.0192934595042032e-10, three_lnu.integrated_branching_ratio(1.2, 3.0, 0.2, 5.0), 1e-14);
+                TEST_CHECK_NEARLY_EQUAL(6.514881129640035e-11 , three_lnu.integrated_branching_ratio(1.2, 3.5, 2.2, 5.0), 1e-15);
+
+                TEST_CHECK_NEARLY_EQUAL(-0.10720983486749855, three_lnu.integrated_forward_backward_asymmetry(1.0, 4.0, 1.0, 4.0), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(-0.09841640103003944, three_lnu.integrated_forward_backward_asymmetry(4.0, 5.0, 3.0, 5.0), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(-0.10745200783863061, three_lnu.integrated_forward_backward_asymmetry(1.2, 3.0, 0.2, 5.0), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(-0.1334186883151141 , three_lnu.integrated_forward_backward_asymmetry(1.2, 3.5, 2.2, 5.0), 1e-5);
+
+                BToThreeLeptonsNeutrino three_lnu_with_tau(p, Options{ { "l", "tau" }, { "lprime", "mu" } });
+
+                TEST_CHECK_NEARLY_EQUAL(2.2656835615631178e-14, three_lnu_with_tau.double_differential_branching_ratio(1.2, 3.2), 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(9.77022421527314e-15  , three_lnu_with_tau.double_differential_branching_ratio(1.5, 3.2), 1e-28);
+                TEST_CHECK_NEARLY_EQUAL(1.1407883572580513e-12, three_lnu_with_tau.double_differential_branching_ratio(1.2, 3.5), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(4.900016933078733e-13 , three_lnu_with_tau.double_differential_branching_ratio(1.5, 3.5), 1e-26);
+                TEST_CHECK_NEARLY_EQUAL(1.1431202742303967e-09, three_lnu_with_tau.double_differential_branching_ratio(0.6, 4.1), 1e-22);
+                TEST_CHECK_NEARLY_EQUAL(2.1967778054652107e-11, three_lnu_with_tau.double_differential_branching_ratio(0.9, 4.1), 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(9.798358180136963e-09 , three_lnu_with_tau.double_differential_branching_ratio(0.6,15.0), 1e-22);
+                TEST_CHECK_NEARLY_EQUAL(1.4812669954450616e-10, three_lnu_with_tau.double_differential_branching_ratio(0.9,15.0), 1e-23);
+
+                TEST_CHECK_NEARLY_EQUAL(2.031669886855895e-12 , three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.0, 0.0, 0.0), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(1.7424121078854753e-14, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0,-1.0, 3.1), 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(1.7424121078854753e-14, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0,-1.0,-3.1), 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(1.7424121078854753e-14, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5,-1.0,-1.0,-3.1), 1e-27);
+                TEST_CHECK_NEARLY_EQUAL(7.81354285945554e-13  , three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 1.0, 1.0, 3.1), 1e-26);
+                TEST_CHECK_NEARLY_EQUAL(1.952956580972857e-12 , three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.6, 0.4, 3.1), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(2.5081122681564525e-12, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.4, 0.6, 0.3), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(2.5075950200134066e-12, three_lnu_with_tau.quintuple_differential_branching_ratio(0.9, 4.5, 0.4, 0.6,-0.3), 1e-25);
+                TEST_CHECK_NEARLY_EQUAL(9.292842351120294e-11 , three_lnu_with_tau.quintuple_differential_branching_ratio(0.6, 4.2, 0.4, 0.6,-0.3), 1e-24);
+                TEST_CHECK_NEARLY_EQUAL(1.500147195568813e-12 , three_lnu_with_tau.quintuple_differential_branching_ratio(1.2,14.6, 0.4, 0.6,-0.3), 1e-25);
+
+                TEST_CHECK_NEARLY_EQUAL(-0.43890105637843724, three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.0, 4.7), 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(-0.49813547368786776, three_lnu_with_tau.double_differential_forward_backward_asymmetry(0.6, 3.2), 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(-0.4958929059233193 , three_lnu_with_tau.double_differential_forward_backward_asymmetry(0.9, 3.2), 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(-0.41899237708674814, three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.5, 4.7), 1e-10);
+                TEST_CHECK_NEARLY_EQUAL(-0.4307210623669162 , three_lnu_with_tau.double_differential_forward_backward_asymmetry(1.2, 4.7), 1e-10);
+
+                TEST_CHECK_NEARLY_EQUAL(1.0814431951945232e-12, three_lnu_with_tau.integrated_branching_ratio(1.0, 4.0, 3.5, 4.0), 1e-16);
+                TEST_CHECK_NEARLY_EQUAL(1.2892379916914902e-13, three_lnu_with_tau.integrated_branching_ratio(4.0, 5.0, 3.2, 5.0), 1e-17);
+                TEST_CHECK_NEARLY_EQUAL(4.327260506854218e-12 , three_lnu_with_tau.integrated_branching_ratio(1.2, 3.0, 3.5, 5.0), 1e-16);
+                TEST_CHECK_NEARLY_EQUAL(4.568873862504263e-12 , three_lnu_with_tau.integrated_branching_ratio(1.2, 3.5, 3.2, 5.0), 1e-16);
+
+                TEST_CHECK_NEARLY_EQUAL(-0.4580920453975816 , three_lnu_with_tau.integrated_forward_backward_asymmetry(1.0, 4.0, 3.5, 4.0), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(-0.3173962670686166 , three_lnu_with_tau.integrated_forward_backward_asymmetry(4.0, 5.0, 3.2, 5.0), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(-0.42333712608602736, three_lnu_with_tau.integrated_forward_backward_asymmetry(1.2, 3.0, 3.5, 5.0), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(-0.4218080496815521 , three_lnu_with_tau.integrated_forward_backward_asymmetry(1.2, 3.5, 3.2, 5.0), 1e-5);
             }
         }
 } b_to_3l_nu_test;

--- a/eos/b-decays/observables.cc
+++ b/eos/b-decays/observables.cc
@@ -64,9 +64,9 @@ namespace eos
     make_b_to_3l_nu_group()
     {
         auto imp = new Implementation<ObservableGroup>(
-            R"(Observables in $B^-\to \ell^-\bar\nu\ell_\prime^+\ell_\prime^-$ decays)",
-            R"(The option "l" selects the charged lepton flavour coming out of the 
-            weak current, "lprime" selects the lepton flavour coming out of the photon.)",
+            R"(Observables in $B^-\to \ell^-\bar\nu\ell'^+\ell'^-$ decays)",
+            R"(The option "l" selects the charged lepton flavour coming out of the )"
+            R"(weak current, "lprime" selects the lepton flavour coming out of the photon.)",
             {
                 make_observable("B_u->enumumu::d2BR/dq2/dk2", R"(\frac{d\mathcal{B}(B^- \to e^-\bar\nu\mu^+\mu^-)}{dq^2/dk^2})",
                         Unit::None(),
@@ -74,7 +74,7 @@ namespace eos
                         std::make_tuple("q2", "k2"),
                         Options{ { "l", "e" }, { "lprime", "mu" } }),
 
-                make_observable("B_u->munuee::d2BR/dq2/dk2", R"(\frac{d\mathcal{B}(B^- \to \mu^-\bar\nue^+e^-)}{dq^2/dk^2})",
+                make_observable("B_u->munuee::d2BR/dq2/dk2", R"(\frac{d\mathcal{B}(B^- \to \mu^-\bar\nu e^+e^-)}{dq^2/dk^2})",
                         Unit::None(),
                         &BToThreeLeptonsNeutrino::double_differential_branching_ratio,
                         std::make_tuple("q2", "k2"),
@@ -86,7 +86,7 @@ namespace eos
                         std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
                         Options{ { "l", "e" }, { "lprime", "mu" } }),
 
-                make_observable("B_u->munuee::BR", R"(\mathcal{B}(B^- \to \mu^-\bar\nue^+e^-))",
+                make_observable("B_u->munuee::BR", R"(\mathcal{B}(B^- \to \mu^-\bar\nu e^+e^-))",
                         Unit::None(),
                         &BToThreeLeptonsNeutrino::integrated_branching_ratio,
                         std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
@@ -98,7 +98,7 @@ namespace eos
                         std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
                         Options{ { "l", "e" }, { "lprime", "mu" } }),
 
-                make_observable("B_u->munuee::A_FB", R"(A_{\mathrm{FB}}(B^- \to \mu^-\bar\nue^+e^-))",
+                make_observable("B_u->munuee::A_FB", R"(A_{\mathrm{FB}}(B^- \to \mu^-\bar\nu e^+e^-))",
                         Unit::None(),
                         &BToThreeLeptonsNeutrino::integrated_forward_backward_asymmetry,
                         std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),

--- a/eos/b-decays/observables.cc
+++ b/eos/b-decays/observables.cc
@@ -80,6 +80,18 @@ namespace eos
                         std::make_tuple("q2", "k2"),
                         Options{ { "l", "mu" }, { "lprime", "e" } }),
 
+                make_observable("B_u->taunuee::d2BR/dq2/dk2", R"(\frac{d\mathcal{B}(B^- \to \tau^-\bar\nu e^+e^-)}{dq^2/dk^2})",
+                        Unit::None(),
+                        &BToThreeLeptonsNeutrino::double_differential_branching_ratio,
+                        std::make_tuple("q2", "k2"),
+                        Options{ { "l", "tau" }, { "lprime", "e" } }),
+
+                make_observable("B_u->taunumumu::d2BR/dq2/dk2", R"(\frac{d\mathcal{B}(B^- \to \tau^-\bar\nu\mu^+\mu^-)}{dq^2/dk^2})",
+                        Unit::None(),
+                        &BToThreeLeptonsNeutrino::double_differential_branching_ratio,
+                        std::make_tuple("q2", "k2"),
+                        Options{ { "l", "tau" }, { "lprime", "mu" } }),
+
                 make_observable("B_u->enumumu::BR", R"(\mathcal{B}(B^- \to e^-\bar\nu\mu^+\mu^-))",
                         Unit::None(),
                         &BToThreeLeptonsNeutrino::integrated_branching_ratio,
@@ -92,6 +104,18 @@ namespace eos
                         std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
                         Options{ { "l", "mu" }, { "lprime", "e" } }),
 
+                make_observable("B_u->taunuee::BR", R"(\mathcal{B}(B^- \to \tau^-\bar\nu e^+e^-))",
+                        Unit::None(),
+                        &BToThreeLeptonsNeutrino::integrated_branching_ratio,
+                        std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
+                        Options{ { "l", "tau" }, { "lprime", "e" } }),
+
+                make_observable("B_u->taunumumu::BR", R"(\mathcal{B}(B^- \to \tau^-\bar\nu\mu^+\mu^-))",
+                        Unit::None(),
+                        &BToThreeLeptonsNeutrino::integrated_branching_ratio,
+                        std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
+                        Options{ { "l", "tau" }, { "lprime", "mu" } }),
+
                 make_observable("B_u->enumumu::A_FB", R"(A_{\mathrm{FB}}(B^- \to e^-\bar\nu\mu^+\mu^-))",
                         Unit::None(),
                         &BToThreeLeptonsNeutrino::integrated_forward_backward_asymmetry,
@@ -103,6 +127,18 @@ namespace eos
                         &BToThreeLeptonsNeutrino::integrated_forward_backward_asymmetry,
                         std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
                         Options{ { "l", "mu" }, { "lprime", "e" } }),
+
+                make_observable("B_u->taunumumu::A_FB", R"(A_{\mathrm{FB}}(B^- \to \tau^-\bar\nu\mu^+\mu^-))",
+                        Unit::None(),
+                        &BToThreeLeptonsNeutrino::integrated_forward_backward_asymmetry,
+                        std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
+                        Options{ { "l", "tau" }, { "lprime", "mu" } }),
+
+                make_observable("B_u->taunuee::A_FB", R"(A_{\mathrm{FB}}(B^- \to \tau^-\bar\nu e^+e^-))",
+                        Unit::None(),
+                        &BToThreeLeptonsNeutrino::integrated_forward_backward_asymmetry,
+                        std::make_tuple("q2_min", "q2_max", "k2_min", "k2_max"),
+                        Options{ { "l", "tau" }, { "lprime", "e" } }),
             }
         );
 


### PR DESCRIPTION
I fixed a sign error in the implementation due to Q_B in equation 50 in 2210.09832, I forgot it.
Added new testcases.
Allowed for the observables to be evaluated with tauon flavour.