### PR TITLE
Improvement to the ``sample-nested`` user interface

### DIFF
--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -726,9 +726,12 @@ class Analysis:
         .. note::
            This method requires the dynesty python module, which can be installed from PyPI.
         """
-        import dynesty
+        import dynesty, tqdm
+        from functools import partial
+
         if print_function is None:
-            print_function = dynesty.results.print_fn
+            print_function = partial(dynesty.results.print_fn, pbar=tqdm.tqdm())
+
         sampler = dynesty.DynamicNestedSampler(self.log_likelihood, self._prior_transform, len(self.varied_parameters), bound=bound, nlive=nlive, rstate = np.random.Generator(np.random.MT19937(seed)), sample=sample)
         sampler.run_nested(dlogz_init=dlogz, maxiter=maxiter, print_progress=print_progress, print_func=print_function)
         return sampler.results

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -702,7 +702,7 @@ class Analysis:
         return self._u_to_par(u)
 
 
-    def sample_nested(self, bound='multi', nlive=250, dlogz=1.0, maxiter=None, seed=10, print_progress=True, sample='auto'):
+    def sample_nested(self, bound='multi', nlive=250, dlogz=1.0, maxiter=None, print_progress=True, print_function=None, seed=10, sample='auto'):
         """
         Return samples of the parameters.
 
@@ -716,6 +716,8 @@ class Analysis:
         :type dlogz: float, optional
         :param maxiter: The maximum number of iterations. Iterations may stop earlier if the termination condition is reached.
         :type maxiter: int, optional
+        :param print_function: The function used to print progress messages. Defaults to using a dynesty-based function.
+        :type print_function: callable, optional
         :param seed: The seed used to initialize the Mersenne Twister pseudo-random number generator.
         :type seed: {None, int, array_like[ints], SeedSequence}, optional
         :param sample: The method used for sampling within the likelihood constraints. For valid values, see dynesty documentation. Defaults to 'auto'.
@@ -725,8 +727,10 @@ class Analysis:
            This method requires the dynesty python module, which can be installed from PyPI.
         """
         import dynesty
+        if print_function is None:
+            print_function = dynesty.results.print_fn
         sampler = dynesty.DynamicNestedSampler(self.log_likelihood, self._prior_transform, len(self.varied_parameters), bound=bound, nlive=nlive, rstate = np.random.Generator(np.random.MT19937(seed)), sample=sample)
-        sampler.run_nested(dlogz_init=dlogz, maxiter=maxiter, print_progress=print_progress)
+        sampler.run_nested(dlogz_init=dlogz, maxiter=maxiter, print_progress=print_progress, print_func=print_function)
         return sampler.results
 
 

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -702,7 +702,7 @@ class Analysis:
         return self._u_to_par(u)
 
 
-    def sample_nested(self, bound='multi', nlive=250, dlogz=1.0, maxiter=None, print_progress=True, print_function=None, seed=10, sample='auto'):
+    def sample_nested(self, bound='multi', nlive=250, dlogz=1.0, maxiter=None, miniter=0, print_progress=True, print_function=None, seed=10, sample='auto'):
         """
         Return samples of the parameters.
 
@@ -716,6 +716,8 @@ class Analysis:
         :type dlogz: float, optional
         :param maxiter: The maximum number of iterations. Iterations may stop earlier if the termination condition is reached.
         :type maxiter: int, optional
+        :param miniter: The minimum number of iterations. Defaults to 0. Samples will be added until miniter is reached, even if the termination condition is reached earlier.
+        :type miniter: int, optional
         :param print_function: The function used to print progress messages. Defaults to using a dynesty-based function.
         :type print_function: callable, optional
         :param seed: The seed used to initialize the Mersenne Twister pseudo-random number generator.
@@ -734,6 +736,9 @@ class Analysis:
 
         sampler = dynesty.DynamicNestedSampler(self.log_likelihood, self._prior_transform, len(self.varied_parameters), bound=bound, nlive=nlive, rstate = np.random.Generator(np.random.MT19937(seed)), sample=sample)
         sampler.run_nested(dlogz_init=dlogz, maxiter=maxiter, print_progress=print_progress, print_func=print_function)
+        while sampler.results['niter'] < miniter:
+            # using mode='full' ensures sampling from the entire posterior
+            sampler.add_batch(mode='full', dlogz_init=dlogz, maxiter=maxiter, print_progress=print_progress, print_func=print_function)
         return sampler.results
 
 

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -223,6 +223,7 @@ _task_argument_map = {
     ('sample-nested', 'n'): 'nlive', ('sample-nested', 'number-of-live-points'): 'nlive', ('sample-nested', 'NLIVE'): 'nlive',
     ('sample-nested', 'd'): 'dlogz', ('sample-nested', 'evidence-tolerance'): 'dlogz', ('sample-nested', 'DLOGZ'): 'dlogz',
     ('sample-nested', 'm'): 'maxiter', ('sample-nested', 'max-number-iterations'): 'maxiter', ('sample-nested', 'MAXITER'): 'maxiter',
+    ('sample-nested', 'min-number-iterations'): 'miniter', ('sample-nested', 'MINITER'): 'miniter',
     ('sample-nested', 's'): 'seed', ('sample-nested', 'use-random-seed'): 'seed', ('sample-nested', 'SEED'): 'seed',
     ('sample-nested', 'M'): 'sample', ('sample-nested', 'sampling-method'): 'sample', ('sample-nested', 'SAMPLE'): 'sample',
     # plot-samples


### PR DESCRIPTION
- [x] add custom print function
- [x] redirect timed output (1 every 15s) to the EOS logger
- [x] support demanding minimum number of samples