### PR TITLE
Add generic classes for multiplicative RGE evolution up to NLL accuracy

### DIFF
--- a/eos/utils/Makefile.am
+++ b/eos/utils/Makefile.am
@@ -106,6 +106,7 @@ include_eos_utils_HEADERS = \
 	qualified-name.hh \
 	quantum-numbers.hh \
 	reference-name.hh \
+	rge.hh rge-impl.hh \
 	stringify.hh \
 	thread.hh \
 	thread_pool.hh \
@@ -140,6 +141,7 @@ TESTS = \
 	qualified-name_TEST \
 	quantum-numbers_TEST \
 	reference-name_TEST \
+	rge_TEST \
 	stringify_TEST \
 	verify_TEST \
 	wilson-polynomial_TEST
@@ -193,6 +195,8 @@ qualified_name_TEST_SOURCES = qualified-name_TEST.cc
 quantum_numbers_TEST_SOURCES = quantum-numbers_TEST.cc
 
 reference_name_TEST_SOURCES = reference-name_TEST.cc
+
+rge_TEST_SOURCES = rge_TEST.cc
 
 stringify_TEST_SOURCES = stringify_TEST.cc
 

--- a/eos/utils/rge-impl.hh
+++ b/eos/utils/rge-impl.hh
@@ -1,0 +1,252 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2023 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_UTILS_RGE_IMPL_HH
+#define EOS_GUARD_EOS_UTILS_RGE_IMPL_HH 1
+
+#include <eos/utils/rge.hh>
+
+#include <gsl/gsl_blas.h>
+#include <gsl/gsl_linalg.h>
+
+namespace eos
+{
+    template <unsigned nf_> struct QCDBetaFunction;
+
+    template <>
+    struct QCDBetaFunction<5u>
+    {
+        static constexpr double beta_0 =  23.0 / 3.0;
+        static constexpr double beta_1 = 116.0 / 3.0;
+    };
+
+    template <unsigned nf_, unsigned dim_>
+    MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>::MultiplicativeRenormalizationGroupEvolution(
+            const std::array<double, dim_> & gamma_0_ev,
+            const std::array<std::array<double, dim_>, dim_> & V):
+        _gamma_0_ev(gamma_0_ev),
+        _V(make_gsl_matrix(dim_, dim_)),
+        _Vinv(make_gsl_matrix(dim_, dim_)),
+        _U_0(make_gsl_matrix(dim_, dim_)),
+        _c_0_0(make_gsl_vector(dim_)),
+        _tmp_matrix(make_gsl_matrix(dim_, dim_)),
+        _tmp_vector(make_gsl_vector(dim_))
+    {
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            for (unsigned j = 0; j < dim_; ++j)
+            {
+                gsl_matrix_set(_V.get(), i, j, V[i][j]);
+            }
+        }
+
+        // tmp_matrix <- V
+        gsl_matrix_memcpy(_tmp_matrix.get(), _V.get());
+
+        gsl_permutation * p = gsl_permutation_alloc(dim_);
+        int signum;
+        // tmp_matrix stores L, U from LU decomposition: P * V = L * U
+        gsl_linalg_LU_decomp(_tmp_matrix.get(), p, &signum);
+        // Vinv <- V^-1
+        gsl_linalg_LU_invert(_tmp_matrix.get(), p, _Vinv.get());
+
+        gsl_permutation_free(p);
+    }
+
+    template <unsigned nf_, unsigned dim_>
+    std::array<double, dim_>
+    MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>::evolve(const double & alpha_s_mu, const double & alpha_s_0,
+            const std::array<double, dim_> & c_0_0) const
+    {
+        // LL evolution:
+        //   c(mu) = U_0 . c(mu_0),
+        // where
+        //   U_0 = V . diag[ eta^(gamma_0_ev / (2 * beta_0)) ] . V^-1
+        // since
+        //   gamma_0 = V^-1,T . diag[ gamma_0_ev ] . V^T,
+
+        const double eta    = alpha_s_0 / alpha_s_mu;
+        const double beta_0 = QCDBetaFunction<nf_>::beta_0;
+
+        gsl_matrix_set_identity(_U_0.get());
+
+        // U_0 <- diag[ eta^(gamma_0_ev / (2 * beta_0)) ]
+        // cf. [BBL:1995A], p. 34, eq. (III.94)
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            gsl_matrix_set(_U_0.get(), i, i, std::pow(eta, _gamma_0_ev[i] / (2.0 * beta_0)));
+            gsl_vector_set(_c_0_0.get(), i, c_0_0[i]);
+        }
+        // tmp_matrix <- V . U_0
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _U_0.get(), 0.0, _tmp_matrix.get());
+        // U_0 <- tmp_matrix . V
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _tmp_matrix.get(), _Vinv.get(), 0.0, _U_0.get());
+
+        // tmp_vector <- U_0 * c_0_0
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _c_0_0.get(), 0.0, _tmp_vector.get());
+
+        std::array<double, dim_> result;
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            result[i] = gsl_vector_get(_tmp_vector.get(), i);
+        }
+
+        return result;
+    }
+
+    template <unsigned nf_, unsigned dim_>
+    MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>::MultiplicativeRenormalizationGroupEvolution(
+            const std::array<double, dim_> & gamma_0_ev,
+            const std::array<std::array<double, dim_>, dim_> & V,
+            const std::array<std::array<double, dim_>, dim_> & gamma_1) :
+        _gamma_0_ev(gamma_0_ev),
+        _V(make_gsl_matrix(dim_, dim_)),
+        _Vinv(make_gsl_matrix(dim_, dim_)),
+        _G(make_gsl_matrix(dim_, dim_)),
+        _U_0(make_gsl_matrix(dim_, dim_)),
+        _J(make_gsl_matrix(dim_, dim_)),
+        _c_0_0(make_gsl_vector(dim_)),
+        _c_0_1(make_gsl_vector(dim_)),
+        _tmp_matrix(make_gsl_matrix(dim_, dim_)),
+        _tmp_matrix_2(make_gsl_matrix(dim_, dim_)),
+        _tmp_vector(make_gsl_vector(dim_)),
+        _tmp_vector_2(make_gsl_vector(dim_))
+    {
+        // V <- V
+        // G <- gamma_1
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            for (unsigned j = 0; j < dim_; ++j)
+            {
+                gsl_matrix_set(_V.get(), i, j, V[i][j]);
+                gsl_matrix_set(_G.get(), i, j, gamma_1[i][j]);
+            }
+        }
+
+        // tmp_matrix <- V
+        gsl_matrix_memcpy(_tmp_matrix.get(), _V.get());
+
+        gsl_permutation * p = gsl_permutation_alloc(dim_);
+        int signum;
+        // tmp_matrix stores L, U from LU decomposition: P . V = L . U
+        gsl_linalg_LU_decomp(_tmp_matrix.get(), p, &signum);
+        // Vinv <- V^-1
+        gsl_linalg_LU_invert(_tmp_matrix.get(), p, _Vinv.get());
+
+        gsl_permutation_free(p);
+
+        // G = V^-1 . gamma_1^T . V, cf. [BBL:1995A], p. 34, eq. (III.96)
+        // tmp_matrix <- V^-1 . gamma_1^T
+        gsl_blas_dgemm(CblasNoTrans, CblasTrans, 1.0, _Vinv.get(), _G.get(), 0.0, _tmp_matrix.get());
+        // G <- tmp_matrix . V
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _tmp_matrix.get(), _V.get(), 0.0, _G.get());
+
+        // J <- H = delta_ij gamma_0_ev_i beta_1 / (2 beta_0^2)
+        //        - G_ij / (2 beta_0 + gamma_0_ev_i - gamma_0_ev_j)
+        // cf. [BBL:1995A], p. 34, eq. (III.97)
+        const double beta_0 = QCDBetaFunction<nf_>::beta_0;
+        const double beta_1 = QCDBetaFunction<nf_>::beta_1;
+
+        for (unsigned i = 0 ; i < dim_; ++i)
+        {
+            for (unsigned j = 0; j < dim_; ++j)
+            {
+                double value = -1.0 * gsl_matrix_get(_G.get(), i, j) / (2.0 * beta_0 + gamma_0_ev[i] - gamma_0_ev[j]);
+                if (i == j)
+                {
+                    value += gamma_0_ev[i] * beta_1 / (2.0 * beta_0 * beta_0);
+                }
+                gsl_matrix_set(_J.get(), i, j, value);
+            }
+        }
+        // tmp <- H . V^-1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _J.get(), _Vinv.get(), 0.0, _tmp_matrix.get());
+        // J <- V . tmp
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _tmp_matrix.get(), 0.0, _J.get());
+
+    }
+
+    template <unsigned nf_, unsigned dim_>
+    std::array<double, dim_>
+    MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>::evolve(const double & alpha_s_mu, const double & alpha_s_0,
+            const std::array<double, dim_> & c_0_0, const std::array<double, dim_> & c_0_1) const
+    {
+        // NLL evolution:
+        //   U = (1 + a_s_mu J) . U_0 . (1 - a_s_0 J)
+        //   c(mu) = U . c_0(mu_0) + a_s_0 * U_0 . c_0_1(mu_0)
+        // where
+        //   a_s(x) = alpha_s(x) / (4 pi),
+        //   U_0 = V . diag[ eta^(gamma_0_ev / (2 * beta_0)) ] . V^-1
+        //   J = V . H . V^-1,
+        // since
+        //   gamma_0 = V^-1,T . diag[ gamma_0_ev ] . V^T,
+        //   H = delta_ij gamma_0_ev_i beta_1 / (2 beta_0^2) - G_ij / (2 beta_0 + gamma_0_ev_i - gamma_0_ev_j),
+        //   G = V^-1 . gamma_1^T . V
+
+        const double eta    = alpha_s_0 / alpha_s_mu;
+        const double beta_0 = QCDBetaFunction<nf_>::beta_0;
+
+        gsl_matrix_set_identity(_U_0.get());
+
+        // U_0 <- diag[ eta^(gamma_0_ev / (2 * beta_0)) ]
+        // cf. [BBL:1995A], p. 34, eq. (III.94)
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            gsl_matrix_set(_U_0.get(), i, i, std::pow(eta, _gamma_0_ev[i] / (2.0 * beta_0)));
+            gsl_vector_set(_c_0_0.get(), i, c_0_0[i]);
+            gsl_vector_set(_c_0_1.get(), i, c_0_1[i]);
+        }
+        // tmp_matrix <- V . U_0
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _U_0.get(), 0.0, _tmp_matrix.get());
+        // U_0 <- tmp_matrix * V^-1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _tmp_matrix.get(), _Vinv.get(), 0.0, _U_0.get());
+
+        // tmp_vector := c_0_0 + alpha_s_0 / (4 pi) * (c_0_1 - J * c_0_0), cf. [BBL:1995A], p. 34, eq. (III.99)
+        // tmp_vector <- c_0_1
+        gsl_vector_memcpy(_tmp_vector.get(), _c_0_1.get());
+        // tmp_vector <- -1.0 * J * c_0_0 + 1.0 * tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, -1.0, _J.get(), _c_0_0.get(), 1.0, _tmp_vector.get());
+        // tmp_vector <- c_0_0 + alpha_s(mu_0) / (4 pi) * tmp_vector
+        gsl_vector_axpby(1.0, _c_0_0.get(), alpha_s_0 / (4.0 * M_PI), _tmp_vector.get());
+
+        // tmp_matrix <- unit_matrix
+        gsl_matrix_set_zero(_tmp_matrix.get());
+        gsl_matrix_set_identity(_tmp_matrix.get());
+        // tmp_matrix2 <- alpha_s(mu) / (4 pi) * J
+        gsl_matrix_memcpy(_tmp_matrix_2.get(), _J.get());
+        gsl_matrix_scale(_tmp_matrix_2.get(), alpha_s_mu / (4.0 * M_PI));
+        // tmp_matrix <- tmp_matrix + tmp_matrix_2
+        gsl_matrix_add(_tmp_matrix.get(), _tmp_matrix_2.get());
+
+        // tmp_vector_2 <- U_0 . tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector.get(), 0.0, _tmp_vector_2.get());
+        // tmp_vector <- tmp_matrix . tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix.get(), _tmp_vector_2.get(), 0.0, _tmp_vector.get());
+
+        std::array<double, dim_> result;
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            result[i] = gsl_vector_get(_tmp_vector.get(), i);
+        }
+
+        return result;
+    }
+}
+
+#endif /* EOS_GUARD_EOS_UTILS_RGE_IMPL_HH */

--- a/eos/utils/rge.hh
+++ b/eos/utils/rge.hh
@@ -1,0 +1,149 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2023 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_UTILS_RGE_HH
+#define EOS_GUARD_EOS_UTILS_RGE_HH 1
+
+#include <eos/maths/gsl-interface.hh>
+
+namespace eos
+{
+
+    template <typename Accuracy_, unsigned nf_, unsigned dim_>
+    class MultiplicativeRenormalizationGroupEvolution;
+
+    namespace accuracy
+    {
+        struct LL;
+        struct NLL;
+    }
+
+    template <unsigned nf_, unsigned dim_>
+    class MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>
+    {
+        private:
+            // gamma_0 = V^-1,T . diag(gamma_0_ev) . V^T, see [BBL:1995A], p. 34, eq. (III.95)
+            std::array<double, dim_> _gamma_0_ev;
+            GSLMatrixPtr _V, _Vinv;
+
+            // evolution matrix
+            GSLMatrixPtr _U_0;
+
+            // initial conditions
+            GSLVectorPtr _c_0_0;
+
+            // temporary storage objects
+            GSLMatrixPtr _tmp_matrix;
+            GSLVectorPtr _tmp_vector;
+
+        public:
+            /*!
+             * Constructor.
+             *
+             * This class expects provision with the anomalous mass dimension matrix (ADM) at LO only,
+             * to provide RGE evolution to leading logarithmic accuracy. The LO gamma_0 matrix is
+             * diagonalized by the matrix V, see [BBL:1995A], p. 34, eq. (III.95):
+             *
+             *   gamma_0 = V^-1,T . diag(gamma_0_ev) . V^T
+             *
+             * Note that, as in [BBL:1995A], the ADM for the operators is expected, not the ADM for
+             * the Wilson coefficients, which is related to the operator ADM by transposition.
+             *
+             * @param gamma_0_ev The eigenvalues of the LO term for the anomalous dimension matrix.
+             * @param V The matrix that diagonalizes the LO term for the anomalous dimension matrix.
+             */
+            MultiplicativeRenormalizationGroupEvolution(const std::array<double, dim_> & gamma_0_ev, const std::array<std::array<double, dim_>, dim_> & V);
+
+            /*!
+             * Evolve the Wilson coefficients from the scale mu_0 to the scale mu at leading-logarithmic accuracy.
+             *
+             * Expects the Wilson coefficients as a series in powers of alpha_(mu_0) / (4 pi):
+             *
+             *   c_0 = c_0_0 + O(alpha_(mu_0))
+             *
+             * @param alpha_s_mu The value of the strong coupling constant at the scale mu.
+             * @param alpha_s_0 The value of the strong coupling constant at the scale mu_0.
+             * @param c_0_0 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^0
+             */
+            std::array<double, dim_> evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0) const;
+    };
+
+    // Next-to-leading logarithmic accuracy, see [BBL:1995A], p. 34, eq. (III.93)
+    template <unsigned nf_, unsigned dim_>
+    class MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>
+    {
+        private:
+            // gamma_0 = V^-1,T . diag(gamma_0_ev) . V^T, see [BBL:1995A], p. 34, eq. (III.95)
+            std::array<double, dim_> _gamma_0_ev;
+            GSLMatrixPtr _V, _Vinv;
+
+            // gamma_1 = V^-1,T . G . V^T, see [BBL:1995A], p. 34, eq. (III.96)
+            GSLMatrixPtr _G;
+
+            // evolution matrices
+            GSLMatrixPtr _U_0;
+            GSLMatrixPtr _J;
+
+            // initial conditions
+            GSLVectorPtr _c_0_0;
+            GSLVectorPtr _c_0_1;
+
+            // temporary storage objects
+            GSLMatrixPtr _tmp_matrix, _tmp_matrix_2;
+            GSLVectorPtr _tmp_vector, _tmp_vector_2;
+
+        public:
+            /*!
+             * Constructor.
+             *
+             * This class expects provision with the anomalous mass dimension matrix (ADM) at LO and NLO,
+             * to provide RGE evolution to next-to-leading logarithmic accuracy. The LO gamma_0 matrix is
+             * diagonalized by the matrix V, see [BBL:1995A], p. 34, eq. (III.95):
+             *
+             *   gamma_0 = V^-1,T . diag(gamma_0_ev) . V^T
+             *
+             * Note that, as in [BBL:1995A], the ADM for the operators is expected, not the ADM for the
+             * Wilson coefficients, which is related to the operator ADM by transposition.
+             *
+             * @param gamma_0_ev The eigenvalues of the LO term for the anomalous dimension matrix.
+             * @param V The matrix that diagonalizes the LO term for the anomalous dimension matrix.
+             * @param gamma_1 The NLO term for the anomalous dimension matrix.
+             */
+            MultiplicativeRenormalizationGroupEvolution(const std::array<double, dim_> & gamma_0_ev, const std::array<std::array<double, dim_>, dim_> & V,
+                    const std::array<std::array<double, dim_>, dim_> & gamma_1);
+
+            /*!
+             * Evolve the Wilson coefficients from the scale mu_0 to the scale mu at next-to-leading logarithmic accuracy.
+             *
+             * Expects the Wilson coefficients as a series in powers of alpha_(mu_0) / (4 pi):
+             *
+             *   c_0 = c_0_0 + alpha_(mu_0) / (4 pi) c_0_1 + O(alpha_(mu_0)^2)
+             *
+             * @param alpha_s_mu The value of the strong coupling constant at the scale mu.
+             * @param alpha_s_0 The value of the strong coupling constant at the scale mu_0.
+             * @param c_0_0 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^0
+             * @param c_0_1 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^1,
+             *              reduced by r^T . c_0_0, cf. [BBL:1995A], p. 34, eqs. (III.84) & (III.99).
+             */
+            std::array<double, dim_> evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0,
+                    const std::array<double, dim_> & c_0_1) const;
+    };
+}
+
+#endif /* EOS_GUARD_EOS_UTILS_RGE_HH */

--- a/eos/utils/rge_TEST.cc
+++ b/eos/utils/rge_TEST.cc
@@ -1,0 +1,231 @@
+
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2023 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <test/test.hh>
+#include <eos/utils/rge-impl.hh>
+
+using namespace test;
+using namespace eos;
+
+class MultiplicativeRGELLTest :
+    public TestCase
+{
+    public:
+        MultiplicativeRGELLTest() :
+            TestCase("multiplicative_rge_ll_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // trivial test case (nf = 5, dim = 10)
+            {
+                const std::array<double, 10u> gamma_0_ev{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+                const std::array<std::array<double, 10u>, 10u> V
+                {{
+                    { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 }
+                }};
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::LL, 5u, 10u> rge(gamma_0_ev, V);
+                const std::array<double, 10u> c_0_0{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+
+                const double alpha_s_mu = 0.218017;
+                const double alpha_s_0  = 0.121864;
+                std::array<double, 10u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
+
+                static const double eps = 1.0e-15;
+                TEST_CHECK_NEARLY_EQUAL(result[0], 0.1, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], 0.2, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[2], 0.3, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[3], 0.4, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[4], 0.5, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[5], 0.6, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[6], 0.7, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[7], 0.8, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[8], 0.9, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[9], 1.0, eps);
+            }
+
+            // current-current test case (nf = 5, dim = 2), checked by S. Meiser 2023/07/10
+            {
+                const double sq2 = std::sqrt(2.0);
+                const std::array<double, 2u> gamma_0_ev{ -8.0, +4.0 };
+                const std::array<std::array<double, 2u>, 2u> V
+                {{
+                    { -1.0 / sq2, +1.0 / sq2 },
+                    { +1.0 / sq2, +1.0 / sq2 },
+                }};
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::LL, 5u, 2u> rge(gamma_0_ev, V);
+                const std::array<double, 2u> c_0_0{ 0.0, 1.0 };
+
+                const double alpha_s_mu = 0.218017;
+                const double alpha_s_0  = 0.121864;
+                std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
+
+                static const double eps = 1.0e-6;
+                TEST_CHECK_NEARLY_EQUAL(result[0], -0.247675, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], +1.106887, eps);
+            }
+
+            // non-symmetric test case (nf = 5, dim = 2), checked by S. Meiser 2023/07/10
+            {
+                const std::array<double, 2u> gamma_0_ev{ -16.0, +2.0 };
+                const std::array<std::array<double, 2u>, 2u> V
+                {{
+                    {  1.0 / 6.0, -4.0 / 3.0 },
+                    {  1.0,        1.0       },
+                }};
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::LL, 5u, 2u> rge(gamma_0_ev, V);
+                const std::array<double, 2u> c_0_0{ 0.0, 1.0 };
+
+                const double alpha_s_mu = 0.218017;
+                const double alpha_s_0  = 0.121864;
+                std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
+
+                static const double eps = 1.0e-6;
+                TEST_CHECK_NEARLY_EQUAL(result[0], +0.134504, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], +1.733962, eps);
+            }
+        }
+} multiplicative_rge_ll_test;
+
+class MultiplicativeRGENLLTest :
+    public TestCase
+{
+    public:
+        MultiplicativeRGENLLTest() :
+            TestCase("multiplicative_rge_nll_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // trivial test case (nf = 5, dim = 10)
+            {
+                const std::array<double, 10u> gamma_0_ev{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+                const std::array<std::array<double, 10u>, 10u> V
+                {{
+                    { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 }
+                }};
+                const std::array<std::array<double, 10u>, 10u> gamma_1
+                {{
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
+                }};
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 10u> rge(gamma_0_ev, V, gamma_1);
+                const std::array<double, 10u> c_0_0{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+                const std::array<double, 10u> c_0_1{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+
+                const double alpha_s_mu = 0.3 * 4.0 * M_PI;
+                const double alpha_s_0  = 0.1 * 4.0 * M_PI;
+                std::array<double, 10u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
+
+                static const double eps = 1.0e-15;
+                TEST_CHECK_NEARLY_EQUAL(result[0], 0.11, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], 0.22, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[2], 0.33, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[3], 0.44, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[4], 0.55, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[5], 0.66, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[6], 0.77, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[7], 0.88, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[8], 0.99, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[9], 1.10, eps);
+            }
+
+            // current-current test case (nf = 5, dim = 2)
+            {
+                const double sq2 = std::sqrt(2.0);
+                const std::array<double, 2u> gamma_0_ev{ -8.0, +4.0 };
+                const std::array<std::array<double, 2u>, 2u> V
+                {{
+                    { -1.0 / sq2, +1.0 / sq2 },
+                    { +1.0 / sq2, +1.0 / sq2 },
+                }};
+                const std::array<std::array<double, 2u>, 2u> gamma_1
+                {{
+                    { -209.0 / 18.0, +41.0 / 6.0   },
+                    { +41.0 / 6.0,   -209.0 / 18.0 }
+                }};
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 2u> rge(gamma_0_ev, V, gamma_1);
+                const std::array<double, 2u> c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u> c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
+
+                const double alpha_s_mu = 0.218017;
+                const double alpha_s_0  = 0.121864;
+                std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
+
+                static const double eps = 1.0e-6;
+                TEST_CHECK_NEARLY_EQUAL(result[0], -0.172203, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], +1.073145, eps);
+            }
+
+            // non-symmetric test case (nf = 5, dim = 2)
+            {
+                const std::array<double, 2u> gamma_0_ev{ -16.0, +2.0 };
+                const std::array<std::array<double, 2u>, 2u> V
+                {{
+                    {  1.0 / 6.0, -4.0 / 3.0 },
+                    {  1.0,        1.0       },
+                }};
+                const std::array<std::array<double, 2u>, 2u> gamma_1
+                {{
+                    { -28.0 / 3.0,    -374.0 / 3.0   },
+                    { -2044.0 / 27.0, -2975.0 / 18.0 },
+                }};
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 2u> rge(gamma_0_ev, V, gamma_1);
+                const std::array<double, 2u> c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u> c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
+
+                const double alpha_s_mu = 0.218017;
+                const double alpha_s_0  = 0.121864;
+                std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
+
+                static const double eps = 1.0e-6;
+                TEST_CHECK_NEARLY_EQUAL(result[0], +0.229589, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], +1.826340, eps);
+            }
+        }
+} multiplicative_rge_nll_test;


### PR DESCRIPTION
GitHub: resolves #618