### PR TITLE
[doc] Fix typo in Python API documentation

### DIFF
--- a/doc/api/python.rst.jinja
+++ b/doc/api/python.rst.jinja
@@ -268,7 +268,7 @@ All item types recognize the following optional keys:
 
  * ``label`` (*str*, may contain LaTeX commands) -- The label that appears in the plot's legend for this plot item.
 
- * ``style`` (*str*, containing any valid Matplotlib styale specification) -- The style of the plot item.
+ * ``style`` (*str*, containing any valid Matplotlib style specification) -- The style of the plot item.
 
 
 {% for key, value in plot_types.items() %}


### PR DESCRIPTION
Closes #572 