### PR TITLE
Fix issue 766

### DIFF
--- a/eos/b-decays/lambdab-to-lambdac2595-l-nu.cc
+++ b/eos/b-decays/lambdab-to-lambdac2595-l-nu.cc
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2017 Elena Graverini
- * Copyright (c) 2017-2018 Danny van Dyk
+ * Copyright (c) 2017-2024 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -44,6 +44,8 @@ namespace eos
 
         UsedParameter m_LambdaC2595;
 
+        LeptonFlavorOption opt_l;
+
         UsedParameter m_l;
 
         UsedParameter g_fermi;
@@ -59,7 +61,8 @@ namespace eos
             m_LambdaB(p["mass::Lambda_b"], u),
             tau_LambdaB(p["life_time::Lambda_b"], u),
             m_LambdaC2595(p["mass::Lambda_c(2595)"], u),
-            m_l(p["mass::" + o.get("l", "mu")], u),
+            opt_l(o, options, "l"),
+            m_l(p["mass::" + opt_l.str()], u),
             g_fermi(p["WET::G_Fermi"], u),
             hbar(p["QM::hbar"], u)
         {
@@ -143,14 +146,14 @@ namespace eos
             return gamma_0(s) * b_l(s);
         }
 
-        double normalized_double_differential_decay_width(const double & s, const double & z) const
+        double normalized_double_differential_decay_width(const double & s, const double & cos_theta_l) const
         {
             if ((s < m_l * m_l) || (lambda(s) < 0.0))
             {
                 return 0.0;
             }
 
-            return gamma_0(s) * (a_l(s) + b_l(s) * z + c_l(s) * power_of<2>(z));
+            return gamma_0(s) * (a_l(s) + b_l(s) * cos_theta_l + c_l(s) * power_of<2>(cos_theta_l));
         }
 
         double differential_decay_width(const double & s) const
@@ -158,9 +161,9 @@ namespace eos
             return normalized_differential_decay_width(s) * std::norm(model->ckm_cb());
         }
 
-        double double_differential_decay_width(const double & s, const double & theta_l) const
+        double double_differential_decay_width(const double & s, const double & cos_theta_l) const
         {
-            return normalized_double_differential_decay_width(s, theta_l) * std::norm(model->ckm_cb());
+            return normalized_double_differential_decay_width(s, cos_theta_l) * std::norm(model->ckm_cb());
         }
 
         double differential_branching_ratio(const double & s) const
@@ -168,9 +171,9 @@ namespace eos
             return differential_decay_width(s) * tau_LambdaB / hbar;
         }
 
-        double double_differential_branching_ratio(const double & s, const double & theta_l) const
+        double double_differential_branching_ratio(const double & s, const double & cos_theta_l) const
         {
-            return double_differential_decay_width(s, theta_l) * tau_LambdaB / hbar;
+            return double_differential_decay_width(s, cos_theta_l) * tau_LambdaB / hbar;
         }
 
         double integrated_branching_ratio(const double & s_min, const double & s_max) const
@@ -237,9 +240,9 @@ namespace eos
     }
 
     double
-    LambdaBToLambdaC2595LeptonNeutrino::double_differential_branching_ratio(const double & s, const double & theta_l) const
+    LambdaBToLambdaC2595LeptonNeutrino::double_differential_branching_ratio(const double & s, const double & cos_theta_l) const
     {
-        return _imp->double_differential_branching_ratio(s, theta_l);
+        return _imp->double_differential_branching_ratio(s, cos_theta_l);
     }
 
     double

--- a/eos/b-decays/lambdab-to-lambdac2625-l-nu.cc
+++ b/eos/b-decays/lambdab-to-lambdac2625-l-nu.cc
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2017 Elena Graverini
- * Copyright (c) 2017 Danny van Dyk
+ * Copyright (c) 2017-2024 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -45,6 +45,8 @@ namespace eos
 
         UsedParameter m_LambdaC2625;
 
+        LeptonFlavorOption opt_l;
+
         UsedParameter m_l;
 
         UsedParameter g_fermi;
@@ -60,7 +62,8 @@ namespace eos
             m_LambdaB(p["mass::Lambda_b"], u),
             tau_LambdaB(p["life_time::Lambda_b"], u),
             m_LambdaC2625(p["mass::Lambda_c(2625)"], u),
-            m_l(p["mass::" + o.get("l", "mu")], u),
+            opt_l(o, options, "l"),
+            m_l(p["mass::" + opt_l.str()], u),
             g_fermi(p["WET::G_Fermi"], u),
             hbar(p["QM::hbar"], u)
         {
@@ -144,14 +147,14 @@ namespace eos
             return gamma_0(s) * b_l(s);
         }
 
-        double normalized_double_differential_decay_width(const double & s, const double & z) const
+        double normalized_double_differential_decay_width(const double & s, const double & cos_theta_l) const
         {
             if ((s < m_l * m_l) || (lambda(s) < 0.0))
             {
                 return 0.0;
             }
 
-            return gamma_0(s) * (a_l(s) + b_l(s) * z + c_l(s) * power_of<2>(z));
+            return gamma_0(s) * (a_l(s) + b_l(s) * cos_theta_l + c_l(s) * power_of<2>(cos_theta_l));
         }
 
         double differential_decay_width(const double & s) const
@@ -159,9 +162,9 @@ namespace eos
             return normalized_differential_decay_width(s) * std::norm(model->ckm_cb());
         }
 
-        double double_differential_decay_width(const double & s, const double & theta_l) const
+        double double_differential_decay_width(const double & s, const double & cos_theta_l) const
         {
-            return normalized_double_differential_decay_width(s, theta_l) * std::norm(model->ckm_cb());
+            return normalized_double_differential_decay_width(s, cos_theta_l) * std::norm(model->ckm_cb());
         }
 
         double differential_branching_ratio(const double & s) const
@@ -179,9 +182,9 @@ namespace eos
             return b_l(s) / (2. * (a_l(s) + c_l(s) / 3.));
         }
 
-        double double_differential_branching_ratio(const double & s, const double & theta_l) const
+        double double_differential_branching_ratio(const double & s, const double & cos_theta_l) const
         {
-            return double_differential_decay_width(s, theta_l) * tau_LambdaB / hbar;
+            return double_differential_decay_width(s, cos_theta_l) * tau_LambdaB / hbar;
         }
 
         double integrated_branching_ratio(const double & s_min, const double & s_max) const
@@ -251,9 +254,9 @@ namespace eos
     }
 
     double
-    LambdaBToLambdaC2625LeptonNeutrino::double_differential_branching_ratio(const double & s, const double & theta_l) const
+    LambdaBToLambdaC2625LeptonNeutrino::double_differential_branching_ratio(const double & s, const double & cos_theta_l) const
     {
-        return _imp->double_differential_branching_ratio(s, theta_l);
+        return _imp->double_differential_branching_ratio(s, cos_theta_l);
     }
 
     double

--- a/eos/b-decays/observables.cc
+++ b/eos/b-decays/observables.cc
@@ -2000,10 +2000,10 @@ namespace eos
                         &LambdaBToLambdaC2595LeptonNeutrino::differential_branching_ratio,
                         std::make_tuple("q2")),
 
-                make_observable("Lambda_b->Lambda_c(2595)lnu::dBR/dsdtheta_l",
+                make_observable("Lambda_b->Lambda_c(2595)lnu::dBR/dsdcos(theta_l)",
                         Unit::InverseGeV2(),
                         &LambdaBToLambdaC2595LeptonNeutrino::double_differential_branching_ratio,
-                        std::make_tuple("q2", "theta_l")),
+                        std::make_tuple("q2", "cos(theta_l)")),
 
                 make_observable("Lambda_b->Lambda_c(2595)lnu::BR", R"(\mathcal{B}(\Lambda_b\to\Lambda_c(2595) \ell^-\bar\nu))",
                         Unit::None(),
@@ -2047,10 +2047,10 @@ namespace eos
                         &LambdaBToLambdaC2625LeptonNeutrino::differential_forward_backward_asymmetry,
                         std::make_tuple("q2")),
 
-                make_observable("Lambda_b->Lambda_c(2625)lnu::dBR/dsdtheta_l",
+                make_observable("Lambda_b->Lambda_c(2625)lnu::dBR/dsdcos(theta_l)",
                         Unit::InverseGeV2(),
                         &LambdaBToLambdaC2625LeptonNeutrino::double_differential_branching_ratio,
-                        std::make_tuple("q2", "theta_l")),
+                        std::make_tuple("q2", "cos(theta_l)")),
 
                 make_observable("Lambda_b->Lambda_c(2625)lnu::BR", R"(\mathcal{B}(\Lambda_b\to\Lambda_c(2625) \ell^-\bar\nu))",
                         Unit::None(),

--- a/eos/observable_TEST.cc
+++ b/eos/observable_TEST.cc
@@ -157,8 +157,6 @@ class ObservableTest :
                     "z", "z_min", "z_max", "z_min_num", "z_max_num", "z_min_denom", "z_max_denom",
                     // needs to be unified with the notation of Re{E} and Im{E}
                     "q2_real", "q2_imag",
-                    // needs to be rewritten in terms of cos(theta_l)
-                    "theta_l",
                     // deprecated
                     "s", "s_min", "s_max",
                     "i",


### PR DESCRIPTION
Some observables used ``theta_l`` to denote $\cos(\theta_\ell)$. This PR fixes this issue:
- [x] fix $\Lambda_b\to\Lambda_c(2595)\ell^-\bar\nu$ code
- [x] fix $\Lambda_b\to\Lambda_c(2625)\ell^-\bar\nu$ code
- [x] fix representation in the list of observables
- [x] remove whitelisting of ``theta_l`` in the test case that ensures usage of canonical kinematic names