### PR TITLE
Make EOS compile with Boost 1.86

### DIFF
--- a/eos/constraint.cc
+++ b/eos/constraint.cc
@@ -31,6 +31,8 @@
 #include <eos/utils/stringify.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
+#include <boost/filesystem/directory.hpp>
+#include <boost/filesystem/file_status.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 

--- a/eos/reference.cc
+++ b/eos/reference.cc
@@ -21,6 +21,8 @@
 #include <eos/utils/private_implementation_pattern-impl.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
+#include <boost/filesystem/directory.hpp>
+#include <boost/filesystem/file_status.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -36,6 +36,8 @@
 #include <vector>
 
 #include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/directory.hpp>
+#include <boost/filesystem/file_status.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/format.hpp>
 #include <yaml-cpp/yaml.h>


### PR DESCRIPTION
In Boost 1.86, some headers are not included through boost/filesystem/operations.hpp anymore and need to be explicitly included. This pull request adds the respective headers in the three affected files.