### PR TITLE
Rewrite example notebook on theory predictions

### DIFF
--- a/doc/user-guide/predictions.yaml
+++ b/doc/user-guide/predictions.yaml
@@ -1,0 +1,1 @@
+../../examples/predictions.yaml

--- a/eos/b-decays/observables.cc
+++ b/eos/b-decays/observables.cc
@@ -55,6 +55,12 @@ namespace eos
                         &BToLeptonNeutrino::branching_ratio,
                         std::make_tuple(),
                         Options{ { "q", "u" } }),
+
+                make_observable("B_c->lnu::BR", R"(\mathcal{B}(B_c^- \to \ell^-\bar\nu))",
+                        Unit::None(),
+                        &BToLeptonNeutrino::branching_ratio,
+                        std::make_tuple(),
+                        Options{ { "q", "c" } }),
             }
         );
 

--- a/examples/predictions.ipynb
+++ b/examples/predictions.ipynb
@@ -11,7 +11,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "EOS can produce theory predictions for any of its built-in observables. The examples following in this section illustrate how to find a specific observable from the list of all built-in observables, construct an [eos.Observable](../reference/python.rst#eos.Observable) object and evaluate it, and estimate the theoretical uncertainties associated with it."
+    "EOS can produce theory predictions for any of its built-in observables. The examples following in this section illustrate\n",
+    "1. how to find a specific observable from the list of all built-in observables;\n",
+    "2. manually construct an [eos.Observable](../reference/python.rst#eos.Observable) object and evaluate it to predict the observables (basic);\n",
+    "3. use an [analysis file](../reference/analysis-file-format.rst) to estimate the theoretical uncertainties associated with one or more observables (advanced)."
    ]
   },
   {
@@ -25,7 +28,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The full list of built-in observables for the most-recent EOS release is available online [here](https://eos.github.io/doc/reference/observables). You can also show this list using the [eos.Observables](../reference/python.rst#eos.Observables) class. Searching for a specific observable is possible by filtering for specific strings in the observable name’s *prefix*, *name*, or *suffix* parts. The following example only shows observables that contain a `'D'` in the prefix part and `'BR'` in the name part:"
+    "The full list of built-in observables for the most-recent EOS release is available online [here](https://eos.github.io/doc/reference/observables). You can also show this list using the [eos.Observables](../reference/python.rst#eos.Observables) class. Searching for a specific observable is possible by filtering for specific strings in the observable name’s *prefix*, *name*, or *suffix* parts. The following example only shows observables that contain a `'B_c'` in the prefix part and `'BR'` in the name part."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You might need to click on the highlighted group heading \"Observables in $B^-\\to\\ell^-\\bar\\nu$ decays\" to expand it."
    ]
   },
   {
@@ -40,7 +50,30 @@
    "outputs": [],
    "source": [
     "import eos\n",
-    "eos.Observables(prefix='D', name='BR')"
+    "eos.Observables(prefix='B_c', name='BR')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next example looks for `'B->Dlnu'` in the prefix part and `'BR'` in the name part."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, you might need to click on the highlighted group heading \"Observables in $B\\to \\bar{D}\\ell^-\\bar\\nu$ decays\" to see the observables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.Observables(prefix='B->Dlnu', name='BR')"
    ]
   },
   {
@@ -54,7 +87,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To make theory predictions of any observable, EOS requires its full name, its [eos.Parameters](../reference/python.rst#eos.Parameters) object, its [eos.Kinematics](../reference/python.rst#eos.Kinematics) object, and its [eos.Options](../reference/python.rst#eos.Options) object. As an example, we will use the integrated branching ratio of $B^-\\to D\\ell^-\\bar\\nu$, which is represented by the name ``B->Dlnu::BR``. The latter is a well formed [eos.QualifiedName](../reference/python.rst#eos.QualifiedName), which is used throughout EOS to address observables and other objects. Additional information about any given observable can be obtained by displaying the full database entry, which also contains information about the kinematic variables required:"
+    "The following is an example on how to interact with EOS at the most basic level. In the process, a few concepts will become clear. For a more elaborate example using Monte Carlo sampling techniques, see the next section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To make theory predictions of any observable, EOS requires its full name, its [eos.Parameters](../reference/python.rst#eos.Parameters) object, its [eos.Kinematics](../reference/python.rst#eos.Kinematics) object, and its [eos.Options](../reference/python.rst#eos.Options) object. As a first example, we will use a very simple observable: the branching ratio of $B_c^-\\to \\ell^-\\bar\\nu$, which is represented by the name ``B_c->lnu::BR``, which was uncovered earlier. The ``B_c->lnu::BR`` is a well formed [eos.QualifiedName](../reference/python.rst#eos.QualifiedName), which is used throughout EOS to address observables and other objects. Additional information about any given observable can be obtained by displaying the full database entry, which also contains information about the kinematic variables required:"
    ]
   },
   {
@@ -69,7 +109,7 @@
    },
    "outputs": [],
    "source": [
-    "eos.Observables()['B->Dlnu::BR']"
+    "eos.Observables()['B_c->lnu::BR']"
    ]
   },
   {
@@ -78,9 +118,8 @@
    "source": [
     "Note that in the above we display a single observable by name using the ``[]`` operator.\n",
     "\n",
-    "From the above output we understand that the observable ``B->Dlnu::BR`` expects two kinematic variables, corresponding here to the lower and upper integration boundaries of the dilepton invariant mass ``q2``.\n",
-    "\n",
-    "We proceed to create an [eos.Observable](../reference/python.rst#eos.Observable) object for ``B->Dlnu::BR`` with the default set of parameters and options,\n",
+    "From the above output we understand that the observable ``B_c->lnu::BR`` expects no kinematic variables (since none is listed).\n",
+    "We proceed to create an [eos.Observable](../reference/python.rst#eos.Observable) object for ``B_c->lnu::BR`` with the default set of parameters and options,\n",
     "and then display it:"
    ]
   },
@@ -96,8 +135,7 @@
    "outputs": [],
    "source": [
     "parameters = eos.Parameters.Defaults()\n",
-    "kinematics = eos.Kinematics(q2_min=0.02, q2_max=11.60)\n",
-    "obs = eos.Observable.make('B->Dlnu::BR', parameters, kinematics, eos.Options())\n",
+    "obs = eos.Observable.make('B_c->lnu::BR', parameters, eos.Kinematics(), eos.Options())\n",
     "display(obs)"
    ]
   },
@@ -106,10 +144,9 @@
    "metadata": {},
    "source": [
     "The default option ``l=mu`` select $\\ell=\\mu$ as the lepton flavour. The value of the observable is shown\n",
-    "to be about $2.4\\%$,\n",
-    "which is compatible with the current world average for the $\\bar{B}^-\\to D^0\\mu^-\\bar\\nu$ branching ratio.\n",
+    "to be about $9.8\\cdot 10^{-5}$; unfortunately, no experiment has been able to see this decay to date.\n",
     "\n",
-    "By setting the ``l`` option to the value ``tau``, we create a different observable representing the $\\bar{B}^-\\to D^0\\tau^-\\bar\\nu$ branching ratio:"
+    "By setting the ``l`` option to the value ``tau``, we create a different observable representing the $B_c^-\\to \\tau^-\\bar\\nu$ branching ratio:"
    ]
   },
   {
@@ -123,8 +160,7 @@
    },
    "outputs": [],
    "source": [
-    "kinematics = eos.Kinematics(q2_min=3.17, q2_max=11.60)\n",
-    "obs = eos.Observable.make('B->Dlnu::BR', parameters, kinematics, eos.Options(l='tau'))\n",
+    "obs = eos.Observable.make('B_c->lnu::BR', parameters, eos.Kinematics(), eos.Options(l='tau'))\n",
     "display(obs)"
    ]
   },
@@ -132,11 +168,50 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The new observable yields a value of $0.71\\%$.\n",
+    "The new observable yields a value of $2.4\\%$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
-    "So far we evaluated the integrated branching ratio. EOS also provides the corresponding differential branching ratio as a function of the squared momentum transfer $q^2$.\n",
-    "The differential branching fraction is accessible through the name ``B->Dlnu::dBR/dq2``.\n",
-    "To illustrate it, we use EOS's plot functions:"
+    "So far we have only evaluated an observable without kinematic dependence.\n",
+    "To change this up, we will now transition to the second example, the differential branching fraction for $\\bar{B}\\to D\\ell^-\\bar\\nu$ accessible through the name ``B->Dlnu::dBR/dq2``.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.Observables()['B->Dlnu::dBR/dq2']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The differential branching fraction is accessible just as we did before, with the exception of providing the kinematic variables through an [eos.Kinematics](../reference/python.rst#eos.Kinematics) object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs = eos.Observable.make('B->Dlnu::dBR/dq2', parameters, eos.Kinematics(q2=4.0), eos.Options(l='tau'))\n",
+    "display(obs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is not very helpful, since we can only look into a single observable at a single kinematic point at a time. To better illustrate the differential branching ratio,\n",
+    "we use EOS's plot functions:"
    ]
   },
   {
@@ -173,7 +248,14 @@
     "        }\n",
     "    ]\n",
     "}\n",
-    "eos.plot.Plotter(plot_args).plot()"
+    "_ = eos.plot.Plotter(plot_args).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above shows two differential branching ratios: one for $\\ell = \\mu$ and one for $\\ell=\\tau$. The two are distinguished by specifying the `'l'` option as part of the observable's qualified name."
    ]
   },
   {
@@ -187,97 +269,285 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To estimate theoretical uncertainties of the observables, EOS uses Bayesian statistics.\n",
-    "The latter interprets the theory parameters as random variables and assigns *a priori*\n",
-    "probability density functions (prior PDFs) for each parameter.\n",
+    "To estimate theoretical uncertainties of an observable $O$, EOS uses Bayesian statistics.\n",
+    "Bayesian Statistics interprets the theory parameters as random variables $\\vec\\vartheta$ and assigns *a priori*\n",
+    "probability density functions (prior PDFs) for each parameter, $P_0(\\vec\\vartheta)$.\n",
+    "Random variates of the observables should then be distributed $O \\sim P_{0,O}$, where\n",
+    "$$\n",
+    "    P_{0,O}(o) = \\int d^N\\vartheta \\delta(O(\\vec\\vartheta) - o) \\, P_0(\\vec\\vartheta)\n",
+    "$$\n",
+    "with $N=\\dim \\vec\\vartheta$. We call $P_{0,O}(o)$ the prior-predictive distribution."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In many cases, the prior PDF $P_0(\\vec\\vartheta)$ is not readily available. Instead, only theoretical likelihoods $P(\\text{data}|\\vec\\vartheta)$ are available.\n",
+    "In those case, we can use Bayes theorem to obtain the *a posteriori* PDF via\n",
+    "$$\n",
+    "    P(\\vec\\vartheta|\\text{data}) = \\frac{P(\\text{data}|\\vec\\vartheta) P_0(\\vec\\vartheta)}{P(\\text{data})}\\,.\n",
+    "$$\n",
+    "The definition of a posterior-predictive distribution then reads\n",
+    "$$\n",
+    "    P_{O}(o) = \\int d^N\\vartheta \\delta(O(\\vec\\vartheta) - o) \\, P(\\vec\\vartheta|\\text{data})\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "EOS provides the means to draw and store Monte Carlo samples for a prior PDF $P_0(\\vec\\vartheta)$, a posterior PDF $P(\\vec\\vartheta|\\text{data})$, and predictive distributions. We store this data within a hierarchy of directories below a \"base directory\". For the purpose of the following examples, we set this base directory to ``./predictions-data``, stored in a convenient global variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EOS_BASE_DIRECTORY='./predictions-data'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We continue with the first example from earlier: the branching ratio of $\\bar{B}_c^- \\to \\ell^-\\bar\\nu$ decays. To leading order in $\\alpha_e$, the decay amplitude is parametrized in terms of a single hadronic matrix element. The latter is known as the $B_c$ decay constant $f_{B_c}$, which is available within EOS as the parameter with qualified name `decay-constant::B_c`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.Parameters()['decay-constant::B_c']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We assume Gaussian prior distributions for the decay constants of the $B_c$ meson with central value $0.434\\,\\text{GeV}$ and standard deviation $0.043\\,\\text{GeV}$.\n",
+    "We specify the prior through the following contents of an analysis file:\n",
+    "```yaml\n",
+    "priors:\n",
+    "  - name: DecayConstant\n",
+    "    descriptions:\n",
+    "      - { parameter: 'decay-constant::B_c',      min:  0.219, max: 0.649, type: 'gaussian', central: 0.434, sigma: 0.043 }\n",
+    "  # ...\n",
     "\n",
-    "We carry on using the integrated branching ratios of $\\bar{B}^-\\to D^0\\left\\lbrace\\mu^-, \\tau^-\\right\\rbrace\\bar\\nu$ decays as examples.\n",
+    "posteriors:\n",
+    "  - name: DecayConstant\n",
+    "    prior:\n",
+    "      - DecayConstant\n",
+    "    likelihood: []\n",
+    "  # ...\n",
+    "\n",
+    "predictions:\n",
+    "  - name: Bc-to-tau-nu\n",
+    "    observables:\n",
+    "      - name: B_c->lnu::BR;l=tau\n",
+    "  # ...\n",
+    "```\n",
+    "The range ``min`` to ``max`` is chosen to contain +/-5 standard deviations of the Gaussian bell curve. The above is a snippet of the accompanying file ``predictions.yaml``."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To draw samples from the (fake) posterior ``DecayConstant``, we use EOS ``tasks`` framework. A task is a repeatedly used piece of code that can rely on the output of previous tasks and store its results for following tasks or further processing with custom Python code.\n",
+    "\n",
+    "The task to draw random samples from a (fake) posterior that contains only prior information and no likelihood is called ``sample_prior``. It is called as follows within Python:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.tasks.sample_prior('./predictions.yaml', 'DecayConstant', base_directory=EOS_BASE_DIRECTORY, N=2000, seed=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a result of running this task, the contents of our base directory now looks as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!tree ./predictions-data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If needed, we can inspect these samples by loading them from disk. This is achieved through the ``eos.data.ImportanceSamples`` class. For example, we can use it to confirm that indeed 2000 samples have been produced:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = eos.data.ImportanceSamples(EOS_BASE_DIRECTORY + '/DecayConstant/samples')\n",
+    "display(output.samples.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now pass the previously-obtained prior samples to the ``predict-observables`` task, thereby producing samples of the prior-predictive PDF for the observable at hand:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eos.tasks.predict_observables('./predictions.yaml', 'DecayConstant', 'Bc-to-tau-nu', base_directory=EOS_BASE_DIRECTORY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The resulting prior-samples are stored in a directory named for the prediction set (``pred-Bc-to-tau-nu``) within the posterior directory (``DecayConstant``):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!tree ./predictions-data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can inspect the so-obtained predictive samples using the ``eos.data.Prediction`` class. The following code loads the samples from disk and compute the (weighted) average and standard deviation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "prediction = eos.data.Prediction(EOS_BASE_DIRECTORY + '/DecayConstant/pred-Bc-to-tau-nu')\n",
+    "avg = np.average(prediction.samples[:, 0], weights=prediction.weights, axis=0)\n",
+    "std = np.sqrt(np.average((prediction.samples[:, 0] - avg)**2, weights=prediction.weights, axis=0))\n",
+    "print(f'BR(B_c->tau nu) = {100 * avg:.2f} +/- {100 * std:.2f} %')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We carry on using the previously shown second example: the integrated branching ratios of $\\bar{B}^-\\to D^0\\left\\lbrace\\mu^-, \\tau^-\\right\\rbrace\\bar\\nu$ decays.\n",
     "The largest source of theoretical uncertainty in these decays arises from the hadronic matrix elements, i.e.,\n",
     "from the form factors $f^{B\\to \\bar{D}}_+(q^2)$ and $f^{B\\to \\bar{D}}_0(q^2)$.\n",
     "Both form factors have been obtained independently using lattice QCD simulations by the HPQCD and Fermilab/MILC (FNAL+MILC) collaborations.\n",
-    "The joint likelihoods for both form factors at different $q^2$ values of each prediction are available in EOS as `Constraint` objects under the names ``B->D::f_++f_0@HPQCD2015A`` and ``B->D::f_++f_0@FNAL+MILC2015B``.\n",
+    "No prior PDF $P_0$ is available; hence, we have to construct a suitable likelihood.\n",
+    "We construct a joint likelihood for both form factors at different $q^2$ values of each prediction are available in EOS as `Constraint` objects under the names ``B->D::f_++f_0@HPQCD2015A`` and ``B->D::f_++f_0@FNAL+MILC2015B``.\n",
     "\n",
     "To use these constraints, we must first decide how to parametrize the form factors.\n",
-    "For what follows we will use a simplified series expansion up to order $N = 2$.\n",
-    "The form factors are written as ([BFW:2010A], [BSZ:2015A]): $$f_i(z) = \\frac{1}{1 - q^2/m_{R_i}^2} \\sum_{k=0}^N \\alpha^{f_i}_k z^k \\, , \\qquad \\text{with } z(q^2, t_0) = \\frac{\\sqrt{t_+ - q^2} - \\sqrt{t_+ - t_0}}{\\sqrt{t_+ - q^2} + \\sqrt{t_+ - t_0}}.$$\n",
-    "\n",
-    "For this example, we will use both the HPQCD and the FNAL+MILC results and create a combined likelihood as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-10-21T13:14:11.561087Z",
-     "start_time": "2021-10-21T13:14:09.742304Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "analysis_args = {\n",
-    "    'priors': [\n",
-    "        { 'parameter': 'B->D::alpha^f+_0@BSZ2015', 'min':  0.0, 'max':  1.0, 'type': 'uniform' },\n",
-    "        { 'parameter': 'B->D::alpha^f+_1@BSZ2015', 'min': -5.0, 'max': +5.0, 'type': 'uniform' },\n",
-    "        { 'parameter': 'B->D::alpha^f+_2@BSZ2015', 'min': -5.0, 'max': +5.0, 'type': 'uniform' },\n",
-    "        { 'parameter': 'B->D::alpha^f0_1@BSZ2015', 'min': -5.0, 'max': +5.0, 'type': 'uniform' },\n",
-    "        { 'parameter': 'B->D::alpha^f0_2@BSZ2015', 'min': -5.0, 'max': +5.0, 'type': 'uniform' }\n",
-    "    ],\n",
-    "    'likelihood': [\n",
-    "        'B->D::f_++f_0@HPQCD:2015A',\n",
-    "        'B->D::f_++f_0@FNAL+MILC:2015B'\n",
-    "    ]\n",
-    "}\n",
-    "analysis = eos.Analysis(**analysis_args)"
+    "For what follows we will use a simplified series expansion (abbreviated SSE) up to order $N = 2$.\n",
+    "The form factors are written as ([BFW:2010A], [BSZ:2015A]): $$f_i(z) = \\frac{1}{1 - q^2/m_{R_i}^2} \\sum_{k=0}^N \\alpha^{f_i}_k z^k \\, , \\qquad \\text{with } z(q^2, t_0) = \\frac{\\sqrt{t_+ - q^2} - \\sqrt{t_+ - t_0}}{\\sqrt{t_+ - q^2} + \\sqrt{t_+ - t_0}}.$$"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we create three observables: the semi-muonic branching ratio, the semi-tauonic branching ratio, and the ratio of the former two.\n",
-    "By using [analysis.parameters](../reference/python.rst#eos.Analysis) in the construction of these observables, we ensure that our observables and the [eos.Analysis](../reference/python.rst#eos.Analysis) object share the same parameter set. This means that changes to the analysis' parameters will affect the evaluation of all three observables."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-10-21T13:14:11.581174Z",
-     "start_time": "2021-10-21T13:14:11.565588Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "obs_mu  = eos.Observable.make(\n",
-    "    'B->Dlnu::BR',\n",
-    "    analysis.parameters,\n",
-    "    eos.Kinematics(q2_min=0.02, q2_max=11.60),\n",
-    "    eos.Options({'l':'mu', 'form-factors':'BSZ2015'})\n",
-    ")\n",
-    "obs_tau = eos.Observable.make(\n",
-    "    'B->Dlnu::BR',\n",
-    "    analysis.parameters,\n",
-    "    eos.Kinematics(q2_min=3.17, q2_max=11.60),\n",
-    "    eos.Options({'l':'tau','form-factors':'BSZ2015'})\n",
-    ")\n",
-    "obs_R_D = eos.Observable.make(\n",
-    "    'B->Dlnu::R_D',\n",
-    "    analysis.parameters,\n",
-    "    eos.Kinematics(q2_mu_min=0.02, q2_mu_max=11.60, q2_tau_min=3.17, q2_tau_max=11.60),\n",
-    "    eos.Options({'form-factors':'BSZ2015'})\n",
-    ")\n",
-    "observables=(obs_mu, obs_tau, obs_R_D)"
+    "We specify the posterior with this combined likelihood through the following contents of an analysis file:\n",
+    "```yaml\n",
+    "priors:\n",
+    "  # other prior components\n",
+    "  - name: FF-SSE\n",
+    "    descriptions:\n",
+    "        { parameter: 'B->D::alpha^f+_0@BSZ2015', min:  0.0, max:  1.0, type: 'uniform' }\n",
+    "        { parameter: 'B->D::alpha^f+_1@BSZ2015', min: -5.0, max: +5.0, type: 'uniform' }\n",
+    "        { parameter: 'B->D::alpha^f+_2@BSZ2015', min: -5.0, max: +5.0, type: 'uniform' }\n",
+    "        { parameter: 'B->D::alpha^f0_1@BSZ2015', min: -5.0, max: +5.0, type: 'uniform' }\n",
+    "        { parameter: 'B->D::alpha^f0_2@BSZ2015', min: -5.0, max: +5.0, type: 'uniform' }\n",
+    "\n",
+    "likelihoods:\n",
+    "  - name: FF-LQCD\n",
+    "    constraints:\n",
+    "      - 'B->D::f_++f_0@HPQCD:2015A'\n",
+    "      - 'B->D::f_++f_0@FNAL+MILC:2015B'\n",
+    "\n",
+    "posteriors:\n",
+    "  # other posteriors\n",
+    "  - name: FF-LQCD-SSE\n",
+    "    global_options:\n",
+    "      form-factors: BSZ2015\n",
+    "    prior:\n",
+    "      - FF-SSE\n",
+    "    likelihood:\n",
+    "      - FF-LQCD\n",
+    "\n",
+    "predictions:\n",
+    "  # other predictions\n",
+    "  - name: B-to-D-mu-nu\n",
+    "    observables:\n",
+    "      - name: B->Dlnu::dBR/dq2;l=mu\n",
+    "        kinematics: [ { q2:  0.02 }, { q2:  0.05 }, { q2:  0.10 }, { q2:  0.15 }, { q2:  0.20 }, { q2:  0.25 },\n",
+    "                      { q2:  0.30 }, { q2:  0.35 }, { q2:  0.40 }, { q2:  0.45 }, { q2:  0.50 }, { q2:  0.55 },\n",
+    "                      { q2:  0.60 }, { q2:  0.65 }, { q2:  0.70 }, { q2:  0.75 }, { q2:  0.80 }, { q2:  0.85 },\n",
+    "                      { q2:  0.90 }, { q2:  0.95 }, { q2:  1.0  }, { q2:  1.5  }, { q2:  2.0  }, { q2:  2.5  },\n",
+    "                      { q2:  3.0  }, { q2:  4.0  }, { q2:  5.0  }, { q2:  6.0 }, { q2:  7.0 }, { q2:  8.0 },\n",
+    "                      { q2:  9.0  }, { q2: 10.0  }, { q2: 11.0  }, { q2: 11.6 } ]\n",
+    "\n",
+    "  - name: B-to-D-tau-nu\n",
+    "    observables:\n",
+    "      - name: B->Dlnu::dBR/dq2;l=tau\n",
+    "        kinematics: [ { q2:  3.2  }, { q2:  4.0 }, { q2:  5.0 }, { q2:  6.0 }, { q2:  7.0 }, { q2:  8.0 },\n",
+    "                      { q2:  9.0  }, { q2: 10.0 }, { q2: 11.0 }, { q2: 11.6 } ]\n",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above, we made sure to provide the option `form-factors=BSZ2015` to ensure that the right form factor plugin is used.\n",
+    "In the above, we made sure to provide the option `form-factors=BSZ2015` to ensure that the right form factor parametrization is used."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, the first step is to sample from the log(posterior). To samples from an intractable posterior PDF, EOS provides the ``sample-nested`` tasks that interfaces with the ``dynesty`` software.\n",
+    "The latter implements black-box posterior sampling by means of the dynamical nested sampling algorithm. The latter requires as controlling input the number of live points (``nlive``) and a threshold for the estimate of the remaining log evidence (``dlogz``). Increasing the former or decreasing the latter will lead to a larger number of importance samples and a longer sampling time.\n",
+    "We refer to the ``dynesty`` documentation for a detailed explanation of both quantities."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "\n",
-    "Sampling from the log(posterior) and -- at the same time -- producing posterior-predictive samples of the three observables is achieved as follows:"
+    "A typical call to ``sample-nested`` reads:"
    ]
   },
   {
@@ -291,153 +561,47 @@
    },
    "outputs": [],
    "source": [
-    "parameter_samples, _, observable_samples = analysis.sample(N=5000, pre_N=1000, observables=observables)"
+    "eos.tasks.sample_nested('predictions.yaml', 'FF-LQCD-SSE', base_directory=EOS_BASE_DIRECTORY, nlive=250, dlogz=0.5, seed=42)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here `N=5000` samples are produced. To illustrate these samples we use EOS' plotting framework:"
+    "The state of our base directory for storing the associated data now looks as follows:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-10-21T13:14:40.664260Z",
-     "start_time": "2021-10-21T13:14:39.801643Z"
-    },
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "plot_args = {\n",
-    "    'plot': {\n",
-    "        'x': { 'label': r'$d\\mathcal{B}/dq^2$',  'range': [0.0,  3e-2] },\n",
-    "        'legend': { 'location': 'upper center' }\n",
-    "    },\n",
-    "    'contents': [\n",
-    "        { 'label': r'$\\ell=\\mu$', 'type': 'histogram', 'bins': 30, 'data': { 'samples': observable_samples[:, 0] }},\n",
-    "        { 'label': r'$\\ell=\\tau$','type': 'histogram', 'bins': 30, 'data': { 'samples': observable_samples[:, 1] }},\n",
-    "    ]\n",
-    "}\n",
-    "eos.plot.Plotter(plot_args).plot()"
+    "!tree -L 2 ./predictions-data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can convince ourselves of the usefullness of the correlated samples by computing the lepton-flavour universality ratio $R_D$ twice: once using EOS' built-in observable ``B->Dlnu::R_D`` as sampled above,\n",
-    "and once by calculating the ratio manually for each sample:"
+    "The posterior samples at hand, we can then produce the posterior-predictive samples as before, using the ``predict-observables`` task for our two prediction sets ``B-to-D-mu-nu`` and ``B-to-D-tau-nu``:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-10-21T13:14:42.010687Z",
-     "start_time": "2021-10-21T13:14:40.667044Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "plot_args = {\n",
-    "    'plot': {\n",
-    "        'x': { 'label': r'$d\\mathcal{B}/dq^2$',  'range': [0.28,  0.32] },\n",
-    "        'legend': { 'location': 'upper left' }\n",
-    "    },\n",
-    "    'contents': [\n",
-    "        { 'label': r'$R_D$ (EOS)',     'type': 'histogram', 'bins': 30, 'color': 'C3', 'data': { 'samples': observable_samples[:, 2] }},\n",
-    "        { 'label': r'$R_D$ (manually)','type': 'histogram', 'bins': 30, 'color': 'C4', 'data': { 'samples': [o[1] / o[0] for o in observable_samples[:]] },\n",
-    "          'histtype': 'step'},\n",
-    "    ]\n",
-    "}\n",
-    "eos.plot.Plotter(plot_args).plot()"
+    "eos.tasks.predict_observables('predictions.yaml', 'FF-LQCD-SSE', 'B-to-D-mu-nu',  base_directory=EOS_BASE_DIRECTORY)\n",
+    "eos.tasks.predict_observables('predictions.yaml', 'FF-LQCD-SSE', 'B-to-D-tau-nu', base_directory=EOS_BASE_DIRECTORY)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the Numpy routines ``numpy.average`` and ``numpy.var`` we can produce numerical estimates\n",
-    "of the mean and the standard deviation:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-10-21T13:14:42.029241Z",
-     "start_time": "2021-10-21T13:14:42.013423Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "print('{obs};{opt}  = {mean:.4f} +/- {std:.4f}'.format(\n",
-    "    obs=obs_mu.name(), opt=obs_mu.options(),\n",
-    "    mean=np.average(observable_samples[:,0]),\n",
-    "    std=np.sqrt(np.var(observable_samples[:, 0]))\n",
-    "))\n",
-    "print('{obs};{opt} = {mean:.4f} +/- {std:.4f}'.format(\n",
-    "    obs=obs_tau.name(), opt=obs_tau.options(),\n",
-    "    mean=np.average(observable_samples[:,1]),\n",
-    "    std=np.sqrt(np.var(observable_samples[:, 1]))\n",
-    "))\n",
-    "print('{obs};{opt}          = {mean:.4f} +/- {std:.4f}'.format(\n",
-    "    obs=obs_R_D.name(), opt=obs_R_D.options(),\n",
-    "    mean=np.average(observable_samples[:,2]),\n",
-    "    std=np.sqrt(np.var(observable_samples[:, 1]))\n",
-    "))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To obtain uncertainty bands for a plot of the differential branching ratios, we can now produce a\n",
-    "sequence of observables at different points in phase space. We then pass these observables on to\n",
-    "[analysis.sample](../reference/python.rst#eos.Analysis.sample), to obtain posterior-predictive samples:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-10-21T13:14:58.025653Z",
-     "start_time": "2021-10-21T13:14:42.032679Z"
-    },
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "mu_q2values  = np.unique(np.concatenate((np.linspace(0.02,  1.00, 20), np.linspace(1.00, 11.60, 20))))\n",
-    "mu_obs       = [eos.Observable.make(\n",
-    "                   'B->Dlnu::dBR/dq2', analysis.parameters, eos.Kinematics(q2=q2),\n",
-    "                   eos.Options({'form-factors': 'BSZ2015', 'l': 'mu'}))\n",
-    "               for q2 in mu_q2values]\n",
-    "tau_q2values = np.linspace(3.17, 11.60, 40)\n",
-    "tau_obs      = [eos.Observable.make(\n",
-    "                   'B->Dlnu::dBR/dq2', analysis.parameters, eos.Kinematics(q2=q2),\n",
-    "                   eos.Options({'form-factors': 'BSZ2015', 'l': 'tau'}))\n",
-    "               for q2 in tau_q2values]\n",
-    "\n",
-    "_, _, mu_samples  = analysis.sample(N=5000, pre_N=1000, observables=mu_obs)\n",
-    "_, _, tau_samples = analysis.sample(N=5000, pre_N=1000, observables=tau_obs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can plot the so-obtained posterior-predictive samples with EOS' plotting framework by running:"
+    "Using the EOS plotting framework, we readily illustrate the posterior-predictive distributions as functions of the momentum transfer $q^2$:"
    ]
   },
   {
@@ -460,15 +624,22 @@
     "    'contents': [\n",
     "        {\n",
     "          'label': r'$\\ell=\\mu$', 'type': 'uncertainty', 'range': [0.02, 11.60],\n",
-    "          'data': { 'samples': mu_samples, 'xvalues': mu_q2values }\n",
+    "          'data-file': f'{EOS_BASE_DIRECTORY}/FF-LQCD-SSE/pred-B-to-D-mu-nu'\n",
     "        },\n",
     "        {\n",
     "          'label': r'$\\ell=\\tau$','type': 'uncertainty', 'range': [3.17, 11.60],\n",
-    "          'data': { 'samples': tau_samples, 'xvalues': tau_q2values }\n",
+    "          'data-file': f'{EOS_BASE_DIRECTORY}/FF-LQCD-SSE/pred-B-to-D-tau-nu'\n",
     "        },\n",
     "    ]\n",
     "}\n",
-    "eos.plot.Plotter(plot_args).plot()"
+    "_ = eos.plot.Plotter(plot_args).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For details on the plotting framework, including a list of the supported plot types, we refer to the reference part of the documentation."
    ]
   }
  ],
@@ -488,7 +659,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.9.18"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/predictions.yaml
+++ b/examples/predictions.yaml
@@ -1,0 +1,53 @@
+priors:
+  - name: DecayConstant
+    descriptions:
+      - { parameter: 'decay-constant::B_c',      min:  0.219, max: 0.649, type: 'gaussian', central: 0.434, sigma: 0.043 }
+
+  - name: FF-SSE
+    descriptions:
+      - { parameter: 'B->D::alpha^f+_0@BSZ2015', min:  0.0, max:  1.0, type: 'uniform' }
+      - { parameter: 'B->D::alpha^f+_1@BSZ2015', min: -5.0, max: +5.0, type: 'uniform' }
+      - { parameter: 'B->D::alpha^f+_2@BSZ2015', min: -5.0, max: +5.0, type: 'uniform' }
+      - { parameter: 'B->D::alpha^f0_1@BSZ2015', min: -5.0, max: +5.0, type: 'uniform' }
+      - { parameter: 'B->D::alpha^f0_2@BSZ2015', min: -5.0, max: +5.0, type: 'uniform' }
+
+likelihoods:
+  - name: FF-LQCD
+    constraints:
+      - 'B->D::f_++f_0@HPQCD:2015A'
+      - 'B->D::f_++f_0@FNAL+MILC:2015B'
+
+posteriors:
+  - name: DecayConstant
+    prior:
+      - DecayConstant
+    likelihood: []
+
+  - name: FF-LQCD-SSE
+    global_options:
+      form-factors: BSZ2015
+    prior:
+      - FF-SSE
+    likelihood:
+      - FF-LQCD
+
+predictions:
+  - name: Bc-to-tau-nu
+    observables:
+      - name: B_c->lnu::BR;l=tau
+
+  - name: B-to-D-mu-nu
+    observables:
+      - name: B->Dlnu::dBR/dq2;l=mu
+        kinematics: [ { q2:  0.02 }, { q2:  0.05 }, { q2:  0.10 }, { q2:  0.15 }, { q2:  0.20 }, { q2:  0.25 },
+                      { q2:  0.30 }, { q2:  0.35 }, { q2:  0.40 }, { q2:  0.45 }, { q2:  0.50 }, { q2:  0.55 },
+                      { q2:  0.60 }, { q2:  0.65 }, { q2:  0.70 }, { q2:  0.75 }, { q2:  0.80 }, { q2:  0.85 },
+                      { q2:  0.90 }, { q2:  0.95 }, { q2:  1.0  }, { q2:  1.5  }, { q2:  2.0  }, { q2:  2.5  },
+                      { q2:  3.0  }, { q2:  4.0  }, { q2:  5.0  }, { q2:  6.0 }, { q2:  7.0 }, { q2:  8.0 },
+                      { q2:  9.0  }, { q2: 10.0  }, { q2: 11.0  }, { q2: 11.6 } ]
+
+  - name: B-to-D-tau-nu
+    observables:
+      - name: B->Dlnu::dBR/dq2;l=tau
+        kinematics: [ { q2:  3.2  }, { q2:  4.0 }, { q2:  5.0 }, { q2:  6.0 }, { q2:  7.0 }, { q2:  8.0 },
+                      { q2:  9.0  }, { q2: 10.0 }, { q2: 11.0 }, { q2: 11.6 } ]

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -384,6 +384,25 @@ class Analysis:
         return -self.log_pdf(u, *args)
 
 
+    def sample_prior(self, N=1000, rng=np.random.mtrand):
+        """
+        Return prior samples of the parameters.
+
+        Obtains random samples of the parameters based on their prior distributions. The code uses inverse transform sampling.
+
+        :param N: Number of samples that shall be returned
+        :type N: int
+        :param rng: Optional random number generator
+
+        :return: An iterable of the parameter samples of size N.
+        """
+        samples = []
+        for _ in range(N):
+            u_samples = rng.uniform(0.0, 1.0, len(self.varied_parameters))
+            samples.append(self._u_to_par(u_samples))
+        return np.array(samples)
+
+
     def sample(self, N=1000, stride=5, pre_N=150, preruns=3, cov_scale=0.1, observables=None, start_point=None, rng=np.random.mtrand,
                return_uspace=False):
         """

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -52,7 +52,7 @@ class AnalysisFile:
         self._priors = { p["name"]: PriorComponent.from_dict(**p) for p in input_data['priors'] }
 
         if 'likelihoods' not in input_data:
-            raise RuntimeError('Cannot load analysis file: need at least one likelihood component')
+            eos.warn('No likelihood components found in analysis file')
 
         self._likelihoods = { ll["name"]: LikelihoodComponent.from_dict(**ll) for ll in input_data['likelihoods'] }
 

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -38,7 +38,7 @@ class CurtailedGaussianDescription(Deserializable):
     sigma:float
     min:float
     max:float
-    type:str=field(repr=False, init=False, default="curtailed gaussian")
+    type:str=field(repr=False, init=False, default="gaussian")
 
 @dataclass
 class GaussianPriorDescription(Deserializable):

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -271,6 +271,32 @@ def sample_mcmc(analysis_file:str, posterior:str, chain:int, base_directory:str=
             eos.error(f' - {p.name()}: {p.evaluate()}')
 
 
+@task('sample-prior', '{posterior}/samples')
+def sample_prior(analysis_file:str, posterior:str, base_directory:str='./', N:int=1000, seed:int=1701):
+    """
+    Samples from a named posterior PDF w/o likelihood information, an effective prior PDF.
+
+    The output file will be stored in EOS_BASE_DIRECTORY/POSTERIOR/samples.
+
+    :param analysis_file: The name of the analysis file that describes the named prior, or an object of class `eos.AnalysisFile`.
+    :type analysis_file: str or `eos.AnalysisFile`
+    :param posterior: The name of the posterior PDF (w/o any likelihood information) from which to draw the samples.
+    :type posterior: str
+    :param base_directory: The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.
+    :type base_directory: str, optional
+    :param N: The number of samples to be stored in the output file. Defaults to 1000.
+    :type N: int, optional
+    :param seed: The seed used to initialize the Mersenne Twister pseudo-random number generator.
+    :type seed: int, optional
+    """
+
+    analysis = analysis_file.analysis(posterior)
+    rng = _np.random.mtrand.RandomState(seed)
+    samples = analysis.sample_prior(N=N, rng=rng)
+    weights =  _np.ones(N) / N
+    eos.data.ImportanceSamples.create(os.path.join(base_directory, posterior, 'samples'), analysis.varied_parameters, samples, weights)
+
+
 @task('find-clusters', '{posterior}/clusters')
 def find_clusters(posterior:str, base_directory:str='./', threshold:float=2.0, K_g:int=1, analysis_file:str=None):
     """


### PR DESCRIPTION
- [x] rewrite the notebook to use additionally a simpler example of an observable without kinematic variables (#712)
- [x] add such a simple observable within the ``cblnu`` sector, which we use as a red thread for all example notebooks
- [x] add a new task ``sample-prior`` to illustrate simple prior sampling using an analysis file (#844, thanks @ery-mcpartland !)
- [x] add a section to the notebook illustrating the use of an analysis file.