### PR TITLE
[form-factors] Fix handling of B LCDA's parameter user

### DIFF
--- a/eos/form-factors/analytic-b-to-gamma-qcdf.cc
+++ b/eos/form-factors/analytic-b-to-gamma-qcdf.cc
@@ -68,6 +68,8 @@ namespace eos
         {
             throw InternalError("The number of weights implemented is smaller than the number of coefficients of phi_+");
         }
+
+        this->uses(*blcdas);
     }
 
     FormFactors<PToGamma> *


### PR DESCRIPTION
Fixes a bug that causes warnings similar to

```
WARNING:EOS:likelihood does not depend on parameter 'B_u::a^phi+_1@FLvD2022'; remove from prior or check options!
```