### PR TITLE
[maths] Fix undefined behaviour in FlatMeasure.

### DIFF
--- a/eos/maths/szego-polynomial.hh
+++ b/eos/maths/szego-polynomial.hh
@@ -104,7 +104,7 @@ namespace eos
                 // Fill I and J recursively and compute Verblunsky coefficients
                 for (unsigned n = 1; n < order_; ++n)
                 {
-                    for (unsigned i = 0; i <= order_; ++i)
+                    for (unsigned i = 0; i < order_; ++i)
                     {
                         // cf. [S:2004B], eq. (1.4), p.2, integrated over the arc of the unit circle
                         I[n][i] = I[n - 1][i + 1] - verblunsky[n - 1] * J[n - 1][i    ];


### PR DESCRIPTION
The warning caused in FlatMeasure in szego-polynomial.hh is caused by one faulty comparison.
Comparing with literature, e.g. the paragraph below Eq. B.6 in [https://arxiv.org/abs/2305.06301](2305.06301), shows that i (k in 2305.06301) is smaller than the order, not smaller or equal.