### PR TITLE
Add initial support to load nabu-based likelihoods

### DIFF
--- a/python/eos/datasets.py
+++ b/python/eos/datasets.py
@@ -223,6 +223,19 @@ class DataSets:
                     lambda x: -log_pdf.evaluate(x),
                     None
                 )
+        elif likelihood.filetype == 'NabuLikelihood':
+            import nabu
+            f = eos.NabuLikelihood(os.path.join(self.storage_directory, id, likelihood.filename))
+            varied_parameters = f.varied_parameters
+            log_pdf = f.likelihood.log_prob
+            chi2 = f.likelihood.chi2
+            return (
+                varied_parameters,
+                lambda x: -log_pdf(x),
+                chi2
+            )
+        else:
+            raise ValueError(f'Unsupported likelihood file type: {likelihood.filetype}')
 
 
     def _repr_html_(self):

--- a/python/eos/datasets_file_description.py
+++ b/python/eos/datasets_file_description.py
@@ -14,7 +14,7 @@ class PublicLikelihoodDescription(Deserializable):
     filetype:str
 
     def __post_init__(self):
-        VALID_FILETYPES = ['MixtureDensity']
+        VALID_FILETYPES = ['MixtureDensity', 'NabuLikelihood']
         if not self.filetype in VALID_FILETYPES:
             raise ValueError(f'Invalid likelihood file type: {self.filetype}')
 


### PR DESCRIPTION
- [x] support saving and loading a nabu likelihood
- [x] support listing a nabu likelihood in the EOS datasets
- [ ] ~produce a nabu likelihood from existing samples as a task~

Requires merging of PR #968 first.