### PR TITLE
Fixes hyperlinks from constraints to observables/parameters

### DIFF
--- a/doc/constraints.rst.py
+++ b/doc/constraints.rst.py
@@ -1,16 +1,10 @@
 import eos
 import re
 import yaml
-from jinja_util import print_template
+from jinja_util import print_template, qn_to_link_map
 
 def latex_to_rst(s):
     return(re.sub(r'\$([^\$]*)\$', r':math:`\1`', s))
-
-qn_to_link_map = {
-    ord(':'): 'co', ord('@'): 'at', ord('/'): 'sl', ord('_'): 'un',
-    ord('('): 'po', ord(')'): 'pc', ord('+'): 'pp', ord('-'): 'mm',
-    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as'
-}
 
 def make_constraints():
     # All observables (pseudo or otherwise), to be used to see if a constraint is an observable or a parameter

--- a/doc/constraints.rst.py
+++ b/doc/constraints.rst.py
@@ -13,6 +13,9 @@ qn_to_link_map = {
 }
 
 def make_constraints():
+    # All observables (pseudo or otherwise), to be used to see if a constraint is an observable or a parameter
+    obs = [qn for qn, _ in eos.Observables()]
+
     result = []
     for qn, entry in eos.Constraints():
         data = yaml.safe_load(entry.serialize())
@@ -25,7 +28,12 @@ def make_constraints():
         observable_entries = []
         for oqn in unique_observables:
             anchor = oqn.translate(qn_to_link_map).lower()
-            observable_entries.append(f'`{ oqn } <observables.html#{ anchor }>`_')
+            if oqn in obs:
+                # We are looking at a (pseudo-)observable so link to the observables page
+                observable_entries.append(f'`{ oqn } <observables.html#{ anchor }>`_')
+            else:
+                # We are looking at a parameter, so link there
+                observable_entries.append(f'`{ oqn } <parameters.html#{ anchor }>`_')
 
         constraint = {
             'observables': ', '.join(observable_entries)

--- a/doc/constraints.rst.py
+++ b/doc/constraints.rst.py
@@ -9,7 +9,7 @@ def latex_to_rst(s):
 qn_to_link_map = {
     ord(':'): 'co', ord('@'): 'at', ord('/'): 'sl', ord('_'): 'un',
     ord('('): 'po', ord(')'): 'pc', ord('+'): 'pp', ord('-'): 'mm',
-    ord('>'): 'to'
+    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as'
 }
 
 def make_constraints():

--- a/doc/jinja_util.py
+++ b/doc/jinja_util.py
@@ -2,7 +2,7 @@
 A helper to avoid (boilerplate) code duplication.
 
 Usage: Create *.rst.py and *.rst.jinja file in the same directory.
-The python file renderes the jinja template.
+The python file renders the jinja template.
 
 In *.rst.py:
 ```

--- a/doc/jinja_util.py
+++ b/doc/jinja_util.py
@@ -43,3 +43,12 @@ def print_template(rst_py__file__, **kwargs):
 
     template = get_template(os.path.abspath(rst_py__file__))
     print(template.render(**kwargs))
+
+
+# Define the string mapping to convert an EOS QualifiedName to something suitable
+# for reStructuredText and HTML
+qn_to_link_map = {
+    ord(':'): 'co', ord('@'): 'at', ord('/'): 'sl', ord('_'): 'un',
+    ord('('): 'po', ord(')'): 'pc', ord('+'): 'pp', ord('-'): 'mm',
+    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as'
+}

--- a/doc/observables.rst.py
+++ b/doc/observables.rst.py
@@ -35,7 +35,7 @@ def make_doc_observables(group):
         if entry.unit() == eos.Unit.Unity():
             unit_string = ''
         else:
-            unit_string = r'\, \left[ {unit_string} \right]'.format(unit_string=entry.unit().latex())
+            unit_string = fr'\, \left[ {entry.unit().latex()} \right]'
 
         latex = entry.latex()
         if len(latex) > 0:

--- a/doc/observables.rst.py
+++ b/doc/observables.rst.py
@@ -1,15 +1,9 @@
 import eos
 import re
-from jinja_util import print_template
+from jinja_util import print_template, qn_to_link_map
 
 def latex_to_rst(s):
     return(re.sub(r'\$([^\$]*)\$', r':math:`\1`', s))
-
-qn_to_link_map = {
-    ord(':'): 'co', ord('@'): 'at', ord('/'): 'sl', ord('_'): 'un',
-    ord('('): 'po', ord(')'): 'pc', ord('+'): 'pp', ord('-'): 'mm',
-    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as'
-}
 
 # Mirror the EOS observables hierarchy as structured string data: arrays of
 # dicts. Observables are organised in groups, which are organised in sections.

--- a/doc/observables.rst.py
+++ b/doc/observables.rst.py
@@ -8,7 +8,7 @@ def latex_to_rst(s):
 qn_to_link_map = {
     ord(':'): 'co', ord('@'): 'at', ord('/'): 'sl', ord('_'): 'un',
     ord('('): 'po', ord(')'): 'pc', ord('+'): 'pp', ord('-'): 'mm',
-    ord('>'): 'to'
+    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as'
 }
 
 # Mirror the EOS observables hierarchy as structured string data: arrays of

--- a/doc/parameters.rst.py
+++ b/doc/parameters.rst.py
@@ -12,7 +12,7 @@ def latex_to_rst(s):
 qn_to_link_map = {
     ord(':'): 'co', ord('@'): 'at', ord('/'): 'sl', ord('_'): 'un',
     ord('('): 'po', ord(')'): 'pc', ord('+'): 'pp', ord('-'): 'mm',
-    ord('>'): 'to'
+    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as'
 }
 
 # Mirror the EOS parameters hierarchy as structured string data: arrays of

--- a/doc/parameters.rst.py
+++ b/doc/parameters.rst.py
@@ -1,6 +1,6 @@
 import eos
 import re
-from jinja_util import print_template
+from jinja_util import print_template, qn_to_link_map
 
 def latex_to_rst(s):
     s = re.sub(r'\$([^\$]*)\$', r':math:`\1`', s) # inline math
@@ -8,12 +8,6 @@ def latex_to_rst(s):
     s = re.sub(r'(\\begin{align})([^\$]*?)(\\end{align})', r'\n.. math::\n\2', s) # align
 
     return(s)
-
-qn_to_link_map = {
-    ord(':'): 'co', ord('@'): 'at', ord('/'): 'sl', ord('_'): 'un',
-    ord('('): 'po', ord(')'): 'pc', ord('+'): 'pp', ord('-'): 'mm',
-    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as'
-}
 
 # Mirror the EOS parameters hierarchy as structured string data: arrays of
 # dicts. Parameters are organised in groups, which are organised in sections.


### PR DESCRIPTION
Adding mangling for asterisks and carets in EOS QualifiedNames, which means the hyperlinks generated in the constraints list match the HTML id's in the parameters and observables list.

Also now checks if the links in the constraint page are to observables or parameters, and makes the link accordingly

Fixes #708 