### PR TITLE
Fix bugs in B_s -> D_s^(*) Pi and B -> D^(*) K ampitudes

### DIFF
--- a/eos/b-decays/bq-to-dq-psd.cc
+++ b/eos/b-decays/bq-to-dq-psd.cc
@@ -121,7 +121,7 @@ namespace eos
                     ckm_factor = [this]() { return conj(model->ckm_us()) * model->ckm_cb(); };
                     wc         = [this](const bool & cp_conjugate) { return model->wet_sbcu(cp_conjugate); };
                     ff_f_0     = std::make_shared<UsedParameter>(p["B->DK::f_0(MK2)"], u);
-                    lcdas      = PseudoscalarLCDAs::make("K", p, o);
+                    lcdas      = PseudoscalarLCDAs::make("Kbar", p, o);
                     break;
                 default:
                     throw InternalError("Invalid quark flavor: " + stringify(opt_q.value()));
@@ -327,8 +327,8 @@ namespace eos
             const complex<double> a_1_nlo = a_1_nlo_re + a_1_nlo_im * 1.0i;
 
             // convoluted 3-particle hard-scattering kernels
-            const double TVLL_nlp = 4.0 * (5.0 * lcdas->kappa4(mu()) * m_P * m_P) / (3.0 * (mb * mb - mc * mc));
-            const double TTLL_nlp = 4.0 * (3.0 - lcdas->omega3(mu())) * 2.0 / pow(1.0 + z, 2);
+            const double TVLL_nlp = +4.0 * (5.0 * lcdas->kappa4(mu()) * m_P * m_P) / (3.0 * (mb * mb - mc * mc));
+            const double TTLL_nlp = -4.0 * (3.0 - lcdas->omega3(mu())) * 2.0 / pow(1.0 + z, 2);
 
             // calculate contributions from three-particle light-meson states
             const complex<double> a_1_nlp =
@@ -369,8 +369,7 @@ namespace eos
         Model::option_specification(),
         { "accuracy",     { "LO", "NLO", "NLP", "LO+NLO", "all" }, "all"   },
         { "cp-conjugate", { "true", "false" },                     "false" },
-        { "q",            { "s", "d" }                                     },
-        { "P",            { "K", "pi"}                                     }
+        { "q",            { "s", "d" }                                     }
     };
 
     BqToDqPseudoscalar::BqToDqPseudoscalar(const Parameters & parameters, const Options & options) :

--- a/eos/b-decays/bq-to-dq-psd_TEST.cc
+++ b/eos/b-decays/bq-to-dq-psd_TEST.cc
@@ -58,6 +58,13 @@ class BqToDqPSDTest :
                 p["CKM::arg(V_us)"] = 0.0;
                 // form factors
                 p["B->DK::f_0(MK2)"] = 0.684239;
+                // LCDA parameters
+                p["K::a1@1GeV"] = 0.07;
+                p["K::a2@1GeV"] = 0.24;
+                p["K::a3@1GeV"] = 0.0;
+                p["K::a4@1GeV"] = 0.0;
+                p["K::omega3@1GeV"] = -1.5;
+                p["K::kappa4@1GeV"] = -0.09;
                 // WC Values
                 p["sbcu::Re{c1}" ] = -0.04235657776117585;
                 p["sbcu::Im{c1}" ] = 0.0;
@@ -71,14 +78,13 @@ class BqToDqPSDTest :
                 {
                     { "accuracy",     "LO+NLO" },
                     { "q",            "d"      },
-                    { "model",        "WET"    },
-                    { "form-factors", "BSZ2015"}
+                    { "model",        "WET"    }
                 };
                 BqToDqPseudoscalar d(p, oo);
 
                 {
                     const double eps = 1.0e-4;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), 1.067522724418928   , eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), 1.067522724418928,    eps);
                     TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), 0.019071548384034125, eps);
 
                     TEST_CHECK_RELATIVE_ERROR(d.decay_width(),     1.4232505232528867e-16, eps);
@@ -106,6 +112,13 @@ class BqToDqPSDTest :
                 p["CKM::arg(V_cb)"] = 0;
                 p["CKM::abs(V_us)"] = 0.2243;
                 p["CKM::arg(V_us)"] = 0;
+                // LCDA parameters
+                p["K::a1@1GeV"] = 0.07;
+                p["K::a2@1GeV"] = 0.24;
+                p["K::a3@1GeV"] = 0.0;
+                p["K::a4@1GeV"] = 0.0;
+                p["K::omega3@1GeV"] = -1.5;
+                p["K::kappa4@1GeV"] = -0.09;
                 // WC Values
                 p["sbcu::Re{c1}" ] = -0.04235657776117585;
                 p["sbcu::Im{c1}" ] = 0;
@@ -117,17 +130,16 @@ class BqToDqPSDTest :
                 p["sbcu::Im{c4}" ] = 0;
                 Options oo
                 {
-                    { "accuracy",     "NLP" },
+                    { "accuracy",     "NLP"    },
                     { "q",            "d"      },
-                    { "model",        "WET"    },
-                    { "form-factors", "BSZ2015"}
+                    { "model",        "WET"    }
                 };
                 BqToDqPseudoscalar d(p, oo);
 
                 {
-                    const double eps = 1.0e-4;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.000816362, eps);
-                    TEST_CHECK_NEARLY_EQUAL(d.im_a_1()  , +0.0        , eps);
+                    const double eps = 1.0e-5;
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), 0.000752259, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.im_a_1(),   0.0,         eps);
                 }
             }
 
@@ -153,6 +165,13 @@ class BqToDqPSDTest :
                 p["CKM::arg(V_us)"] = 0.0;
                 // form factors
                 p["B->DK::f_0(MK2)"] = 0.684239;
+                // LCDA parameters
+                p["K::a1@1GeV"] = 0.07;
+                p["K::a2@1GeV"] = 0.24;
+                p["K::a3@1GeV"] = 0.0;
+                p["K::a4@1GeV"] = 0.0;
+                p["K::omega3@1GeV"] = -1.5;
+                p["K::kappa4@1GeV"] = -0.09;
                 // BSM test case: WET parameter point
                 p["sbcu::Re{c1}"  ] = -1.72424;
                 p["sbcu::Im{c1}"  ] = -1.56379;
@@ -199,8 +218,7 @@ class BqToDqPSDTest :
                 {
                     { "accuracy",     "LO+NLO" },
                     { "q",            "d"      },
-                    { "model",        "WET"    },
-                    { "form-factors", "BSZ2015"}
+                    { "model",        "WET"    }
                 };
                 BqToDqPseudoscalar d(p, oo);
 
@@ -234,6 +252,13 @@ class BqToDqPSDTest :
                 p["CKM::arg(V_cb)"] = 0;
                 p["CKM::abs(V_us)"] = 0.2243;
                 p["CKM::arg(V_us)"] = 0;
+                // LCDA parameters
+                p["K::a1@1GeV"] = 0.07;
+                p["K::a2@1GeV"] = 0.24;
+                p["K::a3@1GeV"] = 0.0;
+                p["K::a4@1GeV"] = 0.0;
+                p["K::omega3@1GeV"] = -1.5;
+                p["K::kappa4@1GeV"] = -0.09;
                 // BSM test case: WET parameter point
                 p["sbcu::Re{c1}"  ] = -1.72424;
                 p["sbcu::Im{c1}"  ] = -1.56379;
@@ -278,17 +303,16 @@ class BqToDqPSDTest :
 
                 Options oo
                 {
-                    { "accuracy",     "NLP" },
+                    { "accuracy",     "NLP"    },
                     { "q",            "d"      },
-                    { "model",        "WET"    },
-                    { "form-factors", "BSZ2015"}
+                    { "model",        "WET"    }
                 };
                 BqToDqPseudoscalar d(p, oo);
 
                 {
-                    const double eps = 1e-4;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), 0.3166137471854839, eps);
-                    TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), 0.2024009114565051, eps);
+                    const double eps = 1e-5;
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.293001, eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), -0.186581, eps);
                 }
             }
         }

--- a/eos/b-decays/bq-to-dstarq-psd.cc
+++ b/eos/b-decays/bq-to-dstarq-psd.cc
@@ -122,7 +122,7 @@ namespace eos
                     ckm_factor = [this]() { return conj(model->ckm_us()) * model->ckm_cb(); };
                     wc         = [this](const bool & cp_conjugate) { return model->wet_sbcu(cp_conjugate); };
                     ff_a_0     = std::make_shared<UsedParameter>(p["B->D^*K::A_0(MK2)"], u);
-                    lcdas      = PseudoscalarLCDAs::make("K", p, o);
+                    lcdas      = PseudoscalarLCDAs::make("Kbar", p, o);
                     break;
                 default:
                     throw InternalError("Invalid quark flavor: " + stringify(opt_q.value()));
@@ -356,8 +356,8 @@ namespace eos
             const complex<double> a_1_nlo = a_1_nlo_re + a_1_nlo_im * 1.0i;
 
             // convoluted 3-particle hard-scattering kernels
-            const double TVLL_nlp = (5.0 * lcdas->kappa4(mu()) * m_P * m_P) / (3.0 * (mb * mb - mc * mc));
-            const double TTLL_nlp = (3.0 - lcdas->omega3(mu())) * 2.0 / pow(1.0 - z, 2);
+            const double TVLL_nlp = +(5.0 * lcdas->kappa4(mu()) * m_P * m_P) / (3.0 * (mb * mb - mc * mc));
+            const double TTLL_nlp = -(3.0 - lcdas->omega3(mu())) * 2.0 / pow(1.0 - z, 2);
 
             // calculate contributions from three-particle light-meson states
             const complex<double> a_1_nlp =
@@ -400,8 +400,7 @@ namespace eos
         Model::option_specification(),
         { "accuracy",     { "LO", "NLO", "NLP", "LO+NLO", "all" }, "all"   },
         { "cp-conjugate", { "true", "false" },  "false" },
-        { "q",            { "s", "d" }                  },
-        { "P",            { "K", "pi"}                  }
+        { "q",            { "s", "d" }                  }
     };
 
     BqToDstarqPseudoscalar::BqToDstarqPseudoscalar(const Parameters & parameters, const Options & options) :

--- a/eos/b-decays/bq-to-dstarq-psd_TEST.cc
+++ b/eos/b-decays/bq-to-dstarq-psd_TEST.cc
@@ -58,6 +58,13 @@ class BqToDstarqPSDTest :
                 p["CKM::arg(V_us)"] = 0.0;
                 // form-factor
                 p["B->D^*K::A_0(MK2)"] = 0.683228;
+                // LCDA parameters
+                p["K::a1@1GeV"] = 0.07;
+                p["K::a2@1GeV"] = 0.24;
+                p["K::a3@1GeV"] = 0.0;
+                p["K::a4@1GeV"] = 0.0;
+                p["K::omega3@1GeV"] = -1.5;
+                p["K::kappa4@1GeV"] = -0.09;
                 // WC Values
                 p["sbcu::Re{c1}" ] = -0.04235657776117585;
                 p["sbcu::Im{c1}" ] = 0.0;
@@ -71,8 +78,7 @@ class BqToDstarqPSDTest :
                 {
                     { "accuracy",     "LO+NLO" },
                     { "q",            "d"      },
-                    { "model",        "WET"    },
-                    { "form-factors", "BSZ2015"}
+                    { "model",        "WET"    }
                 };
                 BqToDstarqPseudoscalar d(p, oo);
                 {
@@ -105,6 +111,13 @@ class BqToDstarqPSDTest :
                 p["CKM::arg(V_cb)"] = 0;
                 p["CKM::abs(V_us)"] = 0.2243;
                 p["CKM::arg(V_us)"] = 0;
+                // LCDA parameters
+                p["K::a1@1GeV"] = 0.07;
+                p["K::a2@1GeV"] = 0.24;
+                p["K::a3@1GeV"] = 0.0;
+                p["K::a4@1GeV"] = 0.0;
+                p["K::omega3@1GeV"] = -1.5;
+                p["K::kappa4@1GeV"] = -0.09;
                 // WC Values
                 p["sbcu::Re{c1}" ] = -0.04235657776117585;
                 p["sbcu::Im{c1}" ] = 0;
@@ -116,16 +129,15 @@ class BqToDstarqPSDTest :
                 p["sbcu::Im{c4}" ] = 0;
                 Options oo
                 {
-                    { "accuracy",     "NLP" },
+                    { "accuracy",     "NLP"    },
                     { "q",            "d"      },
-                    { "model",        "WET"    },
-                    { "form-factors", "BSZ2015"}
+                    { "model",        "WET"    }
                 };
                 BqToDstarqPseudoscalar d(p, oo);
                 {
-                    const double eps = 1.0e-4;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), 0.000816263, eps);
-                    TEST_CHECK_NEARLY_EQUAL(d.im_a_1()  , 0.0        , eps);
+                    const double eps = 1.0e-5;
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.000752259, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.im_a_1(),    0.0,         eps);
                 }
             }
 
@@ -151,6 +163,11 @@ class BqToDstarqPSDTest :
                 p["CKM::arg(V_us)"] = 0.0;
                 // form-factor
                 p["B->D^*K::A_0(MK2)"] = 0.683228;
+                // LCDA parameters
+                p["K::a1@1GeV"] = 0.07;
+                p["K::a2@1GeV"] = 0.24;
+                p["K::a3@1GeV"] = 0.0;
+                p["K::a4@1GeV"] = 0.0;
                 // BSM test case: WET parameter point
                 p["sbcu::Re{c1}"  ] = -1.72424;
                 p["sbcu::Im{c1}"  ] = -1.56379;
@@ -197,8 +214,7 @@ class BqToDstarqPSDTest :
                 {
                     { "accuracy",     "LO+NLO" },
                     { "q",            "d"      },
-                    { "model",        "WET"    },
-                    { "form-factors", "BSZ2015"}
+                    { "model",        "WET"    }
                 };
                 BqToDstarqPseudoscalar d(p, oo);
 
@@ -232,6 +248,13 @@ class BqToDstarqPSDTest :
                 p["CKM::arg(V_cb)"] = 0;
                 p["CKM::abs(V_us)"] = 0.2243;
                 p["CKM::arg(V_us)"] = 0;
+                // LCDA parameters
+                p["K::a1@1GeV"] = 0.07;
+                p["K::a2@1GeV"] = 0.24;
+                p["K::a3@1GeV"] = 0.0;
+                p["K::a4@1GeV"] = 0.0;
+                p["K::omega3@1GeV"] = -1.5;
+                p["K::kappa4@1GeV"] = -0.09;
                 // BSM test case: WET parameter point
                 p["sbcu::Re{c1}"  ] = -1.72424;
                 p["sbcu::Im{c1}"  ] = -1.56379;
@@ -278,15 +301,14 @@ class BqToDstarqPSDTest :
                 {
                     { "accuracy",     "NLP" },
                     { "q",            "d"      },
-                    { "model",        "WET"    },
-                    { "form-factors", "BSZ2015"}
+                    { "model",        "WET"    }
                 };
                 BqToDstarqPseudoscalar d(p, oo);
 
                 {
-                    const double eps = 1e-4;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), 0.139818,  eps);
-                    TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), 0.135191, eps);
+                    const double eps = 1e-5;
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.127433, eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), -0.123423, eps);
                 }
             }
         }


### PR DESCRIPTION
- Changed the K LCDA used from "K" to "Kbar
- Added minus sign to the three-particle hard-scattering kernel for the TLL structure
- Added the LCDA parameters in the test cases to avoid usage of default values
- Updated values for test cases