### PR TITLE
Changes to the release procedure

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,5 +1,7 @@
 on:
-    pull_request:
+  pull_request:
+    branches:
+      - master
 
 name: Check if pre-commit checks pass
 

--- a/.github/workflows/pypi-build+check+deploy.yaml
+++ b/.github/workflows/pypi-build+check+deploy.yaml
@@ -1,6 +1,6 @@
 on:
     push:
-        branches: [ master, testing ]
+        branches: [ release, master, testing ]
 
     pull_request:
 
@@ -83,7 +83,7 @@ jobs:
 
     upload_pypi:
         needs: [ build_wheels ]
-        if: ${{ github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/master') }}
+        if: ${{ github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/release') }}
         runs-on: ubuntu-latest
         name: Deploy EOS wheels to PyPI
         steps:

--- a/.github/workflows/ubuntu-build+check+deploy.yaml
+++ b/.github/workflows/ubuntu-build+check+deploy.yaml
@@ -1,6 +1,6 @@
 on:
     push:
-        branches: [ master, testing ]
+        branches: [ release, master, testing ]
 
     pull_request:
 
@@ -325,8 +325,8 @@ jobs:
                 git config user.name  "EOS"
                 git add --all
                 git commit --allow-empty -m "Updating documentation based on EOS revision ${{ github.sha }}"
-                # only push if running for the master branch or for a versioned release
-                if [[ ${GITHUB_REF#refs/heads/} == "master" || ${GITHUB_REF#refs/tags/v} != ${GITHUB_REF} ]] ; then
+                # only push if running for the release branch or for a versioned release
+                if [[ ${GITHUB_REF#refs/heads/} == "release" || ${GITHUB_REF#refs/tags/v} != ${GITHUB_REF} ]] ; then
                     git push
                 fi
                 popd


### PR DESCRIPTION
As discussed at a recent developer meeting, we will change our release procedure to decrease the number of development release to PyPI.

1. We will continue to push changes to ``master`` via pull requests. Pull request will need passing checks and approval. We will no longer produce (pre)release PyPI wheel or packagecloud .deb files from ``master``.

2. We will periodically push from ``master`` to ``release``. The new branch already exists and a branch protection has been setup. Every push to ``release`` will produce either a prerelease PyPI wheel + documentation; or produce a full release PyPI wheel + documentation + packagecloud .deb file.

- [x] ``pre-commit`` workflow only applied to ``master`` PRs. No need to clutter ``release`` with it.
- [x] ``PyPI`` workflow only deploys wheels when triggers for the ``release`` branch.
- [x] ``Ubuntu`` workflow only deploys documentation and .deb file for the ``release`` branch.