### PR TITLE
Adapt log level messaging, remove redundancy in constraint options

### DIFF
--- a/eos/constraints/B-to-omega-l-nu.yaml
+++ b/eos/constraints/B-to-omega-l-nu.yaml
@@ -22,11 +22,11 @@ B^+->omegalnu::BR@BPR:2021A:
       - {q2_min: 10, q2_max: 12}
       - {q2_min: 12, q2_max: 21}
     options:
-      - {q: u, l: e}
-      - {q: u, l: e}
-      - {q: u, l: e}
-      - {q: u, l: e}
-      - {q: u, l: e}
+      - {l: e}
+      - {l: e}
+      - {l: e}
+      - {l: e}
+      - {l: e}
     means: [1.506e-5, 1.815e-5, 1.471e-5, 1.715e-5, 4.981e-5]
     sigma-stat-hi: [0, 0, 0, 0, 0]
     sigma-stat-lo: [0, 0, 0, 0, 0]

--- a/eos/utils/concrete-cacheable-observable.hh
+++ b/eos/utils/concrete-cacheable-observable.hh
@@ -329,7 +329,7 @@ namespace eos
                     const auto & key = std::get<0>(fo);
                     if (options.has(key))
                     {
-                        Log::instance()->message("[ConcreteCacheableObservableEntry.make]", ll_error)
+                        Log::instance()->message("[ConcreteCacheableObservableEntry.make]", ll_warning)
                             << "Observable '" << _name << "' forces option key '" << key << "' to value '" << _forced_options[key] << "', overriding user-provided value '" << options[key] << "'";
                     }
                 }

--- a/eos/utils/concrete_observable.hh
+++ b/eos/utils/concrete_observable.hh
@@ -196,7 +196,7 @@ namespace eos
                     const auto & key = std::get<0>(fo);
                     if (options.has(key))
                     {
-                        Log::instance()->message("[ConcreteObservableEntry.make]", ll_error)
+                        Log::instance()->message("[ConcreteObservableEntry.make]", ll_warning)
                             << "Observable '" << _name << "' forces option key '" << key << "' to value '" << _forced_options[key] << "', overriding user-provided value '" << options[key] << "'";
                     }
                 }

--- a/eos/utils/expression-observable.cc
+++ b/eos/utils/expression-observable.cc
@@ -178,7 +178,7 @@ namespace eos
             const auto & key = std::get<0>(fo);
             if (options.has(key))
             {
-                Log::instance()->message("[ExpressionObservableEntry.make]", ll_error)
+                Log::instance()->message("[ExpressionObservableEntry.make]", ll_warning)
                     << "Observable '" << _name << "' forces option key '" << key << "' to value '" << _forced_options[key] << "', overriding user-provided value '" << options[key] << "'";
             }
         }

--- a/python/eos_TEST.py
+++ b/python/eos_TEST.py
@@ -192,7 +192,7 @@ class LoggingTests(unittest.TestCase):
         "Computation of specific observable should log error"
         import eos
 
-        with self.assertLogs('EOS', level='ERROR') as cm:
+        with self.assertLogs('EOS', level='WARNING') as cm:
             eos.Observable.make(
                     "B->pilnu::BR",
                     eos.Parameters.Defaults(),
@@ -200,7 +200,7 @@ class LoggingTests(unittest.TestCase):
                     eos.Options(**{'U': 'c'})) # will  be overwritten by the
                                                # implementation of the observable
             self.assertEqual(cm.output,
-                    [r"""ERROR:EOS:[ConcreteObservableEntry.make] Observable 'B->pilnu::BR' forces option key 'U' to value 'u', overriding user-provided value 'c'"""])
+                    [r"""WARNING:EOS:[ConcreteObservableEntry.make] Observable 'B->pilnu::BR' forces option key 'U' to value 'u', overriding user-provided value 'c'"""])
 
 
 # Run legacy test cases


### PR DESCRIPTION
- Adapt log level messaging for cases when when forcing option keys
- Remove option redundancy in `constraints\B-to-omega.yaml`