### PR TITLE
Fix inconsistent definition of kappa_4 parameter appearing in twist 4 Kaon LCDAs

### DIFF
--- a/eos/b-decays/bq-to-dq-psd_TEST.cc
+++ b/eos/b-decays/bq-to-dq-psd_TEST.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2023 Stefan Meiser
+ * Copyright (c) 2023-2024 Stefan Meiser
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -64,7 +64,6 @@ class BqToDqPSDTest :
                 p["K::a3@1GeV"] = 0.0;
                 p["K::a4@1GeV"] = 0.0;
                 p["K::omega3@1GeV"] = -1.5;
-                p["K::kappa4@1GeV"] = -0.09;
                 // WC Values
                 p["sbcu::Re{c1}" ] = -0.04235657776117585;
                 p["sbcu::Im{c1}" ] = 0.0;
@@ -118,7 +117,6 @@ class BqToDqPSDTest :
                 p["K::a3@1GeV"] = 0.0;
                 p["K::a4@1GeV"] = 0.0;
                 p["K::omega3@1GeV"] = -1.5;
-                p["K::kappa4@1GeV"] = -0.09;
                 // WC Values
                 p["sbcu::Re{c1}" ] = -0.04235657776117585;
                 p["sbcu::Im{c1}" ] = 0;
@@ -138,7 +136,7 @@ class BqToDqPSDTest :
 
                 {
                     const double eps = 1.0e-5;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), 0.000752259, eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), 0.000808643, eps);
                     TEST_CHECK_NEARLY_EQUAL(d.im_a_1(),   0.0,         eps);
                 }
             }
@@ -171,7 +169,6 @@ class BqToDqPSDTest :
                 p["K::a3@1GeV"] = 0.0;
                 p["K::a4@1GeV"] = 0.0;
                 p["K::omega3@1GeV"] = -1.5;
-                p["K::kappa4@1GeV"] = -0.09;
                 // BSM test case: WET parameter point
                 p["sbcu::Re{c1}"  ] = -1.72424;
                 p["sbcu::Im{c1}"  ] = -1.56379;
@@ -258,7 +255,6 @@ class BqToDqPSDTest :
                 p["K::a3@1GeV"] = 0.0;
                 p["K::a4@1GeV"] = 0.0;
                 p["K::omega3@1GeV"] = -1.5;
-                p["K::kappa4@1GeV"] = -0.09;
                 // BSM test case: WET parameter point
                 p["sbcu::Re{c1}"  ] = -1.72424;
                 p["sbcu::Im{c1}"  ] = -1.56379;
@@ -310,9 +306,9 @@ class BqToDqPSDTest :
                 BqToDqPseudoscalar d(p, oo);
 
                 {
-                    const double eps = 1e-5;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.293001, eps);
-                    TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), -0.186581, eps);
+                    const double eps = 1.5e-5;
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.313783, eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), -0.200495, eps);
                 }
             }
         }

--- a/eos/b-decays/bq-to-dstarq-psd_TEST.cc
+++ b/eos/b-decays/bq-to-dstarq-psd_TEST.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2023 Stefan Meiser
+ * Copyright (c) 2023-2024 Stefan Meiser
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -64,7 +64,6 @@ class BqToDstarqPSDTest :
                 p["K::a3@1GeV"] = 0.0;
                 p["K::a4@1GeV"] = 0.0;
                 p["K::omega3@1GeV"] = -1.5;
-                p["K::kappa4@1GeV"] = -0.09;
                 // WC Values
                 p["sbcu::Re{c1}" ] = -0.04235657776117585;
                 p["sbcu::Im{c1}" ] = 0.0;
@@ -117,7 +116,6 @@ class BqToDstarqPSDTest :
                 p["K::a3@1GeV"] = 0.0;
                 p["K::a4@1GeV"] = 0.0;
                 p["K::omega3@1GeV"] = -1.5;
-                p["K::kappa4@1GeV"] = -0.09;
                 // WC Values
                 p["sbcu::Re{c1}" ] = -0.04235657776117585;
                 p["sbcu::Im{c1}" ] = 0;
@@ -136,7 +134,7 @@ class BqToDstarqPSDTest :
                 BqToDstarqPseudoscalar d(p, oo);
                 {
                     const double eps = 1.0e-5;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.000752259, eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.000808643, eps);
                     TEST_CHECK_NEARLY_EQUAL(d.im_a_1(),    0.0,         eps);
                 }
             }
@@ -254,7 +252,6 @@ class BqToDstarqPSDTest :
                 p["K::a3@1GeV"] = 0.0;
                 p["K::a4@1GeV"] = 0.0;
                 p["K::omega3@1GeV"] = -1.5;
-                p["K::kappa4@1GeV"] = -0.09;
                 // BSM test case: WET parameter point
                 p["sbcu::Re{c1}"  ] = -1.72424;
                 p["sbcu::Im{c1}"  ] = -1.56379;
@@ -306,9 +303,9 @@ class BqToDstarqPSDTest :
                 BqToDstarqPseudoscalar d(p, oo);
 
                 {
-                    const double eps = 1e-5;
-                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.127433, eps);
-                    TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), -0.123423, eps);
+                    const double eps = 2e-5;
+                    TEST_CHECK_RELATIVE_ERROR(d.re_a_1(), -0.13831,  eps);
+                    TEST_CHECK_RELATIVE_ERROR(d.im_a_1(), -0.133759, eps);
                 }
             }
         }

--- a/eos/form-factors/k-lcdas.cc
+++ b/eos/form-factors/k-lcdas.cc
@@ -43,7 +43,6 @@ namespace eos
 
         // twist 4 parameters
         UsedParameter delta4K_0;
-        UsedParameter kappa4K_0;
         UsedParameter omega4K_0;
 
         // mass and decay constant of the pion
@@ -63,7 +62,6 @@ namespace eos
             lambda3K_0(p["K::lambda3@1GeV"], u),
             omega3K_0(p["K::omega3@1GeV"], u),
             delta4K_0(p["K::delta4@1GeV"], u),
-            kappa4K_0(p["K::kappa4@1GeV"], u),
             omega4K_0(p["K::omega4@1GeV"], u),
             m_K(p["mass::K_u"], u),
             f_K(p["decay-constant::K_u"], u),
@@ -176,9 +174,8 @@ namespace eos
             const double m_s_0 = model->m_s_msbar(mu_0);
             const double m_q_0 = model->m_ud_msbar(mu_0) / 2.0;
 
-            return kappa4K_0
-            - 9.0 / 40.0 * a1K_0 * (std::pow(c_rge, 32.0 / 9.0) - 1.0)
-            + (m_s_0 * m_s_0 - m_q_0 * m_q_0) / (2.0 * m_K * m_K) * (std::pow(c_rge, 8.0) - 1.0);
+            return -1.0 / 8.0 * (m_s_0 - m_q_0) / (m_s_0 + m_q_0) - 9.0 / 40.0 * a1K_0 * std::pow(c_rge, 32.0 / 9.0)
+            + (m_s_0 * m_s_0 - m_q_0 * m_q_0) / (2.0 * m_K * m_K) * std::pow(c_rge, 8.0);
         }
 
         double omega4K(const double & mu) const
@@ -666,7 +663,6 @@ namespace eos
 
         // twist 4 parameters
         UsedParameter delta4K_0;
-        UsedParameter kappa4K_0;
         UsedParameter omega4K_0;
 
         // mass and decay constant of the pion
@@ -686,7 +682,6 @@ namespace eos
             lambda3K_0(p["K::lambda3@1GeV"], u),
             omega3K_0(p["K::omega3@1GeV"], u),
             delta4K_0(p["K::delta4@1GeV"], u),
-            kappa4K_0(p["K::kappa4@1GeV"], u),
             omega4K_0(p["K::omega4@1GeV"], u),
             m_K(p["mass::K_u"], u),
             f_K(p["decay-constant::K_u"], u),
@@ -801,9 +796,8 @@ namespace eos
             const double m_s_0 = model->m_ud_msbar(mu_0) / 2.0; // swapped m_s with m_q
             const double m_q_0 = model->m_s_msbar(mu_0);
 
-            return -kappa4K_0
-            + 9.0 / 40.0 * a1K_0 * (std::pow(c_rge, 32.0 / 9.0) - 1.0)
-            + (m_s_0 * m_s_0 - m_q_0 * m_q_0) / (2.0 * m_K * m_K) * (std::pow(c_rge, 8.0) - 1.0);
+            return -1.0 / 8.0 * (m_s_0 - m_q_0) / (m_s_0 + m_q_0) + 9.0 / 40.0 * a1K_0 * std::pow(c_rge, 32.0 / 9.0)
+                + (m_s_0 * m_s_0 - m_q_0 * m_q_0) / (2.0 * m_K * m_K) * std::pow(c_rge, 8.0);
         }
 
         double omega4K(const double & mu) const

--- a/eos/form-factors/k-lcdas_TEST.cc
+++ b/eos/form-factors/k-lcdas_TEST.cc
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2021 Danny van Dyk
  * Copyright (c) 2022 Carolina Bolognani
+ * Copyright (c) 2024 Stefan Meiser
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -53,8 +54,7 @@ class AntiKaonLCDAsTest :
             p["K::f3@1GeV"]          =  0.0045;
             p["K::omega3@1GeV"]      = -1.5;
             p["K::lambda3@1GeV"]     =  1.6;
-            p["K::delta4@1GeV"]     =  0.18;
-            p["K::kappa4@1GeV"]      = -0.09;
+            p["K::delta4@1GeV"]      =  0.18;
             p["K::omega4@1GeV"]      =  0.2;
             p["mass::K_u"]           =  0.49368;
             p["decay-constant::K_u"] =  0.1561;
@@ -165,63 +165,63 @@ class AntiKaonLCDAsTest :
                 TEST_CHECK_NEARLY_EQUAL(k.delta4(2.0),  0.15437,   eps);
                 TEST_CHECK_NEARLY_EQUAL(k.delta4(3.0),  0.14544,   eps);
 
-                TEST_CHECK_NEARLY_EQUAL(k.kappa4(1.0), -0.09,      eps);
-                TEST_CHECK_NEARLY_EQUAL(k.kappa4(2.0), -0.103105,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.kappa4(3.0), -0.107073,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.kappa4(1.0), -0.070363,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.kappa4(2.0), -0.083466,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.kappa4(3.0), -0.087433,  eps);
 
                 TEST_CHECK_NEARLY_EQUAL(k.omega4(1.0),  0.2,       eps);
                 TEST_CHECK_NEARLY_EQUAL(k.omega4(2.0),  0.137439,  eps);
                 TEST_CHECK_NEARLY_EQUAL(k.omega4(3.0),  0.118188,  eps);
 
                 // phi4, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.1, 1.0), 0.3663714,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.2, 1.0), 0.8035002,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.3, 1.0), 1.1313548,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.1, 1.0), 0.3546348,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.2, 1.0), 0.7872947,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.3, 1.0), 1.1168668,  eps);
 
                 // phi4, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.1, 2.0), 0.3255290,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.2, 2.0), 0.7048003,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.3, 2.0), 0.9952677,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.1, 2.0), 0.3137956,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.2, 2.0), 0.6885918,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.3, 2.0), 0.9807768,  eps);
 
                 // phi4_d1, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.1, 1.0),  4.4619481,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.2, 1.0),  3.9998219,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.3, 1.0),  2.4640627,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.1, 1.0),  4.3817199,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.2, 1.0),  3.9886215,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.3, 1.0),  2.5065593,  eps);
 
                 // phi4_d1, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.1, 2.0),  3.8610347,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.2, 2.0),  3.4987248,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.3, 2.0),  2.2209078,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.1, 2.0),  3.7808052,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.2, 2.0),  3.4875212,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.3, 2.0),  2.2634101,  eps);
 
                 // phi4_d2, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.1, 1.0),  5.1756668,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.2, 1.0), -11.852937,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.3, 1.0), -17.533827,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.1, 1.0),  5.9155005,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.2, 1.0), -11.228389,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.3, 1.0), -17.091844,  eps);
 
                 // phi4_d2, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.1, 2.0),  4.0958549,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.2, 2.0), -9.5516860,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.3, 2.0), -14.990626,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.1, 2.0),  4.8356851,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.2, 2.0), -8.9271334,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.3, 2.0), -14.548637,  eps);
 
                 // psi4, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.1, 1.0),  0.7608706,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.2, 1.0),  0.0317497,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.3, 1.0), -0.4249862,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.1, 1.0),  0.8047785210,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.2, 1.0),  0.0753944603,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.3, 1.0), -0.3907843998,  eps);
 
                 // psi4, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.1, 2.0),  0.6338835,  5.0 * eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.2, 2.0),  0.0037173,  5.0 * eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.3, 2.0), -0.3743138,  5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.1, 2.0),  0.6777910058,  5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.2, 2.0),  0.0473704719,  5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.3, 2.0), -0.3401055477,  5.0 * eps);
 
                 // psi4_i, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.1, 1.0),  0.11623111, eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.2, 1.0),  0.15368080, eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.3, 1.0),  0.13175167, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.1, 1.0), 0.120139861, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.2, 1.0), 0.162056387, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.3, 1.0), 0.144083365, eps);
 
                 // psi4_i, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.1, 2.0),  0.1019395,  5.0 * eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.2, 2.0),  0.1317095,  5.0 * eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.3, 2.0),  0.1111354,  5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.1, 2.0), 0.105845125, 5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.2, 2.0), 0.140082543, 5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.3, 2.0), 0.123465300, 5.0 * eps);
             }
         }
 } anti_k_lcdas_test;
@@ -249,8 +249,7 @@ class KaonLCDAsTest :
             p["K::f3@1GeV"]          =  0.0045;
             p["K::omega3@1GeV"]      = -1.5;
             p["K::lambda3@1GeV"]     = -1.6;
-            p["K::delta4@1GeV"]     =  0.18;
-            p["K::kappa4@1GeV"]      =  0.09;
+            p["K::delta4@1GeV"]      =  0.18;
             p["K::omega4@1GeV"]      =  0.2;
             p["mass::K_u"]           =  0.49368;
             p["decay-constant::K_u"] =  0.1561;
@@ -362,63 +361,63 @@ class KaonLCDAsTest :
                 TEST_CHECK_NEARLY_EQUAL(k.delta4(2.0),  0.15437,  eps);
                 TEST_CHECK_NEARLY_EQUAL(k.delta4(3.0),  0.14544,  eps);
 
-                TEST_CHECK_NEARLY_EQUAL(k.kappa4(1.0), -0.09,     eps);
-                TEST_CHECK_NEARLY_EQUAL(k.kappa4(2.0), -0.103105, eps);
-                TEST_CHECK_NEARLY_EQUAL(k.kappa4(3.0), -0.107073, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.kappa4(1.0), -0.070363, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.kappa4(2.0), -0.083466, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.kappa4(3.0), -0.087433, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(k.omega4(1.0),  0.2,      eps);
                 TEST_CHECK_NEARLY_EQUAL(k.omega4(2.0),  0.137439, eps);
                 TEST_CHECK_NEARLY_EQUAL(k.omega4(3.0),  0.118188, eps);
 
                 // phi4, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.1, 1.0), 0.3663714,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.2, 1.0), 0.8035002,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.3, 1.0), 1.1313548,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.1, 1.0), 0.3546348,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.2, 1.0), 0.7872947,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.3, 1.0), 1.1168668,  eps);
 
                 // phi4, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.1, 2.0), 0.3255290,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.2, 2.0), 0.7048003,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.3, 2.0), 0.9952677,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.1, 2.0), 0.3137956,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.2, 2.0), 0.6885918,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4(0.3, 2.0), 0.9807768,  eps);
 
                 // phi4_d1, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.1, 1.0),  4.4619481,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.2, 1.0),  3.9998219,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.3, 1.0),  2.4640627,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.1, 1.0),  4.3817199,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.2, 1.0),  3.9886215,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.3, 1.0),  2.5065593,  eps);
 
                 // phi4_d1, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.1, 2.0),  3.8610347,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.2, 2.0),  3.4987248,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.3, 2.0),  2.2209078,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.1, 2.0),  3.7808052,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.2, 2.0),  3.4875212,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d1(0.3, 2.0),  2.2634101,  eps);
 
                 // phi4_d2, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.1, 1.0),  5.1756668,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.2, 1.0), -11.852937,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.3, 1.0), -17.533827,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.1, 1.0),  5.9155005,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.2, 1.0), -11.228389,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.3, 1.0), -17.091844,  eps);
 
                 // phi4_d2, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.1, 2.0),  4.0958549,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.2, 2.0), -9.5516860,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.3, 2.0), -14.990626,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.1, 2.0),  4.8356851,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.2, 2.0), -8.9271334,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.phi4_d2(0.3, 2.0), -14.548637,  eps);
 
                 // psi4, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.1, 1.0),  0.7608706,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.2, 1.0),  0.0317497,  eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.3, 1.0), -0.4249862,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.1, 1.0),  0.8047785210,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.2, 1.0),  0.0753944603,  eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.3, 1.0), -0.3907843998,  eps);
 
                 // psi4, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.1, 2.0),  0.6338835,  5.0 * eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.2, 2.0),  0.0037173,  5.0 * eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.3, 2.0), -0.3743138,  5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.1, 2.0),  0.6777910058,  5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.2, 2.0),  0.0473704719,  5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4(0.3, 2.0), -0.3401055477,  5.0 * eps);
 
                 // psi4_i, scale mu = 1.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.1, 1.0), 0.11623111, eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.2, 1.0), 0.15368080, eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.3, 1.0), 0.13175167, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.1, 1.0), 0.120139861, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.2, 1.0), 0.162056387, eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.3, 1.0), 0.144083365, eps);
 
                 // psi4_i, scale mu = 2.0 GeV
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.1, 2.0), 0.1019395, 5.0 * eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.2, 2.0), 0.1317095, 5.0 * eps);
-                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.3, 2.0), 0.1111354, 5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.1, 2.0), 0.105845125, 5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.2, 2.0), 0.140082543, 5.0 * eps);
+                TEST_CHECK_NEARLY_EQUAL(k.psi4_i(0.3, 2.0), 0.123465300, 5.0 * eps);
             }
         }
 } k_lcdas_test;

--- a/eos/parameters/hadron-properties.yaml
+++ b/eos/parameters/hadron-properties.yaml
@@ -843,12 +843,6 @@ groups:
           latex:    '$(\delta^{K})^2(1\,\mathrm{GeV})$'
           unit:     'GeV^2'
           comments: 'cf. [DKMMO:2008A]'
-      'K::kappa4@1GeV' :
-          central: -0.09
-          min:     -0.11
-          max:     -0.07
-          latex:    '$(\kappa_{4K})(1\,\mathrm{GeV})$'
-          unit:     'GeV^2'
       # K^* LCDA parameters
       'K^*::a_1_para@1GeV' :
           central: +0.06


### PR DESCRIPTION
Currently we have eq. 4.19 of https://arxiv.org/pdf/hep-ph/0603063 implemented, with kappa4(mu0) as a parameter. However, kappa_4(mu0) is fixed by eq. 4.18. Thus having kappa4(mu0) as a parameter can lead to inconsistent input, that would violate eq. 4.18. Therefore, I propose to remove kappa4_0 as a parameter and rather just plug in the expression given in 4.18 into 4.19. This ensures that there are no inconsistencies. However, this now breaks a number of test cases that have to be adjusted.

- [x] remove kappa_4(mu0) and update the expression for the running of kappa4.
- [x] fix k-lcda test cases
- [x] look for all other tests that might break