### PR TITLE
Next attempt at fixing the ``weekly-builds`` workflow

### DIFF
--- a/.github/workflows/weekly-builds.yaml
+++ b/.github/workflows/weekly-builds.yaml
@@ -15,19 +15,20 @@ jobs:
               uses: actions/checkout@v4
               with:
                 token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+                fetch-depth: 0 # download all history across all branches
 
             - name: Fetch all branches and push
+              shell: bash
               run: |
-                git remote update origin
                 # determine merge base of origin/master and origin/release
                 BASE=$(git merge-base origin/master origin/release)
-                RELEASE=$(git rev-parse origin/release)
-                MASTER=$(git rev-parse origin/master)
                 echo "BASE = ${BASE}"
+                RELEASE=$(git rev-parse origin/release)
                 echo "RELEASE = ${RELEASE}"
+                MASTER=$(git rev-parse origin/master)
                 echo "MASTER = ${MASTER}"
-                #check if RELEASE and BASE are the same
-                if [ ${RELEASE} = ${BASE} ]; then
+                # check if RELEASE and BASE are the same
+                if [[ ${RELEASE} == ${BASE} ]] ; then
                   echo "origin/release and BASE coincide, should be able to fast-forward"
                   git push origin ${MASTER}:release
                 else


### PR DESCRIPTION
- [x] Use the ``checkout`` action to download the full history across all branches, rather than ``git remote update``.
- [x] Specify the use of ``bash`` as the shell.
- [x] Output the environment variables RELEASE, MASTER, and BASE as soon as they are set.
- [x] Use the bash built-in test utility over the POSIX one (``[[...]]`` rather than ``[...]``).
- [x] Fix potential bug in using ``=`` vs ``==`` operators.