### PR TITLE
Support observables from expressions in analysis file

### DIFF
--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2016, 2019, 2020 Danny van Dyk
- * Copyright (c) 2021 Philip Lüghausen
+ * Copyright (c) 2021-2023 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -449,7 +449,7 @@ BOOST_PYTHON_MODULE(_eos)
             - InverseGeV2
             - InverseGeV4
             - InversePicoSecond
-        )", no_init)
+        )", init<std::string>())
         .def("Undefined", &Unit::Undefined)
         .staticmethod("Undefined")
         .def("Unity", &Unit::None)

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -2,6 +2,7 @@
 # vim: set sw=4 sts=4 et tw=120 :
 
 # Copyright (c) 2020 Danny van Dyk
+# Copytight (c) 2023 Philip LÃghausen
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -67,6 +68,25 @@ class AnalysisFile:
         else:
             self._steps = input_data['steps']
 
+        # Optional: insert custom observables using the expression parser
+        if 'observables' in input_data:
+            for name in input_data['observables']:
+
+                required_keys = ['latex', 'unit', 'options', 'expression']
+                provided_keys = input_data['observables'][name].keys()
+
+                missing_keys  = [key for key in required_keys if key not in provided_keys]
+                if missing_keys:
+                    raise KeyError(f'Missing keys for observable { name }: { missing_keys }')
+
+                ignored_keys = [key for key in provided_keys if key not in required_keys]
+                if ignored_keys:
+                    eos.warn(f'Ignoring unknown keys for observable { name }: { ignored_keys }')
+
+                obs = input_data['observables'][name]
+                options = eos.Options(**obs['options'])
+                eos.Observables().insert(name, obs['latex'], eos.Unit(obs['unit']), options, obs['expression'])
+                eos.info(f'Successfully inserted observable: { name }')
 
     def analysis(self, _posterior):
         """Create an eos.Analysis object for the named posterior."""


### PR DESCRIPTION
The small set of changes allows to use the expression parser to include custom observables in an analysis file.