### PR TITLE
Include <algorithm> where necessary

### DIFF
--- a/eos/b-decays/lifetime.cc
+++ b/eos/b-decays/lifetime.cc
@@ -25,6 +25,7 @@
 #include <eos/utils/private_implementation_pattern-impl.hh>
 
 #include <complex>
+#include <algorithm>
 
 namespace eos
 {

--- a/eos/statistics/log-posterior.cc
+++ b/eos/statistics/log-posterior.cc
@@ -28,6 +28,8 @@
 
 #include <gsl/gsl_cdf.h>
 
+#include <algorithm>
+
 namespace eos
 {
     struct RangeError :

--- a/eos/utils/options.cc
+++ b/eos/utils/options.cc
@@ -24,6 +24,7 @@
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
 #include <map>
+#include <algorithm>
 
 namespace eos
 {

--- a/eos/utils/qcd.cc
+++ b/eos/utils/qcd.cc
@@ -22,6 +22,7 @@
 #include <eos/maths/power-of.hh>
 
 #include <cmath>
+#include <algorithm>
 
 namespace eos
 {


### PR DESCRIPTION
Build from source fails on a Linux system with Python 3.12, Boost 1.83, g++ 14.1.1.
Reason was the use of algorithms from <algorithm> without explicitly including it,