### PR TITLE
[python] Use `numpy.double` instead of the decrepeted `numpy.float` and `numpy.float64`

### DIFF
--- a/python/eos/analysis_TEST.py
+++ b/python/eos/analysis_TEST.py
@@ -56,7 +56,7 @@ class ClassMethodTests(unittest.TestCase):
         values = np.array([4.123, 3.141])
 
         input_output_cases = [
-            {'dirty': np.float64(1.61), 'clean': float(1.61)},
+            {'dirty': np.double(1.61), 'clean': float(1.61)},
             {'dirty': np.str_('Gaussian'), 'clean': str("Gaussian")},
             {
              'dirty': {'type': types[0], 'mean': values[0]}, # Simplified manual contraint with numpy types

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -858,8 +858,8 @@ class Plotter:
                             if self.rescale_by_width:
                                 width = (_kinematics[self.variable + '_max'] - _kinematics[self.variable + '_min'])
 
-                        yvalues.append(np.float(means[i]) / width)
-                        yerrors.append(np.sqrt(np.float(covariance[i, i])) / width)
+                        yvalues.append(np.double(means[i]) / width)
+                        yerrors.append(np.sqrt(np.double(covariance[i, i])) / width)
                 elif constraint['type'] == 'MultivariateGaussian':
                     if not self.observable:
                         raise KeyError('observable needs to be specified for MultivariateGaussian constraints')


### PR DESCRIPTION
GitHub: resolves #576