### PR TITLE
Add tools for the qbcu sector of the WET

### DIFF
--- a/eos/models/ckm.cc
+++ b/eos/models/ckm.cc
@@ -115,7 +115,9 @@ namespace eos
         SMComponent<components::DeltaBS1>(parameters, *this),
         SMComponent<components::WET::CBLNu>(parameters, *this),
         SMComponent<components::WET::UBLNu>(parameters, *this),
-        SMComponent<components::WET::SBNuNu>(parameters, *this)
+        SMComponent<components::WET::SBNuNu>(parameters, *this),
+        SMComponent<components::WET::SBCU>(parameters, *this),
+        SMComponent<components::WET::DBCU>(parameters, *this)
     {
     }
 

--- a/eos/models/ckm.hh
+++ b/eos/models/ckm.hh
@@ -80,7 +80,9 @@ namespace eos
         public SMComponent<components::DeltaBS1>,
         public SMComponent<components::WET::UBLNu>,
         public SMComponent<components::WET::CBLNu>,
-        public SMComponent<components::WET::SBNuNu>
+        public SMComponent<components::WET::SBNuNu>,
+        public SMComponent<components::WET::SBCU>,
+        public SMComponent<components::WET::DBCU>
     {
         public:
             CKMScanModel(const Parameters &, const Options &);

--- a/eos/models/model.hh
+++ b/eos/models/model.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010-2015, 2021 Danny van Dyk
+ * Copyright (c) 2010-2023 Danny van Dyk
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018 Christoph Bobeth
  *
@@ -49,6 +49,8 @@ namespace eos
             struct CBLNu;
             struct UBLNu;
             struct SBNuNu;
+            struct DBCU;
+            struct SBCU;
         }
         struct DeltaBS1;
         ///@}
@@ -151,6 +153,26 @@ namespace eos
     };
 
     /*!
+     * Base class for the sbcu component of models.
+     */
+    template <> class ModelComponent<components::WET::SBCU>
+    {
+        public:
+            /* sbcu Wilson coefficients */
+            virtual WilsonCoefficients<wc::SBCU> wet_sbcu(const bool & cp_conjguate = false) const = 0;
+    };
+
+    /*!
+     * Base class for the dbcu component of models.
+     */
+    template <> class ModelComponent<components::WET::DBCU>
+    {
+        public:
+            /* dbcu Wilson coefficients */
+            virtual WilsonCoefficients<wc::DBCU> wet_dbcu(const bool & cp_conjguate = false) const = 0;
+    };
+
+    /*!
      * Base class for all models.
      */
     class Model :
@@ -161,7 +183,9 @@ namespace eos
         public virtual ModelComponent<components::DeltaBS1>,
         public virtual ModelComponent<components::WET::UBLNu>,
         public virtual ModelComponent<components::WET::CBLNu>,
-        public virtual ModelComponent<components::WET::SBNuNu>
+        public virtual ModelComponent<components::WET::SBNuNu>,
+        public virtual ModelComponent<components::WET::SBCU>,
+        public virtual ModelComponent<components::WET::DBCU>
     {
         public:
             virtual ~Model() = 0;

--- a/eos/models/standard-model.cc
+++ b/eos/models/standard-model.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2012, 2013, 2014, 2015, 2017 Danny van Dyk
+ * Copyright (c) 2010-2023 Danny van Dyk
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018, 2021 Christoph Bobeth
  * Copyright (c) 2022 Philip Lüghausen
@@ -22,12 +22,13 @@
 
 #include <eos/models/top-loops.hh>
 #include <eos/models/standard-model.hh>
-#include <eos/utils/log.hh>
-#include <eos/utils/stringify.hh>
 #include <eos/maths/matrix.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/utils/log.hh>
 #include <eos/utils/private_implementation_pattern-impl.hh>
 #include <eos/utils/qcd.hh>
+#include <eos/utils/rge-impl.hh>
+#include <eos/utils/stringify.hh>
 
 #include <array>
 #include <cmath>
@@ -946,6 +947,164 @@ namespace implementation
         return wc;
     }
 
+    SMComponent<components::WET::SBCU>::SMComponent(const Parameters & p , ParameterUser & u) :
+        _alpha_s_Z__sbcu(p["QCD::alpha_s(MZ)"], u),
+        _m_Z__sbcu(p["mass::Z"], u),
+        _m_W__sbcu(p["mass::W"], u),
+        _mu_0__sbcu(p["sbcu::mu_0"], u),
+        _mu__sbcu(p["sbcu::mu"], u)
+    {
+    }
+
+    WilsonCoefficients<wc::SBCU>
+    SMComponent<components::WET::SBCU>::wet_sbcu(const bool & /* cp_conjugate */) const
+    {
+        // SM Wilson coefficients are real so cp conjugation has no effect
+
+        // RGE
+        static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 10u> rge
+        {
+            // gamma_0: eigenvalues
+            (2.0 / 3.0) * std::array<double, 10u>{{
+                -24.0, -12.0, 6.0, 3.0, (-17.0 - sqrt(241.0)), -24.0, (+1.0 + sqrt(241.0)), (+1.0 - sqrt(241.0)), 3.0, (-17 + sqrt(241.0))
+            }},
+            // gamma_0: V
+            {{
+                {{  -8.0 / 3.0, +4.0 / 3.0,  -8.0 / 3.0, +64.0 / 3.0,  0.0,                                      0.0,   0.0,                                    0.0,                                       0.0,   0.0                                   }},
+                {{ -16.0,       -4.0,        -4.0,       -16.0,        0.0,                                      0.0,   0.0,                                    0.0,                                       0.0,   0.0                                   }},
+                {{  +1.0 / 6.0, -1.0 / 3.0,  +2.0 / 3.0,  -4.0 / 3.0,  0.0,                                      0.0,   0.0,                                    0.0,                                       0.0,   0.0                                   }},
+                {{  +1.0,       +1.0,        +1.0,        +1.0,        0.0,                                      0.0,   0.0,                                    0.0,                                       0.0,   0.0                                   }},
+                {{   0.0,        0.0,         0.0,         0.0,       -53.0 / 3.0 - sqrt(241.0),               -64.0,  86.0 / 15.0 - 2.0 / 5.0 * sqrt(241.0),   2.0 / 15.0 * (43.0 + 3.0 * sqrt(241.0)),   0.0, -53.0 / 3.0 + sqrt(241.0)               }},
+                {{   0.0,        0.0,         0.0,         0.0,       -16.0,                                     0.0, -16.0,                                  -16.0,                                     -64.0, -16.0                                   }},
+                {{   0.0,        0.0,         0.0,         0.0,       +79.0 / 4.0 + 11.0 / 12.0 * sqrt(241.0), +16.0, (-207.0 + 7.0 * sqrt(241.0)) / 30.0,    (-207.0 - 7.0 * sqrt(241.0)) / 30.0,         0.0, +79.0 / 4.0 - 11.0 / 12.0 * sqrt(241.0) }},
+                {{   0.0,        0.0,         0.0,         0.0,       +27.0 + sqrt(241.0),                       0.0,  2.0 * (51.0 - sqrt(241.0)) / 5.0,      2.0 * (51.0 + sqrt(241.0)) / 5.0,          +16.0, +27.0 - sqrt(241.0)                     }},
+                {{   0.0,        0.0,         0.0,         0.0,       (53.0 + 3.0 * sqrt(241.0)) / 48.0,        +1.0, (-43.0 + 3.0 * sqrt(241.0)) / 120.0,    (-43.0 - 3.0 * sqrt(241.0)) / 120.0,         0.0,  (53.0 - 3.0 * sqrt(241.0)) / 48.0      }},
+                {{   0.0,        0.0,         0.0,         0.0,       +1.0,                                      0.0,  +1.0,                                   +1.0,                                      +1.0,  +1.0                                   }}
+            }},
+            // gamma_1
+            {{
+                {{    44.0 /  9.0,  -899.0 / 3.0,  -32.0 /  9.0,  245.0 / 12.0,      0.0,              0.0,            0.0,            0.0,              0.0,            0.0         }},
+                {{  -646.0 / 27.0, -2072.0 / 9.0, -115.0 / 54.0,  739.0 / 72.0,      0.0,              0.0,            0.0,            0.0,              0.0,            0.0         }},
+                {{ -6848.0 /  9.0, -1344.0,        524.0 /  9.0,  178.0,             0.0,              0.0,            0.0,            0.0,              0.0,            0.0         }},
+                {{     0.0,        -8468.0 / 9.0, -172.0 /  9.0,  367.0 / 18.0,      0.0,              0.0,            0.0,            0.0,              0.0,            0.0         }},
+                {{     0.0,            0.0,          0.0,           0.0,         -1832.0 /  9.0,     -64.0 / 3.0,   -104.0 /  9.0,  -296.0 /   9.0,     -7.0 /  18.0,   11.0 /  48.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,          -128.0 / 27.0,     608.0 / 9.0,    -52.0 / 81.0, -1783.0 / 108.0,     11.0 / 216.0,   59.0 / 144.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,         -9488.0 / 27.0,    7108.0 / 9.0,   3052.0 /  9.0,   -31.0 /   9.0,    521.0 /  27.0, -217.0 /  36.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,        -25528.0 / 81.0,     896.0 / 3.0,  -6974.0 / 81.0, -4727.0 /  27.0,    863.0 / 162.0,   38.0 /   9.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,        -26368.0 / 27.0, -249088.0 / 9.0, -91456.0 /  9.0, 68192.0 /   9.0,  -8912.0 /  27.0, 8143.0 /   9.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,        510976.0 / 81.0,  -14080.0 / 9.0,   1600.0 / 81.0, 46960.0 /  27.0, -11794.0 /  81.0,  -41.0 /   6.0 }},
+            }}
+        };
+
+        WilsonCoefficients<wc::SBCU> wc;
+        wc._unprimed.fill(complex<double>(0.0));
+        wc._primed.fill(complex<double>(0.0));
+
+        // only unprimed WCs are non-zero in the SM
+        // leading order in alpha_s
+        const std::array<double, 10u> lo_unprimed = {
+            -1.0 / 9.0, -2.0 / 3.0, +1.0 / 36.0, +1.0 / 6.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        };
+        // next-to-leading order in alpha_s
+        const double L = 2.0 * std::log(_mu_0__sbcu / _m_W__sbcu);
+        const std::array<double, 10u> nlo_unprimed = {
+            +52.0 / 27.0 - 8.0 / 9.0 * L,
+            -85.0 /  9.0 + 2.0 / 3.0 * L,
+             -1.0 / 27.0 + 2.0 / 9.0 * L,
+            +19.0 / 36.0 - 1.0 / 6.0 * L,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        };
+
+        static const auto & beta5 = QCD::beta_function_nf_5;
+        const double alpha_s_mu_0 = QCD::alpha_s(_mu_0__sbcu, _alpha_s_Z__sbcu, _m_Z__sbcu, beta5);
+        const double alpha_s_mu   = QCD::alpha_s(_mu__sbcu,   _alpha_s_Z__sbcu, _m_Z__sbcu, beta5);
+
+        const auto _unprimed = rge.evolve(alpha_s_mu, alpha_s_mu_0, lo_unprimed, nlo_unprimed);
+
+        std::copy(_unprimed.begin(), _unprimed.end(), wc._unprimed.begin());
+
+        return wc;
+    }
+
+    SMComponent<components::WET::DBCU>::SMComponent(const Parameters & p , ParameterUser & u) :
+        _alpha_s_Z__dbcu(p["QCD::alpha_s(MZ)"], u),
+        _m_Z__dbcu(p["mass::Z"], u),
+        _m_W__dbcu(p["mass::W"], u),
+        _mu_0__dbcu(p["dbcu::mu_0"], u),
+        _mu__dbcu(p["dbcu::mu"], u)
+    {
+    }
+
+    WilsonCoefficients<wc::DBCU>
+    SMComponent<components::WET::DBCU>::wet_dbcu(const bool & /* cp_conjugate */) const
+    {
+        // SM Wilson coefficients are real so cp conjugation has no effect
+
+        // RGE
+        static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 10u> rge
+        {
+            // gamma_0: eigenvalues
+            (2.0 / 3.0) * std::array<double, 10u>{{
+                -24.0, -12.0, 6.0, 3.0, (-17.0 - sqrt(241.0)), -24.0, (+1.0 + sqrt(241.0)), (+1.0 - sqrt(241.0)), 3.0, (-17 + sqrt(241.0))
+            }},
+            // gamma_0: V
+            {{
+                {{  -8.0 / 3.0, +4.0 / 3.0,  -8.0 / 3.0, +64.0 / 3.0,  0.0,                                      0.0,   0.0,                                    0.0,                                       0.0,   0.0                                   }},
+                {{ -16.0,       -4.0,        -4.0,       -16.0,        0.0,                                      0.0,   0.0,                                    0.0,                                       0.0,   0.0                                   }},
+                {{  +1.0 / 6.0, -1.0 / 3.0,  +2.0 / 3.0,  -4.0 / 3.0,  0.0,                                      0.0,   0.0,                                    0.0,                                       0.0,   0.0                                   }},
+                {{  +1.0,       +1.0,        +1.0,        +1.0,        0.0,                                      0.0,   0.0,                                    0.0,                                       0.0,   0.0                                   }},
+                {{   0.0,        0.0,         0.0,         0.0,       -53.0 / 3.0 - sqrt(241.0),               -64.0,  86.0 / 15.0 - 2.0 / 5.0 * sqrt(241.0),   2.0 / 15.0 * (43.0 + 3.0 * sqrt(241.0)),   0.0, -53.0 / 3.0 + sqrt(241.0)               }},
+                {{   0.0,        0.0,         0.0,         0.0,       -16.0,                                     0.0, -16.0,                                  -16.0,                                     -64.0, -16.0                                   }},
+                {{   0.0,        0.0,         0.0,         0.0,       +79.0 / 4.0 + 11.0 / 12.0 * sqrt(241.0), +16.0, (-207.0 + 7.0 * sqrt(241.0)) / 30.0,    (-207.0 - 7.0 * sqrt(241.0)) / 30.0,         0.0, +79.0 / 4.0 - 11.0 / 12.0 * sqrt(241.0) }},
+                {{   0.0,        0.0,         0.0,         0.0,       +27.0 + sqrt(241.0),                       0.0,  2.0 * (51.0 - sqrt(241.0)) / 5.0,      2.0 * (51.0 + sqrt(241.0)) / 5.0,          +16.0, +27.0 - sqrt(241.0)                     }},
+                {{   0.0,        0.0,         0.0,         0.0,       (53.0 + 3.0 * sqrt(241.0)) / 48.0,        +1.0, (-43.0 + 3.0 * sqrt(241.0)) / 120.0,    (-43.0 - 3.0 * sqrt(241.0)) / 120.0,         0.0,  (53.0 - 3.0 * sqrt(241.0)) / 48.0      }},
+                {{   0.0,        0.0,         0.0,         0.0,       +1.0,                                      0.0,  +1.0,                                   +1.0,                                      +1.0,  +1.0                                   }}
+            }},
+            // gamma_1
+            {{
+                {{    44.0 /  9.0,  -899.0 / 3.0,  -32.0 /  9.0,  245.0 / 12.0,      0.0,              0.0,            0.0,            0.0,              0.0,            0.0         }},
+                {{  -646.0 / 27.0, -2072.0 / 9.0, -115.0 / 54.0,  739.0 / 72.0,      0.0,              0.0,            0.0,            0.0,              0.0,            0.0         }},
+                {{ -6848.0 /  9.0, -1344.0,        524.0 /  9.0,  178.0,             0.0,              0.0,            0.0,            0.0,              0.0,            0.0         }},
+                {{     0.0,        -8468.0 / 9.0, -172.0 /  9.0,  367.0 / 18.0,      0.0,              0.0,            0.0,            0.0,              0.0,            0.0         }},
+                {{     0.0,            0.0,          0.0,           0.0,         -1832.0 /  9.0,     -64.0 / 3.0,   -104.0 /  9.0,  -296.0 /   9.0,     -7.0 /  18.0,   11.0 /  48.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,          -128.0 / 27.0,     608.0 / 9.0,    -52.0 / 81.0, -1783.0 / 108.0,     11.0 / 216.0,   59.0 / 144.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,         -9488.0 / 27.0,    7108.0 / 9.0,   3052.0 /  9.0,   -31.0 /   9.0,    521.0 /  27.0, -217.0 /  36.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,        -25528.0 / 81.0,     896.0 / 3.0,  -6974.0 / 81.0, -4727.0 /  27.0,    863.0 / 162.0,   38.0 /   9.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,        -26368.0 / 27.0, -249088.0 / 9.0, -91456.0 /  9.0, 68192.0 /   9.0,  -8912.0 /  27.0, 8143.0 /   9.0 }},
+                {{     0.0,            0.0,          0.0,           0.0,        510976.0 / 81.0,  -14080.0 / 9.0,   1600.0 / 81.0, 46960.0 /  27.0, -11794.0 /  81.0,  -41.0 /   6.0 }},
+            }}
+        };
+
+        WilsonCoefficients<wc::DBCU> wc;
+        wc._unprimed.fill(complex<double>(0.0));
+        wc._primed.fill(complex<double>(0.0));
+
+        // only unprimed WCs are non-zero in the SM
+        // leading order in alpha_s
+        const std::array<double, 10u> lo_unprimed = {
+            -1.0 / 9.0, -2.0 / 3.0, +1.0 / 36.0, +1.0 / 6.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        };
+        // next-to-leading order in alpha_s
+        const double L = 2.0 * std::log(_mu_0__dbcu / _m_W__dbcu);
+        const std::array<double, 10u> nlo_unprimed = {
+            +52.0 / 27.0 - 8.0 / 9.0 * L,
+            -85.0 /  9.0 + 2.0 / 3.0 * L,
+             -1.0 / 27.0 + 2.0 / 9.0 * L,
+            +19.0 / 36.0 - 1.0 / 6.0 * L,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        };
+
+        static const auto & beta5 = QCD::beta_function_nf_5;
+        const double alpha_s_mu_0 = QCD::alpha_s(_mu_0__dbcu, _alpha_s_Z__dbcu, _m_Z__dbcu, beta5);
+        const double alpha_s_mu   = QCD::alpha_s(_mu__dbcu,   _alpha_s_Z__dbcu, _m_Z__dbcu, beta5);
+
+        const auto _unprimed = rge.evolve(alpha_s_mu, alpha_s_mu_0, lo_unprimed, nlo_unprimed);
+
+        std::copy(_unprimed.begin(), _unprimed.end(), wc._unprimed.begin());
+
+        return wc;
+    }
+
     StandardModel::StandardModel(const Parameters & p) :
         SMComponent<components::CKM>(p, *this),
         SMComponent<components::QCD>(p, *this),
@@ -953,7 +1112,9 @@ namespace implementation
         SMComponent<components::DeltaBS1>(p, *this),
         SMComponent<components::WET::CBLNu>(p, *this),
         SMComponent<components::WET::UBLNu>(p, *this),
-        SMComponent<components::WET::SBNuNu>(p, *this)
+        SMComponent<components::WET::SBNuNu>(p, *this),
+        SMComponent<components::WET::SBCU>(p, *this),
+        SMComponent<components::WET::DBCU>(p, *this)
     {
     }
 

--- a/eos/models/standard-model.hh
+++ b/eos/models/standard-model.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010-2015, 2021 Danny van Dyk
+ * Copyright (c) 2010-2023 Danny van Dyk
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018 Christoph Bobeth
  *
@@ -202,6 +202,46 @@ namespace eos
             virtual WilsonCoefficients<wc::SBNuNu> wet_sbnunu(const bool & cp_conjugate) const;
     };
 
+    template <> class SMComponent<components::WET::SBCU> :
+    public virtual ModelComponent<components::WET::SBCU>
+    {
+            /* QCD parameters */
+            UsedParameter _alpha_s_Z__sbcu;
+            UsedParameter _m_Z__sbcu;
+
+            /* Matching scale */
+            UsedParameter _m_W__sbcu;
+            UsedParameter _mu_0__sbcu;
+
+            /* Low scale */
+            UsedParameter _mu__sbcu;
+
+        public:
+            SMComponent(const Parameters &, ParameterUser &);
+
+            virtual WilsonCoefficients<wc::SBCU> wet_sbcu(const bool & cp_conjugate) const;
+    };
+
+    template <> class SMComponent<components::WET::DBCU> :
+    public virtual ModelComponent<components::WET::DBCU>
+    {
+            /* QCD parameters */
+            UsedParameter _alpha_s_Z__dbcu;
+            UsedParameter _m_Z__dbcu;
+
+            /* Matching scale */
+            UsedParameter _m_W__dbcu;
+            UsedParameter _mu_0__dbcu;
+
+            /* Low scale */
+            UsedParameter _mu__dbcu;
+
+        public:
+            SMComponent(const Parameters &, ParameterUser &);
+
+            virtual WilsonCoefficients<wc::DBCU> wet_dbcu(const bool & cp_conjugate) const;
+    };
+
     class StandardModel :
         public Model,
         public SMComponent<components::CKM>,
@@ -210,7 +250,9 @@ namespace eos
         public SMComponent<components::DeltaBS1>,
         public SMComponent<components::WET::UBLNu>,
         public SMComponent<components::WET::CBLNu>,
-        public SMComponent<components::WET::SBNuNu>
+        public SMComponent<components::WET::SBNuNu>,
+        public SMComponent<components::WET::SBCU>,
+        public SMComponent<components::WET::DBCU>
     {
         public:
             StandardModel(const Parameters &);

--- a/eos/models/standard-model_TEST.cc
+++ b/eos/models/standard-model_TEST.cc
@@ -101,7 +101,7 @@ class AlphaSTest :
             // Calculation of alpha_s is not self-consistent:
             //   alpha_s(mu) != alpha_s_0
             // So check for relative error
-            TEST_CHECK_NEARLY_EQUAL(0.117620, model.alpha_s(91.1876), 5e-5);
+            TEST_CHECK_NEARLY_EQUAL(model.alpha_s(91.1876), 0.117620, 5e-5);
 
             // Data in agreement with RunDec, cf. [CKS2000]
             TEST_CHECK_NEARLY_EQUAL(model.alpha_s(120.0), 0.112968, eps);
@@ -140,8 +140,8 @@ class TMassesTest :
 
             StandardModel model(reference_parameters());
 
-            TEST_CHECK_RELATIVE_ERROR(167.794, model.m_t_msbar(120.0), eps);
-            TEST_CHECK_RELATIVE_ERROR(173.647, model.m_t_msbar( 80.0), eps);
+            TEST_CHECK_RELATIVE_ERROR(model.m_t_msbar(120.0), 167.794, eps);
+            TEST_CHECK_RELATIVE_ERROR(model.m_t_msbar( 80.0), 173.647, eps);
         }
 } sm_t_masses_test;
 
@@ -161,21 +161,21 @@ class BMassesTest :
             Parameters p = reference_parameters();
             StandardModel model(p);
 
-            TEST_CHECK_NEARLY_EQUAL(3.67956, model.m_b_msbar(9.6), eps);
-            TEST_CHECK_NEARLY_EQUAL(4.10051, model.m_b_msbar(4.8), eps);
-            TEST_CHECK_NEARLY_EQUAL(4.20000, model.m_b_msbar(4.2), eps);
-            TEST_CHECK_NEARLY_EQUAL(4.75221, model.m_b_msbar(2.4), eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_msbar(9.6), 3.67956, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_msbar(4.8), 4.10051, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_msbar(4.2), 4.20000, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_msbar(2.4), 4.75221, eps);
 
-            TEST_CHECK_NEARLY_EQUAL(4.74167, model.m_b_pole(), 1e-3); // Precision is hard-limited in fixed-point routine
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_pole(),     4.74167, 1e-3); // Precision is hard-limited in fixed-point routine
 
-            TEST_CHECK_NEARLY_EQUAL(4.60728, model.m_b_ps(1.0), eps);
-            TEST_CHECK_NEARLY_EQUAL(4.54012, model.m_b_ps(1.5), eps);
-            TEST_CHECK_NEARLY_EQUAL(4.47735, model.m_b_ps(2.0), eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_ps(1.0),    4.60728, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_ps(1.5),    4.54012, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_ps(2.0),    4.47735, eps);
 
-            TEST_CHECK_NEARLY_EQUAL(4.63362, model.m_b_kin(0.75), eps);
-            TEST_CHECK_NEARLY_EQUAL(4.56114, model.m_b_kin(1.00), eps);
-            TEST_CHECK_NEARLY_EQUAL(4.49203, model.m_b_kin(1.25), eps);
-            TEST_CHECK_NEARLY_EQUAL(4.42520, model.m_b_kin(1.50), eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_kin(0.75),  4.63362, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_kin(1.00),  4.56114, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_kin(1.25),  4.49203, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_b_kin(1.50),  4.42520, eps);
         }
 } sm_b_masses_test;
 
@@ -195,16 +195,16 @@ class CMassesTest :
             Parameters p = reference_parameters();
             StandardModel model(p);
 
-            TEST_CHECK_NEARLY_EQUAL(0.891000, model.m_c_msbar(4.8),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.912618, model.m_c_msbar(4.2),  eps);
-            TEST_CHECK_NEARLY_EQUAL(1.270000, model.m_c_msbar(1.27), eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_c_msbar(4.8),  0.891000, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_c_msbar(4.2),  0.912618, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_c_msbar(1.27), 1.270000, eps);
 
-            TEST_CHECK_NEARLY_EQUAL(1.595301, model.m_c_pole(), eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_c_pole(),      1.595301, eps);
 
-            TEST_CHECK_NEARLY_EQUAL(1.203723, model.m_c_kin(0.75), eps);
-            TEST_CHECK_NEARLY_EQUAL(1.060682, model.m_c_kin(1.00), eps);
-            TEST_CHECK_NEARLY_EQUAL(0.931772, model.m_c_kin(1.25), eps);
-            TEST_CHECK_NEARLY_EQUAL(0.813366, model.m_c_kin(1.50), eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_c_kin(0.75),   1.203723, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_c_kin(1.00),   1.060682, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_c_kin(1.25),   0.931772, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_c_kin(1.50),   0.813366, eps);
         }
 } sm_c_masses_test;
 
@@ -224,11 +224,11 @@ class SMassesTest :
             Parameters p = reference_parameters();
             StandardModel model(p);
 
-            TEST_CHECK_NEARLY_EQUAL(0.136682, model.m_s_msbar(1.0),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.106128, model.m_s_msbar(1.7),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.101000, model.m_s_msbar(2.0),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.084980, model.m_s_msbar(4.2),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.082967, model.m_s_msbar(4.8),  eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_s_msbar(1.0), 0.136682, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_s_msbar(1.7), 0.106128, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_s_msbar(2.0), 0.101000, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_s_msbar(4.2), 0.084980, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_s_msbar(4.8), 0.082967, eps);
         }
 } sm_s_masses_test;
 
@@ -248,11 +248,11 @@ class UDMassesTest :
             Parameters p = reference_parameters();
             StandardModel model(p);
 
-            TEST_CHECK_NEARLY_EQUAL(0.010826, model.m_ud_msbar(1.0),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.008000, model.m_ud_msbar(2.0),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.007223, model.m_ud_msbar(3.0),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.006803, model.m_ud_msbar(4.0),  eps);
-            TEST_CHECK_NEARLY_EQUAL(0.006525, model.m_ud_msbar(5.0),  eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_ud_msbar(1.0), 0.010826, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_ud_msbar(2.0), 0.008000, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_ud_msbar(3.0), 0.007223, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_ud_msbar(4.0), 0.006803, eps);
+            TEST_CHECK_NEARLY_EQUAL(model.m_ud_msbar(5.0), 0.006525, eps);
         }
 } sm_ud_masses_test;
 
@@ -275,65 +275,65 @@ class CKMElementsTest :
                 StandardModel model(parameters);
 
                 // values
-                TEST_CHECK_NEARLY_EQUAL(+0.974253267, real(model.ckm_ud()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.000000000, imag(model.ckm_ud()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.97425,     abs(model.ckm_ud()), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_ud()), +0.974253267, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_ud()), +0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_ud()),  +0.97425,     1e-5);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.225428590, real(model.ckm_us()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.000000000, imag(model.ckm_us()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.22543,     abs(model.ckm_us()), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_us()), +0.225428590, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_us()), +0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_us()),  +0.22543,     1e-5);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.001372189, real(model.ckm_ub()), eps);
-                TEST_CHECK_NEARLY_EQUAL(-0.003264270, imag(model.ckm_ub()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.00354,     abs(model.ckm_ub()), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_ub()), +0.001372189, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_ub()), -0.003264270, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_ub()),  +0.00354,     1e-5);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.225296132, real(model.ckm_cd()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.000138121, imag(model.ckm_cd()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.22529,     abs(model.ckm_cd()), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_cd()), +0.225296132, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_cd()), +0.000138121, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_cd()),  +0.22529,     1e-5);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.973416767, real(model.ckm_cs()), eps);
-                TEST_CHECK_NEARLY_EQUAL(-0.000030365, imag(model.ckm_cs()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.97342,     abs(model.ckm_cs()), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_cs()), +0.973416767, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_cs()), -0.000030365, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_cs()),  +0.97342,     1e-5);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.041264513, real(model.ckm_cb()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.000000000, imag(model.ckm_cb()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.04126,     abs(model.ckm_cb()), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_cb()), +0.041264513, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_cb()), +0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_cb()),  +0.04126,     1e-5);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.007966605, real(model.ckm_td()), eps);
-                TEST_CHECK_NEARLY_EQUAL(-0.003177489, imag(model.ckm_td()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.00858,     abs(model.ckm_td()), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_td()), +0.007966605, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_td()), -0.003177489, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_td()),  +0.00858,     1e-5);
 
-                TEST_CHECK_NEARLY_EQUAL(-0.040511671, real(model.ckm_ts()), eps);
-                TEST_CHECK_NEARLY_EQUAL(-0.000735237, imag(model.ckm_ts()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.04052,     abs(model.ckm_ts()), 1e-5);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_ts()), -0.040511671, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_ts()), -0.000735237, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_ts()),  +0.04052,     1e-5);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.999141977, real(model.ckm_tb()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.000000000, imag(model.ckm_tb()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.999141,    abs(model.ckm_tb()), 1e-6);
+                TEST_CHECK_NEARLY_EQUAL(real(model.ckm_tb()), +0.999141977, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(model.ckm_tb()), +0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(abs(model.ckm_tb()),  +0.999141,    1e-6);
 
                 // angles
                 double alpha = arg(-1.0 * model.ckm_td() * conj(model.ckm_tb()) / model.ckm_ud() / conj(model.ckm_ub()));
-                TEST_CHECK_NEARLY_EQUAL(+1.589220699,    alpha, eps);
-                TEST_CHECK_NEARLY_EQUAL(-0.036840406,    std::sin(2.0 * alpha), eps);
+                TEST_CHECK_NEARLY_EQUAL(alpha,                                  +1.589220699, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::sin(2.0 * alpha),                  -0.036840406, eps);
 
                 double beta  = arg(-1.0 * model.ckm_cd() * conj(model.ckm_cb()) / model.ckm_td() / conj(model.ckm_tb()));
-                TEST_CHECK_NEARLY_EQUAL(-2.761464006,    beta, eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.689107918,    std::sin(2.0 * beta), eps);
+                TEST_CHECK_NEARLY_EQUAL(beta,                                   -2.761464006, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::sin(2.0 * beta),                   +0.689107918, eps);
 
                 double gamma = arg(-1.0 * model.ckm_ud() * conj(model.ckm_ub()) / model.ckm_cd() / conj(model.ckm_cb()));
-                TEST_CHECK_NEARLY_EQUAL(-1.969349346,    gamma, eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.935295092,    std::abs(std::sin(2.0 * beta + gamma)), eps);
+                TEST_CHECK_NEARLY_EQUAL(gamma,                                  -1.969349346, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(std::sin(2.0 * beta + gamma)), +0.935295092, eps);
 
                 complex<double> lambda_t = model.ckm_tb() * conj(model.ckm_ts());
-                TEST_CHECK_NEARLY_EQUAL(+0.040483577,    std::abs(lambda_t), eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(lambda_t), +0.040483577, eps);
                 complex<double> lambda_c = model.ckm_cb() * conj(model.ckm_cs());
-                TEST_CHECK_NEARLY_EQUAL(+0.040167570,    std::abs(lambda_c), eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(lambda_c), +0.040167570, eps);
                 complex<double> lambda_u = model.ckm_ub() * conj(model.ckm_us());
-                TEST_CHECK_NEARLY_EQUAL(+0.000798232,    std::abs(lambda_u), eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(lambda_u), +0.000798232, eps);
 
                 // unitarity
-                TEST_CHECK_NEARLY_EQUAL(-1.131956683e-8, real(lambda_t + lambda_c + lambda_u), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,            imag(lambda_t + lambda_c + lambda_u), eps);
+                TEST_CHECK_NEARLY_EQUAL(real(lambda_t + lambda_c + lambda_u), -1.131956683e-8, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(lambda_t + lambda_c + lambda_u), +0.0,            eps);
             }
         }
 } ckm_elements_test;
@@ -358,29 +358,29 @@ class WilsonCoefficientsBToSTest :
                 parameters["sb::mu"] = mu;
                 StandardModel model(parameters);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.2209967815, model.alpha_s(mu), eps);
+                TEST_CHECK_NEARLY_EQUAL(model.alpha_s(mu), +0.2209967815, eps);
 
                 WilsonCoefficients<BToS> wc = model.wilson_coefficients_b_to_s(mu, "mu", false);
-                TEST_CHECK_RELATIVE_ERROR(-0.279801085, real(wc.c1()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(+1.009683640, real(wc.c2()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-0.005775920, real(wc.c3()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-0.083977609, real(wc.c4()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(+0.000401406, real(wc.c5()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(+0.001072008, real(wc.c6()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-0.334390556, real(wc.c7()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-0.180952245, real(wc.c8()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(+4.256827890, real(wc.c9()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-4.160202020, real(wc.c10()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c1()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c2()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c3()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c4()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c5()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c6()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c7()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c8()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c9()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c10()),  eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.279801085, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.009683640, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c3()), -0.005775920, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c4()), -0.083977609, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c5()), +0.000401406, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c6()), +0.001072008, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c7()), -0.334390556, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c8()), -0.180952245, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c9()), +4.256827890, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c10()),-4.160202020, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()), +0.0, eps);
             }
 
             /* Test for 5 active flavors, evolving from mu_0c = 80, mu_0t = 120 to mu = 4.2 */
@@ -391,29 +391,29 @@ class WilsonCoefficientsBToSTest :
                 Parameters parameters = reference_parameters();
                 StandardModel model(parameters);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.2233419372, model.alpha_s(mu), eps);
+                TEST_CHECK_NEARLY_EQUAL(model.alpha_s(mu), +0.2233419372, eps);
 
                 WilsonCoefficients<BToS> wc = model.wilson_coefficients_b_to_s(mu, "mu", false);
-                TEST_CHECK_RELATIVE_ERROR(-0.28768333, real(wc.c1()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(+1.01013250, real(wc.c2()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-0.00600697, real(wc.c3()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-0.08597076, real(wc.c4()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(+0.00041824, real(wc.c5()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(+0.00112410, real(wc.c6()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-0.33613067, real(wc.c7()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-0.18205267, real(wc.c8()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(+4.27450580, real(wc.c9()),  eps);
-                TEST_CHECK_RELATIVE_ERROR(-4.16020202, real(wc.c10()), eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c1()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c2()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c3()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c4()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c5()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c6()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c7()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c8()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c9()),  eps);
-                TEST_CHECK_NEARLY_EQUAL(+0.0,        imag(wc.c10()),  eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.28768333, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.01013250, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c3()), -0.00600697, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c4()), -0.08597076, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c5()), +0.00041824, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c6()), +0.00112410, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c7()), -0.33613067, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c8()), -0.18205267, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c9()), +4.27450580, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c10()),-4.16020202, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()),  +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()), +0.0, eps);
             }
 
             /* Test for equality between SM Wilson coefficients and default parameter values */
@@ -426,7 +426,7 @@ class WilsonCoefficientsBToSTest :
                 parameters["sb::mu"] = mu;
                 StandardModel model(parameters);
 
-                TEST_CHECK_NEARLY_EQUAL(+0.2263282172, model.alpha_s(mu), eps);
+                TEST_CHECK_NEARLY_EQUAL(model.alpha_s(mu), +0.2263282172, eps);
 
                 WilsonCoefficients<BToS> wc = model.wilson_coefficients_b_to_s(mu, "mu", false);
                 TEST_CHECK_RELATIVE_ERROR(parameters["b->s::c1"],           real(wc.c1()),  eps);
@@ -466,22 +466,22 @@ class WilsonCoefficientsSBSBTest :
                 StandardModel model(parameters);
 
                 WilsonCoefficients<wc::SBSB> wc = model.wet_sbsb();
-                TEST_CHECK_NEARLY_EQUAL(+0.001313228, real(wc.c1()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c1()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c2()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c2()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c3()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c3()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c4()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c4()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c5()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c5()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c1p()), eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c1p()), eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c2p()), eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c2p()), eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.c3p()), eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.c3p()), eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1()),  +0.001313228, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()),   0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1p()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1p()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2p()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2p()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3p()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3p()),  0.000000000, eps);
             }
         }
 } wilson_coefficients_sbsb_test;
@@ -505,16 +505,16 @@ class WilsonCoefficientsSBNuNuTest :
                 StandardModel model(parameters);
 
                 WilsonCoefficients<wc::SBNuNu> wc = model.wet_sbnunu(false);
-                TEST_CHECK_NEARLY_EQUAL( 6.605426281, real(wc.cVL()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.cVL()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.cVR()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.cVR()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.cSL()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.cSL()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.cSR()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.cSR()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, real(wc.cTL()),  eps);
-                TEST_CHECK_NEARLY_EQUAL( 0.000000000, imag(wc.cTL()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.cVL()),  6.605426281, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.cVL()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.cVR()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.cVR()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.cSL()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.cSL()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.cSR()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.cSR()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.cTL()),  0.000000000, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.cTL()),  0.000000000, eps);
             }
         }
 } wilson_coefficients_sbnunu_test;

--- a/eos/models/standard-model_TEST.cc
+++ b/eos/models/standard-model_TEST.cc
@@ -48,7 +48,11 @@ reference_parameters()
     result["CKM::rhobar"] = 0.144;
     result["CKM::etabar"] = 0.342;
     // WET sectors
-    result["sbsb::mu"] = 4.2;
+    result["sbsb::mu"]   =  4.2;
+    result["sbcu::mu_0"] = 80.0;
+    result["sbcu::mu"  ] =  4.2;
+    result["dbcu::mu_0"] = 80.0;
+    result["dbcu::mu"  ] =  4.2;
 
     return result;
 }
@@ -514,3 +518,135 @@ class WilsonCoefficientsSBNuNuTest :
             }
         }
 } wilson_coefficients_sbnunu_test;
+
+class WilsonCoefficientsSBCUTest :
+    public TestCase
+{
+    public:
+        WilsonCoefficientsSBCUTest() :
+            TestCase("wilson_coefficients_sbcu_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            /* Test for 5 active flavors, evolving from mu_0 = 80 GeV to mu = 4.2 GeV */
+            {
+                static const double eps = 1e-8;
+
+                Parameters parameters = reference_parameters(); // set scale sbcu::mu
+                StandardModel model(parameters);
+
+                TEST_CHECK_NEARLY_EQUAL( model.alpha_s(80.0), 0.12001051, 1e-6);
+                TEST_CHECK_NEARLY_EQUAL( model.alpha_s( 4.2), 0.22334194, 1e-6);
+
+                WilsonCoefficients<wc::SBCU> wc = model.wet_sbcu(false);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1()),   -0.041858794, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2()),   -0.896743838, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()),    0.011274504, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()),    0.194524251, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10p()),  0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10p()),  0.0,         eps);
+            }
+        }
+} wilson_coefficients_sbcu_test;
+
+class WilsonCoefficientsDBCUTest :
+    public TestCase
+{
+    public:
+        WilsonCoefficientsDBCUTest() :
+            TestCase("wilson_coefficients_dbcu_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            /* Test for 5 active flavors, evolving from mu_0 = 80 GeV to mu = 4.2 GeV */
+            {
+                static const double eps = 1e-8;
+
+                Parameters parameters = reference_parameters(); // set scale sbcu::mu
+                StandardModel model(parameters);
+
+                TEST_CHECK_NEARLY_EQUAL( model.alpha_s(80.0), 0.12001051, 1e-6);
+                TEST_CHECK_NEARLY_EQUAL( model.alpha_s( 4.2), 0.22334194, 1e-6);
+
+                WilsonCoefficients<wc::DBCU> wc = model.wet_dbcu(false);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1()),   -0.041858794, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2()),   -0.896743838, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()),    0.011274504, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()),    0.194524251, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()),    0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9p()),   0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10p()),  0.0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10p()),  0.0,         eps);
+            }
+        }
+} wilson_coefficients_dbcu_test;

--- a/eos/models/wet.hh
+++ b/eos/models/wet.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011, 2013, 2015 Danny van Dyk
+ * Copyright (c) 2011-2023 Danny van Dyk
  * Copyright (c) 2014 Frederik Beaujean
  * Copyright (c) 2014, 2018 Christoph Bobeth
  * Copyright (c) 2018 Ahmet Kokulu
@@ -271,6 +271,37 @@ namespace eos
             virtual WilsonCoefficients<wc::SBNuNu> wet_sbnunu(const bool & cp_conjugate) const;
     };
 
+    template <>
+    class WilsonScanComponent<components::WET::SBCU> :
+    public virtual ModelComponent<components::WET::SBCU>
+    {
+        private:
+            /* sbcu Wilson coefficients */
+            std::array<std::tuple<UsedParameter, UsedParameter>, 20> _sbcu_parameters;
+
+        public:
+            WilsonScanComponent(const Parameters &, const Options &, ParameterUser &);
+
+            /* sbnunu Wilson coefficients */
+            virtual WilsonCoefficients<wc::SBCU> wet_sbcu(const bool & cp_conjugate) const;
+    };
+
+    template <>
+    class WilsonScanComponent<components::WET::DBCU> :
+    public virtual ModelComponent<components::WET::DBCU>
+    {
+        private:
+            /* dbcu Wilson coefficients */
+            std::array<std::tuple<UsedParameter, UsedParameter>, 20> _dbcu_parameters;
+
+
+        public:
+            WilsonScanComponent(const Parameters &, const Options &, ParameterUser &);
+
+            /* sbnunu Wilson coefficients */
+            virtual WilsonCoefficients<wc::DBCU> wet_dbcu(const bool & cp_conjugate) const;
+    };
+
     /*!
      * A model with all possible operators; their Wilson coefficients
      * are allowed to have arbitrary values.
@@ -283,7 +314,9 @@ namespace eos
         public WilsonScanComponent<components::DeltaBS1>,
         public WilsonScanComponent<components::WET::UBLNu>,
         public WilsonScanComponent<components::WET::CBLNu>,
-        public WilsonScanComponent<components::WET::SBNuNu>
+        public WilsonScanComponent<components::WET::SBNuNu>,
+        public WilsonScanComponent<components::WET::SBCU>,
+        public WilsonScanComponent<components::WET::DBCU>
     {
         public:
             WilsonScanModel(const Parameters &, const Options &);
@@ -314,7 +347,9 @@ namespace eos
         public ConstrainedWilsonScanComponent,
         public WilsonScanComponent<components::WET::UBLNu>,
         public WilsonScanComponent<components::WET::CBLNu>,
-        public WilsonScanComponent<components::WET::SBNuNu>
+        public WilsonScanComponent<components::WET::SBNuNu>,
+        public WilsonScanComponent<components::WET::SBCU>,
+        public WilsonScanComponent<components::WET::DBCU>
     {
         public:
             ConstrainedWilsonScanModel(const Parameters &, const Options &);

--- a/eos/models/wet_TEST.cc
+++ b/eos/models/wet_TEST.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011, 2013, 2015 Danny van Dyk
+ * Copyright (c) 2011-2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -30,6 +30,7 @@
 
 using namespace test;
 using namespace eos;
+
 class MakeTest :
     public TestCase
 {
@@ -250,7 +251,289 @@ class WilsonCoefficientsSBSBTest :
                 TEST_CHECK_NEARLY_EQUAL( 0.678901, imag(wc.c5()),  eps);
             }
         }
-} wilson_coefficients_sbsbs_test;
+} wilson_coefficients_sbsb_test;
+
+class WilsonCoefficientsDBCUTest :
+    public TestCase
+{
+    public:
+        WilsonCoefficientsDBCUTest() :
+            TestCase("wilson_coefficients_dbcu_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            /* Test default values against the SM */
+            {
+                static const double eps = 1e-6;
+
+                Parameters p = Parameters::Defaults();
+                Options o{};
+                StandardModel sm(p);
+                WilsonScanModel wet(p, o);
+
+                const auto wc_sm  = sm.wet_dbcu(false);
+                const auto wc_wet = wet.wet_dbcu(false);
+
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c1()),   real(wc_sm.c1()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c2()),   real(wc_sm.c2()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c3()),   real(wc_sm.c3()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c4()),   real(wc_sm.c4()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c5()),   real(wc_sm.c5()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c6()),   real(wc_sm.c6()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c7()),   real(wc_sm.c7()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c8()),   real(wc_sm.c8()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c9()),   real(wc_sm.c9()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c10()),  real(wc_sm.c10()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c1p()),  real(wc_sm.c1p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c2p()),  real(wc_sm.c2p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c3p()),  real(wc_sm.c3p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c4p()),  real(wc_sm.c4p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c5p()),  real(wc_sm.c5p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c6p()),  real(wc_sm.c6p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c7p()),  real(wc_sm.c7p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c8p()),  real(wc_sm.c8p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c9p()),  real(wc_sm.c9p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c10p()), real(wc_sm.c10p()), eps);
+            }
+
+            /* Test passing of WC via cartesian parametrisations */
+            {
+                static const double eps = 1e-6;
+
+                Parameters p = Parameters::Defaults();
+                p["dbcu::Re{c1}"  ] =  0.123456;
+                p["dbcu::Im{c1}"  ] = -0.234567;
+                p["dbcu::Re{c1'}" ] = -0.345678;
+                p["dbcu::Im{c1'}" ] =  0.456789;
+                p["dbcu::Re{c2}"  ] =  0.567890;
+                p["dbcu::Im{c2}"  ] = -0.678901;
+                p["dbcu::Re{c2'}" ] = -0.789012;
+                p["dbcu::Im{c2'}" ] =  0.890123;
+                p["dbcu::Re{c3}"  ] =  0.901234;
+                p["dbcu::Im{c3}"  ] = -0.012345;
+                p["dbcu::Re{c3'}" ] = -0.123456;
+                p["dbcu::Im{c3'}" ] =  0.234567;
+                p["dbcu::Re{c4}"  ] =  0.345678;
+                p["dbcu::Im{c4}"  ] = -0.456789;
+                p["dbcu::Re{c4'}" ] = -0.567890;
+                p["dbcu::Im{c4'}" ] =  0.678901;
+                p["dbcu::Re{c5}"  ] =  0.789012;
+                p["dbcu::Im{c5}"  ] = -0.890123;
+                p["dbcu::Re{c5'}" ] = -0.901234;
+                p["dbcu::Im{c5'}" ] =  0.012345;
+                p["dbcu::Re{c6}"  ] =  0.123456;
+                p["dbcu::Im{c6}"  ] = -0.234567;
+                p["dbcu::Re{c6'}" ] = -0.345678;
+                p["dbcu::Im{c6'}" ] =  0.456789;
+                p["dbcu::Re{c7}"  ] =  0.901234;
+                p["dbcu::Im{c7}"  ] = -0.012345;
+                p["dbcu::Re{c7'}" ] = -0.123456;
+                p["dbcu::Im{c7'}" ] =  0.234567;
+                p["dbcu::Re{c8}"  ] =  0.345678;
+                p["dbcu::Im{c8}"  ] = -0.456789;
+                p["dbcu::Re{c8'}" ] = -0.567890;
+                p["dbcu::Im{c8'}" ] =  0.678901;
+                p["dbcu::Re{c9}"  ] =  0.901234;
+                p["dbcu::Im{c9}"  ] = -0.012345;
+                p["dbcu::Re{c9'}" ] = -0.123456;
+                p["dbcu::Im{c9'}" ] =  0.234567;
+                p["dbcu::Re{c10}" ] =  0.345678;
+                p["dbcu::Im{c10}" ] = -0.456789;
+                p["dbcu::Re{c10'}"] = -0.567890;
+                p["dbcu::Im{c10'}"] =  0.678901;
+                p["dbcu::mu"]      = 4.2;
+
+                Options o{};
+
+                WilsonScanModel model(p, o);
+
+                const auto wc = model.wet_dbcu(false);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1()),    0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()),   -0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1p()),  -0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1p()),   0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2()),    0.56789, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()),   -0.678901, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2p()),  -0.789012, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2p()),   0.890123, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()),    0.901234, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()),   -0.012345, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3p()),  -0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3p()),   0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()),    0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()),   -0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4p()),  -0.56789, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4p()),   0.678901, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()),    0.789012, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()),   -0.890123, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5p()),  -0.901234, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5p()),   0.012345, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()),    0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()),   -0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6p()),  -0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6p()),   0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()),    0.901234, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()),   -0.012345, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7p()),  -0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7p()),   0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()),    0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()),   -0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8p()),  -0.56789, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8p()),   0.678901, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()),    0.901234, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()),   -0.012345, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9p()),  -0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9p()),   0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10()),   0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()),  -0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10p()), -0.56789, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10p()),  0.678901, eps);
+            }
+        }
+} wilson_coefficients_dbcu_test;
+
+class WilsonCoefficientsSBCUTest :
+    public TestCase
+{
+    public:
+        WilsonCoefficientsSBCUTest() :
+            TestCase("wilson_coefficients_sbcu_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            /* Test default values against the SM */
+            {
+                static const double eps = 1e-6;
+
+                Parameters p = Parameters::Defaults();
+                Options o{};
+                StandardModel sm(p);
+                WilsonScanModel wet(p, o);
+
+                const auto wc_sm  = sm.wet_sbcu(false);
+                const auto wc_wet = wet.wet_sbcu(false);
+
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c1()),   real(wc_sm.c1()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c2()),   real(wc_sm.c2()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c3()),   real(wc_sm.c3()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c4()),   real(wc_sm.c4()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c5()),   real(wc_sm.c5()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c6()),   real(wc_sm.c6()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c7()),   real(wc_sm.c7()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c8()),   real(wc_sm.c8()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c9()),   real(wc_sm.c9()),   eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c10()),  real(wc_sm.c10()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c1p()),  real(wc_sm.c1p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c2p()),  real(wc_sm.c2p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c3p()),  real(wc_sm.c3p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c4p()),  real(wc_sm.c4p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c5p()),  real(wc_sm.c5p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c6p()),  real(wc_sm.c6p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c7p()),  real(wc_sm.c7p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c8p()),  real(wc_sm.c8p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c9p()),  real(wc_sm.c9p()),  eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc_wet.c10p()), real(wc_sm.c10p()), eps);
+            }
+
+            /* Test passing of WC via cartesian parametrisations */
+            {
+                static const double eps = 1e-6;
+
+                Parameters p = Parameters::Defaults();
+                p["sbcu::Re{c1}"  ] =  0.123456;
+                p["sbcu::Im{c1}"  ] = -0.234567;
+                p["sbcu::Re{c1'}" ] = -0.345678;
+                p["sbcu::Im{c1'}" ] =  0.456789;
+                p["sbcu::Re{c2}"  ] =  0.567890;
+                p["sbcu::Im{c2}"  ] = -0.678901;
+                p["sbcu::Re{c2'}" ] = -0.789012;
+                p["sbcu::Im{c2'}" ] =  0.890123;
+                p["sbcu::Re{c3}"  ] =  0.901234;
+                p["sbcu::Im{c3}"  ] = -0.012345;
+                p["sbcu::Re{c3'}" ] = -0.123456;
+                p["sbcu::Im{c3'}" ] =  0.234567;
+                p["sbcu::Re{c4}"  ] =  0.345678;
+                p["sbcu::Im{c4}"  ] = -0.456789;
+                p["sbcu::Re{c4'}" ] = -0.567890;
+                p["sbcu::Im{c4'}" ] =  0.678901;
+                p["sbcu::Re{c5}"  ] =  0.789012;
+                p["sbcu::Im{c5}"  ] = -0.890123;
+                p["sbcu::Re{c5'}" ] = -0.901234;
+                p["sbcu::Im{c5'}" ] =  0.012345;
+                p["sbcu::Re{c6}"  ] =  0.123456;
+                p["sbcu::Im{c6}"  ] = -0.234567;
+                p["sbcu::Re{c6'}" ] = -0.345678;
+                p["sbcu::Im{c6'}" ] =  0.456789;
+                p["sbcu::Re{c7}"  ] =  0.901234;
+                p["sbcu::Im{c7}"  ] = -0.012345;
+                p["sbcu::Re{c7'}" ] = -0.123456;
+                p["sbcu::Im{c7'}" ] =  0.234567;
+                p["sbcu::Re{c8}"  ] =  0.345678;
+                p["sbcu::Im{c8}"  ] = -0.456789;
+                p["sbcu::Re{c8'}" ] = -0.567890;
+                p["sbcu::Im{c8'}" ] =  0.678901;
+                p["sbcu::Re{c9}"  ] =  0.901234;
+                p["sbcu::Im{c9}"  ] = -0.012345;
+                p["sbcu::Re{c9'}" ] = -0.123456;
+                p["sbcu::Im{c9'}" ] =  0.234567;
+                p["sbcu::Re{c10}" ] =  0.345678;
+                p["sbcu::Im{c10}" ] = -0.456789;
+                p["sbcu::Re{c10'}"] = -0.567890;
+                p["sbcu::Im{c10'}"] =  0.678901;
+                p["sbcu::mu"]      = 4.2;
+
+                Options o{};
+
+                WilsonScanModel model(p, o);
+
+                const auto wc = model.wet_sbcu(false);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1()),    0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()),   -0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c1p()),  -0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1p()),   0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2()),    0.56789, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()),   -0.678901, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c2p()),  -0.789012, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2p()),   0.890123, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()),    0.901234, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()),   -0.012345, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3p()),  -0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3p()),   0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()),    0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()),   -0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4p()),  -0.56789, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4p()),   0.678901, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()),    0.789012, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()),   -0.890123, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5p()),  -0.901234, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5p()),   0.012345, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()),    0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()),   -0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6p()),  -0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6p()),   0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()),    0.901234, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()),   -0.012345, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7p()),  -0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7p()),   0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()),    0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()),   -0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8p()),  -0.56789, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8p()),   0.678901, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()),    0.901234, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()),   -0.012345, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9p()),  -0.123456, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9p()),   0.234567, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10()),   0.345678, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()),  -0.456789, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10p()), -0.56789, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10p()),  0.678901, eps);
+            }
+        }
+} wilson_coefficients_sbcu_test;
 
 class WilsonCoefficientsSBNuNuTest :
     public TestCase

--- a/eos/models/wilson-coefficients.hh
+++ b/eos/models/wilson-coefficients.hh
@@ -36,6 +36,7 @@ namespace eos
     namespace bern
     {
         struct ClassII {};  // |Delta B| = 1 semileptonic operators, cf. [AFGV:2017A], eq. (2.5), p. 6.
+        struct ClassIII {}; // |Delta B| = 1 = |Delta C| four-quark operators, cf. [AFGB:2017A], eq. (2.6), p. 7.
     }
 
     using ChargedCurrent = bern::ClassII;
@@ -57,6 +58,36 @@ namespace eos
         inline complex<double> csl() const { return _coefficients[2]; }
         inline complex<double> csr() const { return _coefficients[3]; }
         inline complex<double> ct()  const { return _coefficients[4]; }
+    };
+
+    template <> struct WilsonCoefficients<bern::ClassIII>
+    {
+        /*
+         * Following the definitions in [AFGB:2017A], cf. Table 1 and Eq. (2.6).
+        */
+        std::array<complex<double>, 10> _unprimed, _primed;
+
+        inline complex<double> c1()   const { return _unprimed[0]; }
+        inline complex<double> c2()   const { return _unprimed[1]; }
+        inline complex<double> c3()   const { return _unprimed[2]; }
+        inline complex<double> c4()   const { return _unprimed[3]; }
+        inline complex<double> c5()   const { return _unprimed[4]; }
+        inline complex<double> c6()   const { return _unprimed[5]; }
+        inline complex<double> c7()   const { return _unprimed[6]; }
+        inline complex<double> c8()   const { return _unprimed[7]; }
+        inline complex<double> c9()   const { return _unprimed[8]; }
+        inline complex<double> c10()  const { return _unprimed[9]; }
+
+        inline complex<double> c1p()  const { return _primed[0]; }
+        inline complex<double> c2p()  const { return _primed[1]; }
+        inline complex<double> c3p()  const { return _primed[2]; }
+        inline complex<double> c4p()  const { return _primed[3]; }
+        inline complex<double> c5p()  const { return _primed[4]; }
+        inline complex<double> c6p()  const { return _primed[5]; }
+        inline complex<double> c7p()  const { return _primed[6]; }
+        inline complex<double> c8p()  const { return _primed[7]; }
+        inline complex<double> c9p()  const { return _primed[8]; }
+        inline complex<double> c10p() const { return _primed[9]; }
     };
 
     struct BToS {};
@@ -132,8 +163,10 @@ namespace eos
 
     namespace wc
     {
+        struct DBCU {};
         struct SBSB {};
         struct SBNuNu {};
+        struct SBCU {};
     }
 
     /* Wilson coefficients for |Delta B| = |Delta S| = 2 operators */
@@ -222,6 +255,25 @@ namespace eos
         inline complex<double> cSL()   const { return _coefficients[2]; }
         inline complex<double> cSR()   const { return _coefficients[3]; }
         inline complex<double> cTL()   const { return _coefficients[4]; }
-    };}
+    };
+
+    template <> struct WilsonCoefficients<wc::SBCU> :
+        public WilsonCoefficients<bern::ClassIII>
+    {
+        /*
+         * Normalisation:
+         * H^eff = 4 G_F / sqrt(2) V_cb V_us^* \sum C_i O_i
+         */
+    };
+
+    template <> struct WilsonCoefficients<wc::DBCU> :
+        public WilsonCoefficients<bern::ClassIII>
+    {
+        /*
+         * Normalisation:
+         * H^eff = 4 G_F / sqrt(2) V_cb V_ud^* \sum C_i O_i
+         */
+    };
+}
 
 #endif

--- a/eos/models/wilson-coefficients.hh
+++ b/eos/models/wilson-coefficients.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2013, 2015, 2021 Danny van Dyk
+ * Copyright (c) 2010-2023 Danny van Dyk
  * Copyright (c) 2014 Frederik Beaujean
  * Copyright (c) 2014 Christoph Bobeth
  *
@@ -33,18 +33,25 @@ namespace eos
 {
     template <typename Tag_> struct WilsonCoefficients;
 
-    struct ChargedCurrent {};
+    namespace bern
+    {
+        struct ClassII {};  // |Delta B| = 1 semileptonic operators, cf. [AFGV:2017A], eq. (2.5), p. 6.
+    }
+
+    using ChargedCurrent = bern::ClassII;
 
     template <> struct WilsonCoefficients<ChargedCurrent>
     {
         /*
-         * For the definition, cf. [FMvD2013].
+         * We follow the definition of [FMvD2013], eqs. (1) and (2), p. 2.
+         * This coincides with the Bern basis of class II operators in Ref.
+         * [AFGV:2017A], eq. (2.5), p. 6, up to a factor of V_qb.
          */
 
-        /* Order: C_V,L, C_V,R, C_S,L, C_S,R, C_T */
+        /* Order: C_V,L, C_V,R, C_S,L, C_S,R, C_T, or equivalently: 1, 1', 5, 5', 7'. */
         std::array<complex<double>, 5> _coefficients;
 
-        // cf. [FMvD2015], Eqs. (1) and (2)
+        // cf. [FMvD2015], eqs. (1) and (2)
         inline complex<double> cvl() const { return _coefficients[0]; }
         inline complex<double> cvr() const { return _coefficients[1]; }
         inline complex<double> csl() const { return _coefficients[2]; }

--- a/eos/parameters/sm-and-eft.yaml
+++ b/eos/parameters/sm-and-eft.yaml
@@ -1401,3 +1401,463 @@ groups:
           min:     0.0
           max:     0.0
           latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{\nu}\nu}_{T_L}$'
+  # sbcu WET Parameters
+  # {{{
+  - title: '$\bar{s}b\bar{c}u$ WET Parameters'
+    description: >
+        The list of parameters describing the $\bar{s}b\bar{c}u$ Wilson coefficients in the effective Hamiltonian
+        \begin{equation}
+          \mathcal{H}^{\bar{s}b\bar{c}u}_\mathrm{eff}
+          = \frac{4 G_F}{\sqrt{2}} V_{cb} V_{us}^* \sum_i \mathcal{C}^{\bar{s}b\bar{c}u}_i \mathcal{O}^{\bar{s}b\bar{c}u}_i\,.
+        \end{equation}
+        The operators read:
+        \begin{align}
+          \mathcal{O}_{1(')} & = [\bar{s} \gamma^\mu P_{L(R)} b]\, [\bar{c} \gamma_\mu u]
+        \end{align}
+
+    wcxf-relevant: true
+    parameters:
+      'sbcu::mu' :
+          central: 4.2
+          min:     4.2
+          max:     4.2
+          latex:   '$\mu^{\bar{s}b\bar{c}u}$'
+          unit:    'GeV'
+      'sbcu::mu_0' :
+          central: 80.0
+          min:     80.0
+          max:     80.0
+          latex:   '$\mu_0^{\bar{s}b\bar{c}u}$'
+          unit:    'GeV'
+      # Unprimed coefficients
+      'sbcu::Re{c1}' :
+          central: -0.041469
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{1}$'
+      'sbcu::Im{c1}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{1}$'
+      'sbcu::Re{c2}' :
+          central: -0.899772
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{2}$'
+      'sbcu::Im{c2}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{2}$'
+      'sbcu::Re{c3}' :
+          central: 0.011126
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{3}$'
+      'sbcu::Im{c3}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{3}$'
+      'sbcu::Re{c4}' :
+          central: 0.194904
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{4}$'
+      'sbcu::Im{c4}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{4}$'
+      'sbcu::Re{c5}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{5}$'
+      'sbcu::Im{c5}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{5}$'
+      'sbcu::Re{c6}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{6}$'
+      'sbcu::Im{c6}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{6}$'
+      'sbcu::Re{c7}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{7}$'
+      'sbcu::Im{c7}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{7}$'
+      'sbcu::Re{c8}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{8}$'
+      'sbcu::Im{c8}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{8}$'
+      'sbcu::Re{c9}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{9}$'
+      'sbcu::Im{c9}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{9}$'
+      'sbcu::Re{c10}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{10}$'
+      'sbcu::Im{c10}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{10}$'
+      # Primed coefficients
+      "sbcu::Re{c1'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{1\prime}$'
+      "sbcu::Im{c1'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{1\prime}$'
+      "sbcu::Re{c2'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{2\prime}$'
+      "sbcu::Im{c2'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{2\prime}$'
+      "sbcu::Re{c3'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{3\prime}$'
+      "sbcu::Im{c3'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{3\prime}$'
+      "sbcu::Re{c4'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{4\prime}$'
+      "sbcu::Im{c4'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{4\prime}$'
+      "sbcu::Re{c5'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{5\prime}$'
+      "sbcu::Im{c5'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{5\prime}$'
+      "sbcu::Re{c6'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{6\prime}$'
+      "sbcu::Im{c6'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{6\prime}$'
+      "sbcu::Re{c7'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{7\prime}$'
+      "sbcu::Im{c7'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{7\prime}$'
+      "sbcu::Re{c8'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{8\prime}$'
+      "sbcu::Im{c8'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{8\prime}$'
+      "sbcu::Re{c9'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{9\prime}$'
+      "sbcu::Im{c9'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{9\prime}$'
+      "sbcu::Re{c10'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{10\prime}$'
+      "sbcu::Im{c10'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{s}b\bar{c}u}_{10\prime}$'
+  # dbcu WET Parameters
+  # {{{
+  - title: '$\bar{d}b\bar{c}u$ WET Parameters'
+    description: >
+        The list of parameters describing the $\bar{d}b\bar{c}u$ Wilson coefficients in the effective Hamiltonian
+        \begin{equation}
+          \mathcal{H}^{\bar{d}b\bar{c}u}_\mathrm{eff}
+          = \frac{4 G_F}{\sqrt{2}} V_{cb} V_{ud}^* \sum_i \mathcal{C}^{\bar{d}b\bar{c}u}_i \mathcal{O}^{\bar{d}b\bar{c}u}_i\,.
+        \end{equation}
+        The operators read:
+        \begin{align}
+          \mathcal{O}_{1(')} & = [\bar{d} \gamma^\mu P_{L(R)} b]\, [\bar{c} \gamma_\mu u]
+        \end{align}
+
+    wcxf-relevant: true
+    parameters:
+      'dbcu::mu' :
+          central: 4.2
+          min:     4.2
+          max:     4.2
+          latex:   '$\mu^{\bar{d}b\bar{c}u}$'
+          unit:    'GeV'
+      'dbcu::mu_0' :
+          central: 80.0
+          min:     80.0
+          max:     80.0
+          latex:   '$\mu_0^{\bar{d}b\bar{c}u}$'
+          unit:    'GeV'
+      # Unprimed coefficients
+      'dbcu::Re{c1}' :
+          central: -0.041469
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{1}$'
+      'dbcu::Im{c1}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{1}$'
+      'dbcu::Re{c2}' :
+          central: -0.899772
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{2}$'
+      'dbcu::Im{c2}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{2}$'
+      'dbcu::Re{c3}' :
+          central: 0.011126
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{3}$'
+      'dbcu::Im{c3}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{3}$'
+      'dbcu::Re{c4}' :
+          central: 0.194904
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{4}$'
+      'dbcu::Im{c4}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{4}$'
+      'dbcu::Re{c5}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{5}$'
+      'dbcu::Im{c5}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{5}$'
+      'dbcu::Re{c6}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{6}$'
+      'dbcu::Im{c6}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{6}$'
+      'dbcu::Re{c7}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{7}$'
+      'dbcu::Im{c7}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{7}$'
+      'dbcu::Re{c8}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{8}$'
+      'dbcu::Im{c8}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{8}$'
+      'dbcu::Re{c9}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{9}$'
+      'dbcu::Im{c9}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{9}$'
+      'dbcu::Re{c10}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{10}$'
+      'dbcu::Im{c10}' :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{10}$'
+      # Primed coefficients
+      "dbcu::Re{c1'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{1\prime}$'
+      "dbcu::Im{c1'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{1\prime}$'
+      "dbcu::Re{c2'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{2\prime}$'
+      "dbcu::Im{c2'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{2\prime}$'
+      "dbcu::Re{c3'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{3\prime}$'
+      "dbcu::Im{c3'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{3\prime}$'
+      "dbcu::Re{c4'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{4\prime}$'
+      "dbcu::Im{c4'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{4\prime}$'
+      "dbcu::Re{c5'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{5\prime}$'
+      "dbcu::Im{c5'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{5\prime}$'
+      "dbcu::Re{c6'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{6\prime}$'
+      "dbcu::Im{c6'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{6\prime}$'
+      "dbcu::Re{c7'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{7\prime}$'
+      "dbcu::Im{c7'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{7\prime}$'
+      "dbcu::Re{c8'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{8\prime}$'
+      "dbcu::Im{c8'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{8\prime}$'
+      "dbcu::Re{c9'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{9\prime}$'
+      "dbcu::Im{c9'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{9\prime}$'
+      "dbcu::Re{c10'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Re}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{10\prime}$'
+      "dbcu::Im{c10'}" :
+          central: 0.0
+          min:     0.0
+          max:     0.0
+          latex:   '$\mathrm{Im}\, \mathcal{C}^{\bar{d}b\bar{c}u}_{10\prime}$'


### PR DESCRIPTION
Requires prior merging of #660.

Status:
 - [x] Add SM parameters
 - [x] Add WET parameters
 - [x] Add SM matching to NLO and running to NLL
 - [x] Test SM results against @SMeiser's results (NLL w/ LO: check)
 - [x] Set default WET parameters to SM results @ NLL.