### PR TITLE
[github] Specify the python version in the pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,4 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10.13"
       - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
This should remove the warning from github workflow.