### PR TITLE
Expand ``ExpressionParser`` to handle undeclared parameters gracefully

### DIFF
--- a/eos/utils/expression-cacher.hh
+++ b/eos/utils/expression-cacher.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Danny van Dyk
+ * Copyright (c) 2021-2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -40,6 +40,10 @@ namespace eos::exp
             Expression visit(const ObservableNameExpression & e);
 
             Expression visit(const ObservableExpression & e);
+
+            Expression visit(const ParameterNameExpression & e);
+
+            Expression visit(const ParameterExpression & e);
 
             Expression visit(const KinematicVariableNameExpression & e);
 

--- a/eos/utils/expression-cloner.hh
+++ b/eos/utils/expression-cloner.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -43,6 +44,10 @@ namespace eos::exp
             Expression visit(const ObservableNameExpression & e);
 
             Expression visit(const ObservableExpression & e);
+
+            Expression visit(const ParameterNameExpression & e);
+
+            Expression visit(const ParameterExpression & e);
 
             Expression visit(const KinematicVariableNameExpression & e);
 

--- a/eos/utils/expression-evaluator.hh
+++ b/eos/utils/expression-evaluator.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -36,6 +37,10 @@ namespace eos::exp
             double visit(ObservableNameExpression &);
 
             double visit(ObservableExpression & e);
+
+            double visit(ParameterNameExpression &);
+
+            double visit(ParameterExpression & e);
 
             double visit(KinematicVariableNameExpression & e);
 

--- a/eos/utils/expression-fwd.hh
+++ b/eos/utils/expression-fwd.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -29,6 +30,8 @@ namespace eos::exp
     class KinematicVariableNameExpression;
     class KinematicVariableExpression;
     class CachedObservableExpression;
+    class ParameterNameExpression;
+    class ParameterExpression;
 
     using Expression = OneOf<
         BinaryExpression,
@@ -37,7 +40,9 @@ namespace eos::exp
         ObservableExpression,
         KinematicVariableNameExpression,
         KinematicVariableExpression,
-        CachedObservableExpression
+        CachedObservableExpression,
+        ParameterNameExpression,
+        ParameterExpression
     >;
 }
 

--- a/eos/utils/expression-kinematic-reader.hh
+++ b/eos/utils/expression-kinematic-reader.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -46,6 +47,10 @@ namespace eos::exp
             void visit(const ObservableNameExpression & e);
 
             void visit(const ObservableExpression & e);
+
+            void visit(const ParameterNameExpression &);
+
+            void visit(const ParameterExpression &);
 
             void visit(const KinematicVariableNameExpression & e);
 

--- a/eos/utils/expression-maker.hh
+++ b/eos/utils/expression-maker.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -43,6 +44,10 @@ namespace eos::exp
             Expression visit(const ObservableNameExpression & e);
 
             Expression visit(const ObservableExpression & e);
+
+            Expression visit(const ParameterNameExpression & e);
+
+            Expression visit(const ParameterExpression & e);
 
             Expression visit(const KinematicVariableNameExpression & e);
 

--- a/eos/utils/expression-parser-impl.hh
+++ b/eos/utils/expression-parser-impl.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -67,6 +68,11 @@ namespace eos
             return eos::exp::Expression(eos::exp::ObservableNameExpression(name, spec));
         };
 
+        auto make_parameter = [] (const std::string & name)
+        {
+            return eos::exp::Expression(eos::exp::ParameterNameExpression(name));
+        };
+
         auto make_kinematic_variable = [] (const std::string & name)
         {
             return eos::exp::Expression(eos::exp::KinematicVariableNameExpression(name));
@@ -77,6 +83,7 @@ namespace eos
             | constant                                     [ _val = _1 ]
             | (observable_name >> kinematics)              [ _val = phx::bind(make_observable, _1, _2) ]
             | observable_name                              [ _val = phx::bind(make_observable, _1, KinematicsSpecification()) ]
+            | parameter_name                               [ _val = phx::bind(make_parameter, _1)]
             | kinematic_variable_name                      [ _val = phx::bind(make_kinematic_variable, _1) ]
             ;
 
@@ -92,6 +99,12 @@ namespace eos
               "<<"
             >> as_string [ lexeme [ *(char_ - ">>")  ] ] [ _val = _1 ]
             >> ">>"
+            ;
+
+        parameter_name =
+              "[["
+            >> as_string [ lexeme [ *(char_ - "]]")  ] ] [ _val = _1 ]
+            >> "]]"
             ;
 
         kinematics =

--- a/eos/utils/expression-parser.hh
+++ b/eos/utils/expression-parser.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -45,6 +46,7 @@ namespace eos
         qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> primary_expr;
         qi::rule<Iterator, eos::exp::ConstantExpression()       , ascii::space_type> constant;
         qi::rule<Iterator, std::string()                        , ascii::space_type> observable_name;
+        qi::rule<Iterator, std::string()                        , ascii::space_type> parameter_name;
         qi::rule<Iterator, std::string()                        , ascii::space_type> kinematic_variable_name;
 
         using KinematicsSpecification = eos::exp::KinematicsSpecification;

--- a/eos/utils/expression-printer.hh
+++ b/eos/utils/expression-printer.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -40,6 +41,10 @@ namespace eos::exp
             void visit(ObservableNameExpression & e);
 
             void visit(ObservableExpression & e);
+
+            void visit(ParameterNameExpression & e);
+
+            void visit(ParameterExpression & e);
 
             void visit(KinematicVariableNameExpression & e);
 

--- a/eos/utils/expression.cc
+++ b/eos/utils/expression.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General

--- a/eos/utils/expression.hh
+++ b/eos/utils/expression.hh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -21,6 +22,7 @@
 #include <eos/observable-fwd.hh>
 #include <eos/utils/expression-fwd.hh>
 #include <eos/utils/observable_cache.hh>
+#include <eos/utils/parameters.hh>
 #include <eos/utils/qualified-name.hh>
 
 #include <cassert>
@@ -134,6 +136,28 @@ namespace eos::exp
                 cache(cache),
                 id(id),
                 kinematics_specification(kinematics_specification)
+            {
+            }
+    };
+
+    class ParameterNameExpression
+    {
+        public:
+            QualifiedName parameter_name;
+
+            ParameterNameExpression(const QualifiedName & parameter_name) :
+                parameter_name(parameter_name)
+            {
+            }
+    };
+
+    class ParameterExpression
+    {
+        public:
+            Parameter parameter;
+
+            ParameterExpression(const Parameter & parameter) :
+                parameter(parameter)
             {
             }
     };

--- a/eos/utils/qualified-name.cc
+++ b/eos/utils/qualified-name.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2016 Danny van Dyk
+ * Copyright (c) 2016-2023 Danny van Dyk
  * Copyright (c) 2016 Rafael Silva Coutinho
  *
  * This file is part of the EOS project. EOS is free software;
@@ -76,6 +76,14 @@ namespace eos
             if (std::string::npos != pos)
             {
                 throw QualifiedNameSyntaxError("'" + name + "' is not a valid name part: Character '" + name[pos] + "' may not be used");
+            }
+
+            auto pos_opened = name.find("[[");
+            auto pos_closed = name.find("]]");
+
+            if ((std::string::npos != pos_opened) || (std::string::npos != pos_closed))
+            {
+                throw QualifiedNameSyntaxError("'" + name + "' is not a valid prefix part: Neither '[[' nor ']]' may be used");
             }
         }
 


### PR DESCRIPTION
 - [x] Disallow ``[[`` and ``]]`` in qualified names
 - [x] Add classes ``ParameterNameExpression`` and ``ParameterExpression``
 - [x] Let ``ExpressionParser`` handle parameter names as, e.g., ``[[mass::c]]``
 - [x] Test modifications

Github: resolves #701