### PR TITLE
[form-factors] Add inverse and 1st and 2nd logarithmic moments as pseudo observables

### DIFF
--- a/eos/form-factors/b-lcdas-flvd2022.cc
+++ b/eos/form-factors/b-lcdas-flvd2022.cc
@@ -449,6 +449,42 @@ namespace eos
         }
 
         double
+        FLvD2022::inverse_moment(const double & mu) const
+        {
+            // Cp. [FLvD:2022A], Eq. (43)
+            const Weights c = {
+                1.0, 0.0, 1.0 / 3.0, 0.0, 1.0 / 5.0, 0.0, 1.0 / 7.0, 0.0, 1.0 / 9.0
+            };
+
+            auto [a_begin, a_end] = this->coefficient_range(mu);
+            return 1.0 / omega_0 * std::inner_product(a_begin, a_end, c.begin(), 0.0);
+        }
+
+        double
+        FLvD2022::logarithmic_moment_1(const double & mu) const
+        {
+            // Cp. [FLvD:2022A], Eq. (44)
+            const Weights c = {
+                0, -1.0, 0, -2.0 / 3.0, 0.0, -23.0 / 45.0, 0.0, -44.0 / 105.0, 0.0
+            };
+
+            auto [a_begin, a_end] = this->coefficient_range(mu);
+            return 1.0 / omega_0 * std::inner_product(a_begin, a_end, c.begin(), 0.0);
+        }
+
+        double
+        FLvD2022::logarithmic_moment_2(const double & mu) const
+        {
+            // Cp. [FLvD:2022A], Eq. (45)
+            const Weights c = {
+                0.0, 0.0, 4.0 / 3.0, 0.0, 4.0 / 3.0, 0.0, 56.0 / 45.0, 0.0, 3272.0 / 2835.0
+            };
+
+            auto [a_begin, a_end] = this->coefficient_range(mu);
+            return power_of<2>(M_PI) / 6.0 * inverse_moment(mu) + 1.0 / omega_0 * std::inner_product(a_begin, a_end, c.begin(), 0.0);
+        }
+
+        double
         FLvD2022::psi_A(const double & omega, const double & xi) const
         {
             throw InternalError("Function not yet implemented");

--- a/eos/form-factors/b-lcdas-flvd2022.hh
+++ b/eos/form-factors/b-lcdas-flvd2022.hh
@@ -131,10 +131,16 @@ namespace eos
 
                 virtual double psi_bar_bar_4(const double & omega_1, const double & omega_2) const final override;
                 virtual double chi_bar_bar_4(const double & omega_1, const double & omega_2) const final override;
+
                 /*!
                 * Pseudo observables for the two-particle LCDAs
+                *
+                * The logarithmic moments are defined in [FLvD:2022A], Eq. (14) with mu_m_hat = omega_0 * exp(euler_gamma)
                 */
                 virtual double inverse_lambda_plus() const final override;
+                double inverse_moment(const double & mu) const;
+                double logarithmic_moment_1(const double & mu) const;
+                double logarithmic_moment_2(const double & mu) const;
 
                 /*!
                  * Leading power three-particle LCDAs

--- a/eos/form-factors/b-lcdas-flvd2022_TEST.cc
+++ b/eos/form-factors/b-lcdas-flvd2022_TEST.cc
@@ -111,5 +111,30 @@ class FLvD2022Test :
                 auto t2_d2_d2t_phitilde = Observable::make("B::tau^2*d2_d2tau_phitilde_+(-i*tau,mu)@FLvD2022", p, k, o);
                 TEST_CHECK_NEARLY_EQUAL(t2_d2_d2t_phitilde->evaluate(), 20.320360292444562, 1e-12);
             }
+
+            // inverse moment and first and second logarithmic moments
+            {
+                Parameters p = Parameters::Defaults();
+                std::array<double, 9> parameters = { 1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0 };
+
+                p["B_u::mu_0@FLvD2022"] = 1.0;
+                p["B_u::omega_0@FLvD2022"] = 0.3;
+                for (size_t k = 0; k < parameters.size(); k++)
+                {
+                    p["B_u::a^phi+_" + std::to_string(k) + "@FLvD2022"] = parameters[k];
+                }
+
+                Kinematics k = Kinematics({ {"mu", 1.0} });
+                Options o { };
+
+                auto L0 = Observable::make("B::L0@FLvD2022", p, k, o);
+                TEST_CHECK_NEARLY_EQUAL(L0->evaluate(), 16.66666666667032, 1e-10);
+
+                auto L1 = Observable::make("B::L1@FLvD2022", p, k, o);
+                TEST_CHECK_NEARLY_EQUAL(L1->evaluate(), 36.95238095239132, 1e-10);
+
+                auto L2 = Observable::make("B::L2@FLvD2022", p, k, o);
+                TEST_CHECK_NEARLY_EQUAL(L2->evaluate(), 126.63249899776702, 1e-10);
+            }
         }
 } b_lcdas_flvd2022_test;

--- a/eos/form-factors/observables.cc
+++ b/eos/form-factors/observables.cc
@@ -1889,6 +1889,18 @@ namespace eos
                         Unit::None(),
                         &b_lcdas::FLvD2022::t2_d2_d2t_phitilde_plus,
                         std::make_tuple("tau", "mu")),
+                make_observable("B::L0@FLvD2022", R"(L_0)",
+                        Unit::InverseGeV(),
+                        &b_lcdas::FLvD2022::inverse_moment,
+                        std::make_tuple("mu")),
+                make_observable("B::L1@FLvD2022", R"(L_1)",
+                        Unit::InverseGeV(),
+                        &b_lcdas::FLvD2022::logarithmic_moment_1,
+                        std::make_tuple("mu")),
+                make_observable("B::L2@FLvD2022", R"(L_2)",
+                        Unit::InverseGeV(),
+                        &b_lcdas::FLvD2022::logarithmic_moment_2,
+                        std::make_tuple("mu")),
             }
         );
 


### PR DESCRIPTION
The proposed changes add the three pseudo observables $L_0$ ($=\lambda_B^{-1}$), $L_1$ and $L_2$ to the FLvD2022 parametrisation.

One aspect needs reviewing, please: the parent B-LCDA class already has a method `inverse_lambda_plus`, which we could use instead of the new method `inverse_moment`. However, it is missing the renormalisation scale dependence because the parent class was refactored from the exponential model.
Conceptually, the scale dependence should be added to the parent abstract base class. 
I do not see an immediate benefit of such refactoring right now though and think it can be safely postponed.