### PR TITLE
Fix warnings when repeating forced options upon Observable creation

### DIFF
--- a/eos/utils/concrete_observable.hh
+++ b/eos/utils/concrete_observable.hh
@@ -191,13 +191,12 @@ namespace eos
 
             virtual ObservablePtr make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
             {
-                for (const auto & fo : _forced_options)
+                for (const auto & [key, forced_value] : _forced_options)
                 {
-                    const auto & key = std::get<0>(fo);
-                    if (options.has(key))
+                    if (options.has(key) && (options[key] != forced_value))
                     {
-                        Log::instance()->message("[ConcreteObservableEntry.make]", ll_warning)
-                            << "Observable '" << _name << "' forces option key '" << key << "' to value '" << _forced_options[key] << "', overriding user-provided value '" << options[key] << "'";
+                        Log::instance()->message("[ConcreteObservableEntry.make]", ll_error)
+                            << "Observable '" << _name << "' forces option key '" << key << "' to value '" << forced_value << "', overriding user-provided value '" << options[key] << "'";
                     }
                 }
                 return ObservablePtr(new ConcreteObservable<Decay_, Args_ ...>(_name, parameters, kinematics, options + _forced_options, _function, _kinematics_names));

--- a/eos/utils/log.cc
+++ b/eos/utils/log.cc
@@ -132,13 +132,22 @@ namespace eos
 
         Implementation() :
             log_level(ll_error),
-            stream(&std::cerr)
+            stream(nullptr)
         {
         }
 
         void message(const std::string & id, const LogLevel & l, const std::string & m)
         {
             if (l > log_level)
+                return;
+
+            // forward message to all callbacks
+            for (auto & c : callbacks)
+            {
+                c(id, l, m);
+            }
+
+            if (! stream)
                 return;
 
             *stream << program_name << '@' << ::time(0) << ": ";
@@ -173,12 +182,6 @@ namespace eos
                 throw InternalError("Implementation<Log>::message: Bad value for log_level");
             }
             while (false);
-
-            // forward message to all callbacks
-            for (auto & c : callbacks)
-            {
-                c(id, l, m);
-            }
 
             *stream << m << std::endl;
         }

--- a/eos/utils/observable_cache.cc
+++ b/eos/utils/observable_cache.cc
@@ -102,7 +102,7 @@ namespace eos
         ObservableCache::Id add(const ObservablePtr & observable, const ObservableCache & cache)
         {
             if (observable->parameters() != parameters)
-                throw InternalError("ObservableSet::add(): Mismatch of Parameters between different observables detected.");
+                throw InternalError("ObservableCache::add(): Mismatch of Parameters between different observables detected.");
 
             // compare each observable for options, kinematics and name
             unsigned index = 0;

--- a/python/eos/__init__.py
+++ b/python/eos/__init__.py
@@ -86,11 +86,12 @@ def _log_callback(id, level, msg):
 
 _register_log_callback(_log_callback)
 
-# log to stderr by default
-import logging
-logger = logging.getLogger('EOS')
-logger.setLevel(logging.INFO)
-logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+# log to stderr by default in non-interactive Python code
+if not __ipython__:
+    import logging
+    logger = logging.getLogger('EOS')
+    logger.setLevel(logging.INFO)
+    logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 
 import time as _time
 import os as _os

--- a/python/eos_TEST.py
+++ b/python/eos_TEST.py
@@ -200,7 +200,7 @@ class LoggingTests(unittest.TestCase):
                     eos.Options(**{'U': 'c'})) # will  be overwritten by the
                                                # implementation of the observable
             self.assertEqual(cm.output,
-                    [r"""WARNING:EOS:[ConcreteObservableEntry.make] Observable 'B->pilnu::BR' forces option key 'U' to value 'u', overriding user-provided value 'c'"""])
+                    [r"""ERROR:EOS:[ConcreteObservableEntry.make] Observable 'B->pilnu::BR' forces option key 'U' to value 'u', overriding user-provided value 'c'"""])
 
 
 # Run legacy test cases


### PR DESCRIPTION
 - do not log a warning when encountering a repeated forced option in ``Observable::make``; log an error if the forced option is overridden with a different value
 - avoid logging to ``std::cerr`` by default
 - avoid logging to ``sys.stderr`` in an interactive Python environment (i.e., Jupyter)
 - fix typo when raising an ``InternalError`` in ``ObservableCache``.

Github: resolves #666