### PR TITLE
Add pseudo observables for missing BGL coefficients 

### DIFF
--- a/eos/form-factors/observables.cc
+++ b/eos/form-factors/observables.cc
@@ -277,7 +277,7 @@ namespace eos
                         Unit::None(),
                         &BGLCoefficients::S1_a2),
 
-                make_expression_observable("B->D^*::a_1/a_0[S_1]@HQE", R"(a_1^{S_1}/a_0^{S_1})",
+                make_expression_observable("B->D::a_1/a_0[S_1]@HQE", R"(a_1^{S_1}/a_0^{S_1})",
                         Unit::None(),
                         R"(
                         <<B->D::a_1[S_1]@HQE>>
@@ -285,7 +285,7 @@ namespace eos
                         <<B->D::a_0[S_1]@HQE>>
                         )"),
 
-                make_expression_observable("B->D^*::a_2/a_0[S_1]@HQE", R"(a_2^{S_1}/a_0^{S_1})",
+                make_expression_observable("B->D::a_2/a_0[S_1]@HQE", R"(a_2^{S_1}/a_0^{S_1})",
                         Unit::None(),
                         R"(
                         <<B->D::a_2[S_1]@HQE>>
@@ -305,7 +305,7 @@ namespace eos
                         Unit::None(),
                         &BGLCoefficients::V1_a2),
 
-                make_expression_observable("B->D^*::a_1/a_0[V_1]@HQE", R"(a_1^{V_1}/a_0^{V_1})",
+                make_expression_observable("B->D::a_1/a_0[V_1]@HQE", R"(a_1^{V_1}/a_0^{V_1})",
                         Unit::None(),
                         R"(
                         <<B->D::a_1[V_1]@HQE>>
@@ -313,7 +313,7 @@ namespace eos
                         <<B->D::a_0[V_1]@HQE>>
                         )"),
 
-                make_expression_observable("B->D^*::a_2/a_0[V_1]@HQE", R"(a_2^{V_1}/a_0^{V_1})",
+                make_expression_observable("B->D::a_2/a_0[V_1]@HQE", R"(a_2^{V_1}/a_0^{V_1})",
                         Unit::None(),
                         R"(
                         <<B->D::a_2[V_1]@HQE>>

--- a/eos/form-factors/observables.cc
+++ b/eos/form-factors/observables.cc
@@ -27,6 +27,7 @@
 #include <eos/form-factors/observables.hh>
 #include <eos/form-factors/parametric-abr2022.hh>
 #include <eos/form-factors/parametric-bgjvd2019.hh>
+#include <eos/form-factors/parametric-bgl1997.hh>
 #include <eos/form-factors/parametric-bfw2010.hh>
 #include <eos/form-factors/parametric-bmrvd2022.hh>
 #include <eos/form-factors/parametric-kkvdz2022.hh>
@@ -978,6 +979,22 @@ namespace eos
                         /
                         <<B->D^*::a_0[V_4]@HQE>>
                         )"),
+
+                make_observable("B->D^*::a_0[F_1]@BGL", R"(a_0^{F_1})",
+                        Unit::None(),
+                        &BGL1997FormFactors<BToDstar>::a_F1_0),
+
+                make_observable("B->D^*::a_0[F_2]@BGL", R"(a_0^{F_2})",
+                        Unit::None(),
+                        &BGL1997FormFactors<BToDstar>::a_F2_0),
+
+                make_observable("B->D^*::a_0[T_2]@BGL", R"(a_0^{T_2})",
+                        Unit::None(),
+                        &BGL1997FormFactors<BToDstar>::a_T2_0),
+
+                make_observable("B->D^*::a_0[T_23]@BGL", R"(a_0^{T_{23}})",
+                        Unit::None(),
+                        &BGL1997FormFactors<BToDstar>::a_T23_0),
             }
         );
 

--- a/eos/form-factors/parametric-bgl1997-impl.hh
+++ b/eos/form-factors/parametric-bgl1997-impl.hh
@@ -367,7 +367,17 @@ namespace eos
     {
         return 0.0;  //  TODO
     }
+    std::vector<OptionSpecification>::const_iterator
+    BGL1997FormFactors<BToDstar>::begin_options()
+    {
+        return _options.cbegin();
+    }
 
+    std::vector<OptionSpecification>::const_iterator
+    BGL1997FormFactors<BToDstar>::end_options()
+    {
+        return _options.cend();
+    }
 
     std::string
     BGL1997FormFactors<BToD>::_par_name(const std::string & ff_name)
@@ -446,6 +456,18 @@ namespace eos
     BGL1997FormFactors<BToD>::f_plus_T(const double & /*s*/) const
     {
         return 0.0; //  TODO
+    }
+
+    std::vector<OptionSpecification>::const_iterator
+    BGL1997FormFactors<BToD>::begin_options()
+    {
+        return _options.cbegin();
+    }
+
+    std::vector<OptionSpecification>::const_iterator
+    BGL1997FormFactors<BToD>::end_options()
+    {
+        return _options.cend();
     }
 }
 

--- a/eos/form-factors/parametric-bgl1997.cc
+++ b/eos/form-factors/parametric-bgl1997.cc
@@ -23,7 +23,29 @@
 
 namespace eos
 {
+    const std::set<ReferenceName>
+    BGL1997FormFactors<BToDstar>::references
+    {
+        "BGL:1997A"_rn
+    };
+
+    const std::vector<OptionSpecification>
+    BGL1997FormFactors<BToDstar>::_options
+    {
+    };
+
     template class BGL1997FormFactors<BToDstar>;
+
+    const std::set<ReferenceName>
+    BGL1997FormFactors<BToD>::references
+    {
+        "BGL:1997A"_rn
+    };
+
+    const std::vector<OptionSpecification>
+    BGL1997FormFactors<BToD>::_options
+    {
+    };
 
     template class BGL1997FormFactors<BToD>;
 }

--- a/eos/form-factors/parametric-bgl1997.hh
+++ b/eos/form-factors/parametric-bgl1997.hh
@@ -26,6 +26,7 @@
 #include <eos/form-factors/mesonic.hh>
 #include <eos/form-factors/mesonic-processes.hh>
 #include <eos/models/model.hh>
+#include <eos/utils/reference-name.hh>
 
 namespace eos
 {
@@ -63,6 +64,8 @@ namespace eos
 
             static std::string _par_name(const std::string & ff_name);
 
+            static const std::vector<OptionSpecification> _options;
+
         public:
             BGL1997FormFactors(const Parameters &, const Options &);
             ~BGL1997FormFactors();
@@ -96,6 +99,17 @@ namespace eos
             virtual double f_perp_T(const double & s) const;
             virtual double f_para_T(const double & s) const;
             virtual double f_long_T(const double & s) const;
+
+            /*!
+             * References used in the computation of our (pseudo)observables.
+             */
+            static const std::set<ReferenceName> references;
+
+            /*!
+             * Options used in the computation of our (pseudo)observables.
+             */
+            static std::vector<OptionSpecification>::const_iterator begin_options();
+            static std::vector<OptionSpecification>::const_iterator end_options();
     };
 
 
@@ -113,6 +127,8 @@ namespace eos
 
             static std::string _par_name(const std::string & ff_name);
 
+            static const std::vector<OptionSpecification> _options;
+
         public:
             BGL1997FormFactors(const Parameters &, const Options &);
             ~BGL1997FormFactors();
@@ -124,6 +140,17 @@ namespace eos
             virtual double f_t(const double & s) const;
 
             virtual double f_plus_T(const double & s) const;
+
+            /*!
+             * References used in the computation of our (pseudo)observables.
+             */
+            static const std::set<ReferenceName> references;
+
+            /*!
+             * Options used in the computation of our (pseudo)observables.
+             */
+            static std::vector<OptionSpecification>::const_iterator begin_options();
+            static std::vector<OptionSpecification>::const_iterator end_options();
     };
 }
 


### PR DESCRIPTION
Some of the BGL coefficients in our implementation are non-parametric, due to exact relations amongst the form factors at given phase space points. This PR
 - turns the BGL form factor class into an ``ObservableProvider``;
 - exports the pseudo observables for the ``a_0`` coefficients;
 - fixes a bug in the naming of some pseudo observables for the coefficients of the HQE in B->D transitions.

Resolves #590.
 