### PR TITLE
Changes for ``master``

### DIFF
--- a/eos/utils/Makefile.am
+++ b/eos/utils/Makefile.am
@@ -25,6 +25,7 @@ libeosutils_la_SOURCES = \
 	expression-observable.cc expression-observable.hh \
 	expression-parser.cc expression-parser.hh expression-parser-impl.hh \
 	expression-printer.hh \
+	expression-used-parameter-reader.hh \
 	expression-visitors.cc \
 	gsl-hacks.cc \
 	indirect-iterator.hh indirect-iterator-fwd.hh indirect-iterator-impl.hh \

--- a/eos/utils/expression-observable.cc
+++ b/eos/utils/expression-observable.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2024 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -23,6 +24,7 @@
 #include <eos/utils/expression-maker.hh>
 #include <eos/utils/expression-observable.hh>
 #include <eos/utils/expression-parser.hh>
+#include <eos/utils/expression-used-parameter-reader.hh>
 #include <eos/utils/log.hh>
 
 #include <set>
@@ -48,6 +50,14 @@ namespace eos
 
         exp::ExpressionMaker maker(parameters, kinematics, options, this);
         _expression = expression.accept_returning<Expression>(maker);
+
+        exp::ExpressionUsedParameterReader reader;
+        _expression.accept(reader);
+
+        for (Parameter::Id id : reader.parameter_ids)
+        {
+            this->uses(id);
+        }
     }
 
     ExpressionObservable::ExpressionObservable(const QualifiedName & name,
@@ -68,6 +78,14 @@ namespace eos
 
         exp::ExpressionCacher cacher(cache);
         _expression = expression.accept_returning<Expression>(cacher);
+
+        exp::ExpressionUsedParameterReader reader;
+        _expression.accept(reader);
+
+        for (Parameter::Id id : reader.parameter_ids)
+        {
+            this->uses(id);
+        }
     }
 
     double

--- a/eos/utils/expression-parser_TEST.cc
+++ b/eos/utils/expression-parser_TEST.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 Méril Reboud
- * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2023-2024 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -26,6 +26,7 @@
 #include <eos/utils/expression-maker.hh>
 #include <eos/utils/expression-parser-impl.hh>
 #include <eos/utils/expression-printer.hh>
+#include <eos/utils/expression-used-parameter-reader.hh>
 #include <eos/utils/kinematic.hh>
 #include <eos/utils/options.hh>
 #include <eos/utils/parameters.hh>
@@ -211,6 +212,22 @@ class ExpressionParserTest :
 
                 std::set<std::string> expected_kinematic{};
                 TEST_CHECK_EQUAL(expected_kinematic, kinematic_reader.kinematics);
+
+                // Create a usable expression
+                Parameters p = Parameters::Defaults();
+                ExpressionMaker maker(p, Kinematics(), Options());
+                Expression e = test.e.accept_returning<Expression>(maker);
+
+                // Extract used parameters from an expression
+                ExpressionUsedParameterReader used_parameter_reader;
+                e.accept(used_parameter_reader);
+
+                std::set<Parameter::Id> expected_used_parameters
+                {
+                    p["mass::c"].id(),
+                    p["mass::b(MSbar)"].id()
+                };
+                TEST_CHECK_EQUAL(expected_used_parameters, used_parameter_reader.parameter_ids);
             }
 
             // Test numerical evaluation

--- a/eos/utils/expression-used-parameter-reader.hh
+++ b/eos/utils/expression-used-parameter-reader.hh
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Méril Reboud
+ * Copyright (c) 2023-2024 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_UTILS_EXPRESSION_USED_PARAMETER_READER_HH
+#define EOS_GUARD_EOS_UTILS_EXPRESSION_USED_PARAMETER_READER_HH 1
+
+#include <eos/observable.hh>
+#include <eos/utils/expression-fwd.hh>
+
+namespace eos::exp
+{
+    // Visit the expression tree and return the set of used parameters.
+    class ExpressionUsedParameterReader
+    {
+        public:
+            std::set<Parameter::Id> parameter_ids;
+
+            ExpressionUsedParameterReader() = default;
+            ~ExpressionUsedParameterReader() = default;
+
+            void visit(const BinaryExpression & e);
+
+            void visit(const ConstantExpression &);
+
+            void visit(const ObservableNameExpression & e);
+
+            void visit(const ObservableExpression & e);
+
+            void visit(const ParameterNameExpression &);
+
+            void visit(const ParameterExpression &);
+
+            void visit(const KinematicVariableNameExpression & e);
+
+            void visit(const KinematicVariableExpression & e);
+
+            void visit(const CachedObservableExpression & e);
+    };
+}
+
+#endif

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -989,6 +989,10 @@ class Plotter:
                 yvalues = np.array(yvalues)
                 yerrors = np.array(yerrors)
 
+                if len(xvalues) == 0:
+                    eos.info(f'   skipping plot for constraint {name} since it does not contain the requested observable')
+                    return
+
                 if self.plot_residues:
                     yvalues -= obs_values
 


### PR DESCRIPTION
- When plotting a constraint, we currently produce an ungraceful Python exception if the plot contains no data points whatsoever.
This problem, for example, happens if you plot ``process::observable1`` but the constraint does not contain that observable. Practically, this happened in one of my Jupyter notebooks, where I used the same code to create plots for all ``B->D^*`` form factors, but one constraint did not provide information on the tensor form factors.
The user will now be informed of this issue through the logfile and the plotting will continue w/o the use of the constraint at issue.
- When creating an expression observable, it should keep track of the parameters used by the expression and provided through the observable's ``ParameterUser`` interface. This is now done, using a dedicate ``ExpressionVisitor`` called ``ExpressionUsedParameterVisitor`` (#771)