### PR TITLE
Un-hardcoded susceptibilities and resonance masses in BGL parametrization

### DIFF
--- a/eos/form-factors/mesonic.cc
+++ b/eos/form-factors/mesonic.cc
@@ -61,7 +61,7 @@ namespace eos
         { "B->K^*::BFW2010",      &BFW2010FormFactors<BToKstar,   PToV>::make         },
         { "B->D^*::BSZ2015",      &BSZ2015FormFactors<BToDstar,   PToV>::make         },
         { "B->D^*::BGJvD2019",    &HQETFormFactors<BToDstar,      PToV>::make         },
-        { "B->D^*::BGL1997",      &BGL1997FormFactors<BToDstar>::make                 },
+        { "B->D^*::BGL1997",      &BGL1997FormFactors<BToDstar,   PToV>::make         },
         { "B_s->K^*::BSZ2015",    &BSZ2015FormFactors<BsToKstar,  PToV>::make         },
         { "B_s->D_s^*::BSZ2015",  &BSZ2015FormFactors<BsToDsstar, PToV>::make         },
         { "B_s->D_s^*::BGJvD2019",&HQETFormFactors<BsToDsstar,    PToV>::make         },
@@ -345,7 +345,7 @@ namespace eos
         { "B->D::BCL2008",       &BCL2008FormFactors<BToD, 3u>::make                                                                                          },
         { "B->D::BSZ2015",       &BSZ2015FormFactors<BToD,   PToP>::make                                                                                      },
         { "B->D::BGJvD2019",     &HQETFormFactors<BToD,      PToP>::make                                                                                      },
-        { "B->D::BGL1997",       &BGL1997FormFactors<BToD>::make                                                                                              },
+        { "B->D::BGL1997",       &BGL1997FormFactors<BToD,   PToP>::make                                                                                              },
         { "B_s->D_s::BSZ2015",   &BSZ2015FormFactors<BsToDs, PToP>::make                                                                                      },
         { "B_s->D_s::BGJvD2019", &HQETFormFactors<BsToDs,    PToP>::make                                                                                      },
         // c -> d

--- a/eos/form-factors/observables.cc
+++ b/eos/form-factors/observables.cc
@@ -1274,19 +1274,19 @@ namespace eos
 
                 make_observable("B->D^*::a_0[F_1]@BGL", R"(a_0^{F_1})",
                         Unit::None(),
-                        &BGL1997FormFactors<BToDstar>::a_F1_0),
+                        &BGL1997FormFactors<BToDstar, PToV>::a_F1_0),
 
                 make_observable("B->D^*::a_0[F_2]@BGL", R"(a_0^{F_2})",
                         Unit::None(),
-                        &BGL1997FormFactors<BToDstar>::a_F2_0),
+                        &BGL1997FormFactors<BToDstar, PToV>::a_F2_0),
 
                 make_observable("B->D^*::a_0[T_2]@BGL", R"(a_0^{T_2})",
                         Unit::None(),
-                        &BGL1997FormFactors<BToDstar>::a_T2_0),
+                        &BGL1997FormFactors<BToDstar, PToV>::a_T2_0),
 
                 make_observable("B->D^*::a_0[T_23]@BGL", R"(a_0^{T_{23}})",
                         Unit::None(),
-                        &BGL1997FormFactors<BToDstar>::a_T23_0),
+                        &BGL1997FormFactors<BToDstar, PToV>::a_T23_0),
 
                 make_observable("B->D^*::h_A1(q2)", R"(h_{A_1}^{\bar{B}\to D^*}(q^2))",
                         Unit::None(),

--- a/eos/form-factors/parametric-bgl1997-impl.hh
+++ b/eos/form-factors/parametric-bgl1997-impl.hh
@@ -4,6 +4,7 @@
  * Copyright (c) 2020 Danny van Dyk
  * Copyright (c) 2020 Nico Gubernari
  * Copyright (c) 2020 Christoph Bobeth
+ * Copyright (c) 2025 Maximilian Hoverath
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -33,139 +34,112 @@
 
 namespace eos
 {
-    BGL1997FormFactorBase::BGL1997FormFactorBase(const Parameters &, const Options &, ParameterUser &, const double t_p, const double t_m) :
-        _t_p(t_p),
-        _t_m(t_m),
-        _chi_1m( 5.131e-04), // TODO remove hard-coded numerical values
-        _chi_0p( 6.204e-03),
-        _chi_1p( 3.894e-04),
-        _chi_0m(19.421e-03),
-        _chi_T_1m( 8.64e-03 / 4.2 / 4.2), // both at scale 2.31 GeV
-        _chi_T_1p( 4.79e-03 / 4.2 / 4.2)
+    template<typename Process_>
+    std::string BGL1997FormFactors<Process_, PToV>::_par_name(const std::string & ff_name)
+    {
+        return std::string("B->D^*") + std::string("::a^") + ff_name + std::string("@BGL1997");
+    }
+
+    template<typename Process_>
+    BGL1997FormFactors<Process_, PToV>::BGL1997FormFactors(const Parameters & p, const Options & o) :
+        _a_g{{ UsedParameter(p[_par_name("g_0")], *this),
+               UsedParameter(p[_par_name("g_1")], *this),
+               UsedParameter(p[_par_name("g_2")], *this),
+               UsedParameter(p[_par_name("g_3")], *this)
+        }},
+        _a_f{{ UsedParameter(p[_par_name("f_0")], *this),
+               UsedParameter(p[_par_name("f_1")], *this),
+               UsedParameter(p[_par_name("f_2")], *this),
+               UsedParameter(p[_par_name("f_3")], *this)
+        }},
+        _a_F1{{  /* F1_0 parameter determined by identity F1(t_-) = (mB - mV) * f(t_-) */
+                 UsedParameter(p[_par_name("F1_1")], *this),
+                 UsedParameter(p[_par_name("F1_2")], *this),
+                 UsedParameter(p[_par_name("F1_3")], *this)
+        }},
+        _a_F2{{  /* F2_0 parameter determined by identity between F2 and F1 at q2 = 0 */
+                 UsedParameter(p[_par_name("F2_1")], *this),
+                 UsedParameter(p[_par_name("F2_2")], *this),
+                 UsedParameter(p[_par_name("F2_3")], *this)
+        }},
+        _a_T1{{  UsedParameter(p[_par_name("T1_0")], *this),
+                 UsedParameter(p[_par_name("T1_1")], *this),
+                 UsedParameter(p[_par_name("T1_2")], *this),
+                 UsedParameter(p[_par_name("T1_3")], *this)
+        }},
+        _a_T2{{ /* T2_0 parameter determined by identity T1(0) = T2(0) */
+                 UsedParameter(p[_par_name("T2_1")], *this),
+                 UsedParameter(p[_par_name("T2_2")], *this),
+                 UsedParameter(p[_par_name("T2_3")], *this)
+        }},
+        _a_T23{{ /* T23_0 parameter determined by identity between T2 and T23 at q2 = t_- */
+                 UsedParameter(p[_par_name("T23_1")], *this),
+                 UsedParameter(p[_par_name("T23_2")], *this),
+                 UsedParameter(p[_par_name("T23_3")], *this)
+        }},
+        _traits(BGL1997FormFactorTraits<Process_, PToV>(p, o, _options)),
+        _mB(_traits.m_B),
+        _mV(_traits.m_V),
+        t_0(_traits.t_0)
     {
     }
 
-    BGL1997FormFactorBase::~BGL1997FormFactorBase() = default;
+    template<typename Process_>
+    BGL1997FormFactors<Process_, PToV>::~BGL1997FormFactors() = default;
 
-    double
-    BGL1997FormFactorBase::_z(const double & t, const double & t_0) const
+    template<typename Process_>
+    FormFactors<PToV> *
+    BGL1997FormFactors<Process_, PToV>::make(const Parameters & parameters, const Options & options)
     {
-        return (std::sqrt(_t_p - t) - std::sqrt(_t_p - t_0)) / (std::sqrt(_t_p - t) + std::sqrt(_t_p - t_0));
+        return new BGL1997FormFactors(parameters, options);
     }
 
-    double
-    BGL1997FormFactorBase::_phi(const double & s, const double & t_0, const double & K, const unsigned & a, const unsigned & b, const unsigned & c, const double & chi) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::_phi(const double & s, const double & s_0, const double & K, const unsigned & a, const unsigned & b,                                                 const unsigned & c, const double & chi) const
     {
-        const double sq_tp    = std::sqrt(_t_p);
-        const double sq_tp_t  = std::sqrt(_t_p - s);
-        const double sq_tp_t0 = std::sqrt(_t_p - t_0);
-        const double sq_tp_tm = std::sqrt(_t_p - _t_m);
+        const double sq_tp    = std::sqrt(_traits.tp());
+        const double sq_tp_t  = std::sqrt(_traits.tp() - s);
+        const double sq_tp_t0 = std::sqrt(_traits.tp() - s_0);
+        const double sq_tp_tm = std::sqrt(_traits.tp() - _traits.tm());
 
         // [BGL:1997A] eq. (4.14) for OPE at Q^2 = -q^2 = 0
         // => generalization for q^2 != 0 possible, see eq.(4.15)
         return std::sqrt(1.0 / (K * M_PI * chi)) * (sq_tp_t + sq_tp_t0)
                * std::pow(sq_tp_t / sq_tp_t0, 1.0 / 2.0)
-               * std::pow(_t_p - s, a / 4.0)
+               * std::pow(_traits.tp() - s, a / 4.0)
                * std::pow(sq_tp_t + sq_tp_tm, b / 2.0)
                * 1.0 / std::pow(sq_tp_t + sq_tp, c + 3.0);
     }
 
-
-    // TODO hard-coded values of resonances from [BGS2017] table III with some changes (from Nico Gubernari)
-    //  0^+ at 6.704, 7.122
-    //  0^- at 6.275, 6.871, 7.250
-    //  1^+ at 6.739, 6.750, 7.145, 7.150
-    //  1^- at 6.329, 6.910, 7.020
-
-    // TODO look on constraints on FF parametrization coming from kinematic constraints at q^2 = 0
-    // 2 mV A_0 = (mB + mV) A_1 - (mB - mV) A_2
-    // T_2 = T_3
-    // f_+ = f_0
-    std::string
-    BGL1997FormFactors<BToDstar>::_par_name(const std::string & ff_name)
+    // Functions
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::g(const double & s) const
     {
-        return std::string("B->D^*") + std::string("::a^") + ff_name + std::string("@BGL1997");
-    }
-
-    BGL1997FormFactors<BToDstar>::BGL1997FormFactors(const Parameters & p, const Options & o) :
-        BGL1997FormFactorBase(p, o, *this, power_of<2>(BToDstar::m_B + BToDstar::m_V), power_of<2>(BToDstar::m_B - BToDstar::m_V)),
-        _a_g{{   UsedParameter(p[_par_name("g_0")],  *this),
-                 UsedParameter(p[_par_name("g_1")],  *this),
-                 UsedParameter(p[_par_name("g_2")],  *this),
-                 UsedParameter(p[_par_name("g_3")],  *this) }},
-        _a_f{{   UsedParameter(p[_par_name("f_0")],  *this),
-                 UsedParameter(p[_par_name("f_1")],  *this),
-                 UsedParameter(p[_par_name("f_2")],  *this),
-                 UsedParameter(p[_par_name("f_3")],  *this) }},
-        _a_F1{{  /* F1_0 parameter determined by identity F1(t_-) = (mB - mV) * f(t_-) */
-                 UsedParameter(p[_par_name("F1_1")], *this),
-                 UsedParameter(p[_par_name("F1_2")], *this),
-                 UsedParameter(p[_par_name("F1_3")], *this) }},
-        _a_F2{{  /* F2_0 parameter determined by identity between F2 and F1 at q2 = 0 */
-                 UsedParameter(p[_par_name("F2_1")], *this),
-                 UsedParameter(p[_par_name("F2_2")], *this),
-                 UsedParameter(p[_par_name("F2_3")], *this) }},
-        _a_T1{{  UsedParameter(p[_par_name("T1_0")], *this),
-                 UsedParameter(p[_par_name("T1_1")], *this),
-                 UsedParameter(p[_par_name("T1_2")], *this),
-                 UsedParameter(p[_par_name("T1_3")], *this) }},
-        _a_T2{{ /* T2_0 parameter determined by identity T1(0) = T2(0) */
-                 UsedParameter(p[_par_name("T2_1")], *this),
-                 UsedParameter(p[_par_name("T2_2")], *this),
-                 UsedParameter(p[_par_name("T2_3")], *this) }},
-        _a_T23{{ /* T23_0 parameter determined by identity between T2 and T23 at q2 = t_- */
-                 UsedParameter(p[_par_name("T23_1")], *this),
-                 UsedParameter(p[_par_name("T23_2")], *this),
-                 UsedParameter(p[_par_name("T23_3")], *this) }},
-        _mB(BToDstar::m_B),
-        _mB2(power_of<2>(_mB)),
-        _mV(BToDstar::m_V),
-        _mV2(power_of<2>(_mV)),
-        // default t_0 = sqrt(t_p) (sqrt(m_B) - sqrt(m_M))^2 (optimal value)
-        _t_0(p["B->D^*::t_0@BGL1997"], *this)
-    {
-    }
-
-    BGL1997FormFactors<BToDstar>::~BGL1997FormFactors() = default;
-
-    FormFactors<PToV> *
-    BGL1997FormFactors<BToDstar>::make(const Parameters & parameters, const Options & options)
-    {
-        return new BGL1997FormFactors(parameters, options);
-    }
-
-    double
-    BGL1997FormFactors<BToDstar>::g(const double & s) const
-    {
-        // resonances for 1^-
-        const double blaschke = _z(s, 6.329 * 6.329) * _z(s, 6.910 * 6.910) * _z(s, 7.020 * 7.020);
-        const double phi      = _phi(s, _t_0, 96, 3, 3, 1, _chi_1m);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 96, 3, 3, 1, _traits.chi_1m);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = _a_g[0] + _a_g[1] * z + _a_g[2] * z * z + _a_g[3] * z * z * z;
+        const double blaschke = _traits.blaschke_1m(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::f(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::f(const double & s) const
     {
-        // resonances for 1^+
-        const double blaschke = _z(s, 6.739 * 6.739) * _z(s, 6.750 * 6.750) * _z(s, 7.145 * 7.145) * _z(s, 7.150 * 7.150);
-        const double phi      = _phi(s, _t_0, 24, 1, 1, 1, _chi_1p);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 24, 1, 1, 1, _traits.chi_1p);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = _a_f[0] + _a_f[1] * z + _a_f[2] * z * z + _a_f[3] * z * z * z;
+        const double blaschke = _traits.blaschke_1p(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::a_F1_0() const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::a_F1_0() const
     {
-        const double x_f  = _z(_t_m, 6.739 * 6.739) * _z(_t_m, 6.750 * 6.750) * _z(_t_m, 7.145 * 7.145) * _z(_t_m, 7.150 * 7.150) * _phi(_t_m, _t_0, 24.0, 1, 1, 1, _chi_1p);
-        const double x_F1 = _z(_t_m, 6.739 * 6.739) * _z(_t_m, 6.750 * 6.750) * _z(_t_m, 7.145 * 7.145) * _z(_t_m, 7.150 * 7.150) * _phi(_t_m, _t_0, 48.0, 1, 1, 2, _chi_1p)
-                          * (_mB - _mV);
-
-        const double z = _z(_t_m, _t_0);
+        const double z    = _traits._z(_traits.tm(), _traits.t_0, _traits.tp());
+        const double x_f  = _traits.blaschke_1p(_traits.tm()) * _phi(_traits.tm(), _traits.t_0, 24.0, 1, 1, 1, _traits.chi_1p);
+        const double x_F1 = _traits.blaschke_1p(_traits.tm()) * _phi(_traits.tm(), _traits.t_0, 48.0, 1, 1, 2, _traits.chi_1p) * (_mB - _mV);
         std::array<double, 4> an, zn;
         zn[0] = 1.0;
         an[0]  = x_F1 * this->_a_f[0] * zn[0];
@@ -177,27 +151,26 @@ namespace eos
         return std::inner_product(an.begin(), an.end(), zn.begin(), 0.0) / (zn[0] * x_f);
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::F1(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::F1(const double & s) const
     {
-        // resonances for 1^+
-        const double blaschke = _z(s, 6.739 * 6.739) * _z(s, 6.750 * 6.750) * _z(s, 7.145 * 7.145) * _z(s, 7.150 * 7.150);
-        const double phi      = _phi(s, _t_0, 48, 1, 1, 2, _chi_1p);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 48, 1, 1, 2, _traits.chi_1p);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = a_F1_0() + _a_F1[0] * z + _a_F1[1] * z * z + _a_F1[2] * z * z * z;
+        const double blaschke = _traits.blaschke_1p(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::a_F2_0() const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::a_F2_0() const
     {
         const double r    = _mV / _mB;
-        const double wmax = (_mB2 + _mV2) / (2.0 * _mB * _mV);
-        const double x_F1 = _z(0.0, 6.739 * 6.739) * _z(0.0, 6.750 * 6.750) * _z(0.0, 7.145 * 7.145) * _z(0.0, 7.150 * 7.150) * _phi(0.0, _t_0, 48.0, 1, 1, 2, _chi_1p);
-        const double x_F2 = _z(0.0, 6.275 * 6.275) * _z(0.0, 6.871 * 6.871) * _z(0.0, 7.250 * 7.250) *                          _phi(0.0, _t_0, 64.0, 3, 3, 1, _chi_0m)
-                          * (1.0 + r) / ((1.0 - r) * (1.0 + wmax) * r * _mB2);
-        const double z = _z(0.0, _t_0);
+        const double wmax = (power_of<2>(_mB) + power_of<2>(_mV)) / (2.0 * _mB * _mV);
+
+        const double z = _traits._z(0.0, _traits.t_0, _traits.tp());
+        const double x_F1 = _traits.blaschke_1p(0.0) * _phi(0.0, _traits.t_0, 48.0, 1, 1, 2, _traits.chi_1p);
+        const double x_F2 = _traits.blaschke_0m(0.0) * _phi(0.0, _traits.t_0, 64.0, 3, 3, 1, _traits.chi_0m) * (1.0 + r) / ((1.0 - r) * (1.0 + wmax) * r * power_of<2>(_mB));
         std::array<double, 4> an, zn;
         zn[0] = 1.0;
         an[0]  = x_F2 * this->a_F1_0() * zn[0]; // a_F1[0] is the linear coefficient; we need the constant part
@@ -209,67 +182,64 @@ namespace eos
         return std::inner_product(an.begin(), an.end(), zn.begin(), 0.0) / (zn[0] * x_F1);
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::F2(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::F2(const double & s) const
     {
-        // resonances for 0^-
-        const double blaschke = _z(s, 6.275 * 6.275) * _z(s, 6.871 * 6.871) * _z(s, 7.250 * 7.250);
-        const double phi      = _phi(s, _t_0, 64, 3, 3, 1, _chi_0m);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 64, 3, 3, 1, _traits.chi_0m);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = a_F2_0() + _a_F2[0] * z + _a_F2[1] * z * z + _a_F2[2] * z * z * z;
+        const double blaschke = _traits.blaschke_0m(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::v(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::v(const double & s) const
     {
         return (_mB + _mV) / 2.0 * g(s);
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::a_0(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::a_0(const double & s) const
     {
         return F2(s) / 2.0;
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::a_1(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::a_1(const double & s) const
     {
         return 1.0/(_mB + _mV) * f(s);
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::a_2(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::a_2(const double & s) const
     {
-        return (_mB + _mV) / eos::lambda(_mB2, _mV2, s) * ((_mB2 - _mV2 - s) * f(s) - 2.0 * _mV * F1(s));
+        return (_mB + _mV) / eos::lambda(power_of<2>(_mB), power_of<2>(_mV), s) * ((power_of<2>(_mB) - power_of<2>(_mV) - s) * f(s) - 2.0 * _mV * F1(s));
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::a_12(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::a_12(const double & s) const
     {
         return F1(s) / (8.0 * _mB * _mV);
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::t_1(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::t_1(const double & s) const
     {
-        // resonances for 1^-, which have overlap with the tensor current
-        const double blaschke = _z(s, 6.329 * 6.329) * _z(s, 6.910 * 6.910) * _z(s, 7.020 * 7.020);
-        const double phi      = _phi(s, _t_0, 24.0, 3, 3, 2, _chi_T_1m);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 24.0, 3, 3, 2, _traits.chi_T_1m);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = _a_T1[0] + _a_T1[1] * z + _a_T1[2] * z * z + _a_T1[3] * z * z * z;
+        const double blaschke = _traits.blaschke_1m(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::a_T2_0() const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::a_T2_0() const
     {
-        const double x_T2 = _z(0.0, 6.739 * 6.739) * _z(0.0, 6.750 * 6.750) * _z(0.0, 7.145 * 7.145) * _z(0.0, 7.150 * 7.150) * _phi(0.0, _t_0, 24.0 / (_t_p * _t_m), 1, 1, 2, _chi_T_1p);
-        const double x_T1 = _z(0.0, 6.329 * 6.329) * _z(0.0, 6.910 * 6.910) * _z(0.0, 7.020 * 7.020)                          * _phi(0.0, _t_0, 24.0,                 3, 3, 2, _chi_T_1m);
-
-        const double z = _z(0.0, _t_0);
+        const double z = _traits._z(0.0, _traits.t_0, _traits.tp());
+        const double x_T2 = _traits.blaschke_1p(0.0) * _phi(0.0, _traits.t_0, 24.0 / (_traits.tp() * _traits.tm()), 1, 1, 2, _traits.chi_T_1p);
+        const double x_T1 = _traits.blaschke_1m(0.0) * _phi(0.0, _traits.t_0, 24.0, 3, 3, 2, _traits.chi_T_1m);
         std::array<double, 4> an, zn;
         zn[0] = 1.0;
         an[0]  = x_T2 * this->_a_T1[0] * zn[0];
@@ -281,34 +251,32 @@ namespace eos
         return std::inner_product(an.begin(), an.end(), zn.begin(), 0.0) / (zn[0] * x_T1);
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::t_2(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::t_2(const double & s) const
     {
-        // resonances for 1^+, which have overlap with the tensor current
-        const double blaschke = _z(s, 6.739 * 6.739) * _z(s, 6.750 * 6.750) * _z(s, 7.145 * 7.145) * _z(s, 7.150 * 7.150);
-        const double phi      = _phi(s, _t_0, 24.0 / (_t_p * _t_m), 1, 1, 2, _chi_T_1p);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 24.0 / (_traits.tp() * _traits.tm()), 1, 1, 2, _traits.chi_T_1p);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = a_T2_0() + _a_T2[0] * z + _a_T2[1] * z * z + _a_T2[2] * z * z * z;
+        const double blaschke = _traits.blaschke_1p(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::t_3(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::t_3(const double & s) const
     {
         return (
-                (_mB2 - _mV2) * (_mB2 + 3.0 * _mV2 - s) * this->t_2(s)
-                - 8.0 * _mB * _mV2 * (_mB - _mV) * this->t_23(s)
-        ) / eos::lambda(_mB2, _mV2, s);
+                (power_of<2>(_mB) - power_of<2>(_mV)) * (power_of<2>(_mB) + 3.0 * power_of<2>(_mV) - s) * this->t_2(s)
+                - 8.0 * _mB * power_of<2>(_mV) * (_mB - _mV) * this->t_23(s)
+        ) / eos::lambda(power_of<2>(_mB), power_of<2>(_mV), s);
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::a_T23_0() const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::a_T23_0() const
     {
-        const double x_T2  = _z(_t_m, 6.739 * 6.739) * _z(_t_m, 6.750 * 6.750) * _z(_t_m, 7.145 * 7.145) * _z(_t_m, 7.150 * 7.150) * _phi(_t_m, _t_0, 24.0 / (_t_p * _t_m),       1, 1, 2, _chi_T_1p);
-        const double x_T23 = _z(_t_m, 6.739 * 6.739) * _z(_t_m, 6.750 * 6.750) * _z(_t_m, 7.145 * 7.145) * _z(_t_m, 7.150 * 7.150) * _phi(_t_m, _t_0, 3.0 * _t_p / (_mB2 * _mV2), 1, 1, 1, _chi_T_1p)
-                           / (8.0 * _mB * _mV2) * ((_mB + _mV) * (_mB2 + 3.0 * _mV2 - _t_m));
-        const double z = _z(_t_m, _t_0);
+        const double z = _traits._z(_traits.tm(), _traits.t_0, _traits.tp());
+        const double x_T2 = _traits.blaschke_1p(_traits.tm()) * _phi(_traits.tm(), _traits.t_0, 24.0 / (_traits.tp() * _traits.tm()), 1, 1, 2, _traits.chi_T_1p);
+        const double x_T23 = _traits.blaschke_1p(_traits.tm()) * _phi(_traits.tm(), _traits.t_0, 3.0 * _traits.tp() / (power_of<2>(_mB) * power_of<2>(_mV)), 1, 1, 1, _traits.chi_T_1p) / (8.0 * _mB * power_of<2>(_mV)) * ((_mB + _mV) * (power_of<2>(_mB) + 3.0 * power_of<2>(_mV) - _traits.tm()));
         std::array<double, 4> an, zn;
         zn[0] = 1.0;
         an[0]  = x_T23 * this->a_T2_0() * zn[0]; // a_T2[0] is the linear coefficient; we need the constant part
@@ -320,152 +288,201 @@ namespace eos
         return std::inner_product(an.begin(), an.end(), zn.begin(), 0.0) / (zn[0] * x_T2);
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::t_23(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::t_23(const double & s) const
     {
-        // resonances for 1^+, which have overlap with the tensor current
-        const double blaschke = _z(s, 6.739 * 6.739) * _z(s, 6.750 * 6.750) * _z(s, 7.145 * 7.145) * _z(s, 7.150 * 7.150);
-        const double phi      = _phi(s, _t_0, 3.0 * _t_p / (_mB2 * _mV2), 1.0, 1.0, 1.0, _chi_T_1p);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 3.0 * _traits.tp() / (power_of<2>(_mB) * power_of<2>(_mV)), 1.0, 1.0, 1.0, _traits.chi_T_1p);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = a_T23_0() + _a_T23[0] * z + _a_T23[1] * z * z + _a_T23[2] * z * z * z;
+        const double blaschke = _traits.blaschke_1p(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::f_perp(const double & /*s*/) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::f_perp(const double & /*s*/) const
     {
         return 0.0;  //  TODO
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::f_para(const double & /*s*/) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::f_para(const double & /*s*/) const
     {
         return 0.0;  //  TODO
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::f_long(const double & /*s*/) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::f_long(const double & /*s*/) const
     {
         return 0.0;  //  TODO
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::f_perp_T(const double & /*s*/) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::f_perp_T(const double & /*s*/) const
     {
         return 0.0;  //  TODO
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::f_para_T(const double & /*s*/) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::f_para_T(const double & /*s*/) const
     {
         return 0.0;  //  TODO
     }
 
-    double
-    BGL1997FormFactors<BToDstar>::f_long_T(const double & /*s*/) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToV>::f_long_T(const double & /*s*/) const
     {
         return 0.0;  //  TODO
     }
+
+    template<typename Process_>
+    const std::set<ReferenceName> BGL1997FormFactors<Process_, PToV>::references
+    {
+        "BGL:1997A"_rn
+    };
+
+    template<typename Process_>
+    const std::vector<OptionSpecification> BGL1997FormFactors<Process_, PToV>::_options
+    {
+        { "n-bound-states-1m", { "1", "2", "3", "4" }, "3" },
+        { "n-bound-states-1p", { "1", "2", "3", "4" }, "4" },
+        { "n-bound-states-0m", { "1", "2", "3"      }, "3" },
+        { "n-bound-states-0p", { "1", "2"           }, "2" }
+    };
+
+    template<typename Process_>
     std::vector<OptionSpecification>::const_iterator
-    BGL1997FormFactors<BToDstar>::begin_options()
+    BGL1997FormFactors<Process_, PToV>::begin_options()
     {
         return _options.cbegin();
     }
 
+    template<typename Process_>
     std::vector<OptionSpecification>::const_iterator
-    BGL1997FormFactors<BToDstar>::end_options()
+    BGL1997FormFactors<Process_, PToV>::end_options()
     {
         return _options.cend();
     }
 
-    std::string
-    BGL1997FormFactors<BToD>::_par_name(const std::string & ff_name)
+
+    template<typename Process_>
+    std::string BGL1997FormFactors<Process_, PToP>::_par_name(const std::string & ff_name)
     {
         return std::string("B->D") + std::string("::a^") + ff_name + std::string("@BGL1997");
     }
 
-    BGL1997FormFactors<BToD>::BGL1997FormFactors(const Parameters & p, const Options & o) :
-        BGL1997FormFactorBase(p, o, *this, power_of<2>(BToD::m_B + BToD::m_P), power_of<2>(BToD::m_B - BToD::m_P)),
+    template<typename Process_>
+    BGL1997FormFactors<Process_, PToP>::BGL1997FormFactors(const Parameters & p, const Options & o) :
         _a_f_p{{ UsedParameter(p[_par_name("f+_0")], *this),
                  UsedParameter(p[_par_name("f+_1")], *this),
                  UsedParameter(p[_par_name("f+_2")], *this),
-                 UsedParameter(p[_par_name("f+_3")], *this) }},
+                 UsedParameter(p[_par_name("f+_3")], *this)
+        }},
         _a_f_0{{ UsedParameter(p[_par_name("f0_0")], *this),
                  UsedParameter(p[_par_name("f0_1")], *this),
                  UsedParameter(p[_par_name("f0_2")], *this),
-                 UsedParameter(p[_par_name("f0_3")], *this) }},
+                 UsedParameter(p[_par_name("f0_3")], *this)
+        }},
         _a_f_t{{ UsedParameter(p[_par_name("fT_0")], *this),
                  UsedParameter(p[_par_name("fT_1")], *this),
                  UsedParameter(p[_par_name("fT_2")], *this),
                  UsedParameter(p[_par_name("fT_3")], *this) }},
-        _mB(BToD::m_B),
-        _mB2(power_of<2>(_mB)),
-        _mP(BToD::m_P),
-        _mP2(power_of<2>(_mP)),
-        // here optimal t_0 = sqrt(t_p) (sqrt(m_B) - sqrt(m_M))^2
-        _t_0(p["B->D::t_0@BGL1997"], *this)
+        _traits(BGL1997FormFactorTraits<Process_, PToP>(p, o, _options)),
+        _mB(_traits.m_B),
+        _mP(_traits.m_P),
+        t_0(_traits.t_0)
     {
     }
 
-    BGL1997FormFactors<BToD>::~BGL1997FormFactors() = default;
+    template<typename Process_>
+    BGL1997FormFactors<Process_, PToP>::~BGL1997FormFactors() = default;
 
+    template<typename Process_>
     FormFactors<PToP> *
-    BGL1997FormFactors<BToD>::make(const Parameters & parameters, const Options & options)
+    BGL1997FormFactors<Process_, PToP>::make(const Parameters & parameters, const Options & options)
     {
         return new BGL1997FormFactors(parameters, options);
     }
 
-    double
-    BGL1997FormFactors<BToD>::f_p(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToP>::_phi(const double & s, const double & s_0, const double & K, const unsigned & a, const unsigned & b,                                                 const unsigned & c, const double & chi) const
     {
-        // resonances for 1^-
-        const double blaschke = _z(s, 6.329 * 6.329) * _z(s, 6.910 * 6.910) * _z(s, 7.020 * 7.020);
-        const double phi      = _phi(s, _t_0, 48, 3, 3, 2, _chi_1m);
-        const double z        = _z(s, _t_0);
+        const double sq_tp    = std::sqrt(_traits.tp());
+        const double sq_tp_t  = std::sqrt(_traits.tp() - s);
+        const double sq_tp_t0 = std::sqrt(_traits.tp() - s_0);
+        const double sq_tp_tm = std::sqrt(_traits.tp() - _traits.tm());
+
+        // [BGL:1997A] eq. (4.14) for OPE at Q^2 = -q^2 = 0
+        // => generalization for q^2 != 0 possible, see eq.(4.15)
+        return std::sqrt(1.0 / (K * M_PI * chi)) * (sq_tp_t + sq_tp_t0)
+               * std::pow(sq_tp_t / sq_tp_t0, 1.0 / 2.0)
+               * std::pow(_traits.tp() - s, a / 4.0)
+               * std::pow(sq_tp_t + sq_tp_tm, b / 2.0)
+               * 1.0 / std::pow(sq_tp_t + sq_tp, c + 3.0);
+    }
+
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToP>::f_p(const double & s) const
+    {
+        const double phi      = _phi(s, _traits.t_0, 48, 3, 3, 2, _traits.chi_1m);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = _a_f_p[0] + _a_f_p[1] * z + _a_f_p[2] * z * z + _a_f_p[3] * z * z * z;
+        const double blaschke = _traits.blaschke_1m(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToD>::f_0(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToP>::f_0(const double & s) const
     {
-        // resonances for 0^+
-        const double blaschke = _z(s, 6.704 * 6.704) * _z(s, 7.122 * 7.122);
-        const double phi      = _phi(s, _t_0, 16, 1, 1, 1, _chi_0p);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 16, 1, 1, 1, _traits.chi_0p);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = _a_f_0[0] + _a_f_0[1] * z + _a_f_0[2] * z * z + _a_f_0[3] * z * z * z;
+        const double blaschke = _traits.blaschke_0p(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToD>::f_t(const double & s) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToP>::f_t(const double & s) const
     {
-        // resonances for 1^-
-        const double blaschke = _z(s, 6.329 * 6.329) * _z(s, 6.910 * 6.910) * _z(s, 7.020 * 7.020);
-        const double phi      = _phi(s, _t_0, 48.0 * _t_p, 3, 3, 1, _chi_T_1m);
-        const double z        = _z(s, _t_0);
+        const double phi      = _phi(s, _traits.t_0, 48.0 * _traits.tp(), 3, 3, 1, _traits.chi_T_1m);
+        const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = _a_f_t[0] + _a_f_t[1] * z + _a_f_t[2] * z * z + _a_f_t[3] * z * z * z;
+        const double blaschke = _traits.blaschke_1m(s);
 
         return series / phi / blaschke;
     }
 
-    double
-    BGL1997FormFactors<BToD>::f_plus_T(const double & /*s*/) const
+    template<typename Process_>
+    double BGL1997FormFactors<Process_, PToP>::f_plus_T(const double & /*s*/) const
     {
         return 0.0; //  TODO
     }
 
+    template<typename Process_>
+    const std::set<ReferenceName> BGL1997FormFactors<Process_, PToP>::references
+    {
+        "BGL:1997A"_rn
+    };
+
+    template<typename Process_>
+    const std::vector<OptionSpecification> BGL1997FormFactors<Process_, PToP>::_options
+    {
+        { "n-bound-states-1m", { "1", "2", "3", "4" }, "3" },
+        { "n-bound-states-0p", { "1", "2"           }, "2" }
+    };
+
+    template<typename Process_>
     std::vector<OptionSpecification>::const_iterator
-    BGL1997FormFactors<BToD>::begin_options()
+    BGL1997FormFactors<Process_, PToP>::begin_options()
     {
         return _options.cbegin();
     }
 
+    template<typename Process_>
     std::vector<OptionSpecification>::const_iterator
-    BGL1997FormFactors<BToD>::end_options()
+    BGL1997FormFactors<Process_, PToP>::end_options()
     {
         return _options.cend();
     }

--- a/eos/form-factors/parametric-bgl1997.cc
+++ b/eos/form-factors/parametric-bgl1997.cc
@@ -23,29 +23,7 @@
 
 namespace eos
 {
-    const std::set<ReferenceName>
-    BGL1997FormFactors<BToDstar>::references
-    {
-        "BGL:1997A"_rn
-    };
-
-    const std::vector<OptionSpecification>
-    BGL1997FormFactors<BToDstar>::_options
-    {
-    };
-
-    template class BGL1997FormFactors<BToDstar>;
-
-    const std::set<ReferenceName>
-    BGL1997FormFactors<BToD>::references
-    {
-        "BGL:1997A"_rn
-    };
-
-    const std::vector<OptionSpecification>
-    BGL1997FormFactors<BToD>::_options
-    {
-    };
-
-    template class BGL1997FormFactors<BToD>;
+    // b -> c
+    template class BGL1997FormFactors<BToDstar, PToV>;
+    template class BGL1997FormFactors<BToD, PToP>;
 }

--- a/eos/form-factors/parametric-bgl1997_TEST.cc
+++ b/eos/form-factors/parametric-bgl1997_TEST.cc
@@ -49,10 +49,30 @@ class BGL1997FormFactorsTest :
 
             /* Outer function: t_0 = t_0,opt */
             {
-                BGL1997FormFactors<BToDstar> ff(p, Options{ });
+                BGL1997FormFactors<BToDstar, PToV> ff(p, Options{ });
                 const double m_B(BToDstar::m_B);
                 const double m_V(BToDstar::m_V);
                 const double t_0((m_B + m_V)* power_of<2>(std::sqrt(m_B) - std::sqrt(m_V)));
+
+                p["mass::B_c^*@BSZ2015"] = 6.329;
+                p["mass::B_c^*[1]@BSZ2015"] = 6.910;
+                p["mass::B_c^*[2]@BSZ2015"] = 7.020;
+                p["mass::B_c,1@BSZ2015"] = 6.739;
+                p["mass::B_c,1[1]@BSZ2015"] = 6.750;
+                p["mass::B_c,1[2]@BSZ2015"] = 7.145;
+                p["mass::B_c,1[3]@BSZ2015"] = 7.150;
+                p["mass::B_c@BSZ2015"] = 6.275;
+                p["mass::B_c[1]@BSZ2015"] = 6.871;
+                p["mass::B_c[2]@BSZ2015"] = 7.250;
+                p["mass::B_c,0@BSZ2015"] = 6.704;
+                p["mass::B_c,0[1]@BSZ2015"] = 7.122;
+
+                p["b->c::chiOPE[1^-_V]"] = 5.131e-04;
+                p["b->c::chiOPE[0^+_V]"] = 6.204e-03;
+                p["b->c::chiOPE[1^+_A]"] = 3.894e-04;
+                p["b->c::chiOPE[0^-_A]"] = 19.421e-03;
+                p["b->c::chiOPE[1^-_T]"] = 0.0004897959183673469;
+                p["b->c::chiOPE[1^+_T5]"] = 0.0002715419501133787;
 
                 //TEST_CHECK_NEARLY_EQUAL(ff._z(1.0, 2.0), 0.0535063, eps);
 
@@ -81,7 +101,27 @@ class BGL1997FormFactorsTest :
                 const double t_m = (mB - mV) * (mB - mV);
                 const double r   = mV / mB, wmax = (mB * mB + mV * mV) / (2.0 * mB * mV);
                 const double F2factor = (1.0 + r) / ((1.0 - r) * (1.0 + wmax) * r * mB * mB);
-                BGL1997FormFactors<BToDstar> ff(p, Options{ });
+                BGL1997FormFactors<BToDstar, PToV> ff(p, Options{ });
+
+                p["mass::B_c^*@BSZ2015"] = 6.329;
+                p["mass::B_c^*[1]@BSZ2015"] = 6.910;
+                p["mass::B_c^*[2]@BSZ2015"] = 7.020;
+                p["mass::B_c,1@BSZ2015"] = 6.739;
+                p["mass::B_c,1[1]@BSZ2015"] = 6.750;
+                p["mass::B_c,1[2]@BSZ2015"] = 7.145;
+                p["mass::B_c,1[3]@BSZ2015"] = 7.150;
+                p["mass::B_c@BSZ2015"] = 6.275;
+                p["mass::B_c[1]@BSZ2015"] = 6.871;
+                p["mass::B_c[2]@BSZ2015"] = 7.250;
+                p["mass::B_c,0@BSZ2015"] = 6.704;
+                p["mass::B_c,0[1]@BSZ2015"] = 7.122;
+
+                p["b->c::chiOPE[1^-_V]"] = 5.131e-04;
+                p["b->c::chiOPE[0^+_V]"] = 6.204e-03;
+                p["b->c::chiOPE[1^+_A]"] = 3.894e-04;
+                p["b->c::chiOPE[0^-_A]"] = 19.421e-03;
+                p["b->c::chiOPE[1^-_T]"] = 0.0004897959183673469;
+                p["b->c::chiOPE[1^+_T5]"] = 0.0002715419501133787;
 
                 p["B->D^*::a^g_0@BGL1997"] = 0.1e-02;
                 p["B->D^*::a^g_1@BGL1997"] = 0.2e-02;
@@ -233,7 +273,19 @@ class BGL1997FormFactorsTest :
 
             /* B -> D FFs*/
             {
-                BGL1997FormFactors<BToD> ff(p, Options{ });
+                BGL1997FormFactors<BToD, PToP> ff(p, Options{ });
+
+                p["mass::B_c^*@BSZ2015"] = 6.329;
+                p["mass::B_c^*[1]@BSZ2015"] = 6.910;
+                p["mass::B_c^*[2]@BSZ2015"] = 7.020;
+                p["mass::B_c,0@BSZ2015"] = 6.704;
+                p["mass::B_c,0[1]@BSZ2015"] = 7.122;
+
+                p["b->c::chiOPE[1^-_V]"] = 5.131e-04;
+                p["b->c::chiOPE[0^+_V]"] = 6.204e-03;
+                p["b->c::chiOPE[1^-_T]"] = 0.0004897959184;
+
+                p["mass::D_u@BSZ2015"] = 1.870;
 
                 p["B->D::a^f+_0@BGL1997"] = 0.1e-02;
                 p["B->D::a^f+_1@BGL1997"] = 0.2e-02;
@@ -296,8 +348,28 @@ class BGL1997FormFactorsTest :
 
             /* Outer function: t_0 = t_- */
             {
-                BGL1997FormFactors<BToDstar> ff(p, Options{ });
+                BGL1997FormFactors<BToDstar, PToV> ff(p, Options{ });
                 const double t_0(10.684);
+
+                p["mass::B_c^*@BSZ2015"] = 6.329;
+                p["mass::B_c^*[1]@BSZ2015"] = 6.910;
+                p["mass::B_c^*[2]@BSZ2015"] = 7.020;
+                p["mass::B_c,1@BSZ2015"] = 6.739;
+                p["mass::B_c,1[1]@BSZ2015"] = 6.750;
+                p["mass::B_c,1[2]@BSZ2015"] = 7.145;
+                p["mass::B_c,1[3]@BSZ2015"] = 7.150;
+                p["mass::B_c@BSZ2015"] = 6.275;
+                p["mass::B_c[1]@BSZ2015"] = 6.871;
+                p["mass::B_c[2]@BSZ2015"] = 7.250;
+                p["mass::B_c,0@BSZ2015"] = 6.704;
+                p["mass::B_c,0[1]@BSZ2015"] = 7.122;
+
+                p["b->c::chiOPE[1^-_V]"] = 5.131e-04;
+                p["b->c::chiOPE[0^+_V]"] = 6.204e-03;
+                p["b->c::chiOPE[1^+_A]"] = 3.894e-04;
+                p["b->c::chiOPE[0^-_A]"] = 19.421e-03;
+                p["b->c::chiOPE[1^-_T]"] = 0.0004897959183673469;
+                p["b->c::chiOPE[1^+_T5]"] = 0.0002715419501133787;
 
                 //_phi(s, t_0, K, a, b, c, chi);
                 TEST_CHECK_NEARLY_EQUAL(ff._phi(-2.0, t_0, 48, 3, 3, 2, 3.1e-03),                  0.0332310,   eps);
@@ -324,7 +396,27 @@ class BGL1997FormFactorsTest :
                 const double t_m = (mB - mV) * (mB - mV);
                 const double r   = mV / mB, wmax = (mB * mB + mV * mV) / (2.0 * mB * mV);
                 const double F2factor = (1.0 + r) / ((1.0 - r) * (1.0 + wmax) * r * mB * mB);
-                BGL1997FormFactors<BToDstar> ff(p, Options{ });
+                BGL1997FormFactors<BToDstar, PToV> ff(p, Options{ });
+
+                p["mass::B_c^*@BSZ2015"] = 6.329;
+                p["mass::B_c^*[1]@BSZ2015"] = 6.910;
+                p["mass::B_c^*[2]@BSZ2015"] = 7.020;
+                p["mass::B_c,1@BSZ2015"] = 6.739;
+                p["mass::B_c,1[1]@BSZ2015"] = 6.750;
+                p["mass::B_c,1[2]@BSZ2015"] = 7.145;
+                p["mass::B_c,1[3]@BSZ2015"] = 7.150;
+                p["mass::B_c@BSZ2015"] = 6.275;
+                p["mass::B_c[1]@BSZ2015"] = 6.871;
+                p["mass::B_c[2]@BSZ2015"] = 7.250;
+                p["mass::B_c,0@BSZ2015"] = 6.704;
+                p["mass::B_c,0[1]@BSZ2015"] = 7.122;
+
+                p["b->c::chiOPE[1^-_V]"] = 5.131e-04;
+                p["b->c::chiOPE[0^+_V]"] = 6.204e-03;
+                p["b->c::chiOPE[1^+_A]"] = 3.894e-04;
+                p["b->c::chiOPE[0^-_A]"] = 19.421e-03;
+                p["b->c::chiOPE[1^-_T]"] = 0.0004897959183673469;
+                p["b->c::chiOPE[1^+_T5]"] = 0.0002715419501133787;
 
                 p["B->D^*::a^g_0@BGL1997"] = 0.1e-02;
                 p["B->D^*::a^g_1@BGL1997"] = 0.2e-02;
@@ -476,7 +568,19 @@ class BGL1997FormFactorsTest :
 
             /* B -> D FFs*/
             {
-                BGL1997FormFactors<BToD> ff(p, Options{ });
+                BGL1997FormFactors<BToD, PToP> ff(p, Options{ });
+
+                p["mass::B_c^*@BSZ2015"] = 6.329;
+                p["mass::B_c^*[1]@BSZ2015"] = 6.910;
+                p["mass::B_c^*[2]@BSZ2015"] = 7.020;
+                p["mass::B_c,0@BSZ2015"] = 6.704;
+                p["mass::B_c,0[1]@BSZ2015"] = 7.122;
+
+                p["b->c::chiOPE[1^-_V]"] = 5.131e-04;
+                p["b->c::chiOPE[0^+_V]"] = 6.204e-03;
+                p["b->c::chiOPE[1^-_T]"] = 0.0004897959183673469;
+
+                p["mass::D_u@BSZ2015"] = 1.870;
 
                 p["B->D::a^f+_0@BGL1997"] = 0.1e-02;
                 p["B->D::a^f+_1@BGL1997"] = 0.2e-02;

--- a/eos/parameters/hadronic-matrix-elements.yaml
+++ b/eos/parameters/hadronic-matrix-elements.yaml
@@ -43,6 +43,7 @@ groups:
   # }}}
 
   # Masses used in BSZ-like Form Factor Parametrizations
+  # All resonance masses higher order with B_c taken from 1707.09509
   # {{{
   - title: 'Masses used in BSZ-like Form Factor Parametrizations'
     description: ''
@@ -137,6 +138,19 @@ groups:
           max:     +6.2751
           latex:    '$m_{B_c}^\mathrm{BSZ}$'
           unit:     'GeV'
+      # B_c higher order taken from [BGS:2017A]
+      'mass::B_c[1]@BSZ2015' :
+          central: +6.842
+          min:     +6.842
+          max:     +6.842
+          latex:   '$m_{B_c}[1]^\mathrm{BSZ}$'
+          unit:    'GeV'
+      'mass::B_c[2]@BSZ2015' :
+          central: +7.250
+          min:     +7.250
+          max:     +7.250
+          latex:   '$m_{B_c}[2]^\mathrm{BSZ}$'
+          unit:    'GeV'
       'mass::K_d^*@BSZ2015' :
           central: +0.896
           min:     +0.896
@@ -191,6 +205,25 @@ groups:
           max:     +6.3311
           latex:   '$m_{B_c^*}^\mathrm{BSZ}$'
           unit:     'GeV'
+      # B_c^* higher order taken from [BGS:2017A]
+      'mass::B_c^*[1]@BSZ2015' :
+          central: +6.910
+          min:     +6.910
+          max:     +6.910
+          latex:   '$m_{B_c^*}[1]^\mathrm{BSZ}$'
+          unit:    'GeV'
+      'mass::B_c^*[2]@BSZ2015' :
+          central: +7.020
+          min:     +7.020
+          max:     +7.020
+          latex:   '$m_{B_c^*}[2]^\mathrm{BSZ}$'
+          unit:    'GeV'
+      'mass::B_c^*[3]@BSZ2015' :
+          central: +7.280
+          min:     +7.280
+          max:     +7.280
+          latex:   '$m_{B_c^*}[3]^\mathrm{BSZ}$'
+          unit:    'GeV'
       'mass::D_s,0@BSZ2015' :
           central: +2.318
           min:     +2.318
@@ -221,6 +254,13 @@ groups:
           max:     +6.420
           latex:   '$m_{B_{c,0}}^\mathrm{BSZ}$'
           unit:     'GeV'
+      # B_c,0 higher order taken from [BGS:2017A]
+      'mass::B_c,0[1]@BSZ2015' :
+          central: +7.122
+          min:     +7.122
+          max:     +7.122
+          latex:   '$m_{B_{c,0}}[1]^\mathrm{BSZ}$'
+          unit:    'GeV'
       'mass::D_s,1@BSZ2015' :
           central: +2.460
           min:     +2.460
@@ -249,8 +289,27 @@ groups:
           central: +6.7671
           min:     +6.7671
           max:     +6.7671
-          latex:   '$m_{B_c^*}^\mathrm{BSZ}$'
+          latex:   '$m_{B_{c,1}}^\mathrm{BSZ}$'
           unit:     'GeV'
+      # B_c,1 higher order taken from [BGS:2017A]
+      'mass::B_c,1[1]@BSZ2015' :
+          central: +6.750
+          min:     +6.750
+          max:     +6.750
+          latex:   '$m_{B_{c,1}}[1]^\mathrm{BSZ}$'
+          unit:    'GeV'
+      'mass::B_c,1[2]@BSZ2015' :
+          central: +7.145
+          min:     +7.145
+          max:     +7.145
+          latex:   '$m_{B_{c,1}}[2]^\mathrm{BSZ}$'
+          unit:    'GeV'
+      'mass::B_c,1[3]@BSZ2015' :
+          central: +7.150
+          min:     +7.150
+          max:     +7.150
+          latex:   '$m_{B_{c,1}}[3]^\mathrm{BSZ}$'
+          unit:    'GeV'
       'mass::Lambda@BMRvD2022' :
           central: +1.115683
           min:     +1.115683
@@ -3893,6 +3952,50 @@ groups:
           min:      4.24e-04
           max:      4.24e-04
           latex:    '$\chi_{T_5}^{J=1}|{}_\textrm{OPE}$'
+          unit:     'GeV^-2'
+  # }}}
+
+  # Dispersive bounds in b -> c currents
+  # {{{
+  - title: 'Dispersive bounds in the OPE for b -> c currents'
+    description: ''
+    parameters:
+      # reference: [BGS:2017A]
+      'b->c::chiOPE[1^-_V]' :
+          central:  5.131e-04
+          min:      5.131e-04
+          max:      5.131e-04
+          latex:    '$\chi^{J=1}|{}_\textrm{OPE}$'
+          unit:     'GeV^-2'
+      'b->c::chiOPE[0^+_V]' :
+          central:  6.204e-03
+          min:      6.204e-03
+          max:      6.204e-03
+          latex:    '$\chi^{J=0}|{}_\textrm{OPE}$'
+          unit:     '1'
+      'b->c::chiOPE[1^+_A]' :
+          central:  3.894e-04
+          min:      3.894e-04
+          max:      3.894e-04
+          latex:    '$\chi^{J=1}|{}_\textrm{OPE}$'
+          unit:     'GeV^-2'
+      'b->c::chiOPE[0^-_A]' :
+          central:  19.421e-03
+          min:      19.421e-03
+          max:      19.421e-03
+          latex:    '$\chi^{J=0}|{}_\textrm{OPE}$'
+          unit:     '1'
+      'b->c::chiOPE[1^-_T]' :
+          central:  4.898e-04
+          min:      4.898e-04
+          max:      4.898e-04
+          latex:    '$\chi_T^{J=1}|{}_\textrm{OPE}$'
+          unit:     'GeV^-2'
+      'b->c::chiOPE[1^+_T5]' :
+          central:  2.715e-04
+          min:      2.715e-04
+          max:      2.715e-04
+          latex:    '$\chi_{T}^{J=1}|{}_\textrm{OPE}$'
           unit:     'GeV^-2'
   # }}}
 


### PR DESCRIPTION
Fixes #974: It is now possible to dynamically set the resonance masses and susceptibilities of the BGL parametrization to a specific value.