### PR TITLE
[examples] add pyhf example notebook

### DIFF
--- a/eos/observable.cc
+++ b/eos/observable.cc
@@ -5,6 +5,7 @@
  * Copyright (c) 2011 Christian Wacker
  * Copyright (c) 2018, 2019 Ahmet Kokulu
  * Copyright (c) 2018, 2019 Nico Gubernari
+ * Copyright (c) 2024 Lorenz Gärtner
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -345,6 +346,16 @@ namespace eos
         }
 
         ObservableEntries::instance()->insert_or_assign(name, std::shared_ptr<const ObservableEntry>(expression_observable_entry));
+    }
+
+    bool
+    Observables::has(const QualifiedName & name)
+    {
+        auto i(_imp->observable_entries.find(name));
+
+        if (_imp->observable_entries.end() == i)
+            return false;
+        else return true;
     }
 
     std::pair<QualifiedName, ObservableEntryPtr> make_expression_observable(const char * name,

--- a/eos/observable.hh
+++ b/eos/observable.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2010, 2011, 2016-2019, 2022 Danny van Dyk
+ * Copyright (c) 2024 Lorenz Gärtner
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -227,6 +228,13 @@ namespace eos
             * @param expression The expression to be parsed.
             */
             void insert(const QualifiedName & name, const std::string & latex, const Unit & unit, const Options & options, const std::string & expression) const;
+
+            /*!
+             * Verify if an observable with a given name exists.
+             *
+             * @param name  The name to be checked against the known observables.
+             */
+            bool has(const QualifiedName & name);
     };
 
     extern template class WrappedForwardIterator<Observables::ObservableIteratorTag, const std::pair<const QualifiedName, ObservableEntryPtr>>;

--- a/eos/observable_TEST.cc
+++ b/eos/observable_TEST.cc
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021 Méril Reboud
  * Copyright (c) 2021-2023 Danny van Dyk
+ * Copyright (c) 2024 Lorenz Gärtner
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -196,6 +197,14 @@ class ObservableTest :
 
                 TEST_CHECK(found_problematic_observable == false);
 
+            }
+
+            // Observables::has
+            {
+                Observables o = Observables();
+
+                TEST_CHECK_EQUAL(o.has("B_c->lnu::BR"), true);
+                TEST_CHECK_EQUAL(o.has("B_c->lnu::TEST"), false);
             }
         }
 

--- a/examples/pyhf_corr.yaml
+++ b/examples/pyhf_corr.yaml
@@ -1,0 +1,87 @@
+parameters:
+  'ublnul::Re{cVL}' :
+      alias_of: [ 'ubenue::Re{cVL}', 'ubmunumu::Re{cVL}', 'ubtaunutau::Re{cVL}' ]
+      central:   1.0
+      min:      -2.0
+      max:       2.0
+      unit:     '1'
+      latex:    '$\mathrm{Re}\, \mathcal{C}^{\bar{u}b\bar{\nu}_\ell\ell}_{V_L}$'
+
+likelihoods:
+  - name: EXP-pyhf
+    pyhf:
+      file: workspace_corr.json
+      parameter_map:
+        mu: {'name': 'B->pilnu::mu', 'kinematics': {'q2_min': 1.0e-7, 'q2_max': 25.0}}
+
+  - name: EXP-pi
+    constraints:
+      - 'B^0->pi^-l^+nu::BR@HFLAV:2019A;form-factors=BCL2008-4'
+
+  - name: TH-pi
+    constraints:
+      - 'B->pi::form-factors[f_+,f_0,f_T]@LMvD:2021A;form-factors=BCL2008-4'
+      - 'B->pi::f_++f_0+f_T@FNAL+MILC:2015C;form-factors=BCL2008-4'
+      - 'B->pi::f_++f_0@RBC+UKQCD:2015A;form-factors=BCL2008-4'
+
+priors:
+  - name: WET
+    descriptions:
+      - { 'parameter': 'ublnul::Re{cVL}', 'min':  0.7, 'max': 1.7, 'type': 'uniform' }
+
+  - name: FF-pi
+    descriptions:
+      - { 'parameter': 'B->pi::f_+(0)@BCL2008', 'min':   0.21, 'max':  0.32, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_+^1@BCL2008' , 'min':  -2.96, 'max': -0.60, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_+^2@BCL2008' , 'min':  -3.98, 'max':  4.38, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_+^3@BCL2008' , 'min': -18.30, 'max':  9.27, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_0^1@BCL2008' , 'min':  -0.10, 'max':  1.35, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_0^2@BCL2008' , 'min':  -2.08, 'max':  4.65, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_0^3@BCL2008' , 'min':  -4.73, 'max':  9.07, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_0^4@BCL2008' , 'min': -60.00, 'max': 38.00, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::f_T(0)@BCL2008', 'min':   0.18, 'max':  0.32, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_T^1@BCL2008' , 'min':  -3.91, 'max': -0.33, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_T^2@BCL2008' , 'min':  -4.32, 'max':  2.00, 'type': 'uniform' }
+      - { 'parameter': 'B->pi::b_T^3@BCL2008' , 'min':  -7.39, 'max': 10.60, 'type': 'uniform' }
+
+posteriors:
+  - name: WET-pyhf
+    global_options:
+      model: WET
+    fixed_parameters:
+      CKM::abs(V_ub): 3.67e-3
+    prior:
+      - WET
+      # - FF-pi
+    likelihood:
+      # - TH-pi
+      - EXP-pi
+      - EXP-pyhf
+
+  - name: EXP-pyhf
+    global_options:
+      model: WET
+    fixed_parameters:
+      CKM::abs(V_ub): 3.67e-3
+    prior:
+      - WET
+      # - FF-pi
+    likelihood:
+      # - TH-pi
+      - EXP-pyhf
+
+observables:
+  "B->pilnu::mu":
+    latex: "$\\mu$"
+    unit: '1'
+    options: {}
+    expression: "<<B->pilnu::BR;model=WET>> / <<B->pilnu::BR;model=SM>>"
+
+predictions:
+  - name: leptonic-BR-WET
+    global_options:
+      model: WET
+    observables:
+      - name: B_u->lnu::BR;l=e
+      - name: B_u->lnu::BR;l=mu
+      - name: B_u->lnu::BR;l=tau

--- a/examples/pyhf_example.ipynb
+++ b/examples/pyhf_example.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import eos\n",
+    "import pyhf\n",
+    "import json\n",
+    "import yaml\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Analyzing [`pyhf`](https://pyhf.readthedocs.io) likelihoods with `EOS`\n",
+    "\n",
+    "[`pyhf`](https://pyhf.readthedocs.io) has become a statistical tool, widely used in the experimental HEP community. It implements the HistFactory statistical model and has the nice feature of a distributable likelihood format with `JSON` files.\n",
+    "\n",
+    "In this notebook we demonstrate how to add [`pyhf`](https://pyhf.readthedocs.io) likelihoods to `EOS` analyses.\n",
+    "\n",
+    "For the purpose of this example, we construct a simple [`pyhf`](https://pyhf.readthedocs.io) analysis of a $B \\to \\pi l \\nu$ signal decay. The analysis consists of one signal and one background channel with a background uncertainty, correlated across bins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = pyhf.simplemodels.correlated_background(\n",
+    "            signal=[500, 800], bkg=[5000, 6000], bkg_down=[4900, 5800], bkg_up=[5100, 6200]\n",
+    "        )\n",
+    "\n",
+    "data = [6000, 7200]\n",
+    "\n",
+    "workspace = pyhf.Workspace.build(model, data)\n",
+    "\n",
+    "# dump to json\n",
+    "with open('workspace_corr.json', 'w') as f:\n",
+    "    json.dump(workspace, f, indent=2)\n",
+    "\n",
+    "workspace.model().spec"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use [`pyhf`](https://pyhf.readthedocs.io) to fit the model parameters, which are two in this case: `mu` the signal strength, or scaling parameter for the signal, and `correlated_bkg_uncertainty` the correlated background nuisance parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_fit = pyhf.infer.mle.fit(data + model.config.auxdata, model)\n",
+    "for name, value in zip(model.config.par_names, best_fit):\n",
+    "    print(f'{name}: {value}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we measure more `data` as our `signal` +`background` event counts, we obtain a signal strength `mu`>1.\n",
+    "\n",
+    "We add a [`pyhf`](https://pyhf.readthedocs.io) likelihood to an `eos.AnalysisFile` by adding a [`pyhf`](https://pyhf.readthedocs.io) type likelihood:\n",
+    "\n",
+    "```yaml\n",
+    "likelihoods:\n",
+    "  - name: EXP-pyhf\n",
+    "    pyhf:\n",
+    "      file: workspace_corr.json\n",
+    "      parameter_map:\n",
+    "        mu: {'name': 'B->pilnu::mu', 'kinematics': {'q2_min': 1.0e-7, 'q2_max': 25.0}}\n",
+    "```\n",
+    "This likelihood is specified by the `file`, corresponding to the `pyhf workspace`, and an optional `parameter_map` to identify [`pyhf`](https://pyhf.readthedocs.io) parameters with `EOS` parameters or observables.\n",
+    "\n",
+    "The optional `parameter_map` is a dictionary where the key is the parameter name on the [`pyhf`](https://pyhf.readthedocs.io) side and the value is either a\n",
+    "- `string`: This will be associated with an `EOS` parameter, if it exists. Alternatively, a new parameter will be created.\n",
+    "- `dict`: This will be associated with an `EOS` observable. The `dict` consists of a `name` (mandatory) and `kinematics`, `options` (optional).\n",
+    "\n",
+    "In the above case we want to associate the signal strength `mu` with an `EOS` observable,\n",
+    "```yaml\n",
+    "observables:\n",
+    "  \"B->pilnu::mu\":\n",
+    "    latex: \"$\\\\mu$\"\n",
+    "    unit: '1'\n",
+    "    options: {}\n",
+    "    expression: \"<<B->pilnu::BR;model=WET>> / <<B->pilnu::BR;model=SM>>\"\n",
+    "\n",
+    "```\n",
+    "This observable corresponds to the WET $B \\to \\pi l \\nu$ branching ratio, relative to the SM.\n",
+    "\n",
+    "We want to infer the posterior of the (lepton flavor independent, see `pyhf_corr.yaml`) `ublnul::Re{cVL}` Wilson coefficient, for which we add a prior:\n",
+    "```yaml\n",
+    "priors:\n",
+    "  - name: WET\n",
+    "    descriptions:\n",
+    "      - { 'parameter': 'ublnul::Re{cVL}', 'min':  0.5, 'max': 2.0, 'type': 'uniform' }\n",
+    "```\n",
+    "Constrained [`pyhf`](https://pyhf.readthedocs.io) parameters are automatically assigned the corresponding priors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "af = eos.AnalysisFile(\"pyhf_corr.yaml\")\n",
+    "af"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have added two posteriors. `EXP-pyhf` for the pure [`pyhf`](https://pyhf.readthedocs.io) model with two parameters and `WET-pyhf` including additional $B \\to \\pi l nu$ experimental constraints and $B \\to \\pi$ form factor constraints.\n",
+    "\n",
+    "We can now use the `nested_sampling` capabilities of `EOS` to sample from these posteriors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.tasks.sample_nested(af, 'EXP-pyhf', base_directory='./', bound='multi', nlive=100, dlogz=9.0, maxiter=4000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the above command uses an unreasonably large value for `dlogz` (9.0) and small values for `maxiter` (4000), which is only done for the sake of this example.\n",
+    "In practice, you should use a smaller value for `dlogz` at about 1% of the log-evidence. For `maxiter`, you should use a value that is large enough to ensure that the sampler has converged.\n",
+    "Ideally, no value for `maxiter` should be required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.tasks.corner_plot(af, 'EXP-pyhf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also extract the estimated value of $C_{V_L}$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameter_samples = eos.data.ImportanceSamples('./EXP-pyhf/samples')\n",
+    "\n",
+    "mean = np.average(parameter_samples.samples[:,0], weights = parameter_samples.weights)\n",
+    "std = np.sqrt(np.average((parameter_samples.samples[:,0]-mean)**2, weights = parameter_samples.weights))\n",
+    "\n",
+    "print(f'$C_{{V_L}}$ = {mean:.4f} +/- {std:.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Due to the excess we found in the measured data, we see a slight increase in $C_{V_L}$. The value of the nuisance parameter is slightly pulled to a negative value, due to the larger signal contribution in the second bin of the [`pyhf`](https://pyhf.readthedocs.io) analysis.\n",
+    "\n",
+    "We can also compare the posterior mode to the best fit point from above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.tasks.find_mode(af, 'EXP-pyhf', base_directory='./')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mode = eos.data.Mode('./EXP-pyhf/mode-default')\n",
+    "print(f'EOS posterior mode: $C_{{V_L}} = {mode.mode[0]:.3f}')\n",
+    "print(f'pyhf best fit: $C_{{V_L}} = {np.sqrt(best_fit[1]):.3f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we look at the `WET-pyhf` posterior, including additional measurements and properly accounting for form factor uncertainties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.tasks.sample_nested(af, 'WET-pyhf', base_directory='./', bound='multi', nlive=100, dlogz=9.0, maxiter=4000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.tasks.corner_plot(af, 'WET-pyhf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameter_samples = eos.data.ImportanceSamples('./WET-pyhf/samples')\n",
+    "\n",
+    "mean = np.average(parameter_samples.samples[:,0], weights = parameter_samples.weights)\n",
+    "std = np.sqrt(np.average((parameter_samples.samples[:,0]-mean)**2, weights = parameter_samples.weights))\n",
+    "\n",
+    "print(f'$C_{{V_L}}$ = {mean:.4f} +/- {std:.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that the value of $C_{V_L}$ is significantly smaller than in the previous case, due to the inclusion of the additional measurements. In return, the nuisance parameter is pulled to much larger values, to compensate for the smaller Wilson coefficient."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/pyhf_uncorr.yaml
+++ b/examples/pyhf_uncorr.yaml
@@ -1,0 +1,17 @@
+priors:
+  - name: EXP-pyhf-params
+    descriptions:
+      - {'parameter': 'pyhf::mu',
+        'min': -2,
+        'max':  6,
+        'type': 'uniform'}
+likelihoods:
+  - name: EXP-pyhf
+    pyhf:
+      file: workspace_uncorr.json
+posteriors:
+  - name: EXP-pyhf-posterior
+    prior:
+      - EXP-pyhf-params
+    likelihood:
+      - EXP-pyhf

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2016-2024 Danny van Dyk
  * Copyright (c) 2021-2023 Philip Lüghausen
+ * Copyright (c) 2024 Lorenz Gärtner
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -914,6 +915,7 @@ BOOST_PYTHON_MODULE(_eos)
             :param expression: The expression to be parsed.
             :type expression: std::string
         )", args("name", "latex", "unit", "options", "expression"))
+        .def("__contains__", &Observables::has)
         .def("sections", range(&Observables::begin_sections, &Observables::end_sections))
         ;
 

--- a/python/eos/analysis_TEST.d/analysis_file_pyhf.yaml
+++ b/python/eos/analysis_TEST.d/analysis_file_pyhf.yaml
@@ -1,0 +1,16 @@
+likelihoods:
+  - name: EXP-pyhf
+    pyhf:
+      file: workspace.json
+
+priors:
+  - name: MU
+    descriptions:
+      - { 'parameter': 'pyhf::mu', 'min':  0., 'max': 10., 'type': 'uniform' }
+
+posteriors:
+  - name: EXP-pyhf
+    prior:
+      - MU
+    likelihood:
+      - EXP-pyhf


### PR DESCRIPTION
Add a pyhf example (see #807).

TODOs:
- [x] fix renaming through `parameter_map`. This is not actually renaming the parameter, but only the qualified name.
- [ ] fix warning ```RuntimeWarning: invalid value encountered in subtract
  return xlogy(n, lam) - lam - gammaln(n + 1.0)  # type: ignore[no-any-return]```