### PR TITLE
Rewrite ``prior::Transform`` to use LU decomposition

### DIFF
--- a/eos/statistics/log-prior.hh
+++ b/eos/statistics/log-prior.hh
@@ -130,7 +130,7 @@ namespace eos
                     gsl_vector * mean, gsl_matrix * covariance);
             static LogPriorPtr Poisson(const Parameters & parameters, const std::string & name, const double & k);
             static LogPriorPtr Transform(const Parameters & parameters, const std::vector<QualifiedName> & names, const std::vector<double> & shift, const std::vector<std::vector<double>> & transform,
-                        const std::vector<double> &  min, const std::vector<double> & max);
+                        const std::vector<double> & min, const std::vector<double> & max);
             ///@}
 
             /*!


### PR DESCRIPTION
- [x] Use LU decomposition rather than Cholesky decomposition (which only works for hermitian positive definite matrices)
- [x] Rather than inverting the transformation matrix, keep the LU decomposition and solve the system. This is fast and numerically more stable.