### PR TITLE
Refactor parameters declare

### DIFF
--- a/eos/utils/expression-parser_TEST.cc
+++ b/eos/utils/expression-parser_TEST.cc
@@ -368,17 +368,26 @@ class ExpressionParserTest :
                 test.e.accept(printer);
                 TEST_CHECK_EQUAL(out.str(), "ParameterNameExpression(undeclared::parameter)");
 
-                Parameters p = Parameters::Defaults();
-                ExpressionMaker maker(p, Kinematics(), Options());
+                // test with default parameters as stored on disk
+                {
+                    Parameters p = Parameters::Defaults();
+                    ExpressionMaker maker(p, Kinematics(), Options());
 
-                TEST_CHECK_THROWS(UnknownParameterError, test.e.accept_returning<Expression>(maker));
+                    TEST_CHECK_THROWS(UnknownParameterError, test.e.accept_returning<Expression>(maker));
+                }
 
-                Expression e;
-                p.declare("undeclared::parameter", "", Unit::Undefined(), 1.0, 0.0, 2.0);
-                TEST_CHECK_NO_THROW(e = test.e.accept_returning<Expression>(maker));
+                // test after declaring "undeclared::parameter"
+                {
+                    Parameters::declare("undeclared::parameter", "", Unit::Undefined(), 1.0, 0.0, 2.0);
+                    Parameters p = Parameters::Defaults();
+                    ExpressionMaker maker(p, Kinematics(), Options());
 
-                ExpressionEvaluator evaluator;
-                TEST_CHECK_NEARLY_EQUAL(e.accept_returning<double>(evaluator), 1.0, 1e-10);
+                    Expression e;
+                    TEST_CHECK_NO_THROW(e = test.e.accept_returning<Expression>(maker));
+
+                    ExpressionEvaluator evaluator;
+                    TEST_CHECK_NEARLY_EQUAL(e.accept_returning<double>(evaluator), 1.0, 1e-10);
+                }
             }
         }
 } expression_parser_test;

--- a/eos/utils/kmatrix_TEST.cc
+++ b/eos/utils/kmatrix_TEST.cc
@@ -193,12 +193,13 @@ class KMatrixTest :
 
             constexpr double eps = 1e-4;
 
+            Parameters::declare("test::g0_1", "g_0^1", Unit::None(),  1.0);
+            Parameters::declare("test::c_1",  "c_1",   Unit::None(),  0.0);
+            Parameters::declare("test::m_1",  "m_1",   Unit::GeV(),  15.0);
+            Parameters::declare("test::g0_2", "g_0^2", Unit::None(),  2.2);
+            Parameters::declare("test::m_2",  "m_2",   Unit::GeV(),   2.0);
+
             Parameters p = Parameters::Defaults();
-
-            p.declare("test::g0_1", "g_0^1", Unit::None(),  1.0);
-            p.declare("test::c_1",  "c_1",   Unit::None(),  0.0);
-            p.declare("test::m_1",  "m_1",   Unit::GeV(),  15.0);
-
 
             // One channel, one resonnance:
             // In the limit where the resonance mass is much larger
@@ -234,9 +235,6 @@ class KMatrixTest :
 
             p["test::g0_1"] = 1.1;
             p["test::m_1"] = 1.0;
-
-            p.declare("test::g0_2", "g_0^2", Unit::None(), 2.2);
-            p.declare("test::m_2",  "m_2",   Unit::GeV(),  2.0);
 
             // One channel, two resonances
             {

--- a/eos/utils/parameters.hh
+++ b/eos/utils/parameters.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010-2022 Danny van Dyk
+ * Copyright (c) 2010-2023 Danny van Dyk
  * Copyright (c) 2021 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
@@ -34,6 +34,9 @@
 
 namespace eos
 {
+    // Forward declarations
+    class ParameterDefaults;
+
     /*!
      * UnknownParameterError is thrown when no parameter of a given
      * name could be found.
@@ -105,6 +108,7 @@ namespace eos
 
         public:
             friend class Parameter;
+            friend class ParameterDefaults;
             friend struct Implementation<Parameter>;
             friend struct Implementation<Parameters>;
 
@@ -142,15 +146,38 @@ namespace eos
             SectionIterator end_sections() const;
             ///@}
 
+            ///@name Access to default parameters
+            ///@{
+            /*!
+             * Declare a new default parameter.
+             *
+             * @param name  Name of the new parameter to be declared.
+             * @param latex LaTeX representation of the new parameter.
+             * @param unit  Unit of the new parameter.
+             * @param value (Optional) value for the new parameter.
+             * @param min   (Optional) minimal value for the new parameter.
+             * @param max   (Optional) maximal value for the new parameter.
+             */
+            static void declare(const QualifiedName & name, const std::string & latex, Unit unit,
+                const double & value = 0.0,
+                const double & min = -std::numeric_limits<double>::max(),
+                const double & max = +std::numeric_limits<double>::max());
+            ///@}
+
             ///@name Parameter access
             ///@{
             /*!
-             * Declare a new parameter.
+             * Declare a previously undeclared parameter in the default set of parameters and insert it
+             * into this parameter set.
              *
              * @param name  Name of the new parameter to be declared.
+             * @param latex LaTeX representation of the new parameter.
+             * @param unit  Unit of the new parameter.
              * @param value (Optional) value for the new parameter.
+             * @param min   (Optional) minimal value for the new parameter.
+             * @param max   (Optional) maximal value for the new parameter.
              */
-            Parameter declare(const QualifiedName & name, const std::string & latex, Unit unit,
+            Parameter declare_and_insert(const QualifiedName & name, const std::string & latex, Unit unit,
                 const double & value = 0.0,
                 const double & min = -std::numeric_limits<double>::max(),
                 const double & max = +std::numeric_limits<double>::max());
@@ -227,6 +254,7 @@ namespace eos
 
         public:
             friend class Parameters;
+            friend class ParameterDefaults;
             friend struct Implementation<Parameters>;
 
             /*!

--- a/eos/utils/parameters_TEST.cc
+++ b/eos/utils/parameters_TEST.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011 Danny van Dyk
+ * Copyright (c) 2011-2023 Danny van Dyk
  * Copyright (c) 2021 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
@@ -51,8 +51,9 @@ class ParametersTest :
 
             // Declaring a new parameter
             {
-                Parameters original = Parameters::Defaults();
-                Parameter new_parameter = original.declare("mass::boeing747", R"(\text{Boeing 747})", Unit::Undefined(), 100000.0, 90000.0, 110000.0);
+                Parameters::declare("mass::boeing747", R"(\text{Boeing 747})", Unit::Undefined(), 100000.0, 90000.0, 110000.0);
+                Parameters parameters = Parameters::Defaults();
+                Parameter new_parameter = parameters["mass::boeing747"];
 
                 TEST_CHECK_EQUAL(new_parameter.name(),      "mass::boeing747");
                 TEST_CHECK_EQUAL(new_parameter.latex(),     R"(\text{Boeing 747})");

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -211,9 +211,28 @@ BOOST_PYTHON_MODULE(_eos)
         .def("__getitem__", (Parameter (Parameters::*)(const QualifiedName &) const) &Parameters::operator[])
         .def("by_id", (Parameter (Parameters::*)(const Parameter::Id &) const) &Parameters::operator[])
         .def("__iter__", range(&Parameters::begin, &Parameters::end))
-        .def("declare", &Parameters::declare, return_value_policy<return_by_value>(),
+        .def("declare", &Parameters::declare,
             R"(
-            Declare a new parameter.
+            Declare a new parameter as part of the default parameter set.
+
+            :param name: The name of the parameter to declare.
+            :type name: eos.QualifiedName
+            :param latex: The LaTeX representation for the parameter.
+            :type latex: str
+            :param unit: The unit in which the parameter is expressed.
+            :type unit: eos.Unit
+            :param value: The initial value for the parameter.
+            :type value: float
+            :param min: The minimum value that the parameter can attain.
+            :type min: float
+            :param max: The maximum value that the parameter can attain.
+            :type max: float
+            )", args("name", "latex", "unit", "value", "min", "max"))
+        .staticmethod("declare")
+        .def("declare_and_insert", &Parameters::declare_and_insert,
+            R"(
+            Declare a new parameter as part of the default parameter set and
+            insert it into this parameter set.
 
             :param name: The name of the parameter to declare.
             :type name: eos.QualifiedName

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -34,10 +34,10 @@ class AnalysisFile:
         self.analysis_file = analysis_file
 
         if not os.path.exists(analysis_file):
-            raise RuntimeError('Cannot load analysis file: \'{}\' does not exist'.format(analysis_file))
+            raise RuntimeError(f'Cannot load analysis file: \'{analysis_file}\' does not exist')
 
         if not os.path.isfile(analysis_file):
-            raise RuntimeError('Cannot load analysis file: \'{}\' is not a file'.format(analysis_file))
+            raise RuntimeError(f'Cannot load analysis file: \'{analysis_file}\' is not a file')
 
         instructions = None
         with open(analysis_file) as input_file:
@@ -93,7 +93,7 @@ class AnalysisFile:
     def analysis(self, _posterior):
         """Create an eos.Analysis object for the named posterior."""
         if _posterior not in self._posteriors:
-            raise RuntimeError('Cannot create analysis for unknown posterior: \'{}\''.format(_posterior))
+            raise RuntimeError(f'Cannot create analysis for unknown posterior: \'{_posterior}\'')
 
         posterior = self._posteriors[_posterior]
 
@@ -168,9 +168,9 @@ class AnalysisFile:
     def observables(self, _posterior, _prediction, parameters):
         """Creates a list of eos.Observable objects for the named set of posterior and predictions."""
         if _posterior not in self._posteriors:
-            raise RuntimeError('Cannot create observables for unknown posterior: \'{}\''.format(_prediction))
+            raise RuntimeError(f'Cannot create observables for unknown posterior: \'{_prediction}\'')
         if _prediction not in self.predictions:
-            raise RuntimeError('Cannot create observables for unknown set of predictions: \'{}\''.format(_prediction))
+            raise RuntimeError(f'Cannot create observables for unknown set of predictions: \'{_prediction}\'')
 
         posterior = self._posteriors[_posterior]
         prediction = self.predictions[_prediction]
@@ -216,7 +216,7 @@ class AnalysisFile:
             for p, o in zip(prediction['observables'], observables):
                 if o is None:
                     unknown_observables.add(p['name'])
-            raise RuntimeError('Prediction \'{}\' contains unknown observable names: {}'.format(_prediction, unknown_observables))
+            raise RuntimeError(f'Prediction \'{_prediction}\' contains unknown observable names: {unknown_observables}')
 
         return observables
 

--- a/python/eos/pyhf_likelihood.py
+++ b/python/eos/pyhf_likelihood.py
@@ -57,7 +57,7 @@ class PyhfLogLikelihood:
             if self.parameters.has(qn):
                 p = self.parameters[qn]
             else:
-                p = self.parameters.declare(qn, pn, eos.Unit.Undefined(), v, bounds[0], bounds[1])
+                p = self.parameters.declare_and_insert(qn, pn, eos.Unit.Undefined(), v, bounds[0], bounds[1])
 
             p.set(v)
             self.varied_parameters.append(p)


### PR DESCRIPTION
Summary of change of functionality:

 - default values are loaded at the first creation of a ``Parameter`` objects,
   and stored in the ``ParameterDefaults`` singleton;
 - ``Parameters::declare`` has become a static method returning ``void``;
 - ``Parameters::decalare_and_insert`` has been added to facilitate declaring
   a new parameter globally and inserting it into the current parameter set;
 - test cases and Python interface have been adjusted.

Request review from @lorenzennio for changes to the handling of parameters in ``python/eos/pyhf_likelihood.py``.