### PR TITLE
Various workflow related changes

### DIFF
--- a/.github/actions/report-activity/action.yml
+++ b/.github/actions/report-activity/action.yml
@@ -1,0 +1,5 @@
+name: 'Create Activity Report'
+description: 'Creates an activity report for an EOS developer meeting'
+runs:
+  using: 'node20'
+  main: 'index.js'

--- a/.github/actions/report-activity/index.js
+++ b/.github/actions/report-activity/index.js
@@ -1,0 +1,138 @@
+const github = require('@actions/github');
+const core = require('@actions/core');
+
+const token = process.env.GITHUB_ACCESS_TOKEN;
+if (! token)
+{
+	console.error('Environment variable \'GITHUB_ACCESS_TOKEN\' not set!');
+	process.exit(1);
+}
+
+/* setup octokit */
+const octokit = github.getOctokit(token);
+const REPO    = 'eos/eos'
+
+/* determine current date and last date */
+const moment   = require('moment');
+const current = moment().format('YYYY-MM-DD')
+const last    = moment().subtract(2, 'weeks').format('YYYY-MM-DD')
+
+const nunjucks = require('nunjucks');
+const fs       = require('fs');
+
+
+const fetchClosedIssues = async () => {
+	let returnValue = []
+
+	try
+	{
+		const query = `repo:${REPO} is:issue state:closed updated:${last}..${current}`;
+
+		const queryResult = await octokit.rest.search.issuesAndPullRequests({q: query});
+
+		queryResult.data.items.forEach((item) => {
+			returnValue.push({ number: item.number, title: item.title });
+		});
+	}
+	catch (error)
+	{
+		console.error(error);
+	}
+
+	return returnValue;
+};
+
+const fetchClosedPulls = async () => {
+	let returnValue = []
+
+	try
+	{
+		const query = `repo:${REPO} is:pull state:closed updated:${last}..${current}`;
+
+		const queryResult = await octokit.rest.search.issuesAndPullRequests({q: query});
+
+		queryResult.data.items.forEach((item) => {
+			returnValue.push({ number: item.number, title: item.title });
+		});
+	}
+	catch (error)
+	{
+		console.error(error);
+	}
+
+	return returnValue;
+};
+
+const fetchOpenedIssues = async () => {
+	let returnValue = []
+
+	try
+	{
+		const query = `repo:${REPO} is:issue state:open created:${last}..${current}`;
+
+		const queryResult = await octokit.rest.search.issuesAndPullRequests({q: query});
+
+		queryResult.data.items.forEach((item) => {
+			returnValue.push({ number: item.number, title: item.title });
+		});
+	}
+	catch (error)
+	{
+		console.error(error);
+	}
+
+	return returnValue;
+};
+
+const fetchOpenedPulls = async () => {
+	let returnValue = []
+
+	try
+	{
+		const query = `repo:${REPO} is:pull state:open created:${last}..${current}`;
+
+		const queryResult = await octokit.rest.search.issuesAndPullRequests({q: query});
+
+		queryResult.data.items.forEach((item) => {
+			returnValue.push({ number: item.number, title: item.title });
+		});
+	}
+	catch (error)
+	{
+		console.error(error);
+	}
+
+	return returnValue;
+};
+
+/* extract activity info and render report */
+const main = async () => {
+	try
+	{
+		const closedIssues = await fetchClosedIssues();
+		const closedPulls  = await fetchClosedPulls();
+		const openedIssues = await fetchOpenedIssues();
+		const openedPulls  = await fetchOpenedPulls();
+
+		nunjucks.configure({ autoescape: true });
+		let render = nunjucks.render('./.github/actions/report-activity/template.md', {
+			'closedIssues': closedIssues,
+			'closedPulls':  closedPulls,
+			'openedIssues': openedIssues,
+			'openedPulls':  openedPulls,
+			'current':      current
+		});
+		console.log(`Writing report to ${process.cwd()}/agenda-${current}.md`);
+		fs.writeFile(`agenda-${current}.md`, render, function(err) {
+			if (err) {
+				return console.log(err);
+			}
+		});
+	}
+	catch (error)
+	{
+		console.error(error);
+	}
+};
+
+main();

--- a/.github/actions/report-activity/package.json
+++ b/.github/actions/report-activity/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "report-activity",
+    "version": "1.0.0",
+    "description": "Create a status report for the EOS developer meetings",
+    "main": "index.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "EOS Authors",
+    "license": "ISC",
+    "dependencies": {
+      "fs": "^0.0.1-security",
+      "moment": "^2.30.1",
+      "nunjucks": "^3.2.4"
+    }
+}

--- a/.github/actions/report-activity/template.md
+++ b/.github/actions/report-activity/template.md
@@ -1,0 +1,45 @@
+## Agenda for {{ current }} Developer Meeting ##
+
+### Issues closed since the last meeting ###
+
+{% if closedIssues.length > 0 %}
+{% for issue in closedIssues %}
+- [{{ issue.number }}](https://github.com/eos/eos/issues/{{ issue.number }}): {{ issue.title }}<br/>
+
+{% endfor %}
+{% else %}
+None
+{% endif %}
+
+### PRs closed since the last meeting ###
+
+{% if closedPulls.length > 0 %}
+{% for pull in closedPulls %}
+- [{{ pull.number }}](https://github.com/eos/eos/pulls/{{ pulls.number }}): {{ issue.title }}<br/>
+
+{% endfor %}
+{% else %}
+None
+{% endif %}
+
+### Issues opened since the last meeting ###
+
+{% if openedIssues.length > 0%}
+{% for issue in openedIssues %}
+- [{{ issue.number }}](https://github.com/eos/eos/issues/{{ issue.number }}): {{ issue.title }}<br/>
+
+{% endfor %}
+{% else %}
+None
+{% endif %}
+
+### Issues opened since the last meeting ###
+
+{% if openedPulls.length > 0 %}
+{% for pull in openedPulls %}
+- [{{ pull.number }}](https://github.com/eos/eos/pulls/{{ pulls.number }}): {{ issue.title }}<br/>
+
+{% endfor %}
+{% else %}
+None
+{% endif %}

--- a/.github/workflows/pypi-build+check+deploy.yaml
+++ b/.github/workflows/pypi-build+check+deploy.yaml
@@ -67,8 +67,8 @@ jobs:
                     ${{ steps.prerelease.outputs.option }} \
                     --with-boost-python-suffix=${{ matrix.boost_python_suffix }} \
                     --enable-lto
-                  make -j2 all
-                  make -j2 check VERBOSE=1
+                  make -j4 all
+                  make -j4 check VERBOSE=1
                   make -C python eoshep-before DESTDIR={package}
                   popd
                 CIBW_TEST_COMMAND: |

--- a/.github/workflows/pypi-build+check+deploy.yaml
+++ b/.github/workflows/pypi-build+check+deploy.yaml
@@ -27,7 +27,7 @@ jobs:
         name: Build and check EOS wheels on ${{ matrix.arch }} for Python version ${{ matrix.version }}
         steps:
             - name: Checkout git repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install QEMU and emulation on the Ubuntu runner
               if: runner.os == 'Linux'
@@ -48,7 +48,7 @@ jobs:
                 fi
 
             - name: Build EOS, run tests, and create wheels
-              uses: pypa/cibuildwheel@v2.15.0
+              uses: pypa/cibuildwheel@v2.16.5
               with:
                 package-dir: eoshep
               env:
@@ -76,8 +76,9 @@ jobs:
                   python3 -c 'import eos ; print(eos.__version__)'
 
             - name: Upload wheels as artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
+                name: wheel-${{ matrix.arch }}-${{ matrix.version }}
                 path: ./wheelhouse/*.whl
 
     upload_pypi:
@@ -86,9 +87,10 @@ jobs:
         runs-on: ubuntu-latest
         name: Deploy EOS wheels to PyPI
         steps:
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v4
               with:
-                name: artifact
+                pattern: wheel-*
+                merge-multiple: true
                 path: dist
 
             - uses: pypa/gh-action-pypi-publish@v1.4.2

--- a/.github/workflows/report-activity.yaml
+++ b/.github/workflows/report-activity.yaml
@@ -1,0 +1,48 @@
+on:
+  schedule:
+    - cron: '5 8 * * TUE'
+
+name: Report Activity
+
+jobs:
+    report:
+        runs-on: ubuntu-20.04
+        name: Create the weekly activity report
+        steps:
+            - name: Checkout git repository
+              uses: actions/checkout@v4
+
+            - name: Install Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: '20'
+
+            - name: Install dependencies
+              shell: bash
+              run: |
+                npm install @actions/github @actions/core moment nunjucks fs
+
+            - name: Clone the wiki repository
+              uses: actions/checkout@v4
+              with:
+                repository: ${{ github.repository }}.wiki.git
+                token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+                path: ./wiki
+                ref: master
+
+            - name: Report activity
+              env:
+                GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+              uses: ./.github/actions/report-activity
+
+            - name: Commit and push the report
+              shell: bash
+              run: |
+                mv agenda-*.md ./wiki
+                pushd ./wiki
+                git config user.name github-actions
+                git config user.email github-actions@github.com
+                git add ./agenda-*.md
+                git commit -m "Update the weekly activity report"
+                git push
+                popd

--- a/.github/workflows/ubuntu-build+check+deploy.yaml
+++ b/.github/workflows/ubuntu-build+check+deploy.yaml
@@ -26,7 +26,7 @@ jobs:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:6786758f8846fa987e0773e1163546a1b48090f6
         steps:
             - name: Checkout git repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 path: _src/
 
@@ -69,13 +69,13 @@ jobs:
                 tar caf _build.tar _build
 
             - name: Upload configured source as artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: eos-source-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
                 path: _src.tar
 
             - name: Upload build as artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: eos-build-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
                 path: _build.tar
@@ -92,12 +92,12 @@ jobs:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:6786758f8846fa987e0773e1163546a1b48090f6
         steps:
             - name: Download configured source as artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: eos-source-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
 
             - name: Download build as artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: eos-build-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
 
@@ -123,7 +123,7 @@ jobs:
                 tar caf doc.tar _build/doc/html
 
             - name: Upload documentation as artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: eos-doc-${{ github.sha }}
                 path: doc.tar
@@ -141,12 +141,12 @@ jobs:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:6786758f8846fa987e0773e1163546a1b48090f6
         steps:
             - name: Download configured source as artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: eos-source-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
 
             - name: Download build as artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: eos-build-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
 
@@ -172,12 +172,12 @@ jobs:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:6786758f8846fa987e0773e1163546a1b48090f6
         steps:
             - name: Download configured source as artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: eos-source-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
 
             - name: Download build as artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: eos-build-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
 
@@ -196,7 +196,7 @@ jobs:
 
             - name: Upload processed example notebooks as artifact
               if: always()
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: eos-examples-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
                 path: _src/examples/*.ipynb
@@ -213,7 +213,7 @@ jobs:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:6786758f8846fa987e0773e1163546a1b48090f6
         steps:
             - name: Checkout git repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 path: _src/
 
@@ -284,7 +284,7 @@ jobs:
                 package_cloud push eos/eos/ubuntu/${{ matrix.cfg.os }} /tmp/eos-${EOS_VERSION}.deb
 
             - name: Upload .deb file as artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: eos-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}.deb
                 path: /tmp/eos-*.deb
@@ -309,7 +309,7 @@ jobs:
                 git clone -o gh "https://eos:${GITHUB_ACCESS_TOKEN}@github.com/eos/doc" _build/doc/html
 
             - name: Download documentation as artifact
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: eos-doc-${{ github.sha }}
 

--- a/.github/workflows/ubuntu-build+check+deploy.yaml
+++ b/.github/workflows/ubuntu-build+check+deploy.yaml
@@ -64,7 +64,7 @@ jobs:
               shell: bash
               run: |
                 pushd _build
-                make -j2 all
+                make -j4 all
                 popd
                 tar caf _build.tar _build
 
@@ -156,7 +156,7 @@ jobs:
                 tar fx _src.tar
                 tar fx _build.tar
                 pushd _build
-                make -j2 distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-python --prefix=/usr" VERBOSE=1
+                make -j4 distcheck DISTCHECK_CONFIGURE_FLAGS="--enable-python --prefix=/usr" VERBOSE=1
                 popd
 
     ubuntu-examples:
@@ -254,7 +254,7 @@ jobs:
               shell: bash
               run: |
                 pushd _build
-                make -j2 all
+                make -j4 all
                 popd
 
             - name: Build .deb file


### PR DESCRIPTION
- [x] add 'report-activity' action, which produces a (templated) report on opened/closed issues and PRs during the last two weeks
- [x] add 'report-activity' workflow, which
  - [x] run the previous action every week on a Tuesday
  - [x] commits the report to the wiki
- [x] bump versions of various actions to ensure compatibility with ``node20`` (``node16`` is deprecated by GitHub)
  - [x] work around breaking changes when bumping ``actions/{download,upload}-artifact`` to ``v4``
- [x] run workflow with up to 4 parallel make jobs rather than 2, following upgrade of the GitHub-hosted runners