### PR TITLE
Move Ubuntu-based workflows to 24.04

### DIFF
--- a/.github/workflows/pypi-build+check+deploy.yaml
+++ b/.github/workflows/pypi-build+check+deploy.yaml
@@ -18,9 +18,9 @@ jobs:
         strategy:
             matrix:
                 include:
-                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 310, version: cp310, runner: ubuntu-20.04     }
-                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 311, version: cp311, runner: ubuntu-20.04     }
-                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 312, version: cp312, runner: ubuntu-20.04     }
+                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 310, version: cp310, runner: ubuntu-24.04     }
+                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 311, version: cp311, runner: ubuntu-24.04     }
+                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 312, version: cp312, runner: ubuntu-24.04     }
                   - { arch: aarch64, cxxflags: '-march=armv8.5-a', boost_python_suffix: 310, version: cp310, runner: ubuntu-24.04-arm }
         runs-on: ${{ matrix.runner }}
         name: Build and check EOS wheels on ${{ matrix.arch }} for Python version ${{ matrix.version }}

--- a/.github/workflows/report-activity.yaml
+++ b/.github/workflows/report-activity.yaml
@@ -6,7 +6,7 @@ name: Report Activity
 
 jobs:
     report:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Create the weekly activity report
         steps:
             - name: Checkout git repository

--- a/.github/workflows/ubuntu-build+check+deploy.yaml
+++ b/.github/workflows/ubuntu-build+check+deploy.yaml
@@ -21,7 +21,7 @@ jobs:
                     - { os: jammy,    cxx: g++,          cxxflags: '-O2 -g -march=x86-64' }
                     - { os: jammy,    cxx: clang++-14,   cxxflags: '-O2 -g -march=x86-64' }
         name: Build on ${{ matrix.cfg.os }} using ${{ matrix.cfg.cxx }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         container:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:26605c04dc7409908fec23d012b416f18f4d846c
         steps:
@@ -87,7 +87,7 @@ jobs:
                 cfg:
                     - { os: jammy,    cxx: g++,          cxxflags: '-O2 -g -march=x86-64' }
         name: Documentation on ${{ matrix.cfg.os }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         container:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:26605c04dc7409908fec23d012b416f18f4d846c
         steps:
@@ -136,7 +136,7 @@ jobs:
                     - { os: jammy,    cxx: g++,          cxxflags: '-O2 -g -march=x86-64' }
                     - { os: jammy,    cxx: clang++-14,   cxxflags: '-O2 -g -march=x86-64' }
         name: Check on ${{ matrix.cfg.os }} using ${{ matrix.cfg.cxx }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         container:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:26605c04dc7409908fec23d012b416f18f4d846c
         steps:
@@ -167,7 +167,7 @@ jobs:
                     - { os: jammy,    cxx: g++,          cxxflags: '-O2 -g -march=x86-64' }
                     - { os: jammy,    cxx: clang++-14,   cxxflags: '-O2 -g -march=x86-64' }
         name: Run examples on ${{ matrix.cfg.os }} using ${{ matrix.cfg.cxx }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         container:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:26605c04dc7409908fec23d012b416f18f4d846c
         steps:
@@ -208,7 +208,7 @@ jobs:
                 cfg:
                     - { os: jammy,    cxx: g++,          cxxflags: '-O2 -g -march=x86-64' }
         name: Deploy on ${{ matrix.cfg.os }} using ${{ matrix.cfg.cxx }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         container:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:26605c04dc7409908fec23d012b416f18f4d846c
         steps:
@@ -296,7 +296,7 @@ jobs:
                 cfg:
                     - { os: jammy,    cxx: g++,          cxxflags: '-O2 -g -march=x86-64' }
         name: Deploy documentation on ${{ matrix.cfg.os }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         container:
             image: eoshep/ubuntu-${{ matrix.cfg.os }}:26605c04dc7409908fec23d012b416f18f4d846c
         steps:

--- a/.github/workflows/weekly-builds.yaml
+++ b/.github/workflows/weekly-builds.yaml
@@ -8,7 +8,7 @@ name: Trigger the build of weekly development releases
 
 jobs:
     report:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Push branch ``master`` to branch ``release``
         steps:
             - name: Checkout git repository


### PR DESCRIPTION
Given the recent warning that
```
[t]he Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025[,]
```
let's move things to Ubuntu 24.04!

This affects
- the PyPI ``build+check+deploy`` workflow,
- the Ubuntu ``build+check+deploy`` workflow,
- the ``weekly-builds`` workflow, and
- the ``report-activity`` workflow.

For the first two, only the runner's image will be updated. The last two should not depend on the runner image version.