### PR TITLE
[constraints] Add Bq-to-Dq-P constraints to constraint Makefile

### DIFF
--- a/eos/constraints/Makefile.am
+++ b/eos/constraints/Makefile.am
@@ -3,6 +3,7 @@ MAINTAINERCLEANFILES = Makefile.in
 
 CONSTRAINTS_FILES = \
 	Bq-to-dilepton.yaml \
+	Bq-to-Dq-P.yaml \
 	B-to-K-charmonium.yaml \
 	B-to-K-ll.yaml \
 	B-to-Kstar-charmonium.yaml \


### PR DESCRIPTION
- Add Bq-to-Dq-P constraints to constraint Makefile, which in a previous version was forgotten