### PR TITLE
[rare-b-decays] Fix inconsistency in Wilson coefficient interpretation

### DIFF
--- a/eos/rare-b-decays/b-to-vec-nu-nu.cc
+++ b/eos/rare-b-decays/b-to-vec-nu-nu.cc
@@ -204,12 +204,12 @@ namespace eos
 
             // third term in square brackets in [FLS:2021A], eq. (13)
             const double contr_scalar = q2 * lambda / (8.0 * (m_b + m_D) * (m_b + m_D)) * A0 * A0
-                                      * 2 * std::norm(wc.cSR() - wc.cSL());
+                                      * std::norm(wc.cSR() - wc.cSL());
 
             // fourth term in square brackets in [FLS:2021A], eq. (13)
-            const double contr_tensor = q2 * (32 * m_B2 * m_V2 / (3 * (m_B + m_V) * (m_B + m_V)) * T23 * T23
-                                      + (4 * lambda * T1 * T1 + 4 * (m_B2 - m_V2) * (m_B2 - m_V2) * T2 * T2) / (3 * q2) )
-                                      * 2 * std::norm(wc.cTL());
+            const double contr_tensor = q2 * (32.0 * m_B2 * m_V2 / (3.0 * (m_B + m_V) * (m_B + m_V)) * T23 * T23
+                                      + (4.0 * lambda * T1 * T1 + 4.0 * (m_B2 - m_V2) * (m_B2 - m_V2) * T2 * T2) / (3.0 * q2) )
+                                      * std::norm(wc.cTL());
 
             // assume the production of 3 diagonal neutrino flavors (nu_i nubar_i)
             return 3.0 * norm * (contr_vector + contr_axial + contr_scalar + contr_tensor);


### PR DESCRIPTION
I noticed that I have accidentally added a factor of 2 for the scalar and tensor Wilson coefficients, due to what is written in eq. 13 of https://arxiv.org/pdf/2111.04327.pdf. Later I noticed that the way we implemented eq. 8 in 

https://github.com/eos/eos/blob/4328b6320282b0543ceecfb6715a50eb6a9e102d/eos/rare-b-decays/b-to-psd-nu-nu.cc#L193-L198

I should not have added factors of 2 here. Sorry about that!