### PR TITLE
Switch to free Github-hosted aarch64 runners

### DIFF
--- a/.github/workflows/pypi-build+check+deploy.yaml
+++ b/.github/workflows/pypi-build+check+deploy.yaml
@@ -18,10 +18,10 @@ jobs:
         strategy:
             matrix:
                 include:
-                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 310, version: cp310, runner: ubuntu-20.04         }
-                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 311, version: cp311, runner: ubuntu-20.04         }
-                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 312, version: cp312, runner: ubuntu-20.04         }
-                  - { arch: aarch64, cxxflags: '-march=armv8.5-a', boost_python_suffix: 310, version: cp310, runner: ubuntu-24.04-aarch64 }
+                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 310, version: cp310, runner: ubuntu-20.04     }
+                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 311, version: cp311, runner: ubuntu-20.04     }
+                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 312, version: cp312, runner: ubuntu-20.04     }
+                  - { arch: aarch64, cxxflags: '-march=armv8.5-a', boost_python_suffix: 310, version: cp310, runner: ubuntu-24.04-arm }
         runs-on: ${{ matrix.runner }}
         name: Build and check EOS wheels on ${{ matrix.arch }} for Python version ${{ matrix.version }}
         steps:


### PR DESCRIPTION
... and save @dvandyk about 20 quid per month :wink:

It seems to be working:
![image](https://github.com/user-attachments/assets/60d2048c-ea8e-41f2-ae65-db64d0920e8d)
