### PR TITLE
Fixes various broken links in documentation

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -14,8 +14,10 @@ log
 .*.swp
 
 # the following files are generated
-constraints.rst
-observables.rst
-parameters.rst
-references.rst
-api/python.rst
+reference/bibliography.rst
+reference/constraints.rst
+reference/observables.rst
+reference/parameters.rst
+reference/python.rst
+reference/signal-pdfs.rst
+user-guide/CKM-pi/*

--- a/doc/jinja_util.py
+++ b/doc/jinja_util.py
@@ -50,5 +50,7 @@ def print_template(rst_py__file__, **kwargs):
 qn_to_link_map = {
     ord(':'): 'co', ord('@'): 'at', ord('/'): 'sl', ord('_'): 'un',
     ord('('): 'po', ord(')'): 'pc', ord('+'): 'pp', ord('-'): 'mm',
-    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as'
+    ord('>'): 'to', ord('^'): 'ca', ord('*'): 'as', ord('['): 'so',
+    ord(']'): 'sc', ord('{'): 'bo', ord('}'): 'bc', ord('\''): 'pr',
+    ord(','): 'cm'
 }

--- a/doc/reference/command-line-interface.rst
+++ b/doc/reference/command-line-interface.rst
@@ -16,8 +16,8 @@ To circumvent this problem, you can alternatively
   * use EOS on remote workstations or compute clusters via the command-line interface.
 
 Working in the command-line interface requires that all analyses are defined within an analysis file.
-For an example of an analysis file see the corresponding `section in the user guide <user-guide/analysis-file-format-example.html>`_.
-For the description of the file format see the corresponding `section in the reference <reference/analysis-file-format.html>`_.
+For an example of an analysis file see the corresponding `section in the user guide <../user-guide/analysis-organisation.html>`_.
+For the description of the file format see the corresponding `section in the reference <analysis-file-format.html>`_.
 The following provide a documentation of the command-line interface, which is available through a single script called ``eos-analysis``.
 
 .. argparse::

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -136,7 +136,7 @@ BBKT:1998A:
   authors: 'Ball, P. and Braun, V. M. and Koike, Y. and Tanaka, K.'
   eprint:
     archive: arXiv
-    id: oai:arXiv.org:9802299
+    id: oai:arXiv.org:hep-ph/9802299
   inspire-id: Ball:1998sk
   title: 'Higher twist distribution amplitudes of vector mesons in QCD: Formalism and twist - three distributions'
 BBL:1995A:

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -757,12 +757,12 @@ BOOST_PYTHON_MODULE(_eos)
             Represents an observable or pseudo observable known to EOS.
 
             New observable objects are created using the :meth:`make <eos.Observable.make>` static method.
-            See also `the complete list of observables <../observables.html>`_.
+            See also `the complete list of observables <../reference/observables.html>`_.
         )", no_init)
         .def("make", &Observable::make, return_value_policy<return_by_value>(), R"(
             Makes a new :class:`Observable` object.
 
-            :param name: The name of the observable. See `the complete list of observables <../observables.html>`_.
+            :param name: The name of the observable. See `the complete list of observables <../reference/observables.html>`_.
             :type name: eos.QualifiedName
             :param parameters: The set of parameters to which this observable is bound.
             :type parameters: eos.Parameters
@@ -850,7 +850,7 @@ BOOST_PYTHON_MODULE(_eos)
             Represents a probability density function (PDF) for any of the physics signals known to EOS.
 
             New PDF objects are created using the :meth:`make <eos.SignalPDF.make>` static method.
-            See also `the complete list of PDFs <../signal-pdfs.html>`_.
+            See also `the complete list of PDFs <../reference/signal-pdfs.html>`_.
     )", no_init)
         .def("make", &SignalPDF::make, return_value_policy<return_by_value>()) // docstring is maintained in python/eos/signal_pdf.py
         .staticmethod("make")

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -54,7 +54,7 @@ class Analysis:
     :type global_options: dict, optional
     :param priors: The priors for this analysis as a list of prior descriptions. See :ref:`below <eos-Analysis-prior-descriptions>` for what consitutes a valid prior description.
     :type priors: iterable
-    :param likelihood: The likelihood as a list of individual constraints from the internal data base of experimental and theoretical constraints; cf. `the complete list of constraints <../constraints.html>`_.
+    :param likelihood: The likelihood as a list of individual constraints from the internal data base of experimental and theoretical constraints; cf. `the complete list of constraints <../reference/constraints.html>`_.
     :type likelihood: iterable
     :param external_likelihood: The external likelihood blocks as a list or iterable of objects returned by :py:meth:`eos.LogLikelihoodBlock.External`.
     :type external_likelihood: list or iterable of :py:class:`eos.LogLikelihoodBlock`.

--- a/python/eos/observable.py
+++ b/python/eos/observable.py
@@ -32,7 +32,7 @@ class Observables(_Observables):
     :param suffix: Only show observables whose qualified names contain the provided ``suffix`` in their suffix part.
     :type suffix: str
 
-    See also `the complete list of observables <../observables.html>`_ in this documentation.
+    See also `the complete list of observables <../reference/observables.html>`_ in this documentation.
     """
     def __init__(self, prefix=None, name=None, suffix=None, showall=False):
         super().__init__()

--- a/python/eos/parameter.py
+++ b/python/eos/parameter.py
@@ -31,7 +31,7 @@ class Parameters(_Parameters):
     :param suffix: Only show parameters whose qualified names contain the provided ``suffix`` in their suffix part.
     :type suffix: str
 
-    See also `the complete list of parameters <../parameters.html>`_.
+    See also `the complete list of parameters <../reference/parameters.html>`_.
     """
     def __new__(cls, *args, **kwargs):
         instance = _Parameters.Defaults()

--- a/python/eos/plot/plotter.py
+++ b/python/eos/plot/plotter.py
@@ -402,15 +402,15 @@ class Plotter:
         Plotting Observables
         --------------------
 
-        Contents items of type ``observable`` are used to display one of the built-in `observables <../observables.html>`_.
+        Contents items of type ``observable`` are used to display one of the built-in `observables <../reference/observables.html>`_.
         The following keys are mandatory:
 
          * ``observable`` (:class:`QualifiedName <eos.QualifiedName>`) -- The name of the observable that will be plotted.
-           Must identify one of the observables known to EOS; see `the complete list of observables <../observables.html>`_.
+           Must identify one of the observables known to EOS; see `the complete list of observables <../reference/observables.html>`_.
          * ``range`` (*list* or *tuple* of two *float*) --The tuple of [minimal, maximal] values of the specified kinematic variable
            for which the observable will be evaluated.
          * ``variable`` (*str*) -- The name of the kinematic or parameter variable to which the x axis will be mapped; see
-           `the complete list of parameters <../parameters.html>`_.
+           `the complete list of parameters <../reference/parameters.html>`_.
 
         Example:
 
@@ -535,7 +535,7 @@ class Plotter:
         --------------------------
 
         Contents items of type ``uncertainty`` are used to display uncertainty bands at 68% probability
-        for one of the built-in `observables <../observables.html>`_. This item type requires that either
+        for one of the built-in `observables <../reference/observables.html>`_. This item type requires that either
         a predictive distribution of the observables has been previously produced.
 
         Exactly one of the following keys is mandatory:
@@ -778,17 +778,17 @@ class Plotter:
         Plotting Constraints
         --------------------
 
-        Contents items of type ``constraints`` are used to display one of the built-in `experimental or theoretical constraints <../constraints.html>`_.
+        Contents items of type ``constraints`` are used to display one of the built-in `experimental or theoretical constraints <../reference/constraints.html>`_.
         The following keys are mandatory:
 
          * ``constraints`` (:class:`QualifiedName <eos.QualifiedName>` or iterable thereof) -- The name or the list of names of the constraints
-           that will be plotted. Must identify at least one of the constraints known to EOS; see `the complete list of constraints <../constraints.html>`_.
+           that will be plotted. Must identify at least one of the constraints known to EOS; see `the complete list of constraints <../reference/constraints.html>`_.
          * ``variable`` (*str*) -- The name of the kinematic variable to which the x axis will be mapped.
 
         When plotting multivariate constraints, the following key is also mandatory:
 
          * ``observable`` (:class:`QualifiedName <eos.QualifiedName>`) -- The name of the observable whose constraints will be plotted.
-           Must identify one of the observables known to EOS; see `the complete list of observables <../observables.html>`_.
+           Must identify one of the observables known to EOS; see `the complete list of observables <../reference/observables.html>`_.
            This is only mandatory in multivariate constraints, since these can constrain more than one observable simultaneously.
 
         The following keys are optional:

--- a/python/eos/signal_pdf.py
+++ b/python/eos/signal_pdf.py
@@ -109,7 +109,7 @@ class SignalPDF(_SignalPDF):
         """
         Makes a new :class:`SignalPDF` object.
 
-        :param name: The name of the probability density function (PDF). See `the complete list of PDFs <../signal-pdfs.html>`_.
+        :param name: The name of the probability density function (PDF). See `the complete list of PDFs <../reference/signal-pdfs.html>`_.
         :type name: eos.QualifiedName
         :param parameters: The set of parameters to which this PDF is bound.
         :type parameters: eos.Parameters
@@ -148,7 +148,7 @@ class SignalPDFs(_SignalPDFs):
     :param suffix: Only show observables whose qualified names contain the provided ``suffix`` in their suffix part.
     :type suffix: str
 
-    See also `the complete list of signal PDFs <../signal-pdfs.html>`_ in this documentation.
+    See also `the complete list of signal PDFs <../reference/signal-pdfs.html>`_ in this documentation.
     """
     def __init__(self, prefix=None, name=None, suffix=None, showall=False):
         super().__init__()


### PR DESCRIPTION
In the process of solving #805 I found more links in the rest of the documentation that were "broken".
I say "broken", since most of these actually work on the live documentation but take you to the wrong place. For example go to https://eos.github.io/doc/reference/python.html#eos.Analysis and click the link for the "complete list of constraints" - you'll find yourself on the page for the constraints in EOS v1.0.10 not 1.0.11!
This is because when Danny reorganised the documentation, the pages got added to their new locations in the [eos/doc](https://github.com/eos/doc/) repo but the old ones were not removed.