### PR TITLE
Fix links in weekly activity report action and fix weekly build workflow

### DIFF
--- a/.github/actions/report-activity/template.md
+++ b/.github/actions/report-activity/template.md
@@ -15,7 +15,7 @@ None
 
 {% if closedPulls.length > 0 %}
 {% for pull in closedPulls %}
-- [{{ pull.number }}](https://github.com/eos/eos/pulls/{{ pull.number }}): {{ pull.title }}<br/>
+- [{{ pull.number }}](https://github.com/eos/eos/pull/{{ pull.number }}): {{ pull.title }}<br/>
 
 {% endfor %}
 {% else %}
@@ -37,7 +37,7 @@ None
 
 {% if openedPulls.length > 0 %}
 {% for pull in openedPulls %}
-- [{{ pull.number }}](https://github.com/eos/eos/pulls/{{ pull.number }}): {{ pull.title }}<br/>
+- [{{ pull.number }}](https://github.com/eos/eos/pull/{{ pull.number }}): {{ pull.title }}<br/>
 
 {% endfor %}
 {% else %}

--- a/.github/workflows/weekly-builds.yaml
+++ b/.github/workflows/weekly-builds.yaml
@@ -9,12 +9,14 @@ name: Trigger the build of weekly development releases
 jobs:
     report:
         runs-on: ubuntu-20.04
-        name: Create PR to merge ``master`` into ``release``
+        name: Push branch ``master`` to branch ``release``
         steps:
             - name: Checkout git repository
               uses: actions/checkout@v4
+              with:
+                token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
 
-            - name: Create pull request
-              run: gh pr create -B release -H master --title 'Weekly PR to merge ``master`` into ``release``' --body 'Created by ``weekly-builds`` workflow.'
-              env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Fetch all branches and push
+              run: |
+                git remote update origin
+                git push origin origin/master:release


### PR DESCRIPTION
- [x] Links to pull request fixed (#841 
- [x] Abandoned usage of PRs for weekly build and reverted to ``git push``. Tested it with a manual ``workflow_dispatch`` on branch ``testing``, and it works!