### PR TITLE
Add means to alias parameters

### DIFF
--- a/doc/reference/analysis-file-format.rst
+++ b/doc/reference/analysis-file-format.rst
@@ -8,7 +8,7 @@ Typical analyses carried out using EOS require a high degree of organisation,
 as discussed in the `example on analysis organisation <../user-guide/analysis-organisation.html>`_.
 This example highlights that EOS provides the means to store one or more analysis within an external text file file,
 a so-called analysis file. Using this feature is beneficial in particular when the several analyses share common elements.
-Every EOS analysis file is a YAML file that define the individual steps of one or more Bayesina analysis.
+Every EOS analysis file is a YAML file that define the individual steps of one or more Bayesian analysis.
 At the top level, the format includes the following YAML keys:
 
  - ``priors`` (**mandatory**) --- The list of priors within the analysis.
@@ -17,9 +17,11 @@ At the top level, the format includes the following YAML keys:
 
  - ``posteriors`` (**mandatory**) --- The list of posteriors within the analysis.
 
- - ``predictions`` (**optional**) --- The list of theory predictions within the analysis.
-
  - ``observables`` (**optional**) --- The list of custom observables defined for the scope of the analysis.
+
+ - ``parameters`` (**optional**) --- The list of new parameters defined for the scope of the analysis.
+
+ - ``predictions`` (**optional**) --- The list of theory predictions within the analysis.
 
 The following example illustrates the analysis file format at the hand of a real-world example.
 
@@ -36,10 +38,10 @@ Priors
 The ``priors`` key contains a list of *named* priors. Each prior has one mandatory key:
 
   - ``name`` (**mandatory**) --- The unique name of this prior.
-  - ``parameters`` (**mandatory**) --- The ordered list of parameters described by this prior.
+  - ``descriptions`` (**mandatory**) --- The ordered list of parameters described by this prior.
 
-For a univariate prior, ``parameters`` contains only a single prior description, which is a key/value map describing the prior.
-For an uncorrelated multivariate prior, ``parameters`` contains more than one prior description.
+For a univariate prior, ``descriptions`` contains only a single prior description, which is a key/value map describing the prior.
+For an uncorrelated multivariate prior, ``descriptions`` contains more than one prior description.
 The format for a prior description is the same as used in the :class:`Analysis <eos.Analysis>` constructor.
 For example, the following code create two named priors ``CKM`` (univariate) and ``FF-pi`` (multivariate but uncorrelated).
 
@@ -47,11 +49,11 @@ For example, the following code create two named priors ``CKM`` (univariate) and
 
    priors:
      - name: CKM
-       parameters:
+       descriptions:
         - { 'parameter': 'CKM::abs(V_ub)', 'min': 3.0e-3, 'max': 4.0e-3, 'type': 'uniform' }
 
      - name: FF-pi
-       parameters:
+       descriptions:
          - { 'parameter':  'B->pi::f_+(0)@BCL2008' , 'min':   0.21 , 'max':   0.32 , 'type': 'uniform' }
          - { 'parameter':  'B->pi::b_+^1@BCL2008'  , 'min':  -2.96 , 'max':  -0.60 , 'type': 'uniform' }
          - { 'parameter':  'B->pi::b_+^2@BCL2008'  , 'min':  -3.98 , 'max':   4.38 , 'type': 'uniform' }
@@ -66,7 +68,7 @@ For example, the following code create two named priors ``CKM`` (univariate) and
          - { 'parameter':  'B->pi::b_T^3@BCL2008'  , 'min':  -7.39 , 'max':  10.60 , 'type': 'uniform' }
 
 
-For a correlated multivariate prior, ``parameters`` contains a single element consisting of a key/value pair.
+For a correlated multivariate prior, ``descriptions`` contains a single element consisting of a key/value pair.
 The mandatorys key is ``constraint`` and the value is the qualified name of an EOS constraint.
 The following example illustrates the organisation of a correlated multivariate prior.
 
@@ -74,7 +76,7 @@ The following example illustrates the organisation of a correlated multivariate 
 
    priors:
      - name: FF-rho
-       parameters:
+       descriptions:
          - { 'constraint': 'B->rho::FormFactors[parametric,LCSR]@BSZ:2015A' }
 
 
@@ -84,20 +86,40 @@ Likelihoods
 The ``likelihoods`` key contains a list of *named* likelihoods. Each likelihood has two mandatory keys:
 
   - ``name`` (**mandatory**) --- The unique name of this likelihood.
-  - ``constraints`` (**mandatory**) --- The ordered list of EOS constraint names that comprise this likelihood.
+  - ``constraints`` or ``manual_constraints`` or ``pyhf`` (**mandatory**) --- The ordered list of EOS objects that comprise this likelihood.
 
-The following example illustrates the organisation of a likelihood.
+The likelihoods can be of three types:
 
-.. code-block:: yaml
+  - ``constraints`` The following example illustrates the organisation of a likelihood for a simple constraint.
 
-  - name: EXP-pi
-    constraints:
-      - 'B^0->pi^-l^+nu::BR@HFLAV:2019A;form-factors=BCL2008-4'
+  .. code-block:: yaml
+
+    - name: EXP-pi
+      constraints:
+        - 'B^0->pi^-l^+nu::BR@HFLAV:2019A;form-factors=BCL2008-4'
+
+  - ``manual_constraints`` Additional manually-specified constraints can also be added.
+  The syntax needs to follow the syntax of the usual ``EOS constraints``, as in the following example.
+
+  .. code-block:: yaml
+
+    - name: manual-TH-pi
+      manual_constraints:
+        "B->pi::form-factor-ratio":
+          type: "Gaussian"
+          observable: "B->pi::f_0(q2)/f_+(q2)"
+          kinematics: {'q2': 0}
+          options: {'form-factors': 'BSZ2015'}
+          mean: 1
+          sigma-stat: {"hi": 0., "lo": 0.}
+          sigma-sys:  {"hi": 0.1, "lo": 0.1}
+
+  - ``pyhf``
 
 Posteriors
 ~~~~~~~~~~
 
-The ``posteriors`` key contains a list of *named* posteriors. Each posterior contains two mandator and various optional keys:
+The ``posteriors`` key contains a list of *named* posteriors. Each posterior contains two mandatory and various optional keys:
 
   - ``name`` (**mandatory**) --- The unique name of this posterior.
   - ``prior`` (**mandatory**) --- The ordered list of named priors that are used as part of this posterior.
@@ -121,6 +143,7 @@ The following example illustrates the organisation of a posterior.
          - TH-pi
          - EXP-pi
 
+
 Observables
 ~~~~~~~~~~~
 
@@ -137,3 +160,85 @@ For example, the following code defines the ratio of two :math:`B \to \pi` form-
       options: {}
       expression:
         '<<B->pi::f_+(q2)>> / <<B->pi::f_0(q2)>>'
+
+
+Parameters
+~~~~~~~~~~~
+
+New parameters can also be defined in the analysis description. This can be useful in two cases:
+
+  1. The new parameter(s) can be directly used in a custom observable and added to the analysis priors.
+  The combination of new observables, parameters and manual constraints make ``EOS`` extremely flexible.
+  The syntax for a new parameter follows:
+
+  .. code-block:: yaml
+
+    parameters:
+      'prefix::name' :
+          central: +1.0
+          min:     +0.0
+          max:     +2.0
+          unit:     '1'
+          latex:    '$p_\mathrm{user}$'
+
+  2. New parameters can also be used as aliases for existing parameters. Varying the alias will then vary all the aliased parameters.
+  This is particularly useful in analyses that assumes some symmetry amongst the parameters.
+  E.g. for a fit to Wilson coefficients under the assumption of lepton flavor universality, we can use
+
+  .. code-block:: yaml
+
+    parameters:
+      'ublnul::Re{cVL}' :
+        alias_of: [ 'ubenue::Re{cVL}', 'ubmunumu::Re{cVL}', 'ubtaunutau::Re{cVL}' ]
+        central: +1.0
+        min:     +0.0
+        max:     +2.0
+        unit:     '1'
+        latex:    '$\mathrm{Re}\, \mathcal{C}^{\bar{u}b\bar{\ell}\nu_\ell}_{V_L}$'
+
+
+Predictions
+~~~~~~~~~~~
+
+The last step of an analysis usually consists in the prediction of a set of observables based on previously obtained importance samples.
+The recognized ``predictions`` keys are:
+
+  - ``name`` (**mandatory**) The name of the set of predictions.
+  - ``observables`` (**mandatory**) The list of observables that need to be predicted. This should contain valid existing or manually-specified observables.
+  - ``global_options`` (**optional**) The global options that should be used in the evaluation of the observables.
+  - ``fixed_parameters`` (**optional**) A dictionary of parameters and their values that will be fixed in the evaluation of the observables.
+
+The observables accept two keys:
+  - ``name`` (**mandatory**) The qualified name of the observable.
+    Options can be specified in the observable name following the syntax of [eos.QualifiedName](../reference/python.rst#eos.QualifiedName).
+    A warning will be raised if the observable option override the global options defined above.
+  - ``kinematics`` (**optional**) The dictionary of kinematics specifications for the observables.
+    For brevety, a list of kinematic specification can be provided. In this case, one observable per specification will be created.
+
+The following code provides a valid example of predictions.
+
+.. code-block:: yaml
+
+  predictions:
+  - name: BR
+    global_options:
+      model: CKM
+    observables:
+      - name: B_u->lnu::BR;l=e
+      - name: B_u->lnu::BR;l=mu
+      - name: B_u->lnu::BR;l=tau
+
+  - name: dBR
+    global_options:
+      l: e
+      q: d
+      model: CKM
+      form-factors: BCL2008
+    observables:
+      - name: B->pilnu::dBR/dq2
+        kinematics: [ { q2:  1.0 }, { q2:  2.0 }, { q2:  3.0 }, { q2:  4.0 }, { q2:  5.0 },
+                      { q2:  6.0 }, { q2:  7.0 }, { q2:  8.0 }, { q2:  9.0 }, { q2: 10.0 },
+                      { q2: 11.0 }, { q2: 12.0 }, { q2: 13.0 }, { q2: 14.0 }, { q2: 15.0 },
+                      { q2: 16.0 }, { q2: 17.0 }, { q2: 18.0 }, { q2: 19.0 }, { q2: 20.0 },
+                      { q2: 21.0 }, { q2: 22.0 }, { q2: 23.0 }, { q2: 24.0 }, { q2: 25.0 },
+                      { q2: 26.0 }, { q2: 27.0 } ]

--- a/doc/user-guide/b-to-u-l-nu.yaml
+++ b/doc/user-guide/b-to-u-l-nu.yaml
@@ -1,0 +1,1 @@
+../../examples/b-to-u-l-nu.yaml

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -521,7 +521,7 @@ namespace eos
                 return _sections;
             }
 
-            void insert(const QualifiedName & key, const Parameter::Template & value)
+            void declare(const QualifiedName & key, const Parameter::Template & value)
             {
                 unsigned idx = _data->data.size();
                 _data->data.push_back(Parameter::Data{ value, idx });
@@ -735,7 +735,7 @@ namespace eos
     void
     Parameters::declare(const QualifiedName & name, const std::string & latex, Unit unit, const double & value, const double & min, const double & max)
     {
-        ParameterDefaults::instance()->insert(name, Parameter::Template { name, min, value, max, latex, unit });
+        ParameterDefaults::instance()->declare(name, Parameter::Template { name, min, value, max, latex, unit });
     }
 
     Parameter
@@ -752,7 +752,7 @@ namespace eos
         }
 
         // declare the new parameter ...
-        ParameterDefaults::instance()->insert(name, Parameter::Template { name, min, value, max, latex, unit });
+        ParameterDefaults::instance()->declare(name, Parameter::Template { name, min, value, max, latex, unit });
 
         // ... and insert it into this parameter set ...
         unsigned idx = _imp->parameters.size();

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010-2023 Danny van Dyk
+ * Copyright (c) 2010-2024 Danny van Dyk
  * Copyright (c) 2021 Philip Lüghausen
  * Copyright (c) 2010 Christian Wacker
  *
@@ -527,6 +527,15 @@ namespace eos
                 _data->data.push_back(Parameter::Data{ value, idx });
                 _map[key] = idx;
             }
+
+            void redirect(const QualifiedName & name, const Parameter::Id & id)
+            {
+                auto i = _map.find(name);
+                if (_map.end() == i)
+                    throw UnknownParameterError(name);
+
+                i->second = id;
+            }
     };
 
     template <>
@@ -754,6 +763,27 @@ namespace eos
         // ... before returning it
         return _imp->parameters.back();
     }
+
+    void
+    Parameters::redirect(const QualifiedName & name, const Parameter::Id & id)
+    {
+        ParameterDefaults::instance()->redirect(name, id);
+    }
+
+    void
+    Parameters::redirect_and_apply(const QualifiedName & name, const Parameter::Id & id)
+    {
+        // redirect the parameter to the new id ...
+        ParameterDefaults::instance()->redirect(name, id);
+
+        // ... and apply the change to this parameter set ...
+        auto i = _imp->parameters_map.find(name);
+        if (_imp->parameters_map.end() == i)
+            throw UnknownParameterError(name);
+
+        i->second = id;
+    }
+
     void
     Parameters::set(const QualifiedName & name, const double & value)
     {

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -521,11 +521,13 @@ namespace eos
                 return _sections;
             }
 
-            void declare(const QualifiedName & key, const Parameter::Template & value)
+            Parameter::Id declare(const QualifiedName & key, const Parameter::Template & value)
             {
                 unsigned idx = _data->data.size();
                 _data->data.push_back(Parameter::Data{ value, idx });
                 _map[key] = idx;
+
+                return idx;
             }
 
             void redirect(const QualifiedName & name, const Parameter::Id & id)
@@ -732,10 +734,10 @@ namespace eos
         return _imp->parameters[id];
     }
 
-    void
+    Parameter::Id
     Parameters::declare(const QualifiedName & name, const std::string & latex, Unit unit, const double & value, const double & min, const double & max)
     {
-        ParameterDefaults::instance()->declare(name, Parameter::Template { name, min, value, max, latex, unit });
+        return ParameterDefaults::instance()->declare(name, Parameter::Template { name, min, value, max, latex, unit });
     }
 
     Parameter

--- a/eos/utils/parameters.hh
+++ b/eos/utils/parameters.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010-2023 Danny van Dyk
+ * Copyright (c) 2010-2024 Danny van Dyk
  * Copyright (c) 2021 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
@@ -162,6 +162,18 @@ namespace eos
                 const double & value = 0.0,
                 const double & min = -std::numeric_limits<double>::max(),
                 const double & max = +std::numeric_limits<double>::max());
+
+            /*!
+             * Redirect a parameter name to a different parameter id in the default set of parameters.
+             *
+             * The internal mapping of the parameter name will be redirected to the new id.
+             * If the the parameter's previous id is not already aliased, it will become inaccessible.
+             * This is useful for example to alias a parameter name to a different parameter object.
+             *
+             * @param name  Name of the parameter to be redirected.
+             * @param id    The id of the parameter to which the name shall be redirected.
+             */
+            static void redirect(const QualifiedName & name, const unsigned & id);
             ///@}
 
             ///@name Parameter access
@@ -181,6 +193,19 @@ namespace eos
                 const double & value = 0.0,
                 const double & min = -std::numeric_limits<double>::max(),
                 const double & max = +std::numeric_limits<double>::max());
+
+            /*!
+             * Redirect a parameter name to a different parameter id in the default set of parameters
+             * and apply the redirection to this parameter set.
+             *
+             * The internal mapping of the parameter name will be redirected to the new id.
+             * If the the parameter's previous id is not already aliased, it will become inaccessible.
+             * This is useful for example to alias a parameter name to a different parameter object.
+             *
+             * @param name  Name of the parameter to be redirected.
+             * @param id    The id of the parameter to which the name shall be redirected.
+             */
+            void redirect_and_apply(const QualifiedName & name, const unsigned & id);
 
             /*!
              * Set a parameter's numeric value.

--- a/eos/utils/parameters.hh
+++ b/eos/utils/parameters.hh
@@ -158,7 +158,7 @@ namespace eos
              * @param min   (Optional) minimal value for the new parameter.
              * @param max   (Optional) maximal value for the new parameter.
              */
-            static void declare(const QualifiedName & name, const std::string & latex, Unit unit,
+            static unsigned declare(const QualifiedName & name, const std::string & latex, Unit unit,
                 const double & value = 0.0,
                 const double & min = -std::numeric_limits<double>::max(),
                 const double & max = +std::numeric_limits<double>::max());

--- a/eos/utils/parameters_TEST.cc
+++ b/eos/utils/parameters_TEST.cc
@@ -105,5 +105,59 @@ class ParametersTest :
 
                 TEST_CHECK_EQUAL(p.has("mass::boing747"), true);
             }
+
+            // Parameters::redirect
+            {
+                Parameters p = Parameters::Defaults();
+
+                Parameter p_tau = p["ubtaunutau::Re{cVL}"];
+                Parameter::Id id_tau = p_tau.id();
+                p_tau.set(-9.87);
+
+                TEST_CHECK_NEARLY_EQUAL(p_tau.evaluate(), -9.87, 1e-12);
+
+                Parameter p_ell = p.declare_and_insert("ublnul::Re{cVL}", R"(\text{Re} C_{V_L}^{ub\ell\nu_\ell})", Unit::None(), 1.23, -1.0, 1.0);
+                Parameter::Id id_ell = p_ell.id();
+
+                TEST_CHECK_NEARLY_EQUAL(p_ell.evaluate(), +1.23, 1e-12);
+
+                // redirect the tau parameter name to the lepton-flavor universal parameter
+                p.redirect_and_apply("ubtaunutau::Re{cVL}", id_ell);
+
+                // check that the old tau parameter still has the old parameter id
+                TEST_CHECK_EQUAL(p_tau.id(), id_tau);
+
+                // re-access the tau parameter
+                p_tau = p["ubtaunutau::Re{cVL}"];
+
+                // check that the tau parameter now has the value and id of the lepton-flavor universal parameter
+                TEST_CHECK_NEARLY_EQUAL(p_tau.evaluate(), +1.23, 1e-12);
+                TEST_CHECK_EQUAL(p_tau.id(), id_ell);
+
+                // check a new Parameters object
+                {
+                    Parameters p2 = Parameters::Defaults();
+                    Parameter p2_tau = p2["ubtaunutau::Re{cVL}"];
+                    TEST_CHECK_NEARLY_EQUAL(p2_tau.evaluate(), +1.23, 1e-12);
+                }
+
+                // undo the redirect
+                p.redirect_and_apply("ubtaunutau::Re{cVL}", id_tau);
+
+                // re-access the tau parameter
+                p_tau = p["ubtaunutau::Re{cVL}"];
+
+                // check that the tau parameter now has the value and id as at the beginning
+                TEST_CHECK_NEARLY_EQUAL(p_tau.evaluate(), -9.87, 1e-12);
+                TEST_CHECK_EQUAL(p_tau.id(), id_tau);
+
+                // check a new Parameters object
+                {
+                    Parameters p2 = Parameters::Defaults();
+                    Parameter p2_tau = p2["ubtaunutau::Re{cVL}"];
+                    TEST_CHECK_NEARLY_EQUAL(p2_tau.evaluate(), +1.00, 1e-12); // default value
+                }
+
+            }
         }
 } parameters_test;

--- a/eos/utils/parameters_TEST.cc
+++ b/eos/utils/parameters_TEST.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011-2023 Danny van Dyk
+ * Copyright (c) 2011-2024 Danny van Dyk
  * Copyright (c) 2021 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
@@ -93,6 +93,17 @@ class ParametersTest :
 
                 TEST_CHECK_EQUAL(p.has("mass::tau"), true);
                 TEST_CHECK_EQUAL(p.has("mass::boing747"), false);
+            }
+
+            // Parameters::declare_and_insert
+            {
+                Parameters p = Parameters::Defaults();
+
+                TEST_CHECK_EQUAL(p.has("mass::boing747"), false);
+
+                p.declare_and_insert("mass::boing747", R"(\text{Boeing 747})", Unit::Undefined(), 100000.0, 90000.0, 110000.0);
+
+                TEST_CHECK_EQUAL(p.has("mass::boing747"), true);
             }
         }
 } parameters_test;

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -6,6 +6,7 @@ LINUX_EXAMPLES = \
 	basics.ipynb \
 	predictions.ipynb \
 	inference.ipynb \
+	analysis-organisation.ipynb \
 	simulation.ipynb
 
 MACOSX_EXAMPLES =

--- a/examples/analysis-organisation.ipynb
+++ b/examples/analysis-organisation.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After the examples discussing observable prediction and parameter inference, the examples in this notebook illustrate how to organise your analysis or analyses. This notebook relies on a companion file named `b-to-u-l-nu.yaml`, which fully describes a number of individual priors and likelihoods. These objects serve as the building blocks to construct individual posteriors, which are then available for the overall analysis."
+    "After the examples discussing observable prediction and parameter inference, this notebook illustrate how to organise your analysis or analyses. This presentation is based on the physical example of the analysis of $b \\to u \\ell \\nu$ exclusive decays. The analysis properties are encoded in a companion file named `b-to-u-l-nu.yaml`, which fully describes a number of individual priors and likelihoods. These objects serve as the building blocks to construct individual posteriors, which are then available for the overall analysis."
    ]
   },
   {
@@ -34,74 +34,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <table>\n",
-       "            <colgroup>\n",
-       "                <col width=\"100%\" id=\"posterior\"    style=\"min-width: 200px\">\n",
-       "            </colgroup>\n",
-       "            <thead>\n",
-       "                <tr>\n",
-       "                    <th style=\"text-align: center\">priors</th>\n",
-       "                </tr>\n",
-       "            </thead>\n",
-       "            <tbody>\n",
-       "        \n",
-       "                <tr>\n",
-       "                    <td style=\"text-align: left\">CKM</td>\n",
-       "                </tr>\n",
-       "            \n",
-       "                <tr>\n",
-       "                    <td style=\"text-align: left\">FF-pi</td>\n",
-       "                </tr>\n",
-       "            \n",
-       "            </tbody>\n",
-       "            <thead>\n",
-       "                <tr>\n",
-       "                    <th style=\"text-align: center\">likelihoods</th>\n",
-       "                </tr>\n",
-       "            </thead>\n",
-       "            <tbody>\n",
-       "        \n",
-       "                <tr>\n",
-       "                    <td style=\"text-align: left\">TH-pi</td>\n",
-       "                </tr>\n",
-       "            \n",
-       "                <tr>\n",
-       "                    <td style=\"text-align: left\">EXP-pi</td>\n",
-       "                </tr>\n",
-       "            \n",
-       "            </tbody>\n",
-       "            <thead>\n",
-       "                <tr>\n",
-       "                    <th style=\"text-align: center\">posteriors</th>\n",
-       "                </tr>\n",
-       "            </thead>\n",
-       "            <tbody>\n",
-       "        \n",
-       "                <tr>\n",
-       "                    <td style=\"text-align: left\">CKM-pi</td>\n",
-       "                </tr>\n",
-       "            \n",
-       "            </tbody>\n",
-       "        </table>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<eos.analysis_file.AnalysisFile at 0x7f305afc9a30>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import eos\n",
+    "import os\n",
+    "\n",
     "af = eos.AnalysisFile('./b-to-u-l-nu.yaml')\n",
     "display(af)"
    ]
@@ -111,7 +50,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The analysis file defines one posterior `CKM-pi` and a few priors and likelihoods, which are used to define the two posteriors. The file format is YAML, and analysis files can be written using the text editor of one's choice."
+    "The ``display`` command outputs the structure of the analysis file. In our case the file defines one posterior `CKM-pi` and a few priors and likelihoods, which are used to define the two posteriors. The file format is YAML, and analysis files can be written using the text editor of one's choice."
    ]
   },
   {
@@ -145,7 +84,7 @@
     "      - { 'parameter':  'B->pi::b_T^3@BCL2008'  , 'min':  -7.39 , 'max':  10.60 , 'type': 'uniform' }\n",
     "```\n",
     "The definition associates a list of all parameters varied as part of this prior with the key `parameters`. Each element of the list is a dictionary representing a single parameter. It provides the parameter's full name as `parameter`, lists the `min`/`max` interval, and specifies the `type` of prior distribution.\n",
-    "This format reflects the expectations of the `prior` keyword argument of `eos.Analysis`."
+    "This format reflects the expectations of the `prior` keyword argument of [eos.Analysis](../reference/python.rst#eos.Analysis)."
    ]
   },
   {
@@ -161,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All likelihoods are contained within a list associated with the top-level key `likelihoods`. By convention, theoretical and experimental likelihoods are defined separately from each other and their names are prefixed with `TH-` and `EXP-`, respectively. In the example file, the `TH-pi` likelihoods is defined as follows:\n",
+    "All likelihoods are contained within a list associated with the top-level key `likelihoods`. In the EOS convention, theoretical and experimental likelihoods should be defined separately from each other and their names prefixed with `TH-` and `EXP-`, respectively. In the example file, the `TH-pi` likelihoods is defined as follows:\n",
     "```\n",
     "  - name: TH-pi\n",
     "    constraints:\n",
@@ -169,7 +108,7 @@
     "      - 'B->pi::f_++f_0+f_T@FNAL+MILC:2015C;form-factors=BCL2008-4'\n",
     "      - 'B->pi::f_++f_0@RBC+UKQCD:2015A;form-factors=BCL2008-4'\n",
     "```\n",
-    " The definition associates a list of constraints with the key `constraints`. Each element of the list is a string referring to one of the built-in `EOS` constraints. This format reflects the expectations of the `constraints` keyword argument of `eos.Analysis`."
+    " The definition associates a list of constraints with the key `constraints`. Each element of the list is a string referring to one of the built-in [EOS constraints](https://eos.github.io/doc/reference/constraints). This format reflects the expectations of the `constraints` keyword argument of [eos.Analysis](../reference/python.rst#eos.Analysis)."
    ]
   },
   {
@@ -226,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,24 +201,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1437d981f6b84fe8801a327ce5b591e6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Accordion(children=(Output(layout=Layout(height='200px', overflow='auto')),), titles=('CKM-pi/nested',))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "eos.tasks.sample_nested(af, 'CKM-pi', base_directory=BASE_DIRECTORY, bound='multi', nlive=100, dlogz=9.0, maxiter=3000)"
    ]
@@ -308,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = os.path.join(base_directory, 'CKM-all', 'dynesty_results')\n",
+    "path = os.path.join(BASE_DIRECTORY, 'CKM-pi', 'nested')\n",
     "ns_results = eos.data.DynestyResults(path)"
    ]
   },
@@ -338,8 +262,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eos.tasks.corner_plot(analysis_file=af, posterior='CKM-all',\n",
-    "                      base_directory='./', format=['pdf', 'png'])"
+    "eos.tasks.corner_plot(analysis_file=af, posterior='CKM-pi', base_directory=BASE_DIRECTORY, format=['pdf', 'png'])"
    ]
   },
   {
@@ -356,10 +279,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eos.tasks.predict_observables(analysis_file=af, posterior='CKM-all',\n",
+    "eos.tasks.predict_observables(analysis_file=af, posterior='CKM-pi',\n",
     "                              prediction='leptonic-BR-CKM',\n",
-    "                              base_directory=base_directory)"
+    "                              base_directory=BASE_DIRECTORY)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These samples can be analyzed as described in the [inference](inference.rst) notebook, e.g. with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions = eos.data.Prediction('./CKM-pi/pred-leptonic-BR-CKM')\n",
+    "lo, mi, up = eos.Plotter._weighted_quantiles(predictions.samples[:, 0], # Here 0 gives access to the prediction with the option l = e\n",
+    "                                             [0.15865, 0.5, 0.84135],\n",
+    "                                             predictions.weights)\n",
+    "\n",
+    "from IPython.display import Markdown as md\n",
+    "md(f\"\"\"$\\\\mathcal{{B}}(\\\\bar{{B}} \\\\to e^- \\\\bar{{\\\\nu}}_e) = \\\n",
+    "        {10**12*mi:.2f} ^ {{+{10**12*(up-mi):.2f}}} _ {{{10**12*(lo-mi):.2f}}} \\\\times 10^{{-12}}$\n",
+    "        (from a naive sampling)\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
@@ -378,7 +330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.14"
+   "version": "3.10.12"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker : */
 
 /*
- * Copyright (c) 2016-2023 Danny van Dyk
+ * Copyright (c) 2016-2024 Danny van Dyk
  * Copyright (c) 2021-2023 Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
@@ -246,6 +246,8 @@ BOOST_PYTHON_MODULE(_eos)
             :type min: float
             :param max: The maximum value that the parameter can attain.
             :type max: float
+            :return: The newly inserted parameter.
+            :rtype: eos.Parameter
             )", args("name", "latex", "unit", "value", "min", "max"))
         .def("sections", range(&Parameters::begin_sections, &Parameters::end_sections))
         .def("set", &Parameters::set,

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -249,6 +249,20 @@ BOOST_PYTHON_MODULE(_eos)
             :return: The newly inserted parameter.
             :rtype: eos.Parameter
             )", args("name", "latex", "unit", "value", "min", "max"))
+        .def("redirect", &Parameters::redirect,
+            R"(
+            Redirect a parameter name to a different parameter id in the default set of parameters.
+
+            The internal mapping of the parameter name will be redirected to the new id.
+            If the the parameter's previous id is not already aliased, it will become inaccessible.
+            This is useful for example to alias a parameter name to a different parameter object.
+
+            :param name: The name of the parameter to be redirected.
+            :type name:
+            :param id: The id of the parameter to which the name shall be redirected.
+            :type id: eos.Parameter::Id
+            )", args("name", "id"))
+        .staticmethod("redirect")
         .def("sections", range(&Parameters::begin_sections, &Parameters::end_sections))
         .def("set", &Parameters::set,
             R"(

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -68,14 +68,14 @@ class AnalysisFile:
         if 'observables' in input_data:
             for name in input_data['observables']:
 
-                required_keys = ['latex', 'unit', 'options', 'expression']
+                required_keys = {'latex', 'unit', 'options', 'expression'}
                 provided_keys = input_data['observables'][name].keys()
 
-                missing_keys  = [key for key in required_keys if key not in provided_keys]
+                missing_keys  = required_keys - provided_keys
                 if missing_keys:
                     raise KeyError(f'Missing keys for observable { name }: { missing_keys }')
 
-                ignored_keys = [key for key in provided_keys if key not in required_keys]
+                ignored_keys = provided_keys - required_keys
                 if ignored_keys:
                     eos.warn(f'Ignoring unknown keys for observable { name }: { ignored_keys }')
 
@@ -88,14 +88,14 @@ class AnalysisFile:
         if 'parameters' in input_data:
             for name in input_data['parameters']:
 
-                required_keys = ['latex', 'unit', 'central', 'min', 'max']
+                required_keys = {'latex', 'unit', 'central', 'min', 'max'}
                 provided_keys = input_data['parameters'][name].keys()
 
-                missing_keys  = [key for key in required_keys if key not in provided_keys]
+                missing_keys  = required_keys - provided_keys
                 if missing_keys:
                     raise KeyError(f'Missing keys for parameter { name }: { missing_keys }')
 
-                ignored_keys = [key for key in provided_keys if key not in required_keys]
+                ignored_keys = provided_keys - required_keys
                 if ignored_keys:
                     eos.warn(f'Ignoring unknown keys for parameter { name }: { ignored_keys }')
 

--- a/src/scripts/eos-analysis_TEST.d/analysis.yaml
+++ b/src/scripts/eos-analysis_TEST.d/analysis.yaml
@@ -1,3 +1,12 @@
+parameters:
+  'ublnul::Re{cVL}' :
+      alias_of: [ 'ubenue::Re{cVL}', 'ubmunumu::Re{cVL}', 'ubtaunutau::Re{cVL}' ]
+      central: +1.0
+      min:     +1.0
+      max:     +1.0
+      unit:     '1'
+      latex:    '$\mathrm{Re}\, \mathcal{C}^{\bar{u}b\bar{\ell}\nu_\ell}_{V_L}$'
+
 likelihoods:
   - name: lattice
     constraints:


### PR DESCRIPTION
This PR implements suggestion 4 of issue #801, following feedback from @smeiser and @MJKirk.

Example code for an analysis file:
```yaml
parameters:
  'ublnul::Re{cVL}' :
      alias_of: [ 'ubenue::Re{cVL}', 'ubmunumu::Re{cVL}', 'ubtaunutau::Re{cVL}' ]
      central: +1.0
      min:     +0.0
      max:     +2.0
      unit:     '1'
      latex:    '$\mathrm{Re}\, \mathcal{C}^{\bar{u}b\bar{\ell}\nu_\ell}_{V_L}$'
```