### PR TITLE
Filter samples task

### DIFF
--- a/doc/reference/analysis-file-format.rst
+++ b/doc/reference/analysis-file-format.rst
@@ -25,6 +25,8 @@ At the top level, the format includes the following YAML keys:
 
  - ``steps`` (**optional**) --- The list of steps to be executed in the analysis.
 
+ - ``masks`` (**optional**) --- The list of masks for filtering samples defined for the analysis.
+
 The following example illustrates the analysis file format at the hand of a real-world example.
 
 .. toggle-header::
@@ -297,3 +299,39 @@ The following example illustrates the description of two nested sampling steps, 
         - task: 'corner-plot'
           arguments:
             posterior: 'WET-all'
+
+Masks
+~~~~~
+
+In some analyses, the resulting posterior is multi-modal, and it is useful to be able to define within the analysis file a filter, or mask, that selects a subset of the posterior samples.
+The masks section allows to define a mask as a set of (pseudo-)observables, and filtering on any or all (pseudo-)observables being > 0.
+
+The ``masks`` key contains a list of *named* masks. Each mask contains two mandatory keys:
+
+  - ``name`` (**mandatory**) --- The unique name of this mask.
+  - ``description`` (**mandatory**) --- A list of expressions that define the mask.
+  - ``logical_combination`` (**optional**) --- The logical combination to take of the expressions in the mask. The options are ``and`` and ``or``, defaults to ``and``.
+
+
+The ``descriptions`` block contains a list of either existing EOS observable names, ,new observable names and valid expressions, or the name of a previously defined mask.
+An example is shown below:
+
+.. code-block:: yaml
+
+  masks:
+    - name: fplus-arg-large
+      description:
+        - name: '0->pipi::Arg{f_+}(2)'
+          expression: '<<0->pipi::Arg{f_+}(q2)>>[q2=2] - 4.5'
+    - name: abs-b3-large
+      logical_combination: 'or'
+      description:
+        - name: 0->pipi::b3positive
+          expression: '[[0->pipi::b_(+,1)^3@KKRvD2024]] + 0.1'
+        - name: 0->pipi::b3negative
+          expression: '-[[0->pipi::b_(+,1)^4@KKRvD2024]] - 0.1'
+    - name: fplus-arg-large-or-abs-b3-large
+      logical_combination: 'or'
+      description:
+        - mask_name: fplus-arg-large
+        - mask_name: abs-b3-large

--- a/python/eos/data/native.py
+++ b/python/eos/data/native.py
@@ -697,3 +697,52 @@ class NabuLikelihood:
             yaml.dump(description, description_file, default_flow_style=False)
 
         likelihood.save(os.path.join(path, 'likelihood.nabu'))
+
+
+class SampleMask:
+    def __init__(self, path):
+        """ Read a mask from a file.
+
+        :param path: Path to the storage location.
+        :type path: str
+        """
+        if not os.path.exists(path) or not os.path.isdir(path):
+            raise RuntimeError(f'Path {path} does not exist or is not a directory')
+
+        f = os.path.join(path, 'description.yaml')
+        if not os.path.exists(f) or not os.path.isfile(f):
+            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+
+        with open(f) as df:
+            description = yaml.load(df, Loader=yaml.SafeLoader)
+
+        if not description['type'] == 'Mask':
+            raise RuntimeError(f'Path {path} not pointing to a Mode file')
+
+        self.type = 'Mask'
+        self.observables = description['observables']
+
+        f = os.path.join(path, 'mask.npy')
+        if not os.path.exists(f) or not os.path.isfile(f):
+            raise RuntimeError(f'Weights file {f} does not exist or is not a file')
+        self.mask = _np.load(f)
+
+    @staticmethod
+    def create(path, mask, observables):
+        """ Write a new Mask object to disk.
+
+        :param path: Path to the storage location, which will be created as a directory.
+        :type path: str
+        :param mask: Mask as a 1D boolean array
+        :type mask: list or iterable of bool
+        :param observables: Observables as a 1D array
+        """
+        description = {}
+        description['version'] = eos.__version__
+        description['type'] = 'Mask'
+        description['observables'] = observables
+
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
+            yaml.dump(description, description_file, default_flow_style=False)
+        _np.save(os.path.join(path, 'mask.npy'), mask)

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -343,6 +343,10 @@ EOS_BASE_DIRECTORY/posterior/mode-LABEL.
         help = 'The label used for the generated data file.',
         dest = 'label', action = 'store', type = str, default = 'default'
     )
+    parser_find_mode.add_argument('-M', '--mask-name', metavar = 'MASK-NAME',
+        help = 'The name of the mask to apply to the importance samples.',
+        dest = 'mask_name', action = 'store', type = str
+    )
     parser_find_mode.add_argument('-b', '--base-directory',
         help = 'The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.',
         dest = 'base_directory', action = 'store', default = get_from_env('EOS_BASE_DIRECTORY', './')
@@ -436,6 +440,10 @@ The output files will be stored in EOS_BASE_DIRECTORY/POSTERIOR/pred-PREDICTION.
         help = 'The index beyond the last sample to use for the predictions.',
         dest = 'end', action = 'store', type = int, default = None
     )
+    parser_predict_observables.add_argument('-M', '--mask-name', metavar = 'MASK-NAME',
+        help = 'The name of the mask to apply to the samples.',
+        dest = 'mask_name', action = 'store', type = str
+    )
     parser_predict_observables.add_argument('-b', '--base-directory',
         help = 'The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.',
         dest = 'base_directory', action = 'store', default = get_from_env('EOS_BASE_DIRECTORY', './')
@@ -469,6 +477,10 @@ The output files will be stored in EOS_BASE_DIRECTORY/POSTERIOR/plots.
     parser_corner_plot.add_argument('-F', '--format',
         help = 'The plot output format. Can be a comma separated list of formats.',
         dest = 'format', action = 'store', type = lambda s: s.split(','), default = 'pdf'
+    )
+    parser_corner_plot.add_argument('-M', '--mask-name', metavar = 'MASK-NAME',
+        help = 'The name of the mask to apply to the samples.',
+        dest = 'mask_name', action = 'store', type = str
     )
     parser_corner_plot.add_argument('-b', '--base-directory',
         help = 'The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.',
@@ -514,6 +526,29 @@ Lists the dependencies of a step defined within the analysis file.
         help = 'The id of the step for which to list the dependencies.'
     )
     parser_list_step_dependencies.set_defaults(cmd = cmd_list_step_dependencies)
+
+
+    # create-mask
+    parser_create_mask = subparsers.add_parser('create-mask',
+        parents = [common_subparser],
+        description =
+'''
+Create a mask that can be applied to samples from a named posterior based on a set of observables.
+''',
+        help = 'Filters samples from a posterior.'
+    )
+    parser_create_mask.add_argument('posterior', metavar = 'POSTERIOR',
+        help = 'The name of the posterior PDF from which to draw the samples.'
+    )
+    parser_create_mask.add_argument('mask_name', metavar = 'MASK-NAME',
+        help = 'The name of the mask to create.',
+        action = 'store', type = str
+    )
+    parser_create_mask.add_argument('-b', '--base-directory',
+        help = 'The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.',
+        dest = 'base_directory', action = 'store', default = get_from_env('EOS_BASE_DIRECTORY', './')
+    )
+    parser_create_mask.set_defaults(cmd = cmd_create_mask)
 
 
     # report
@@ -773,6 +808,11 @@ def cmd_list_step_dependencies(args):
         print('\n'.join(result))
     elif isinstance(result, str):
         print(result)
+
+
+# Filter samples
+def cmd_create_mask(args):
+    return eos.create_mask(**args_to_dict(args))
 
 
 # Report


### PR DESCRIPTION
A minimum working example here -- for now, can only filter based on a set of observables from a Prediction part of an analysis file, and the resulting mask can be applied to `predict-observables`.
The mask reading and writing should almost certainly be split off into a new class in eos/data/native, I just couldn't be bothered to do it yet.
This draft PR is just to allow some discussion of the details.

In terms of defining the observables, I see three potential options:
1. Give a comma separated list on the command line, e.g. `--filter-obs=0->pipi::Arg{f_+}(q2);I=1;q2=0.5,0->pipi::Arg{f_+}(q2);I=1;q2=1`
2. Re-use the `predictions` section of the analysis file, as done here
3. Add a new `filtering-obs` section, which is essentially a copy of the predictions section
4. 
My preference would be 3., as specifying full observables via the command line as in 1. seems difficult to do in general (unless they can only refer to custom observables from the analysis file, and all the kinematics/options are fixed there -- and this case would basically become 3. anyway).
For case 3., you could also specify the mask label in the analysis file, and so the user would just need to give the name of the filter set and the posterior as an argument.