### PR TITLE
Bump minimal Python version to 3.9

### DIFF
--- a/.github/workflows/pypi-build+check+deploy.yaml
+++ b/.github/workflows/pypi-build+check+deploy.yaml
@@ -19,7 +19,6 @@ jobs:
         strategy:
             matrix:
                 include:
-                  - { arch: x86_64,  cxxflags: '-march=x86-64', boost_python_suffix: 38,  version: cp38  }
                   - { arch: x86_64,  cxxflags: '-march=x86-64', boost_python_suffix: 39,  version: cp39  }
                   - { arch: x86_64,  cxxflags: '-march=x86-64', boost_python_suffix: 310, version: cp310 }
                   - { arch: x86_64,  cxxflags: '-march=x86-64', boost_python_suffix: 311, version: cp311 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
    rev: v3.3.1
    hooks:
     - id: pyupgrade
-      args: [--py38-plus]
+      args: [--py39-plus]
 
  - repo: https://github.com/pre-commit/pygrep-hooks
    rev: v1.10.0

--- a/configure.ac
+++ b/configure.ac
@@ -263,7 +263,7 @@ AC_ARG_WITH([boost-python-suffix],
 dnl }}}
 dnl {{{ python checks (you can change the required python version below)
 if test "x$enable_python" == xyes ; then
-	AM_PATH_PYTHON([3.8])
+	AM_PATH_PYTHON([3.9])
 	PY_PREFIX=`$PYTHON -c 'import sys ; print(sys.prefix)'`
 	PYTHON_LIBS="`python$PYTHON_VERSION-config --libs`"
 	if python$PYTHON_VERSION-config --libs --embed 2>&1 > /dev/null ; then

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -49,5 +49,5 @@ setup(
     ],
     include_package_data=True,
     ext_modules=[Extension('_eos', sources=['dummy.cc'])],
-    python_requires='~=3.8'
+    python_requires='~=3.9'
 )


### PR DESCRIPTION
- [x] disable PyPI workflow for Python 3.8
- [x] bump minimal Python version in ``configure.ac``
- [x] bump minimal Python version in ``python/setup.py.in``
- [x] bump Python compatibility to ``--py39-plus`` for the ``pyupgrade`` ``pre-commit`` hook