### PR TITLE
Add support for calling a limited set of builtin unary functions within an expression

### DIFF
--- a/eos/utils/expression-cacher.hh
+++ b/eos/utils/expression-cacher.hh
@@ -35,6 +35,8 @@ namespace eos::exp
 
             Expression visit(const BinaryExpression & e);
 
+            Expression visit(const FunctionExpression & e);
+
             Expression visit(const ConstantExpression & e);
 
             Expression visit(const ObservableNameExpression & e);

--- a/eos/utils/expression-cloner.hh
+++ b/eos/utils/expression-cloner.hh
@@ -39,6 +39,8 @@ namespace eos::exp
 
             Expression visit(const BinaryExpression & e);
 
+            Expression visit(const FunctionExpression & e);
+
             Expression visit(const ConstantExpression & e);
 
             Expression visit(const ObservableNameExpression & e);

--- a/eos/utils/expression-evaluator.hh
+++ b/eos/utils/expression-evaluator.hh
@@ -32,6 +32,8 @@ namespace eos::exp
 
             double visit(BinaryExpression & e);
 
+            double visit(FunctionExpression & e);
+
             double visit(ConstantExpression & e);
 
             double visit(ObservableNameExpression &);

--- a/eos/utils/expression-fwd.hh
+++ b/eos/utils/expression-fwd.hh
@@ -24,6 +24,7 @@
 namespace eos::exp
 {
     class BinaryExpression;
+    class FunctionExpression;
     class ConstantExpression;
     class ObservableNameExpression;
     class ObservableExpression;
@@ -35,6 +36,7 @@ namespace eos::exp
 
     using Expression = OneOf<
         BinaryExpression,
+        FunctionExpression,
         ConstantExpression,
         ObservableNameExpression,
         ObservableExpression,

--- a/eos/utils/expression-kinematic-reader.hh
+++ b/eos/utils/expression-kinematic-reader.hh
@@ -42,6 +42,8 @@ namespace eos::exp
 
             void visit(const BinaryExpression & e);
 
+            void visit(const FunctionExpression & e);
+
             void visit(const ConstantExpression &);
 
             void visit(const ObservableNameExpression & e);

--- a/eos/utils/expression-maker.hh
+++ b/eos/utils/expression-maker.hh
@@ -39,6 +39,8 @@ namespace eos::exp
 
             Expression visit(const BinaryExpression & e);
 
+            Expression visit(const FunctionExpression & e);
+
             Expression visit(const ConstantExpression & e);
 
             Expression visit(const ObservableNameExpression & e);

--- a/eos/utils/expression-parser-impl.hh
+++ b/eos/utils/expression-parser-impl.hh
@@ -85,6 +85,7 @@ namespace eos
             | observable_name                              [ _val = phx::bind(make_observable, _1, KinematicsSpecification()) ]
             | parameter_name                               [ _val = phx::bind(make_parameter, _1)]
             | kinematic_variable_name                      [ _val = phx::bind(make_kinematic_variable, _1) ]
+            | function_expr                                [ _val = _1 ]
             ;
 
         constant = double_ | int_;
@@ -128,6 +129,26 @@ namespace eos
             as_string [ lexeme [ *~char_(",=>]") ] ]
             >> '='
             >> double_
+            )
+            ;
+
+        auto make_function = [] (const std::string & f, const auto & arg)
+        {
+            return eos::exp::FunctionExpression(f, arg);
+        };
+
+        function_expr =
+            (
+            function_name
+            >> '('
+            >> primary_expr
+            >> ')'
+            ) [ _val = phx::bind(make_function, _1, _2)]
+            ;
+
+        function_name =
+            *(
+                string("exp") | string("cos") | string("sin")
             )
             ;
     }

--- a/eos/utils/expression-parser.hh
+++ b/eos/utils/expression-parser.hh
@@ -42,12 +42,14 @@ namespace eos
         qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> additive_expr;
         qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> multiplicative_expr;
         qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> exponential_expr;
+        qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> function_expr;
 
         qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> primary_expr;
         qi::rule<Iterator, eos::exp::ConstantExpression()       , ascii::space_type> constant;
         qi::rule<Iterator, std::string()                        , ascii::space_type> observable_name;
         qi::rule<Iterator, std::string()                        , ascii::space_type> parameter_name;
         qi::rule<Iterator, std::string()                        , ascii::space_type> kinematic_variable_name;
+        qi::rule<Iterator, std::string()                        , ascii::space_type> function_name;
 
         using KinematicsSpecification = eos::exp::KinematicsSpecification;
 

--- a/eos/utils/expression-parser_TEST.cc
+++ b/eos/utils/expression-parser_TEST.cc
@@ -99,6 +99,15 @@ class ExpressionParserTest :
                 ExpressionTest test3("2^(1+3.5)+3");
                 TEST_CHECK(test3.completed);
                 TEST_CHECK_RELATIVE_ERROR(test3.e.accept_returning<double>(evaluator), 25.627416998, 1e-5);
+
+                // Function evaluation for built-in functions
+                ExpressionTest test4("exp(0.0)");
+                TEST_CHECK(test4.completed);
+                TEST_CHECK_RELATIVE_ERROR(test4.e.accept_returning<double>(evaluator), 1.0, 1e-16);
+
+                ExpressionTest test5("sin(0.0)");
+                TEST_CHECK(test5.completed);
+                TEST_CHECK_NEARLY_EQUAL(test5.e.accept_returning<double>(evaluator), 0.0, 1e-16);
             }
 
             // testing parsing of an expression containing kinematic variables

--- a/eos/utils/expression-printer.hh
+++ b/eos/utils/expression-printer.hh
@@ -36,6 +36,8 @@ namespace eos::exp
 
             void visit(BinaryExpression & e);
 
+            void visit(FunctionExpression & e);
+
             void visit(ConstantExpression & e);
 
             void visit(ObservableNameExpression & e);

--- a/eos/utils/expression-used-parameter-reader.hh
+++ b/eos/utils/expression-used-parameter-reader.hh
@@ -35,6 +35,8 @@ namespace eos::exp
 
             void visit(const BinaryExpression & e);
 
+            void visit(const FunctionExpression & e);
+
             void visit(const ConstantExpression &);
 
             void visit(const ObservableNameExpression & e);

--- a/eos/utils/expression-visitors.cc
+++ b/eos/utils/expression-visitors.cc
@@ -56,6 +56,14 @@ namespace eos::exp
         _os << ")";
     }
 
+    void ExpressionPrinter::visit(FunctionExpression & e)
+    {
+        _os << "FunctionExpression(";
+        _os << e.fname << ", ";
+        e.arg.accept(*this);
+        _os << ")";
+    }
+
     void ExpressionPrinter::visit(ConstantExpression & e)
     {
         _os << "ConstantExpression(" << e.value << ")";
@@ -157,6 +165,12 @@ namespace eos::exp
     }
 
     double
+    ExpressionEvaluator::visit(FunctionExpression & e)
+    {
+        return e.f(e.arg.accept_returning<double>(*this));
+    }
+
+    double
     ExpressionEvaluator::visit(ConstantExpression & e)
     {
         return e.value;
@@ -225,6 +239,12 @@ namespace eos::exp
     ExpressionCloner::visit(const BinaryExpression & e)
     {
         return BinaryExpression(e.op, e.lhs.accept_returning<Expression>(*this), e.rhs.accept_returning<Expression>(*this));
+    }
+
+    Expression
+    ExpressionCloner::visit(const FunctionExpression & e)
+    {
+        return FunctionExpression(e.fname, e.arg.accept_returning<Expression>(*this));
     }
 
     Expression
@@ -339,6 +359,12 @@ namespace eos::exp
     ExpressionMaker::visit(const BinaryExpression & e)
     {
         return BinaryExpression(e.op, e.lhs.accept_returning<Expression>(*this), e.rhs.accept_returning<Expression>(*this));
+    }
+
+    Expression
+    ExpressionMaker::visit(const FunctionExpression & e)
+    {
+        return FunctionExpression(e.fname, e.arg.accept_returning<Expression>(*this));
     }
 
     Expression
@@ -496,6 +522,12 @@ namespace eos::exp
     }
 
     void
+    ExpressionKinematicReader::visit(const FunctionExpression & e)
+    {
+        e.arg.accept(*this);
+    }
+
+    void
     ExpressionKinematicReader::visit(const ConstantExpression &)
     {
     }
@@ -644,6 +676,12 @@ namespace eos::exp
     }
 
     Expression
+    ExpressionCacher::visit(const FunctionExpression & e)
+    {
+        return FunctionExpression(e.fname, e.arg.accept_returning<Expression>(*this));
+    }
+
+    Expression
     ExpressionCacher::visit(const ConstantExpression & e)
     {
         return ConstantExpression(e);
@@ -709,6 +747,12 @@ namespace eos::exp
     {
         e.lhs.accept(*this);
         e.rhs.accept(*this);
+    }
+
+    void
+    ExpressionUsedParameterReader::visit(const FunctionExpression & e)
+    {
+        e.arg.accept(*this);
     }
 
     void

--- a/eos/utils/expression.cc
+++ b/eos/utils/expression.cc
@@ -23,6 +23,11 @@
 
 namespace eos::exp
 {
+    ExpressionError::ExpressionError(const std::string & msg) :
+        eos::Exception("Invalid expression statement (" + msg + ")")
+    {
+    }
+
     double BinaryExpression::sum(const double & a, const double & b)        { return a + b; }
     double BinaryExpression::difference(const double & a, const double & b) { return a - b; }
     double BinaryExpression::product(const double & a, const double & b)    { return a * b; }

--- a/eos/utils/expression.cc
+++ b/eos/utils/expression.cc
@@ -48,4 +48,23 @@ namespace eos::exp
                 return nullptr;
         }
     }
+
+    FunctionExpression::FunctionExpression(const std::string & f, const Expression & arg) :
+        f(nullptr),
+        fname(f),
+        arg(arg)
+    {
+        static const std::map<std::string, FunctionType> function_table
+        {
+            { std::string("exp"), FunctionType([] (const double & x) -> double { return std::exp(x); }) },
+            { std::string("sin"), FunctionType([] (const double & x) -> double { return std::sin(x); }) },
+            { std::string("cos"), FunctionType([] (const double & x) -> double { return std::cos(x); }) }
+        };
+
+        auto it = function_table.find(f);
+        if (function_table.end() == it)
+            throw ExpressionError("unknown function name " + f);
+
+        this->f = it->second;
+    }
 }

--- a/eos/utils/expression.hh
+++ b/eos/utils/expression.hh
@@ -32,6 +32,13 @@
 
 namespace eos::exp
 {
+    class ExpressionError :
+        public eos::Exception
+    {
+        public:
+            ExpressionError(const std::string & msg);
+    };
+
     class BinaryExpression
     {
         public:

--- a/eos/utils/expression.hh
+++ b/eos/utils/expression.hh
@@ -63,6 +63,20 @@ namespace eos::exp
             }
     };
 
+    class FunctionExpression
+    {
+        public:
+            using FunctionType = double(*)(const double &);
+
+            FunctionType f;
+            std::string fname;
+            Expression arg;
+
+            FunctionExpression() {};
+
+            FunctionExpression(const std::string & f, const Expression & arg);
+    };
+
     class ConstantExpression
     {
         public:


### PR DESCRIPTION
Currently supported are:
- [x] ``exp(...)``
- [x] ``sin(...)``
- [x] ``cos(...)``