### PR TITLE
Increase efficiency of the ``sample-nested`` tasks through prior sampling

### DIFF
--- a/.github/workflows/manylinux-build+check+deploy.yaml
+++ b/.github/workflows/manylinux-build+check+deploy.yaml
@@ -26,7 +26,7 @@ jobs:
                     - { pypath: cp310-cp310, pysuffix: cp310, pyboostsuffix: 310 }
                     - { pypath: cp311-cp311, pysuffix: cp311, pyboostsuffix: 311 }
         container:
-            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:c3b826a70d729805258243fb5d95dbe5ae2fbd2f
+            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:537d22c4154fd860f6f3fefa164c5ec9f62254b3
         steps:
             - name: Checkout git repository
               uses: actions/checkout@v3
@@ -96,7 +96,7 @@ jobs:
                     - { pypath: cp39-cp39,   pysuffix: cp39,  pyboostsuffix: 39  }
                     - { pypath: cp310-cp310, pysuffix: cp310, pyboostsuffix: 310 }
         container:
-            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:c3b826a70d729805258243fb5d95dbe5ae2fbd2f
+            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:537d22c4154fd860f6f3fefa164c5ec9f62254b3
         steps:
             - name: Download configured source as artifact
               uses: actions/download-artifact@v3
@@ -136,7 +136,7 @@ jobs:
                     - { pypath: cp39-cp39,   pysuffix: cp39,  pyboostsuffix: 39  }
                     - { pypath: cp310-cp310, pysuffix: cp310, pyboostsuffix: 310 }
         container:
-            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:c3b826a70d729805258243fb5d95dbe5ae2fbd2f
+            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:537d22c4154fd860f6f3fefa164c5ec9f62254b3
         steps:
             - name: Download configured source as artifact
               uses: actions/download-artifact@v3

--- a/eos/constraint.hh
+++ b/eos/constraint.hh
@@ -23,6 +23,7 @@
 
 #include <eos/observable.hh>
 #include <eos/statistics/log-likelihood-fwd.hh>
+#include <eos/statistics/log-prior.hh>
 #include <eos/utils/iterator-range.hh>
 #include <eos/utils/observable_cache.hh>
 #include <eos/utils/private_implementation_pattern.hh>
@@ -107,6 +108,9 @@ namespace eos
 
             /// Make a new constraint based on this entry.
             virtual Constraint make(const QualifiedName &, const Options &) const = 0;
+
+            /// Make a new log(prior) based on this entry.
+            virtual LogPriorPtr make_prior(const Parameters &, const Options &) const = 0;
 
             /// Return the entry's name
             virtual const QualifiedName & name() const = 0;

--- a/eos/statistics/Makefile.am
+++ b/eos/statistics/Makefile.am
@@ -25,6 +25,7 @@ include_eos_statistics_HEADERS = \
 	test-statistic.hh
 
 AM_TESTS_ENVIRONMENT = \
+	export EOS_TESTS_CONSTRAINTS="$(top_srcdir)/eos/constraints"; \
 	export EOS_TESTS_PARAMETERS="$(top_srcdir)/eos/parameters";
 
 TESTS = \

--- a/eos/statistics/goodness-of-fit.cc
+++ b/eos/statistics/goodness-of-fit.cc
@@ -42,7 +42,7 @@ namespace eos
         Implementation(const LogPosterior & log_posterior) :
             log_posterior(log_posterior),
             total_chi_square(0.0),
-            total_degrees_of_freedom(log_posterior.informative_priors() - log_posterior.parameter_descriptions().size()),
+            total_degrees_of_freedom(log_posterior.informative_priors() - log_posterior.varied_parameters().size()),
             current_constraint(nullptr)
         {
             compute_test_statistics();

--- a/eos/statistics/log-posterior.hh
+++ b/eos/statistics/log-posterior.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2011 Frederik Beaujean
+ * Copyright (c) 2015-2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -35,8 +36,7 @@
 
 namespace eos
 {
-    class LogPosterior :
-        public Density
+    class LogPosterior
     {
         public:
             friend struct Implementation<LogPosterior>;
@@ -59,32 +59,24 @@ namespace eos
             virtual ~LogPosterior();
 
             /// Clone this LogPosterior
-            // todo remove
-            LogPosteriorPtr old_clone() const;
+            LogPosteriorPtr clone() const;
 
-            virtual DensityPtr clone() const;
-
+            /// Evaluate the Log(posterior) density at the current parameter values.
             virtual double evaluate() const;
-
-            virtual Iterator begin() const;
-            virtual Iterator end() const;
             ///@}
 
             ///@name Accessors
             ///@{
-            // todo remove
-            /// Retrieve a set of all parameters, including ranges
-            const std::vector<ParameterDescription> & parameter_descriptions() const;
+            /// Retrieve a set of all varied parameters
+            const std::vector<Parameter> & varied_parameters() const;
 
-            // todo remove as functionality available from begin(), end()
             /*!
              * Retrieve a parameter by index.
              *
              * @param index The index of the parameter.
              */
-            MutablePtr operator[] (const unsigned & index) const;
+            Parameter operator[] (const unsigned & index) const;
 
-            // todo remove
             /// Retrieve our associated Parameters object
             Parameters parameters() const;
 
@@ -102,13 +94,7 @@ namespace eos
             /// Retrieve the overall Log(prior).
             double log_prior() const;
 
-            /*!
-             * Find the prior for a given parameter
-             */
-            LogPriorPtr log_prior(const std::string & name) const;
-
             /// Retrieve the overall Log(posterior)
-            /// Incorporate normalization constant, the evidence here in getter if available.
             double log_posterior() const;
 
             /*!
@@ -119,13 +105,6 @@ namespace eos
 
             PriorIterator begin_priors() const;
             PriorIterator end_priors() const;
-
-            /*!
-             * Check if a given parameter is a nuisance parameter for this LogPosterior.
-             *
-             * @param name The name of the parameter we are interested in.
-             */
-            bool nuisance(const std::string & name) const;
 
             /*!
              * Returns the number of informative priors.
@@ -148,17 +127,17 @@ namespace eos
 
             Parameters _parameters;
 
+            /// names of all parameters. prevent using a parameter twice
+            std::set<QualifiedName> _parameter_names;
+
             /// prior in N dimensions can decouple
             /// at most into N 1D priors
             std::vector<LogPriorPtr> _priors;
 
             unsigned _informative_priors;
 
-            /// Parameter, minimum, maximum, nuisance
-            std::vector<ParameterDescription> _parameter_descriptions;
-
-            /// names of all parameters. prevent using a parameter twice
-            std::set<std::string> _parameter_names;
+            /// Parameters with priors
+            std::vector<Parameter> _varied_parameters;
     };
 
     extern template class WrappedForwardIterator<LogPosterior::PriorIteratorTag, const LogPriorPtr>;

--- a/eos/statistics/log-posterior_TEST.cc
+++ b/eos/statistics/log-posterior_TEST.cc
@@ -87,7 +87,7 @@ class LogPosteriorTest :
 
 
                 // 4.4 +- 0.1
-                log_posterior.add(LogPrior::Gauss(parameters, "mass::b(MSbar)",
+                log_posterior.add(LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)",
                         ParameterRange
                             { 3.7, 4.9 }, 4.3, 4.4, 4.5));
 

--- a/eos/statistics/log-posterior_TEST.cc
+++ b/eos/statistics/log-posterior_TEST.cc
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2010, 2011 Frederik Beaujean
- * Copyright (c) 2011, 2012, 2013, 2015, 2016 Danny van Dyk
+ * Copyright (c) 2011-2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -42,14 +42,14 @@ class LogPosteriorTest :
             {
                 LogPosterior log_posterior = make_log_posterior(false);
 
-                auto clone1 = log_posterior.old_clone();
-                auto clone2 = log_posterior.old_clone();
+                auto clone1 = log_posterior.clone();
+                auto clone2 = log_posterior.clone();
 
                 // make sure observable's value is not equal to central value
-                MutablePtr p = (*clone1)[0];
-                p->set(4.3); //posterior mode
+                Parameter p = (*clone1)[0];
+                p.set(4.3); //posterior mode
                 p = (*clone2)[0];
-                p->set(4.4); //log_prior mode
+                p.set(4.4); //log_prior mode
 
                 // for comparison used ipython's log(scipy.stats.norm.pdf(4.3, loc=4.4, scale=0.1))
                 // value at center of both Gaussian distributions. so pdf the same
@@ -67,7 +67,7 @@ class LogPosteriorTest :
                 // now change a parameter which is not scanned
                 TEST_CHECK(log_posterior.parameters()["b->s::Re{c7}"] != 2.599);
                 log_posterior.parameters()["b->s::Re{c7}"] = 2.599;
-                LogPosteriorPtr clone3 = log_posterior.old_clone();
+                LogPosteriorPtr clone3 = log_posterior.clone();
 
                 TEST_CHECK_EQUAL(double(log_posterior.parameters()["b->s::Re{c7}"] ),
                                  double( clone3->parameters()["b->s::Re{c7}"] ));
@@ -83,7 +83,7 @@ class LogPosteriorTest :
                 LogPosterior log_posterior(llh);
 
                 // store a clone with no parameters
-                auto clone_bare = log_posterior.old_clone();
+                auto clone_bare = log_posterior.clone();
 
 
                 // 4.4 +- 0.1
@@ -93,8 +93,8 @@ class LogPosteriorTest :
 
 
 
-                MutablePtr p = log_posterior[0];
-                p->set(4.3); //posterior mode
+                Parameter p = log_posterior[0];
+                p.set(4.3); //posterior mode
 
 
                 TEST_CHECK_NEARLY_EQUAL(log_posterior.log_likelihood()(), +0.88364655978936768, eps);
@@ -104,33 +104,22 @@ class LogPosteriorTest :
 
                 // now check cloning
 
-                auto clone = log_posterior.old_clone();
-                MutablePtr p2 = (*clone)[0];
+                auto clone = log_posterior.clone();
+                Parameter p2 = (*clone)[0];
 
-                TEST_CHECK_EQUAL(p->evaluate(), p2->evaluate());
+                TEST_CHECK_EQUAL(p.evaluate(), p2.evaluate());
 
 
                 // change clone only
-                p2->set(4.112);
+                p2.set(4.112);
                 TEST_CHECK(log_posterior.log_likelihood()() != clone->log_likelihood()());
                 TEST_CHECK(log_posterior.log_prior() != clone->log_prior());
 
                 // same value for clone and original
-                p2->set(4.3);
+                p2.set(4.3);
 
                 TEST_CHECK_EQUAL(log_posterior.log_likelihood()(), clone->log_likelihood()());
                 TEST_CHECK_EQUAL(log_posterior.log_prior(), clone->log_prior());
-            }
-
-            // nuisance properties.nuisance())
-            {
-                LogPosterior log_posterior = make_log_posterior(false);
-
-                TEST_CHECK(!log_posterior.nuisance("mass::b(MSbar)"));
-
-                log_posterior.add(LogPrior::Flat(log_posterior.parameters(), "mass::c", ParameterRange{ 1.4, 2.2}), true);
-
-                TEST_CHECK(log_posterior.nuisance("mass::c"));
             }
 
             // stop if prior undefined

--- a/eos/statistics/log-posterior_TEST.hh
+++ b/eos/statistics/log-posterior_TEST.hh
@@ -141,7 +141,7 @@ namespace eos
 
         LogPriorPtr prior = flat ?
             LogPrior::Flat(parameters, "mass::b(MSbar)", ParameterRange{3.7, 4.9} ) :
-            LogPrior::Gauss(parameters, "mass::b(MSbar)", ParameterRange{3.7, 4.9}, 4.3, 4.4, 4.5);
+            LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", ParameterRange{3.7, 4.9}, 4.3, 4.4, 4.5);
 
         LogPosterior result(llh);
         result.add(prior);

--- a/eos/statistics/log-prior.cc
+++ b/eos/statistics/log-prior.cc
@@ -55,7 +55,7 @@ namespace eos
     template <>
     struct WrappedForwardIteratorTraits<LogPrior::IteratorTag>
     {
-        using UnderlyingIterator = std::vector<ParameterDescription>::iterator;
+        using UnderlyingIterator = std::vector<Parameter>::iterator;
     };
 
     namespace priors
@@ -107,7 +107,7 @@ namespace eos
                         throw RangeError("LogPrior::Flat(" + _name +"): minimum (" + stringify(range.min)
                                           + ") must be smaller than maximum (" + stringify(range.max) + ")");
                     }
-                    _parameter_descriptions.push_back(ParameterDescription{ _parameters[name].clone(), range.min, range.max, false });
+                    _varied_parameters.push_back(_parameter);
                 }
 
                 virtual ~Flat()
@@ -203,7 +203,7 @@ namespace eos
                         throw RangeError("LogPrior::Gauss(" + _name +"): minimum (" + stringify(range.min)
                                           + ") must be smaller than maximum (" + stringify(range.max) + ")");
                     }
-                    _parameter_descriptions.push_back(ParameterDescription{ _parameters[name].clone(), range.min, range.max, false });
+                    _varied_parameters.push_back(_parameter);
                 }
 
                 virtual ~CurtailedGauss()
@@ -231,7 +231,7 @@ namespace eos
                     double sigma = 0.0, norm = 0.0;
 
                     // read parameter's current value
-                    double x = _parameter_descriptions.front().parameter->evaluate();
+                    double x = _parameter.evaluate();
 
                     if (x < _central)
                     {
@@ -314,7 +314,7 @@ namespace eos
                     _max(mu_0 * lambda),
                     _ln_lambda(std::log(lambda))
                 {
-                    _parameter_descriptions.push_back(ParameterDescription{ _parameters[name].clone(), mu_0 / lambda, mu_0 * lambda, false });
+                    _varied_parameters.push_back(_parameter);
                 }
 
                 virtual ~Scale()
@@ -332,7 +332,7 @@ namespace eos
                 virtual double operator()() const
                 {
                     // read parameter's current value
-                    double x = _parameter_descriptions.front().parameter->evaluate();
+                    double x = _parameter.evaluate();
 
                     if ((x < _min) || (_max < x))
                         return -std::numeric_limits<double>::infinity();
@@ -427,7 +427,7 @@ namespace eos
                     {
                         const auto & param = parameters[n];
                         _parameters.push_back(param);
-                        _parameter_descriptions.push_back(ParameterDescription{ param.clone(), -inf, +inf, false });
+                        _varied_parameters.push_back(param);
                     }
 
                     // cholesky decomposition (informally: the sqrt of the covariance matrix)
@@ -630,13 +630,13 @@ namespace eos
     LogPrior::Iterator
     LogPrior::begin()
     {
-        return LogPrior::Iterator(_parameter_descriptions.begin());
+        return LogPrior::Iterator(_varied_parameters.begin());
     }
 
     LogPrior::Iterator
     LogPrior::end()
     {
-        return LogPrior::Iterator(_parameter_descriptions.end());
+        return LogPrior::Iterator(_varied_parameters.end());
     }
 
     LogPriorPtr
@@ -764,5 +764,5 @@ namespace eos
         throw priors::UnknownPriorError("Cannot construct prior from '" + s + "'");
     }
 
-    template class WrappedForwardIterator<LogPrior::IteratorTag, ParameterDescription>;
+    template class WrappedForwardIterator<LogPrior::IteratorTag, Parameter>;
 }

--- a/eos/statistics/log-prior.cc
+++ b/eos/statistics/log-prior.cc
@@ -120,16 +120,6 @@ namespace eos
                     _parameter.set(_parameter.evaluate_generator() * (_range.max - _range.min) + _range.min);
                 }
 
-                virtual double mean() const
-                {
-                    return (_range.max - _range.min) / 2.0;
-                }
-
-                virtual double variance() const
-                {
-                    return power_of<2>(_range.max - _range.min) / 12.0;
-                }
-
                 virtual bool informative() const
                 {
                     return false;
@@ -254,17 +244,6 @@ namespace eos
                        _parameter.set(gsl_cdf_gaussian_Pinv((p - _prob_lower) / _c_a + 0.5,  _sigma_upper) + _central);
                 }
 
-                virtual double mean() const
-                {
-                    return _central;
-                }
-
-                ///Only true if parameter range is the whole real line
-                virtual double variance() const
-                {
-                    return (power_of<2>(_sigma_upper) + power_of<2>(_sigma_lower)) / 2.0;
-                }
-
                 virtual bool informative() const
                 {
                     return true;
@@ -339,18 +318,6 @@ namespace eos
                     // inverse CDF: x = \mu_0 * \lambda^(2 p - 1)
 
                     _parameter.set(_mu_0 * std::pow(_lambda, 2.0 * _parameter.evaluate_generator() - 1.0));
-                }
-
-                virtual double mean() const
-                {
-                    return _mu_0 * (_lambda * _lambda - 1.0) / (2.0 * _lambda * _ln_lambda);
-                }
-
-                ///Only true if parameter range is the whole real line
-                virtual double variance() const
-                {
-                    return _mu_0 * _mu_0 * (_lambda * _lambda - 1.0) * (1.0 - _lambda * _lambda + (1.0 + _lambda * _lambda) * _ln_lambda)
-                        / (4.0 * _lambda * _lambda * _ln_lambda * _ln_lambda);
                 }
 
                 virtual bool informative() const

--- a/eos/statistics/log-prior.cc
+++ b/eos/statistics/log-prior.cc
@@ -127,9 +127,9 @@ namespace eos
         };
 
         /*!
-         * [asymmetric] Gaussian or Normal prior distribution
+         * [asymmetric] Gaussian or Normal prior distribution with finite support
          */
-        class Gauss :
+        class CurtailedGauss :
             public LogPrior
         {
             private:
@@ -160,7 +160,7 @@ namespace eos
                 const double _norm_lower, _norm_upper;
 
             public:
-                Gauss(const Parameters & parameters, const std::string & name, const ParameterRange & range,
+                CurtailedGauss(const Parameters & parameters, const std::string & name, const ParameterRange & range,
                         const double & lower, const double & central, const double & upper) :
                     LogPrior(parameters),
                     _parameter(parameters[name]),
@@ -186,7 +186,7 @@ namespace eos
                     _parameter_descriptions.push_back(ParameterDescription{ _parameters[name].clone(), range.min, range.max, false });
                 }
 
-                virtual ~Gauss()
+                virtual ~CurtailedGauss()
                 {
                 }
 
@@ -228,7 +228,7 @@ namespace eos
 
                 virtual LogPriorPtr clone(const Parameters & parameters) const
                 {
-                    return LogPriorPtr(new priors::Gauss(parameters, _name, _range, _lower, _central, _upper));
+                    return LogPriorPtr(new priors::CurtailedGauss(parameters, _name, _range, _lower, _central, _upper));
                 }
 
                 virtual void sample()
@@ -353,7 +353,7 @@ namespace eos
     }
 
     LogPriorPtr
-    LogPrior::Gauss(const Parameters & parameters, const std::string & name, const ParameterRange & range,
+    LogPrior::CurtailedGauss(const Parameters & parameters, const std::string & name, const ParameterRange & range,
             const double & lower, const double & central, const double & upper)
     {
         // check input
@@ -363,7 +363,7 @@ namespace eos
         if (upper <= central)
             throw InternalError("LogPrior::Gauss: upper value (" + stringify(upper) + ") <= central value (" + stringify(central) + ")");
 
-        LogPriorPtr prior = std::make_shared<eos::priors::Gauss>(parameters, name, range, lower, central, upper);
+        LogPriorPtr prior = std::make_shared<eos::priors::CurtailedGauss>(parameters, name, range, lower, central, upper);
 
         return prior;
     }
@@ -454,7 +454,7 @@ namespace eos
             }
 
             if (prior_type == "Gaussian")
-                return Gauss(parameters, par_name, range, central - sigma_lower, central, central + sigma_upper);
+                return CurtailedGauss(parameters, par_name, range, central - sigma_lower, central, central + sigma_upper);
         }
 
         throw priors::UnknownPriorError("Cannot construct prior from '" + s + "'");

--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -92,11 +92,12 @@ namespace eos
             virtual double operator() () const = 0;
 
             /*!
-             * Evaluate the inverse cumulative density function of the prior.
+             * Generate a prior sample from the inverse CDF and a set of generator values.
              *
-             * @param p The cumulative probability for which we seek the parameter value.
+             * The generator values must have been passed to all Parameter objects via their respective
+             * set_generator() method.
              */
-            virtual double inverse_cdf(const double & p) const = 0;
+            virtual void sample() = 0;
 
             /*!
              * Return the mean of the distribution.

--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -105,13 +105,14 @@ namespace eos
             virtual bool informative() const = 0;
             ///@}
 
-            ///@name Named constructors for 1D prior distributions
+            ///@name Named constructors for 1D prior distributions with finite support
             ///@{
             static LogPriorPtr Flat(const Parameters & parameters, const std::string & name, const ParameterRange & range);
-            static LogPriorPtr Gauss(const Parameters & parameters, const std::string & name, const ParameterRange & range,
+            static LogPriorPtr CurtailedGauss(const Parameters & parameters, const std::string & name, const ParameterRange & range,
                     const double & lower, const double & central, const double & upper);
             static LogPriorPtr Scale(const Parameters & parameter, const std::string & name, const ParameterRange & range,
                     const double & mu_0, const double & lambda);
+            ///@}
 
             /*!
              * Construct a prior from its string representation.
@@ -121,7 +122,6 @@ namespace eos
              * @return Pointer to the ready made prior.
              */
             static LogPriorPtr Make(const Parameters & parameters, const std::string & serialization);
-            ///@}
     };
 
     extern template class WrappedForwardIterator<LogPrior::IteratorTag, ParameterDescription>;

--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -100,16 +100,6 @@ namespace eos
             virtual void sample() = 0;
 
             /*!
-             * Return the mean of the distribution.
-             */
-            virtual double mean() const = 0;
-
-            /*!
-             * Return the variance of this distribution.
-             */
-            virtual double variance() const = 0;
-
-            /*!
              * Return whether or not this prior is informative.
              */
             virtual bool informative() const = 0;

--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -102,6 +102,13 @@ namespace eos
             virtual void sample() = 0;
 
             /*!
+             * Compute the vector of cummulative probabilities.
+             *
+             * The results are stored it in the generator values of the Parameter objects.
+             */
+            virtual void compute_cdf() = 0;
+
+            /*!
              * Return whether or not this prior is informative.
              */
             virtual bool informative() const = 0;

--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2011 Frederik Beaujean
+ * Copyright (c) 2019-2022 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General

--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -48,7 +48,7 @@ namespace eos
             Parameters _parameters;
 
             /// All parameters for which this prior provides information.
-            std::vector<ParameterDescription> _parameter_descriptions;
+            std::vector<Parameter> _varied_parameters;
 
         public:
             ///@name Basic Functions
@@ -79,7 +79,7 @@ namespace eos
             ///@name Iteration over descriptions
             ///@{
             struct IteratorTag;
-            using Iterator = WrappedForwardIterator<IteratorTag, ParameterDescription>;
+            using Iterator = WrappedForwardIterator<IteratorTag, Parameter>;
 
             Iterator begin();
             Iterator end();
@@ -139,7 +139,7 @@ namespace eos
             static LogPriorPtr Make(const Parameters & parameters, const std::string & serialization);
     };
 
-    extern template class WrappedForwardIterator<LogPrior::IteratorTag, ParameterDescription>;
+    extern template class WrappedForwardIterator<LogPrior::IteratorTag, Parameter>;
 }
 
 #endif

--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -28,7 +28,9 @@
 #include <vector>
 #include <memory>
 
-#include  <gsl/gsl_rng.h>
+#include <gsl/gsl_matrix.h>
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_vector.h>
 
 namespace eos
 {
@@ -112,6 +114,12 @@ namespace eos
                     const double & lower, const double & central, const double & upper);
             static LogPriorPtr Scale(const Parameters & parameter, const std::string & name, const ParameterRange & range,
                     const double & mu_0, const double & lambda);
+            ///@}
+
+            ///@name Named constructors for prior distributions with infinite support
+            ///@{
+            static LogPriorPtr MultivariateGaussian(const Parameters & parameters, const std::vector<QualifiedName> & names,
+                    gsl_vector * mean, gsl_matrix * covariance);
             ///@}
 
             /*!

--- a/eos/statistics/log-prior_TEST.cc
+++ b/eos/statistics/log-prior_TEST.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2011 Frederik Beaujean
+ * Copyright (c) 2011-2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -71,8 +72,7 @@ class LogPriorTest :
                 TEST_CHECK_NEARLY_EQUAL(inverse_cdf(flat_prior, param, 1.0), 4.5,                eps);
 
                 // a continuous parameter of interest
-                TEST_CHECK(! flat_prior->begin()->nuisance);
-                TEST_CHECK_EQUAL(flat_prior->begin()->parameter->name(), "mass::b(MSbar)");
+                TEST_CHECK_EQUAL(flat_prior->begin()->name(), "mass::b(MSbar)");
             }
 
 

--- a/eos/statistics/log-prior_TEST.cc
+++ b/eos/statistics/log-prior_TEST.cc
@@ -18,6 +18,7 @@
  */
 
 #include <test/test.hh>
+#include <eos/constraint.hh>
 #include <eos/statistics/log-prior.hh>
 #include <eos/maths/power-of.hh>
 
@@ -168,6 +169,56 @@ class LogPriorTest :
                 TEST_CHECK_NEARLY_EQUAL(inverse_cdf(scale_prior, param, 0.0), mu_0 / lambda, eps);
                 // upper boundary at p = 1.0
                 TEST_CHECK_NEARLY_EQUAL(inverse_cdf(scale_prior, param, 1.0), mu_0 * lambda, eps);
+            }
+
+            // Multivariate Gaussian
+            {
+                // look up constraint entry
+                auto entry = Constraints()["B->K::FormFactors[parametric,LCSR]@GKvD:2018A"];
+                // create prior
+                auto prior = entry->make_prior(parameters, Options());
+
+                // set generator values to 0.5 and sample
+                parameters["B->K::alpha^f+_0@BSZ2015"].set_generator(0.5);
+                parameters["B->K::alpha^f+_1@BSZ2015"].set_generator(0.5);
+                parameters["B->K::alpha^f+_2@BSZ2015"].set_generator(0.5);
+                parameters["B->K::alpha^f0_1@BSZ2015"].set_generator(0.5);
+                parameters["B->K::alpha^f0_2@BSZ2015"].set_generator(0.5);
+                parameters["B->K::alpha^fT_0@BSZ2015"].set_generator(0.5);
+                parameters["B->K::alpha^fT_1@BSZ2015"].set_generator(0.5);
+                parameters["B->K::alpha^fT_2@BSZ2015"].set_generator(0.5);
+                prior->sample();
+
+                // check that the parameters are at the median
+                TEST_CHECK_NEARLY_EQUAL(+0.2655528728950212, parameters["B->K::alpha^f+_0@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.6466140804171657, parameters["B->K::alpha^f+_1@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.1337677825631754, parameters["B->K::alpha^f+_2@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(+0.3841222758978433, parameters["B->K::alpha^f0_1@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.6628825163091753, parameters["B->K::alpha^f0_2@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(+0.2510192324158927, parameters["B->K::alpha^fT_0@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.6508680050905388, parameters["B->K::alpha^fT_1@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(+0.0999901466869552, parameters["B->K::alpha^fT_2@BSZ2015"], eps);
+
+                // set generator values to 0.5 and sample
+                parameters["B->K::alpha^f+_0@BSZ2015"].set_generator(0.15865525393145702);
+                parameters["B->K::alpha^f+_1@BSZ2015"].set_generator(0.15865525393145702);
+                parameters["B->K::alpha^f+_2@BSZ2015"].set_generator(0.15865525393145702);
+                parameters["B->K::alpha^f0_1@BSZ2015"].set_generator(0.15865525393145702);
+                parameters["B->K::alpha^f0_2@BSZ2015"].set_generator(0.15865525393145702);
+                parameters["B->K::alpha^fT_0@BSZ2015"].set_generator(0.15865525393145702);
+                parameters["B->K::alpha^fT_1@BSZ2015"].set_generator(0.15865525393145702);
+                parameters["B->K::alpha^fT_2@BSZ2015"].set_generator(0.15865525393145702);
+                prior->sample();
+
+                // check that the parameters match the reference implementation
+                TEST_CHECK_NEARLY_EQUAL(+0.185453816796, parameters["B->K::alpha^f+_0@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.802422750729, parameters["B->K::alpha^f+_1@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(+2.133896762012, parameters["B->K::alpha^f+_2@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(+0.013676201228, parameters["B->K::alpha^f0_1@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.697392274325, parameters["B->K::alpha^f0_2@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(+0.162651391807, parameters["B->K::alpha^fT_0@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(-0.790991231378, parameters["B->K::alpha^fT_1@BSZ2015"], eps);
+                TEST_CHECK_NEARLY_EQUAL(+4.223260161888, parameters["B->K::alpha^fT_2@BSZ2015"], eps);
             }
 
             //Make

--- a/eos/statistics/log-prior_TEST.cc
+++ b/eos/statistics/log-prior_TEST.cc
@@ -86,7 +86,7 @@ class LogPriorTest :
              */
             {
                 // use factory
-                LogPriorPtr gauss_prior = LogPrior::Gauss(parameters, "mass::b(MSbar)", ParameterRange{ 4.15, 4.57 },
+                LogPriorPtr gauss_prior = LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", ParameterRange{ 4.15, 4.57 },
                         central - sig_lower, central, central + sig_upper);
 
                 parameters["mass::b(MSbar)"] = 4.2;
@@ -111,7 +111,7 @@ class LogPriorTest :
             // cloning
             {
                 Parameters independent = Parameters::Defaults();
-                LogPriorPtr gauss_prior1 = LogPrior::Gauss(parameters, "mass::b(MSbar)", ParameterRange{ 4.15, 4.57 },
+                LogPriorPtr gauss_prior1 = LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", ParameterRange{ 4.15, 4.57 },
                         central - sig_lower, central, central+sig_upper);
                 LogPriorPtr gauss_prior2 = gauss_prior1->clone(independent);
 
@@ -123,7 +123,7 @@ class LogPriorTest :
 
             // vary one sigma interval
             {
-                LogPriorPtr gauss_prior = LogPrior::Gauss(parameters, "mass::b(MSbar)", ParameterRange{ 3.7, 4.9 },
+                LogPriorPtr gauss_prior = LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", ParameterRange{ 3.7, 4.9 },
                         4.3, 4.4, 4.5);
 
                 parameters["mass::b(MSbar)"] = 4.2;
@@ -135,7 +135,7 @@ class LogPriorTest :
 
             // asymmetric
             {
-                LogPriorPtr gauss_prior = LogPrior::Gauss(parameters, "mass::b(MSbar)", ParameterRange{ 0.2, 0.55 },
+                LogPriorPtr gauss_prior = LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", ParameterRange{ 0.2, 0.55 },
                             0.319, 0.369, 0.485);
 
                 parameters["mass::b(MSbar)"] = 0.32;

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Danny van Dyk
+ * Copyright (c) 2010-2022 Danny van Dyk
  * Copyright (c) 2021 Philip Lüghausen
  * Copyright (c) 2010 Christian Wacker
  *
@@ -188,13 +188,14 @@ namespace eos
     struct Parameter::Data :
         Parameter::Template
     {
-        double value;
+        double value, generator_value;
 
         Parameter::Id id;
 
         Data(const Parameter::Template & t, const Parameter::Id & i) :
             Parameter::Template(t),
             value(t.central),
+            generator_value(0.0),
             id(i)
         {
         }
@@ -761,6 +762,12 @@ namespace eos
         return _parameters_data->data[_index].value;
     }
 
+    double
+    Parameter::evaluate_generator() const
+    {
+        return _parameters_data->data[_index].generator_value;
+    }
+
     const Parameter &
     Parameter::operator= (const double & value)
     {
@@ -773,6 +780,12 @@ namespace eos
     Parameter::set(const double & value)
     {
         _parameters_data->data[_index].value = value;
+    }
+
+    void
+    Parameter::set_generator(const double & value)
+    {
+        _parameters_data->data[_index].generator_value = value;
     }
 
     const double &

--- a/eos/utils/parameters.hh
+++ b/eos/utils/parameters.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2012, 2013, 2019 Danny van Dyk
+ * Copyright (c) 2010-2022 Danny van Dyk
  * Copyright (c) 2021 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
@@ -253,11 +253,17 @@ namespace eos
             /// Retrieve a Parameter's numeric value.
             virtual double evaluate() const;
 
+            /// Retrieve a Parameter's generator value, used for prior sampling.
+            virtual double evaluate_generator() const;
+
             /// Set a Parameter's numeric value.
             virtual const Parameter & operator= (const double &);
 
             /// Set a Parameter's numeric value.
             virtual void set(const double &);
+
+            /// Set a Parameter's generator value, used for prior sampling.
+            virtual void set_generator(const double &);
             ///@}
 
             ///@name Access to Meta Data

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -288,6 +288,9 @@ BOOST_PYTHON_MODULE(_eos)
         .def("suffix_part", &QualifiedName::suffix_part, return_value_policy<copy_const_reference>(), R"(
             Returns the optional suffix part of the name, i.e., the part following the optional '@'.
         )")
+        .def("options_part", &QualifiedName::options, return_value_policy<copy_const_reference>(), R"(
+            Returns the optional options part of the name, i.e., the part following the optional ';'.
+        )")
         ;
     implicitly_convertible<std::string, QualifiedName>();
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -690,7 +690,7 @@ BOOST_PYTHON_MODULE(_eos)
             Returns the cumulative probabilities :math:`p` assigned to each parameter via its
             :meth:`Parameter.evaluate_generator` method.
         )")
-        .def("parameter_descriptions", range(&LogPrior::begin, &LogPrior::end))
+        .def("varied_parameters", range(&LogPrior::begin, &LogPrior::end))
         ;
 
     // LogPosterior

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -331,6 +331,12 @@ BOOST_PYTHON_MODULE(_eos)
         .def("override_from_file", &Parameters::override_from_file)
         ;
 
+    // Mutable
+    register_ptr_to_python<std::shared_ptr<Mutable>>();
+    class_<Mutable, boost::noncopyable>("Mutable", no_init)
+        .def("name", &Mutable::name, return_value_policy<copy_const_reference>())
+        ;
+
     // Parameter
     class_<Parameter>("Parameter", R"(
             Represents a single real-valued scalar parameter in EOS.

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -582,6 +582,7 @@ BOOST_PYTHON_MODULE(_eos)
     register_ptr_to_python<std::shared_ptr<const ConstraintEntry>>();
     class_<eos::ConstraintEntry, boost::noncopyable>("ConstraintEntry", no_init)
         .def("make", &ConstraintEntry::make, return_value_policy<return_by_value>())
+        .def("make_prior", &ConstraintEntry::make_prior, return_value_policy<return_by_value>())
         .def("name", &ConstraintEntry::name, return_value_policy<copy_const_reference>())
         .def("type", &ConstraintEntry::type, return_value_policy<copy_const_reference>())
         .def("observables", range(&ConstraintEntry::begin_observable_names, &ConstraintEntry::end_observable_names))

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -664,12 +664,10 @@ BOOST_PYTHON_MODULE(_eos)
             :type lambda: float, strictly positive
         )", args("parameters", "name", "range", "mu_0", "scale"))
         .staticmethod("Scale")
-        .def("inverse_cdf", &LogPrior::inverse_cdf, R"(
-            Returns the parameter value corresponding to the cumulative propability :math:`p`.
-
-            :param p: The cumulative propability.
-            :type p: float, [0.0, 1.0]
-        )", args("p"))
+        .def("sample", &LogPrior::sample, R"(
+            Sets its parameters' values corresponding to the cumulative propability :math:`p` assigned to
+            each parameter via its :meth:`Parameter.set_generator` method.
+        )")
         ;
 
     // LogPosterior

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker : */
 
 /*
- * Copyright (c) 2016-2022 Danny van Dyk
+ * Copyright (c) 2016-2023 Danny van Dyk
  * Copyright (c) 2021-2023 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
@@ -681,6 +681,10 @@ BOOST_PYTHON_MODULE(_eos)
         .def("sample", &LogPrior::sample, R"(
             Sets its parameters' values corresponding to the cumulative propability :math:`p` assigned to
             each parameter via its :meth:`Parameter.set_generator` method.
+        )")
+        .def("compute_cdf", &LogPrior::compute_cdf, R"(
+            Returns the cumulative probabilities :math:`p` assigned to each parameter via its
+            :meth:`Parameter.evaluate_generator` method.
         )")
         .def("parameter_descriptions", range(&LogPrior::begin, &LogPrior::end))
         ;

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -377,6 +377,10 @@ BOOST_PYTHON_MODULE(_eos)
             R"(
             Return the current value of a parameter.
             )")
+        .def("evaluate_generator", &Parameter::evaluate_generator,
+            R"(
+            Return the current generator value of a parameter.
+            )")
         ;
 
     // ParameterUser

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -682,6 +682,9 @@ BOOST_PYTHON_MODULE(_eos)
             :type lambda: float, strictly positive
         )", args("parameters", "name", "range", "mu_0", "scale"))
         .staticmethod("Scale")
+        .def("evaluate", &LogPrior::operator(), R"(
+            Returns the logarithm of the prior's probability density at the current parameter values.
+        )")
         .def("sample", &LogPrior::sample, R"(
             Sets its parameters' values corresponding to the cumulative propability :math:`p` assigned to
             each parameter via its :meth:`Parameter.set_generator` method.

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -622,11 +622,11 @@ BOOST_PYTHON_MODULE(_eos)
         .def("Flat", &LogPrior::Flat, return_value_policy<return_by_value>(), "Alias for :meth:`LogPrior.Uniform`.",
             args("parameters", "name", "range"))
         .staticmethod("Flat")
-        .def("Gauss", &LogPrior::Gauss, return_value_policy<return_by_value>(), R"(
-            Returns a new Gaussian prior as a LogPrior.
+        .def("CurtailedGauss", &LogPrior::CurtailedGauss, return_value_policy<return_by_value>(), R"(
+            Returns a new (curtailed) Gaussian prior as a LogPrior.
 
             The prior's support is provided by the `range` parameter, with the
-            68% probability interval [`lower`, `upper`] and the mode provided
+            approximate 68% probability interval [`lower`, `upper`] and the mode provided
             by the parameter `central`.
 
             :param parameters: The parameters to which this LogPrior is bound.
@@ -642,7 +642,7 @@ BOOST_PYTHON_MODULE(_eos)
             :param upper: The upper boundary of the 68% probability interval.
             :type upper: float
         )", args("parameters", "name", "range", "lower", "central", "upper"))
-        .staticmethod("Gauss")
+        .staticmethod("CurtailedGauss")
         .def("Scale", &LogPrior::Scale, return_value_policy<return_by_value>(), R"(
             Returns a new Scale prior as a LogPrior.
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -608,6 +608,10 @@ BOOST_PYTHON_MODULE(_eos)
         .def("insert", &Constraints::insert)
         ;
 
+    class_<ParameterDescription>("ParameterDescription")
+        .def_readonly("parameter", &ParameterDescription::parameter)
+        ;
+
     // LogPrior
     register_ptr_to_python<std::shared_ptr<LogPrior>>();
     class_<LogPrior, boost::noncopyable>("LogPrior", R"(
@@ -678,6 +682,7 @@ BOOST_PYTHON_MODULE(_eos)
             Sets its parameters' values corresponding to the cumulative propability :math:`p` assigned to
             each parameter via its :meth:`Parameter.set_generator` method.
         )")
+        .def("parameter_descriptions", range(&LogPrior::begin, &LogPrior::end))
         ;
 
     // LogPosterior

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker : */
 
 /*
- * Copyright (c) 2016, 2019, 2020 Danny van Dyk
+ * Copyright (c) 2016-2022 Danny van Dyk
  * Copyright (c) 2021-2023 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
@@ -353,6 +353,13 @@ BOOST_PYTHON_MODULE(_eos)
             Set the value of a parameter.
 
             :param value: The value to set the parameter to.
+            :type value: float
+            )")
+        .def("set_generator", &Parameter::set_generator,
+            R"(
+            Set the generator value of a parameter.
+
+            :param value: The value to set the parameter's generator to.
             :type value: float
             )")
         .def("set_max", &Parameter::set_max)

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -151,8 +151,19 @@ class Analysis:
             else:
                 raise ValueError('Prior specification must contains either a parameter or a constraint')
 
+        # check for duplicate entries in the likelihood
+        set_likelihood = set(likelihood)
+        if len(set_likelihood) != len(likelihood):
+            raise ValueError(f'The likelihood contains duplicate entries')
+        set_manual_constraints = set(manual_constraints.keys())
+        if len(set_manual_constraints) != len(manual_constraints):
+            raise ValueError(f'The manual constraints contain duplicate entries')
+        set_intersection = set_likelihood.intersection(set_manual_constraints)
+        if len(set_intersection) > 0:
+            raise ValueError(f'The likelihood contains constraint names also present in the manual_constraints: {set_intersection}')
+
         # record all constraints that comprise the likelihood
-        self._constraint_names = list(likelihood) + list(manual_constraints.keys())
+        self._constraint_names = list(set_likelihood.union(set_manual_constraints))
 
         # create the likelihood
         for constraint_name in self._constraint_names:

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -119,7 +119,7 @@ class Analysis:
                     sigma_lo = sigma
                     sigma_hi = sigma
                 self._log_posterior.add(
-                    eos.LogPrior.Gauss(
+                    eos.LogPrior.CurtailedGauss(
                         self.parameters, parameter, eos.ParameterRange(minv, maxv),
                         central - sigma_lo, central, central + sigma_hi
                     ),

--- a/python/eos/analysis_TEST.py
+++ b/python/eos/analysis_TEST.py
@@ -62,13 +62,13 @@ class ClassMethodTests(unittest.TestCase):
         point = bfp.point
 
         self.assertTrue(
-            np.max(analysis._par_to_x(point)) < 1.0
+            np.max(analysis._par_to_u(point)) < 1.0
             )
         self.assertTrue(
-            np.min(analysis._par_to_x(point)) > -1.0
+            np.min(analysis._par_to_u(point)) >= 0.0
             )
         self.assertTrue(
-            np.max(analysis._x_to_par(analysis._par_to_x(point)) - point) < 1e-10
+            np.max(analysis._u_to_par(analysis._par_to_u(point)) - point) < 1e-10
             )
 
 

--- a/python/eos/data/native.py
+++ b/python/eos/data/native.py
@@ -105,6 +105,11 @@ class MarkovChain:
             raise RuntimeError('Samples file {} does not exist or is not a file'.format(f))
         self.samples = _np.load(f)
 
+        f = os.path.join(path, 'usamples.npy')
+        if not os.path.exists(f) or not os.path.isfile(f):
+            raise RuntimeError('U-space samples file {} does not exist or is not a file'.format(f))
+        self.usamples = _np.load(f)
+
         if description['has-weights']:
             f = os.path.join(path, 'weights.npy')
             if not os.path.exists(f) or not os.path.isfile(f):
@@ -115,15 +120,17 @@ class MarkovChain:
 
 
     @staticmethod
-    def create(path, parameters, samples, weights=None):
+    def create(path, parameters, samples, usamples, weights=None):
         """ Write a new MarkovChain object to disk.
 
         :param path: Path to the storage location, which will be created as a directory.
         :type path: str
         :param parameters: Parameter descriptions as a 1D array of shape (N, ).
         :type parameters: list or iterable of eos.Parameter
-        :param samples: Samples as a 2D array of shape (N, P).
+        :param samples: Samples in parameter space as a 2D array of shape (N, P).
         :type samples: 2D numpy array
+        :param usamples: Samples in u space as a 2D array of shape (N, P).
+        :type usamples: 2D numpy array
         :param weights: Weights on a linear scale as a 2D array of shape (N, 1).
         :type weights: 2D numpy array, optional
         """
@@ -140,6 +147,9 @@ class MarkovChain:
         if not samples.shape[1] == len(parameters):
             raise RuntimeError('Shape of samples {} incompatible with number of parameters {}'.format(samples.shape, len(parameters)))
 
+        if not usamples.shape[1] == len(parameters):
+            raise RuntimeError('Shape of usamples {} incompatible with number of parameters {}'.format(usamples.shape, len(parameters)))
+
         if not weights is None and not samples.shape[0] == weights.shape[0]:
             raise RuntimeError('Shape of weights {} incompatible with shape of samples {}'.format(weights.shape, samples.shape))
 
@@ -147,6 +157,7 @@ class MarkovChain:
         with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
             yaml.dump(description, description_file, default_flow_style=False)
         _np.save(os.path.join(path, 'samples.npy'), samples)
+        _np.save(os.path.join(path, 'usamples.npy'), usamples)
 
         if not weights is None:
             _np.save(os.path.join(path, 'weights.npy'), weights)

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -1,6 +1,6 @@
 # vim: set sw=4 sts=4 et tw=120 :
 
-# Copyright (c) 2020-2021 Danny van Dyk
+# Copyright (c) 2020-2023 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -234,8 +234,8 @@ def sample_mcmc(analysis_file:str, posterior:str, chain:int, base_directory:str=
     analysis = analysis_file.analysis(posterior)
     rng = _np.random.mtrand.RandomState(int(chain) + 1701)
     try:
-        samples, weights = analysis.sample(N=N, stride=stride, pre_N=pre_N, preruns=preruns, rng=rng, cov_scale=cov_scale, start_point=start_point)
-        eos.data.MarkovChain.create(os.path.join(base_directory, posterior, f'mcmc-{chain:04}'), analysis.varied_parameters, samples, weights)
+        samples, usamples, weights = analysis.sample(N=N, stride=stride, pre_N=pre_N, preruns=preruns, rng=rng, cov_scale=cov_scale, start_point=start_point, return_uspace=True)
+        eos.data.MarkovChain.create(os.path.join(base_directory, posterior, f'mcmc-{chain:04}'), analysis.varied_parameters, samples, usamples, weights)
     except RuntimeError as e:
         eos.error('encountered run time error ({e}) in parameter point:'.format(e=e))
         for p in analysis.varied_parameters:
@@ -263,7 +263,7 @@ def find_clusters(posterior:str, base_directory:str='./', threshold:float=2.0, K
 
     import pathlib
     input_paths = [str(p) for p in pathlib.Path(os.path.join(base_directory, posterior)).glob('mcmc-*')]
-    chains    = [eos.data.MarkovChain(path).samples for path in input_paths]
+    chains    = [eos.data.MarkovChain(path).usamples for path in input_paths]
     n = len(chains[0])
     for chain in chains:
         assert len(chain) == n, 'Every chains must contain the same number of samples'


### PR DESCRIPTION
This PR makes a few changes to the code base.

 - [x] Each parameter receives an additional floating point value, the generator value, expected to be in ``[0, 1)``. This makes it possible to pass the generator value from Python to the C++ side (via ``evaluate_generator`` and ``set_generator``).
 - [x] The member function ``LogPrior::inverse_cdf`` is retired in lieu of ``LogPrior::sample``. Inverse transform sampling is still possible, and for a univariate prior it simply takes the form
 ```
# replaces
#   p = prior.inverse_cdf(u)
# for a univariate prior
p.set_generator(u)
prior.sample()
p = prior.evaluate()
 ```
 - [x] The member functions ``LogPrior::mean`` and ``LogPrior::variance`` are not used and cannot be adapted to the multivariate case; they are removed!
 - [x] The existing ``LogPrior::Gauss`` has been renamed to ``LogPrior::CurtailedGauss``, to reflect that the Gaussian tails are cut off outside a user-defined interval.
 - [x] A multivariate Gaussian log(prior) is added.
 - [x] Means to create a ``LogPrior`` from an existing ``ConstraintEntry`` are added for
   - [x] ``MultivariateGaussianCovarianceConstraintEntry`` (does not yet check that each "observable" is referring to a parameter!)
   - [x] ``MultivariateGaussianConstraintEntry``
   - [x] For the purpose of this PR, all other ``ConstraintEntry``s now throw an ``InternalError`` if their ``make_prior`` functions are called.
 - [x] Export the functions needed to create a ``LogPrior`` from a constraint
 - [x] Implement and export ``LogPrior::compute_cdf``, which provides access to the CDF for a univariate prior and the principal components' CDFs for a multivariate prior. The results are stored in the parameters' generator values. In short, this provides the inverse to ``LogPrior::sample``. Happy to discuss the naming.
 - [x] The ``eos.Analysis`` class is modified to exclusively use the parameters' u-space representation, i.e., to ``optimize``, ``sample_mcmc``, ``sample_pmc``, and ``sample_nested`` on the generator values / the cummulative prior probability.
 - [x] The internal variable ``eos.Analysis._bounds`` is removed. All bounds are implicity ``[0, 1)`` in u space.
 - [x] The ``eos.Analysis`` class is modified to optionally accept a single constraint as a prior. For example:
```
priors=[
  { 'constraint': 'foo->foo::bar@BAZ:2023A' },
  { 'parameter': 'mass::b(MSbar)', 'min': 4.15, 'max': 4.21, 'type': 'uniform' },
]
```
  - [x] ``eos.Analysis`` should check that there are no overlapping priors, either constraint vs constraint, or constraint vs univariate prior. I think this might already be done, through the ``LogPosterior`` class. If not, ``LogPosterior::add`` should do the checking, ideally by means of a ``std::set<QualifiedName>`` for all the parameter names. **Edit:** Indeed, this is done, see https://github.com/eos/eos/blob/e16907c243ee8bf62b77b98dbedde2ac49ce0fe7/eos/statistics/log-posterior.hh#L161
  - [x] The return value of ``bool LogPosterior::add(LogPriorPtr, bool)`` should be checked by ``eos.Analysis``, and a suitable Python error be thrown to indicate that the analysis description is defective.
  - [x] Create a test case that utilizes (ideally an existing) multivariate gaussian constraint to test that samples drawn using these improvements are correctly distributed. (@fnovak42) See e.g. [here](https://en.wikipedia.org/wiki/Normality_test) for possible tests.
    - [ ] ~Apply this branch to an existing real-world example, e.g. ``CKM-rho`` from eos/data#2023-01.~
    - [x] Check that the log(evidence) is correctly computer after this change. The existing unit test should provide an analytically calculable example.
    - [x] Check if the unit test's covariance matrix is sufficiently regular.