### PR TITLE
Fix code block in docs

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -214,6 +214,7 @@ the ``dynesty``, ``matplotlib``, ``networkx``, ``scipy``, ``pypmc``, ``pyyaml``,
 
 
 ::
+
   # Make sure to activate your virtual environment first
   pip install dynesty matplotlib networkx scipy pypmc pyyaml wilson
 


### PR DESCRIPTION
Closes #812 

Unfortunately, the pre-commit hook [rstcheck/rstcheck](https://github.com/rstcheck/rstcheck) only flags this at the lowest level ( "INFO" ) along with several other things that are fine and which we don't care about. So that doesn't seem a useful thing to enable.