### PR TITLE
Fix 'fixed_parameters' initialization for predictions

### DIFF
--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -114,7 +114,7 @@ class AnalysisFile:
             options = eos.Options()
 
         if 'fixed_parameters' in prediction:
-            for (p, v) in prediction['fixed_parameters']:
+            for (p, v) in prediction['fixed_parameters'].items():
                 parameters.set(p, v)
 
         observables = [eos.Observable.make(

--- a/src/scripts/eos-analysis_TEST.d/analysis.yaml
+++ b/src/scripts/eos-analysis_TEST.d/analysis.yaml
@@ -75,6 +75,8 @@ predictions:
     global_options:
         model: CKM
         form-factors: BCL2008
+    fixed_parameters:
+        mass::e: 5.0e-4  # This is meant to test the "fixed_parameters" key
     observables:
       - name: B->pilnu::P(q2_min,q2_max)
         kinematics: { 'q2_min': 0.01, 'q2_max': 2.00 }


### PR DESCRIPTION
The syntax error in the loop initialization in `analysis_file.py` was fixed so that the parameters can be specified. A test was also added to `analysis.yaml` to check the modification.