### PR TITLE
Position space pseudo observable for ``b_lcdas::FLvD2022``

### DIFF
--- a/eos/form-factors/b-lcdas-flvd2022.cc
+++ b/eos/form-factors/b-lcdas-flvd2022.cc
@@ -36,8 +36,8 @@ namespace eos
     namespace b_lcdas
     {
         FLvD2022::FLvD2022(const Parameters & p, const Options & o) :
-            opt_q(o, "q", { "u", "s" }, "u"),
-            opt_gminus(o, "gminus", { "zero", "WW-limit" }, "WW-limit"),
+            opt_q(o, options, "q"),
+            opt_gminus(o, options, "gminus"),
             switch_gminus(1.0),
             mu_0(p[parameter("mu_0")], *this),
             omega_0(p[parameter("omega_0")], *this),
@@ -399,6 +399,31 @@ namespace eos
             Diagnostics results;
             // add diagnostic results here
             return results;
+        }
+
+        const std::set<ReferenceName>
+        FLvD2022::references
+        {
+            "DBG:2013A"_rn
+        };
+
+        const std::vector<OptionSpecification>
+        FLvD2022::options
+        {
+            { "q",       { "u", "s" },           "u"        },
+            { "g-minus", { "zero", "WW-limit" }, "WW-limit" }
+        };
+
+        std::vector<OptionSpecification>::const_iterator
+        FLvD2022::begin_options()
+        {
+            return options.cbegin();
+        }
+
+        std::vector<OptionSpecification>::const_iterator
+        FLvD2022::end_options()
+        {
+            return options.cend();
         }
     }
 

--- a/eos/form-factors/b-lcdas-flvd2022.cc
+++ b/eos/form-factors/b-lcdas-flvd2022.cc
@@ -53,6 +53,13 @@ namespace eos
                 UsedParameter(p[parameter("a^phi+_8")], *this)
             })
         {
+            // Verify the size of Weights used internally
+            Weights weights;
+            if (weights.size() < a.size())
+            {
+                throw InternalError("The number of weights implemented is smaller than the number of coefficients of phi_+");
+            }
+
             if (opt_gminus.value() == "zero")
             {
                 switch_gminus = 0.0;
@@ -80,7 +87,7 @@ namespace eos
         FLvD2022::coefficient_range(const double & mu) const
         {
             // copy values to array of doubles
-            static thread_local std::array<double, 9> values;
+            static thread_local std::array<double, number_of_parameters> values;
             for (size_t i = 0; i < values.size(); i++)
             {
                 values[i] = a[i]; // evaluates UsedParameter

--- a/eos/form-factors/b-lcdas-flvd2022.cc
+++ b/eos/form-factors/b-lcdas-flvd2022.cc
@@ -28,6 +28,7 @@
 
 #include <cmath>
 #include <limits>
+#include <numeric>
 
 #include <gsl/gsl_sf_gamma.h>
 
@@ -220,6 +221,89 @@ namespace eos
             throw InternalError("Function not yet implemented");
         }
 
+        double
+        FLvD2022::phitilde_plus(const double & tau, const double & mu) const
+        {
+            const double x = tau * omega_0;
+
+            const double p1 = (x - 1.0) / (x + 1.0);
+            const double p2 = p1 * p1;
+            const double p3 = p2 * p1;
+            const double p4 = p3 * p1;
+            const double p5 = p4 * p1;
+            const double p6 = p5 * p1;
+            const double p7 = p6 * p1;
+            const double p8 = p7 * p1;
+
+            const Weights c = {
+                1.0, p1, p2, p3, p4, p5, p6, p7, p8
+            };
+
+            auto [a_begin, a_end] = this->coefficient_range(mu);
+            return 1.0 / power_of<2>(1.0 + x) * std::inner_product(a_begin, a_end, c.begin(), 0.0);
+        }
+
+        double
+        FLvD2022::t_d_dt_phitilde_plus(const double & tau, const double & mu) const
+        {
+            const double x = tau * omega_0;
+
+            const double p1 = (x - 1.0) / (x + 1.0);
+            const double p2 = p1 * p1;
+            const double p3 = p2 * p1;
+            const double p4 = p3 * p1;
+            const double p5 = p4 * p1;
+            const double p6 = p5 * p1;
+            const double p7 = p6 * p1;
+            const double p8 = p7 * p1;
+
+            const Weights c = {
+                1.0 - x,
+                (2.0 - x) * p1,
+                (3.0 - x) * p2,
+                (4.0 - x) * p3,
+                (5.0 - x) * p4,
+                (6.0 - x) * p5,
+                (7.0 - x) * p6,
+                (8.0 - x) * p7,
+                (9.0 - x) * p8
+            };
+
+            auto [a_begin, a_end] = this->coefficient_range(mu);
+            return 2.0 * x / power_of<3>(x + 1.0) / (x - 1.0) * std::inner_product(a_begin, a_end, c.begin(), 0.0);
+        }
+
+        double
+        FLvD2022::t2_d2_d2t_phitilde_plus(const double & tau, const double & mu) const
+        {
+            const double x = tau * omega_0;
+
+            const double p1 = (x - 1.0) / (x + 1.0);
+            const double p2 = p1 * p1;
+            const double p3 = p2 * p1;
+            const double p4 = p3 * p1;
+            const double p5 = p4 * p1;
+            const double p6 = p5 * p1;
+            const double p7 = p6 * p1;
+            const double p8 = p7 * p1;
+
+            const double xminus2 = (1.0 - x) * (1.0 - x);
+
+            const Weights c = {
+                3 * xminus2,
+                p1 * (6 - 6 * x + 3 * xminus2),
+                p2 * (8 + 2 * (4 - 6 * x) + 3 * xminus2),
+                p3 * (18 + 3 * (4 - 6 * x) + 3 * xminus2),
+                p4 * (32 + 4 * (4 - 6 * x) + 3 * xminus2),
+                p5 * (50 + 5 * (4 - 6 * x) + 3 * xminus2),
+                p6 * (72 + 6 * (4 - 6 * x) + 3 * xminus2),
+                p7 * (98 + 7 * (4 - 6 * x) + 3 * xminus2),
+                p8 * (128 + 8 * (4 - 6 * x) + 3 * xminus2)
+            };
+
+            auto [a_begin, a_end] = this->coefficient_range(mu);
+            return 2.0 * power_of<2>(x) / power_of<2>(x - 1.0) / power_of<4>(x + 1.0) * std::inner_product(a_begin, a_end, c.begin(), 0.0);
+        }
 
         /* Next-to-leading twist two-particle LCDAs */
 
@@ -411,14 +495,14 @@ namespace eos
         const std::set<ReferenceName>
         FLvD2022::references
         {
-            "DBG:2013A"_rn
+            "FLvD:2022A"_rn
         };
 
         const std::vector<OptionSpecification>
         FLvD2022::options
         {
             { "q",       { "u", "s" },           "u"        },
-            { "g-minus", { "zero", "WW-limit" }, "WW-limit" }
+            { "gminus", { "zero", "WW-limit" }, "WW-limit" }
         };
 
         std::vector<OptionSpecification>::const_iterator

--- a/eos/form-factors/b-lcdas-flvd2022.hh
+++ b/eos/form-factors/b-lcdas-flvd2022.hh
@@ -43,13 +43,16 @@ namespace eos
             public BMesonLCDAs
         {
             private:
+                const static unsigned int number_of_parameters = 9u;
+                using Weights = std::array<double, number_of_parameters>; // We implement the weights as fixed-size arrays
+
                 SpecifiedOption opt_q;
                 SpecifiedOption opt_gminus;
                 double switch_gminus;
 
                 UsedParameter mu_0;
                 UsedParameter omega_0;
-                std::array<UsedParameter, 9> a; // at the scale mu_0
+                std::array<UsedParameter, number_of_parameters> a; // at the scale mu_0
 
                 std::string parameter(const char * _name) const;
 

--- a/eos/form-factors/b-lcdas-flvd2022.hh
+++ b/eos/form-factors/b-lcdas-flvd2022.hh
@@ -72,7 +72,7 @@ namespace eos
                 virtual std::tuple<BMesonLCDAs::CoefficientIterator, BMesonLCDAs::CoefficientIterator> coefficient_range(const double & mu) const final override;
 
                 /*!
-                 * Leading twist two-particle LCDAs
+                 * Leading twist two-particle LCDAs in momentum space
                  *
                  * omega: plus-component of the spectator momentum
                  */
@@ -80,6 +80,15 @@ namespace eos
                 virtual double phi_minus(const double & omega) const final override;
                 virtual double phi_bar(const double & omega) const final override;
                 virtual double phi_bar_d1(const double & omega) const final override;
+
+                /*!
+                 * Leading twist two-particle LCDAs in position space
+                 *
+                 * tau: minus-component of the spectator position on the negative imaginary axis: tau = -i*t
+                 */
+                double phitilde_plus(const double & tau, const double & mu) const;
+                double t_d_dt_phitilde_plus(const double & tau, const double & mu) const;
+                double t2_d2_d2t_phitilde_plus(const double & tau, const double & mu) const;
 
                 /*!
                  * Next-to-leading twist two-particle LCDAs

--- a/eos/form-factors/b-lcdas-flvd2022.hh
+++ b/eos/form-factors/b-lcdas-flvd2022.hh
@@ -26,6 +26,7 @@
 #include <eos/utils/parameters.hh>
 #include <eos/utils/options.hh>
 #include <eos/utils/options-impl.hh>
+#include <eos/utils/reference-name.hh>
 
 #include <array>
 #include <string>
@@ -42,8 +43,8 @@ namespace eos
             public BMesonLCDAs
         {
             private:
-                SwitchOption opt_q;
-                SwitchOption opt_gminus;
+                SpecifiedOption opt_q;
+                SpecifiedOption opt_gminus;
                 double switch_gminus;
 
                 UsedParameter mu_0;
@@ -51,6 +52,8 @@ namespace eos
                 std::array<UsedParameter, 9> a; // at the scale mu_0
 
                 std::string parameter(const char * _name) const;
+
+                static const std::vector<OptionSpecification> options;
 
             public:
                 FLvD2022(const Parameters & parameters, const Options & options);
@@ -142,6 +145,17 @@ namespace eos
 
                 /* Internal diagnostics */
                 virtual Diagnostics diagnostics() const final override;
+
+                /*!
+                * References used in the computation of our (pseudo)observables.
+                */
+                static const std::set<ReferenceName> references;
+
+                /*!
+                * Options used in the computation of our (pseudo)observables.
+                */
+                static std::vector<OptionSpecification>::const_iterator begin_options();
+                static std::vector<OptionSpecification>::const_iterator end_options();
         };
     }
 }

--- a/eos/form-factors/observables.cc
+++ b/eos/form-factors/observables.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et tw=150 foldmethod=marker : */
 
 /*
- * Copyright (c) 2019, 2020 Danny van Dyk
+ * Copyright (c) 2019-2022 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -24,6 +24,7 @@
 #include <eos/form-factors/analytic-b-to-v-lcsr.hh>
 #include <eos/form-factors/analytic-b-to-p-lcsr.hh>
 #include <eos/form-factors/b-lcdas.hh>
+#include <eos/form-factors/b-lcdas-flvd2022.hh>
 #include <eos/form-factors/observables.hh>
 #include <eos/form-factors/parametric-abr2022.hh>
 #include <eos/form-factors/parametric-bgjvd2019.hh>
@@ -1739,6 +1740,34 @@ namespace eos
     }
     // }}}
 
+    // B-meson LCDAs
+    // {{{
+
+    ObservableGroup
+    make_b_meson_lcdas_group()
+    {
+        auto imp = new Implementation<ObservableGroup>(
+            R"($B$-meson LCDAs)",
+            R"(Pseudo observables arising in the description of $B$-meson Light-Cone Distribution Amplitudes (LCDAs).)",
+            {
+                make_observable("B::phitilde_+(-i*tau,mu)@FLvD2022", R"(\tilde\phi_{B,+}(-i \tau, \mu))",
+                        Unit::None(),
+                        &b_lcdas::FLvD2022::phitilde_plus,
+                        std::make_tuple("tau", "mu")),
+                make_observable("B::tau*d_dtau_phitilde_+(-i*tau,mu)@FLvD2022", R"(-i \tau \, \tilde\phi^{\prime}_{B,+}(-i \tau, \mu))",
+                        Unit::None(),
+                        &b_lcdas::FLvD2022::t_d_dt_phitilde_plus,
+                        std::make_tuple("tau", "mu")),
+                make_observable("B::tau^2*d2_d2tau_phitilde_+(-i*tau,mu)@FLvD2022", R"(-\tau^2 \, \tilde\phi^{\prime\prime}_{B,+}(-i \tau, \mu))",
+                        Unit::None(),
+                        &b_lcdas::FLvD2022::t2_d2_d2t_phitilde_plus,
+                        std::make_tuple("tau", "mu")),
+            }
+        );
+
+        return ObservableGroup(imp);
+    }
+    // }}}
     ObservableSection
     make_form_factors_section()
     {
@@ -1782,6 +1811,9 @@ namespace eos
 
                 // unitarity bounds
                 make_unitarity_bounds_group(),
+
+                // B-meson LCDAs
+                make_b_meson_lcdas_group(),
             }
         );
 


### PR DESCRIPTION
The proposed changes allow to use the position space LCDA of the B meson $\tilde\phi_{B,+}(\tau)$ and its derivative as a constraint for the parametrisation introduced in `[FLvD:2022A]`. Such information can be extracted from theory through an operator product expansion.