### PR TITLE
Changes for master

### DIFF
--- a/eos/form-factors/k-lcdas.cc
+++ b/eos/form-factors/k-lcdas.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2021 Danny van Dyk
+ * Copyright (c) 2021-2024 Danny van Dyk
  * Copyright (c) 2022 Carolina Bolognani
  *
  * This file is part of the EOS project. EOS is free software;
@@ -191,15 +191,7 @@ namespace eos
     };
 
     AntiKaonLCDAs::AntiKaonLCDAs(const Parameters & p, const Options & o) :
-        PrivateImplementationPattern<AntiKaonLCDAs>(new Implementation<AntiKaonLCDAs>(p, o, *this)),
-        gp_1_1o2(1, 1.0 / 2.0),
-        gp_1_3o2(1, 3.0 / 2.0),
-        gp_2_1o2(2, 1.0 / 2.0),
-        gp_2_3o2(2, 3.0 / 2.0),
-        gp_3_1o2(3, 1.0 / 2.0),
-        gp_3_3o2(3, 3.0 / 2.0),
-        gp_4_1o2(4, 1.0 / 2.0),
-        gp_4_3o2(4, 3.0 / 2.0)
+        PrivateImplementationPattern<AntiKaonLCDAs>(new Implementation<AntiKaonLCDAs>(p, o, *this))
     {
     }
 
@@ -277,6 +269,8 @@ namespace eos
     AntiKaonLCDAs::phi(const double & u, const double & mu) const
     {
         // Gegenbauer polynomials C_n^(3/2)
+        static const GegenbauerPolynomial gp_1_3o2(1.0, 3.0 / 2.0);
+        static const GegenbauerPolynomial gp_2_3o2(2.0, 3.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c1 = gp_1_3o2.evaluate(x);
         const double c2 = gp_2_3o2.evaluate(x);
@@ -303,6 +297,10 @@ namespace eos
         const double lambda3K = _imp->lambda3K(mu);
 
         // Gegenbauer polynomials C_n^(1/2)
+        static const GegenbauerPolynomial gp_1_1o2(1.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_2_1o2(2.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_3_1o2(3.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_4_1o2(4.0, 1.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c1 = gp_1_1o2.evaluate(x);
         const double c2 = gp_2_1o2.evaluate(x);
@@ -337,6 +335,9 @@ namespace eos
         const double lambda3K = _imp->lambda3K(mu);
 
         // Gegenbauer polynomials C_n^(3/2)
+        static const GegenbauerPolynomial gp_1_3o2(1.0, 3.0 / 2.0);
+        static const GegenbauerPolynomial gp_2_3o2(2.0, 3.0 / 2.0);
+        static const GegenbauerPolynomial gp_3_3o2(3.0, 3.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c1 = gp_1_3o2.evaluate(x);
         const double c2 = gp_2_3o2.evaluate(x);
@@ -563,6 +564,10 @@ namespace eos
         const double ubar = 1.0 - u, lnubar = std::log(ubar);
 
         // Gegenbauer polynomials C_n^(1/2)
+        static const GegenbauerPolynomial gp_1_1o2(1.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_2_1o2(2.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_3_1o2(3.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_4_1o2(4.0, 1.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c0 = 1.0;
         const double c1 = gp_1_1o2.evaluate(x);
@@ -810,15 +815,7 @@ namespace eos
     };
 
     KaonLCDAs::KaonLCDAs(const Parameters & p, const Options & o) :
-        PrivateImplementationPattern<KaonLCDAs>(new Implementation<KaonLCDAs>(p, o, *this)),
-        gp_1_1o2(1, 1.0 / 2.0),
-        gp_1_3o2(1, 3.0 / 2.0),
-        gp_2_1o2(2, 1.0 / 2.0),
-        gp_2_3o2(2, 3.0 / 2.0),
-        gp_3_1o2(3, 1.0 / 2.0),
-        gp_3_3o2(3, 3.0 / 2.0),
-        gp_4_1o2(4, 1.0 / 2.0),
-        gp_4_3o2(4, 3.0 / 2.0)
+        PrivateImplementationPattern<KaonLCDAs>(new Implementation<KaonLCDAs>(p, o, *this))
     {
     }
 
@@ -896,6 +893,8 @@ namespace eos
     KaonLCDAs::phi(const double & u, const double & mu) const
     {
         // Gegenbauer polynomials C_n^(3/2)
+        static const GegenbauerPolynomial gp_1_3o2(1.0, 3.0 / 2.0);
+        static const GegenbauerPolynomial gp_2_3o2(2.0, 3.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c1 = gp_1_3o2.evaluate(x);
         const double c2 = gp_2_3o2.evaluate(x);
@@ -922,6 +921,10 @@ namespace eos
         const double lambda3K = _imp->lambda3K(mu);
 
         // Gegenbauer polynomials C_n^(1/2)
+        static const GegenbauerPolynomial gp_1_1o2(1.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_2_1o2(2.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_3_1o2(3.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_4_1o2(4.0, 1.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c1 = gp_1_1o2.evaluate(x);
         const double c2 = gp_2_1o2.evaluate(x);
@@ -956,6 +959,9 @@ namespace eos
         const double lambda3K = _imp->lambda3K(mu);
 
         // Gegenbauer polynomials C_n^(3/2)
+        static const GegenbauerPolynomial gp_1_3o2(1.0, 3.0 / 2.0);
+        static const GegenbauerPolynomial gp_2_3o2(2.0, 3.0 / 2.0);
+        static const GegenbauerPolynomial gp_3_3o2(3.0, 3.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c1 = gp_1_3o2.evaluate(x);
         const double c2 = gp_2_3o2.evaluate(x);
@@ -1182,6 +1188,10 @@ namespace eos
         const double ubar = 1.0 - u, lnubar = std::log(ubar);
 
         // Gegenbauer polynomials C_n^(1/2)
+        static const GegenbauerPolynomial gp_1_1o2(1.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_2_1o2(2.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_3_1o2(3.0, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_4_1o2(4.0, 1.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c0 = 1.0;
         const double c1 = gp_1_1o2.evaluate(x);

--- a/eos/form-factors/k-lcdas.hh
+++ b/eos/form-factors/k-lcdas.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2021-2023 Danny van Dyk
+ * Copyright (c) 2021-2024 Danny van Dyk
  * Copyright (c) 2022 Carolina Bolognani
  *
  * This file is part of the EOS project. EOS is free software;
@@ -38,16 +38,6 @@ namespace eos
             ~AntiKaonLCDAs();
 
             static PseudoscalarLCDAs * make(const Parameters &, const Options &);
-
-            /* Gegenbauer polynomials */
-            const GegenbauerPolynomial gp_1_1o2;
-            const GegenbauerPolynomial gp_1_3o2;
-            const GegenbauerPolynomial gp_2_1o2;
-            const GegenbauerPolynomial gp_2_3o2;
-            const GegenbauerPolynomial gp_3_1o2;
-            const GegenbauerPolynomial gp_3_3o2;
-            const GegenbauerPolynomial gp_4_1o2;
-            const GegenbauerPolynomial gp_4_3o2;
 
             /* Twist 2 LCDA Gegenbauer coefficients */
             double a1(const double & mu) const override;
@@ -95,16 +85,6 @@ namespace eos
             ~KaonLCDAs();
 
             static PseudoscalarLCDAs * make(const Parameters &, const Options &);
-
-            /* Gegenbauer polynomials */
-            const GegenbauerPolynomial gp_1_1o2;
-            const GegenbauerPolynomial gp_1_3o2;
-            const GegenbauerPolynomial gp_2_1o2;
-            const GegenbauerPolynomial gp_2_3o2;
-            const GegenbauerPolynomial gp_3_1o2;
-            const GegenbauerPolynomial gp_3_3o2;
-            const GegenbauerPolynomial gp_4_1o2;
-            const GegenbauerPolynomial gp_4_3o2;
 
             /* Twist 2 LCDA Gegenbauer coefficients */
             double a1(const double & mu) const override;

--- a/eos/form-factors/pi-lcdas.cc
+++ b/eos/form-factors/pi-lcdas.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2014 Danny van Dyk
+ * Copyright (c) 2014-2024 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -145,11 +145,7 @@ namespace eos
     };
 
     PionLCDAs::PionLCDAs(const Parameters & p, const Options & o) :
-        PrivateImplementationPattern<PionLCDAs>(new Implementation<PionLCDAs>(p, o, *this)),
-        gp_2_1o2(2, 1.0 / 2.0),
-        gp_2_3o2(2, 3.0 / 2.0),
-        gp_4_1o2(4, 1.0 / 2.0),
-        gp_4_3o2(4, 3.0 / 2.0)
+        PrivateImplementationPattern<PionLCDAs>(new Implementation<PionLCDAs>(p, o, *this))
     {
     }
 
@@ -215,6 +211,8 @@ namespace eos
     PionLCDAs::phi(const double & u, const double & mu) const
     {
         // Gegenbauer polynomials C_n^(3/2)
+        static const GegenbauerPolynomial gp_2_3o2(2, 3.0 / 2.0);
+        static const GegenbauerPolynomial gp_4_3o2(4, 3.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c2 = gp_2_3o2.evaluate(x);
         const double c4 = gp_4_3o2.evaluate(x);
@@ -230,6 +228,8 @@ namespace eos
         const double omega3 = _imp->omega3(mu);
 
         // Gegenbauer polynomials C_n^(1/2)
+        static const GegenbauerPolynomial gp_2_1o2(2, 1.0 / 2.0);
+        static const GegenbauerPolynomial gp_4_1o2(4, 1.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c2 = gp_2_1o2.evaluate(x);
         const double c4 = gp_4_1o2.evaluate(x);
@@ -245,6 +245,7 @@ namespace eos
         const double omega3 = _imp->omega3(mu);
 
         // Gegenbauer polynomials C_n^(3/2)
+        static const GegenbauerPolynomial gp_2_3o2(2, 3.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c2 = gp_2_3o2.evaluate(x);
 
@@ -259,6 +260,7 @@ namespace eos
         const double omega3 = _imp->omega3(mu);
 
         // Gegenbauer polynomials C_n^(3/2)
+        static const GegenbauerPolynomial gp_2_3o2(2, 3.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c2 = gp_2_3o2.evaluate(x);
 
@@ -311,6 +313,7 @@ namespace eos
     PionLCDAs::psi4(const double & u, const double & mu) const
     {
         // Gegenbauer polynomials C_n^(1/2)
+        static const GegenbauerPolynomial gp_2_1o2(2, 1.0 / 2.0);
         const double x = 2.0 * u - 1.0;
         const double c2 = gp_2_1o2.evaluate(x);
 

--- a/eos/form-factors/pi-lcdas.hh
+++ b/eos/form-factors/pi-lcdas.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2014-2023 Danny van Dyk
+ * Copyright (c) 2014-2024 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -37,12 +37,6 @@ namespace eos
             ~PionLCDAs();
 
             static PseudoscalarLCDAs * make(const Parameters &, const Options &);
-
-            /* Gegenbauer polynomials */
-            const GegenbauerPolynomial gp_2_1o2;
-            const GegenbauerPolynomial gp_2_3o2;
-            const GegenbauerPolynomial gp_4_1o2;
-            const GegenbauerPolynomial gp_4_3o2;
 
             /* Twist 2 LCDA (even) Gegenbauer coefficients */
             double a1(const double & /*mu*/) const override { return 0.0; }

--- a/eos/observable_TEST.cc
+++ b/eos/observable_TEST.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2021-2023 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -19,6 +20,9 @@
 #include <eos/observable.hh>
 #include <eos/utils/options.hh>
 #include <eos/utils/units.hh>
+
+#include <ranges>
+#include <iostream>
 
 using namespace test;
 using namespace eos;
@@ -126,6 +130,60 @@ class ObservableTest :
                         <<test::obs1>>[q2_min=>q2_min_num] * {q2_min}
                     )")
                 );
+            }
+
+            /* Test the names of the kinematic variables against a whitelist */
+            {
+                static const std::set<std::string> allowed_kinematic_variables
+                {
+                    "q2", "q2_min", "q2_max",
+                    "q2_num", "q2_min_num", "q2_max_num",
+                    "q2_denom", "q2_min_denom", "q2_max_denom",
+                    "Re{q2}", "Im{q2}",
+                    "q2_e", "q2_e_min", "q2_e_max",
+                    "q2_mu", "q2_mu_min", "q2_mu_max",
+                    "q2_tau", "q2_tau_min", "q2_tau_max",
+                    "k2", "k2_min", "k2_max", "k2_min_num", "k2_max_num", "k2_min_denom", "k2_max_denom",
+                    "cos(theta_l)",
+                    "cos(theta_pi)",
+                    "cos(theta_k)",
+                    "phi",
+                    "E", "E_min", "E_max",
+                    "Re{E}", "Im{E}",
+                    "E_gamma", "E_gamma_min",
+                    "E_pi",
+                    "w", "w_min", "w_max", "w_min_num", "w_max_num", "w_min_denom", "w_max_denom",
+                    "mu", "tau",
+                    "z", "z_min", "z_max", "z_min_num", "z_max_num", "z_min_denom", "z_max_denom",
+                    // needs to be unified with the notation of Re{E} and Im{E}
+                    "q2_real", "q2_imag",
+                    // needs to be rewritten in terms of cos(theta_l)
+                    "theta_l",
+                    // deprecated
+                    "s", "s_min", "s_max",
+                    "i",
+                    "c_D", "c_D_min", "c_D_max",
+                    "c_l", "c_l_min", "c_l_max",
+                    "chi", "chi_min", "chi_max",
+                };
+
+                auto observables = Observables();
+
+                bool found_problematic_observable = false;
+
+                for (auto const & [name, entry] : observables)
+                {
+                    for (auto const & kinematic_variable : std::ranges::subrange(entry->begin_kinematic_variables(), entry->end_kinematic_variables()))
+                    {
+                        if (allowed_kinematic_variables.find(kinematic_variable) != allowed_kinematic_variables.end())
+                            continue;
+
+                        found_problematic_observable = true;
+                        std::cerr << "Found problematic observable: " << name << ", with kinematic variable: " << kinematic_variable << std::endl;
+                    }
+                }
+
+                TEST_CHECK(found_problematic_observable == false);
             }
         }
 

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -240,9 +240,9 @@ def sample_mcmc(analysis_file:str, posterior:str, chain:int, base_directory:str=
         samples, usamples, weights = analysis.sample(N=N, stride=stride, pre_N=pre_N, preruns=preruns, rng=rng, cov_scale=cov_scale, start_point=start_point, return_uspace=True)
         eos.data.MarkovChain.create(os.path.join(base_directory, posterior, f'mcmc-{chain:04}'), analysis.varied_parameters, samples, usamples, weights)
     except RuntimeError as e:
-        eos.error('encountered run time error ({e}) in parameter point:'.format(e=e))
+        eos.error(f'encountered run time error ({e}) in parameter point:')
         for p in analysis.varied_parameters:
-            eos.error(' - {n}: {v}'.format(n=p.name(), v=p.evaluate()))
+            eos.error(f' - {p.name()}: {p.evaluate()}')
 
 
 @task('find-clusters', '{posterior}/clusters')
@@ -274,7 +274,7 @@ def find_clusters(posterior:str, base_directory:str='./', threshold:float=2.0, K
     groups = pypmc.mix_adapt.r_value.r_group([_np.mean(chain.T, axis=1) for chain in chains],
                            [_np.var (chain.T, axis=1, ddof=1) for chain in chains],
                            n, threshold)
-    eos.info('Found {} groups using an R value threshold of {}'.format(len(groups), threshold))
+    eos.info(f'Found {len(groups)} groups using an R value threshold of {threshold}')
     density   = pypmc.mix_adapt.r_value.make_r_gaussmix(chains, K_g=K_g, critical_r=threshold)
     eos.info(f'Created mixture density with {len(density.components)} components')
     eos.data.MixtureDensity.create(os.path.join(base_directory, posterior, 'clusters'), density)
@@ -359,7 +359,7 @@ def sample_pmc(analysis_file:str, posterior:str, base_directory:str='./', step_N
     elif initial_proposal == 'product':
         initial_density = eos.data.MixtureDensity(os.path.join(base_directory, posterior, 'product')).density()
     else:
-        eos.error("Could not initialize proposal in sample_pmc: argument {} is not supported.".format(initial_proposal))
+        eos.error(f"Could not initialize proposal in sample_pmc: argument {initial_proposal} is not supported.")
 
     samples, weights, posterior_values, proposal = analysis.sample_pmc(initial_density, step_N=step_N, steps=steps, final_N=final_N,
                                                      rng=rng, final_perplexity_threshold=perplexity_threshold,
@@ -420,11 +420,11 @@ def predict_observables(analysis_file:str, posterior:str, prediction:str, base_d
             cache.update()
             observable_samples.append([cache[id] for id in observable_ids])
         except RuntimeError as e:
-            eos.error('skipping prediction for sample {i} due to runtime error ({e}): {s}'.format(i=i, e=e, s=sample))
+            eos.error(f'skipping prediction for sample {i} due to runtime error ({e}): {sample}')
             observable_samples.append([_np.nan for _ in observable_ids])
     observable_samples = _np.array(observable_samples)
 
-    output_path = os.path.join(base_directory, posterior, 'pred-{}'.format(prediction))
+    output_path = os.path.join(base_directory, posterior, f'pred-{prediction}')
     eos.data.Prediction.create(output_path, observables, observable_samples, data.weights[begin:end])
 
 

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -474,6 +474,18 @@ Runs a list of subcommands based on the pre-recorded steps defined within an ana
     )
     parser_run.set_defaults(cmd = cmd_run)
 
+
+    # init
+    parser_init = subparsers.add_parser('init',
+        parents = [common_subparser],
+        description =
+'''
+Initializes a new analysis directory based on the EOS analysis template.
+''',
+        help = 'Initializes a new analysis directory.'
+    )
+    parser_init.set_defaults(cmd = cmd_init)
+
     ## end of commands
 
     return parser
@@ -661,6 +673,35 @@ def cmd_list_posteriors(args):
     analysis_file = make_analysis_file(args)
     for name, lh in analysis_file.posteriors.items():
         print(name)
+
+
+# Initialize analysis directory
+def cmd_init(args):
+    import io, requests, zipfile
+
+    def download_template_zip():
+        try:
+            response = requests.get('https://github.com/eos/analysis-template/archive/main.zip')
+        except OSError as e:
+            eos.error(f'Failed to download analysis template: error = {e}')
+            sys.exit(1)
+
+        # validate response
+        if not response.status_code == 200:
+            eos.error(f'Failed to download analysis template: status code = {response.status_code}')
+            sys.exit(2)
+
+        return response.content
+
+    def strip_leading_directory(zip):
+        for name in zip.namelist():
+            path = '/'.join(name.split('/')[1:])
+            yield path
+
+    with zipfile.ZipFile(io.BytesIO(download_template_zip())) as zip:
+        for member in zip.namelist():
+            path = '/'.join(member.split('/')[1:])
+            zip.extract(member, path)
 
 
 if __name__ == '__main__':

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2020-2022 Danny van Dyk
+# Copyright (c) 2020-2023 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -44,8 +44,8 @@ def _parser():
         dest = 'verbose', action = 'count', default = 0
     )
     common_subparser.add_argument('-f', '--analysis-file',
-        help = 'The analysis file. Defaults to \'.analysis.yaml\'.',
-        dest = 'analysis_file', action = 'store', default = '.analysis.yaml'
+        help = 'The analysis file. Defaults to \'analysis.yaml\'.',
+        dest = 'analysis_file', action = 'store', default = 'analysis.yaml'
     )
     subparsers = parser.add_subparsers(title = 'commands')
 


### PR DESCRIPTION
Merges the following changes:

- use ``analysis.yaml`` instead of the (hidden) ``.analysis.yaml`` as the default name for an analysis files in ``eos-analysis``
- run ``pyupgrade`` on ``python/eos/tasks.py``
- provide means to specify optional required modules for every task (#693)
- add a new subcommand ``eos-analysis init``, which install the contents of [eos/analysis-template](https://github.com/eos/analysis-template) into the current working directory
- check the names of kinematic variables in all observables against a whitelist (#750)
- improve the usage of ``GegenbauerPolynomial`` in classes ``PionLCDAs``, ``AntiKaonLCDAs``, and ``KaonLCDAs`` (in furtherance of addressing #747)