### PR TITLE
Miscellaneous changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# All reviews should go to @eos/maintainers by default
+*                   @eos/maintainers
+
+# @dvandyk should review commits to the core code
+eos/maths           @dvandyk
+eos/statistics      @dvandyk
+eos/utils           @dvandyk
+python/_eos/        @dvandyk
+python/_eos.cc      @dvandyk
+
+# @mreboud should review commits to:
+eos/rare-b-decays   @mreboud
+eos/scattering      @mreboud
+
+# @lorenzennio should review commits to pyhf code
+python/eos/*pyhf*   @lorenzennio

--- a/eos/utils/options.hh
+++ b/eos/utils/options.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2015, 2018 Danny van Dyk
+ * Copyright (c) 2010-2024 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -31,8 +31,7 @@
 namespace eos
 {
     /*!
-     * UnknownOptionError is thrown when no option of a given name could be
-     * found.
+     * UnknownOptionError is thrown when an Options object does not contain a value for a given option key.
      */
     struct UnknownOptionError :
         public Exception
@@ -50,7 +49,7 @@ namespace eos
     };
 
     /*!
-     * UnspecifiedOptionError is thrown when a mandatory option is not specified.
+     * UnspecifiedOptionError is thrown by an observable provider or similar when a mandatory option is not specified.
      */
     struct UnspecifiedOptionError :
         public Exception

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -299,11 +299,11 @@ def sample_prior(analysis_file:str, posterior:str, base_directory:str='./', N:in
 
 @task('find-clusters', '{posterior}/clusters')
 def find_clusters(posterior:str, base_directory:str='./', threshold:float=2.0, K_g:int=1, analysis_file:str=None):
-    """
+    r"""
     Finds clusters among posterior MCMC samples, grouped by Gelman-Rubin R value, and creates a Gaussian mixture density.
 
     Finding clusters and creating a Gaussian mixture density is a necessary intermediate step before using the sample-pmc subcommand.
-    The input files are expected in EOS_BASE_DIRECTORY/POSTERIOR/mcmc-*. All MCMC input files present will be used in the clustering.
+    The input files are expected in EOS_BASE_DIRECTORY/POSTERIOR/mcmc-\*. All MCMC input files present will be used in the clustering.
     The output files will be stored in EOS_BASE_DIRECTORY/POSTERIOR/clusters.
 
     :param posterior: The name of the posterior.


### PR DESCRIPTION
Nothing to serious
- [x] Fix the docstring for ``eos.tasks.find_clusters``
- [x] Clarify who throws ``UnknownOptionError`` and ``UnspecifiedOptionError`` (all uses are correct as far as I can see; triggered by a recent PR review that was about to introduce an incorrect use)
- [x] Add a basic ``CODEOWNERS`` file: if we have Github Team support, we should leverage it!