### PR TITLE
Update actions runner to ``ubuntu-20.04`` for PyPI jobs

### DIFF
--- a/.github/workflows/manylinux-build+check+deploy.yaml
+++ b/.github/workflows/manylinux-build+check+deploy.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
     pypi-build:
         name: Build on manylinux2014
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         strategy:
             matrix:
                 cfg:
@@ -87,7 +87,7 @@ jobs:
     pypi-check:
         needs: pypi-build
         name: Check on manylinux2014
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         strategy:
             matrix:
                 cfg:
@@ -127,7 +127,7 @@ jobs:
     pypi-deploy:
         needs: [ pypi-build, pypi-check ]
         name: Deploy on PyPI
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         strategy:
             matrix:
                 cfg:


### PR DESCRIPTION
Github is deprecating the ``ubuntu-18.04`` runner, which is currently still used by the PyPI workflow. Although a docker container is used, we need to update the runner.