### PR TITLE
Add a basic ``eos-list-observables`` script

### DIFF
--- a/src/scripts/Makefile.am
+++ b/src/scripts/Makefile.am
@@ -8,6 +8,7 @@ if EOS_ENABLE_PYTHON
 bin_SCRIPTS = \
 	eos-analysis \
 	eos-data \
+	eos-list-observables \
 	eos-list-references \
 	eos-make-constraint \
 	eos-merge-mcmc \
@@ -33,6 +34,7 @@ endif
 EXTRA_DIST = \
 	eos-analysis \
 	eos-data \
+	eos-list-observables \
 	eos-list-references \
 	eos-make-constraint \
 	eos-merge-mcmc \

--- a/src/scripts/eos-list-observables
+++ b/src/scripts/eos-list-observables
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2024 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import argparse
+import eos
+import collections
+import yaml
+import sys
+
+def main():
+    parser = argparse.ArgumentParser(description='List observables implemented in EOS')
+    parser.add_argument('qns', metavar='QUALIFIEDNAME', type=str, nargs='*', help='Qualified name of an observable')
+
+    args = parser.parse_args()
+
+    obs = eos.Observables()
+
+    for qn, entry in obs:
+        if args.qns and qn not in args.qns:
+            continue
+
+        print(f'{qn}')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/scripts/eos-list-references
+++ b/src/scripts/eos-list-references
@@ -44,7 +44,6 @@ def main():
             print('    {}'.format(eprint))
         print()
 
-    exit(0);
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Since I deleted the old ``eos-list-observables`` CLI program, let me at least add a basic script doing the same job.