### PR TITLE
Update CD for Python 3.11

### DIFF
--- a/.github/workflows/manylinux-build+check+deploy.yaml
+++ b/.github/workflows/manylinux-build+check+deploy.yaml
@@ -25,7 +25,7 @@ jobs:
                     - { pypath: cp310-cp310, pysuffix: cp310, pyboostsuffix: 310 }
                     - { pypath: cp311-cp311, pysuffix: cp311, pyboostsuffix: 311 }
         container:
-            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:537d22c4154fd860f6f3fefa164c5ec9f62254b3
+            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:ebe6250346ec778718df80367776d1333a8f96d6
         steps:
             - name: Checkout git repository
               uses: actions/checkout@v3
@@ -93,8 +93,9 @@ jobs:
                     - { pypath: cp38-cp38,   pysuffix: cp38,  pyboostsuffix: 38  }
                     - { pypath: cp39-cp39,   pysuffix: cp39,  pyboostsuffix: 39  }
                     - { pypath: cp310-cp310, pysuffix: cp310, pyboostsuffix: 310 }
+                    - { pypath: cp311-cp311, pysuffix: cp311, pyboostsuffix: 311 }
         container:
-            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:537d22c4154fd860f6f3fefa164c5ec9f62254b3
+            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:ebe6250346ec778718df80367776d1333a8f96d6
         steps:
             - name: Download configured source as artifact
               uses: actions/download-artifact@v3
@@ -132,8 +133,9 @@ jobs:
                     - { pypath: cp38-cp38,   pysuffix: cp38,  pyboostsuffix: 38  }
                     - { pypath: cp39-cp39,   pysuffix: cp39,  pyboostsuffix: 39  }
                     - { pypath: cp310-cp310, pysuffix: cp310, pyboostsuffix: 310 }
+                    - { pypath: cp311-cp311, pysuffix: cp311, pyboostsuffix: 311 }
         container:
-            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:537d22c4154fd860f6f3fefa164c5ec9f62254b3
+            image: eoshep/manylinux2014-${{ matrix.cfg.pysuffix }}:ebe6250346ec778718df80367776d1333a8f96d6
         steps:
             - name: Download configured source as artifact
               uses: actions/download-artifact@v3


### PR DESCRIPTION
Hi there, I think Python 3.11 wheels are created but not uploaded in the CD and are therefore also [missing in PyPI](https://pypi.org/project/eoshep/#files).

Just added the missing lines, AFAIU just a typo