### PR TITLE
Clean up nonleptonic amplitudes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
    hooks:
     - id: clang-format
       types_or: [ 'c++' ]
-      exclude: ^(eos/b-decays/|eos/c-decays/|eos/form-factors/|eos/maths/|eos/meson-mixing/|eos/nonleptonic-amplitudes/|eos/nonlocal-form-factors/|eos/rare-b-decays/|eos/scattering/|eos/statistics/|eos/utils/)
+      exclude: ^(eos/b-decays/|eos/c-decays/|eos/form-factors/|eos/maths/|eos/meson-mixing/|eos/nonlocal-form-factors/|eos/rare-b-decays/|eos/scattering/|eos/statistics/|eos/utils/)
 
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.4.0

--- a/eos/nonleptonic-amplitudes/nonleptonic-amplitudes-adapter.hh
+++ b/eos/nonleptonic-amplitudes/nonleptonic-amplitudes-adapter.hh
@@ -30,9 +30,7 @@
 namespace eos
 {
     /* Amplitude adapter class for interfacing Observable */
-    template <typename Transition_, typename ... Args_>
-    class NonleptonicAmplitudesAdapter :
-        public Observable
+    template <typename Transition_, typename... Args_> class NonleptonicAmplitudesAdapter : public Observable
     {
         private:
             QualifiedName _name;
@@ -47,20 +45,17 @@ namespace eos
 
             std::shared_ptr<NonleptonicAmplitudes<Transition_>> _nonleptonic_amplitudes;
 
-            std::function<double (const NonleptonicAmplitudes<Transition_> *, const Args_ & ...)> _nonleptonic_amplitudes_function;
+            std::function<double(const NonleptonicAmplitudes<Transition_> *, const Args_ &...)> _nonleptonic_amplitudes_function;
 
-            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> _kinematics_names;
+            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> _kinematics_names;
 
-            std::tuple<const NonleptonicAmplitudes<Transition_> *, typename impl::ConvertTo<Args_, KinematicVariable>::Type ...> _argument_tuple;
+            std::tuple<const NonleptonicAmplitudes<Transition_> *, typename impl::ConvertTo<Args_, KinematicVariable>::Type...> _argument_tuple;
 
         public:
-            NonleptonicAmplitudesAdapter(const QualifiedName & name,
-                    const qnp::Prefix & process,
-                    const Parameters & parameters,
-                    const Kinematics & kinematics,
-                    const Options & options,
-                    const std::function<double (const NonleptonicAmplitudes<Transition_> *, const Args_ & ...)> & nonleptonic_amplitudes_function,
-                    const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> & kinematics_names) :
+            NonleptonicAmplitudesAdapter(const QualifiedName & name, const qnp::Prefix & process, const Parameters & parameters, const Kinematics & kinematics,
+                                         const Options &                                                                             options,
+                                         const std::function<double(const NonleptonicAmplitudes<Transition_> *, const Args_ &...)> & nonleptonic_amplitudes_function,
+                                         const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> &                  kinematics_names) :
                 _name(name),
                 _process(process),
                 _parameters(parameters),
@@ -72,55 +67,66 @@ namespace eos
                 _argument_tuple(impl::TupleMaker<sizeof...(Args_)>::make(_kinematics, _kinematics_names, _nonleptonic_amplitudes.get()))
             {
                 if (! _options.has("representation"))
+                {
                     throw UnknownOptionError("representation");
+                }
 
                 if (! _nonleptonic_amplitudes)
+                {
                     throw NoSuchNonleptonicAmplitudeError(process.str(), options["representation"]);
+                }
 
                 uses(*_nonleptonic_amplitudes);
             }
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual double evaluate() const
+            virtual double
+            evaluate() const
             {
-                std::tuple<const NonleptonicAmplitudes<Transition_> *, typename impl::ConvertTo<Args_, double>::Type ...> values = _argument_tuple;
+                std::tuple<const NonleptonicAmplitudes<Transition_> *, typename impl::ConvertTo<Args_, double>::Type...> values = _argument_tuple;
 
                 return std::apply(_nonleptonic_amplitudes_function, values);
-            };
+            }
 
-            virtual Parameters parameters()
+            virtual Parameters
+            parameters()
             {
                 return _parameters;
-            };
+            }
 
-            virtual Kinematics kinematics()
+            virtual Kinematics
+            kinematics()
             {
                 return _kinematics;
-            };
+            }
 
-            virtual Options options()
+            virtual Options
+            options()
             {
                 return _options;
             }
 
-            virtual ObservablePtr clone() const
+            virtual ObservablePtr
+            clone() const
             {
-                return ObservablePtr(new NonleptonicAmplitudesAdapter(_name, _process, _parameters.clone(), _kinematics.clone(), _options, _nonleptonic_amplitudes_function, _kinematics_names));
+                return ObservablePtr(
+                        new NonleptonicAmplitudesAdapter(_name, _process, _parameters.clone(), _kinematics.clone(), _options, _nonleptonic_amplitudes_function, _kinematics_names));
             }
 
-            virtual ObservablePtr clone(const Parameters & parameters) const
+            virtual ObservablePtr
+            clone(const Parameters & parameters) const
             {
-                return ObservablePtr(new NonleptonicAmplitudesAdapter(_name, _process, parameters, _kinematics.clone(), _options, _nonleptonic_amplitudes_function, _kinematics_names));
+                return ObservablePtr(
+                        new NonleptonicAmplitudesAdapter(_name, _process, parameters, _kinematics.clone(), _options, _nonleptonic_amplitudes_function, _kinematics_names));
             }
     };
 
-    template <typename Transition_, typename ... Args_>
-    class NonleptonicAmplitudesAdapterEntry :
-        public ObservableEntry
+    template <typename Transition_, typename... Args_> class NonleptonicAmplitudesAdapterEntry : public ObservableEntry
     {
         private:
             QualifiedName _name;
@@ -131,21 +137,18 @@ namespace eos
 
             qnp::Prefix _process;
 
-            std::function<double (const NonleptonicAmplitudes<Transition_> *, const Args_ & ...)> _nonleptonic_amplitudes_function;
+            std::function<double(const NonleptonicAmplitudes<Transition_> *, const Args_ &...)> _nonleptonic_amplitudes_function;
 
-            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> _kinematics_names;
+            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> _kinematics_names;
 
             std::array<const std::string, sizeof...(Args_)> _kinematics_names_array;
 
             const std::vector<OptionSpecification> _options;
 
         public:
-            NonleptonicAmplitudesAdapterEntry(const QualifiedName & name,
-                    const std::string & latex,
-                    const Unit & unit,
-                    const qnp::Prefix & process,
-                    const std::function<double (const NonleptonicAmplitudes<Transition_> *, const Args_ & ...)> & nonleptonic_amplitudes_function,
-                    const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> & kinematics_names) :
+            NonleptonicAmplitudesAdapterEntry(const QualifiedName & name, const std::string & latex, const Unit & unit, const qnp::Prefix & process,
+                                              const std::function<double(const NonleptonicAmplitudes<Transition_> *, const Args_ &...)> & nonleptonic_amplitudes_function,
+                                              const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> &                  kinematics_names) :
                 _name(name),
                 _latex(latex),
                 _unit(unit),
@@ -157,57 +160,66 @@ namespace eos
             {
             }
 
-            ~NonleptonicAmplitudesAdapterEntry()
-            {
-            }
+            ~NonleptonicAmplitudesAdapterEntry() {}
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual const std::string & latex() const
+            virtual const std::string &
+            latex() const
             {
                 return _latex;
             }
 
-            virtual const Unit & unit() const
+            virtual const Unit &
+            unit() const
             {
                 return _unit;
             }
 
-            virtual ObservableEntry::KinematicVariableIterator begin_kinematic_variables() const
+            virtual ObservableEntry::KinematicVariableIterator
+            begin_kinematic_variables() const
             {
                 return _kinematics_names_array.begin();
             }
 
-            virtual ObservableEntry::KinematicVariableIterator end_kinematic_variables() const
+            virtual ObservableEntry::KinematicVariableIterator
+            end_kinematic_variables() const
             {
                 return _kinematics_names_array.end();
             }
 
-            virtual ObservableEntry::OptionIterator begin_options() const
+            virtual ObservableEntry::OptionIterator
+            begin_options() const
             {
                 return _options.begin();
             }
 
-            virtual ObservableEntry::OptionIterator end_options() const
+            virtual ObservableEntry::OptionIterator
+            end_options() const
             {
                 return _options.end();
             }
 
-            virtual ObservablePtr make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
+            virtual ObservablePtr
+            make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
             {
-                return ObservablePtr(new NonleptonicAmplitudesAdapter<Transition_, Args_ ...>(_name, _process, parameters, kinematics, options, _nonleptonic_amplitudes_function, _kinematics_names));
+                return ObservablePtr(
+                        new NonleptonicAmplitudesAdapter<Transition_,
+                                                         Args_...>(_name, _process, parameters, kinematics, options, _nonleptonic_amplitudes_function, _kinematics_names));
             }
 
-            virtual std::ostream & insert(std::ostream & os) const
+            virtual std::ostream &
+            insert(std::ostream & os) const
             {
                 os << "    type: adapter for one nonloeptonic amplitude" << std::endl;
 
                 return os;
             }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh
+++ b/eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh
@@ -22,11 +22,9 @@
 
 namespace eos
 {
-    template <typename Transition_>
-    class NonleptonicAmplitudes;
+    template <typename Transition_> class NonleptonicAmplitudes;
 
-    template <typename Transition_>
-    class NonleptonicAmplitudeFactory;
-}
+    template <typename Transition_> class NonleptonicAmplitudeFactory;
+} // namespace eos
 
 #endif

--- a/eos/nonleptonic-amplitudes/nonleptonic-amplitudes.cc
+++ b/eos/nonleptonic-amplitudes/nonleptonic-amplitudes.cc
@@ -17,11 +17,11 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
-#include <eos/nonleptonic-amplitudes/topological-amplitudes.hh>
-#include <eos/nonleptonic-amplitudes/su3f-amplitudes.hh>
-#include <eos/nonleptonic-amplitudes/qcdf-amplitudes.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
+#include <eos/nonleptonic-amplitudes/qcdf-amplitudes.hh>
+#include <eos/nonleptonic-amplitudes/su3f-amplitudes.hh>
+#include <eos/nonleptonic-amplitudes/topological-amplitudes.hh>
 #include <eos/utils/options-impl.hh>
 
 #include <map>
@@ -35,7 +35,8 @@ namespace eos
 
     namespace su3f
     {
-        void transpose(rank2 & M)
+        void
+        transpose(rank2 & M)
         {
             for (size_t i = 0; i < 3; ++i)
             {
@@ -47,6 +48,7 @@ namespace eos
         }
 
         // Note that this matrix is transposed w.r.t [HTX:2021A] to follow the convention M^i_j = M[i][j]
+        // clang-format off
         const std::map<LightMeson, std::function<void (const double &, rank2 &)>>
         psd_octet
         {
@@ -79,16 +81,15 @@ namespace eos
                                         }};
                                     } }
         };
-    }
+        // clang-format on
+    } // namespace su3f
 
-    NonleptonicAmplitudes<PToPP>::~NonleptonicAmplitudes() {};
+    NonleptonicAmplitudes<PToPP>::~NonleptonicAmplitudes(){};
 
-    const std::map<NonleptonicAmplitudeFactory<PToPP>::KeyType, NonleptonicAmplitudeFactory<PToPP>::ValueType>
-    NonleptonicAmplitudeFactory<PToPP>::amplitudes
-    {
-        { "B->PP::topological",         &TopologicalRepresentation<PToPP>::make},
-        { "B->PP::SU3F",                &SU3FRepresentation<PToPP>::make},
-        { "B->PP::QCDF",                &QCDFRepresentation<PToPP>::make}
+    const std::map<NonleptonicAmplitudeFactory<PToPP>::KeyType, NonleptonicAmplitudeFactory<PToPP>::ValueType> NonleptonicAmplitudeFactory<PToPP>::amplitudes{
+        { "B->PP::topological", &TopologicalRepresentation<PToPP>::make },
+        {        "B->PP::SU3F",        &SU3FRepresentation<PToPP>::make },
+        {        "B->PP::QCDF",        &QCDFRepresentation<PToPP>::make }
     };
 
     std::shared_ptr<NonleptonicAmplitudes<PToPP>>
@@ -112,11 +113,13 @@ namespace eos
     OptionSpecification
     NonleptonicAmplitudeFactory<PToPP>::option_specification(const qnp::Prefix & process)
     {
-        OptionSpecification result { "representation", {}, "" };
+        OptionSpecification result{ "representation", {}, "" };
         for (const auto & ff : NonleptonicAmplitudeFactory<PToPP>::amplitudes)
         {
             if (process == std::get<0>(ff).prefix_part())
+            {
                 result.allowed_values.push_back(std::get<0>(ff).name_part().str());
+            }
         }
 
         return result;
@@ -131,8 +134,12 @@ namespace eos
             allowed_values.insert(std::get<0>(ff).name_part().str());
         }
 
-        OptionSpecification result { "representation", { allowed_values.cbegin(), allowed_values.cend() }, "" };
+        OptionSpecification result{
+            "representation",
+            { allowed_values.cbegin(), allowed_values.cend() },
+            ""
+        };
         return result;
     }
 
-}
+} // namespace eos

--- a/eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh
+++ b/eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh
@@ -20,9 +20,9 @@
 #ifndef EOS_GUARD_EOS_NONLEPTONIC_AMPLITUDES_NONLEPTONIC_AMPLITUDES_HH
 #define EOS_GUARD_EOS_NONLEPTONIC_AMPLITUDES_NONLEPTONIC_AMPLITUDES_HH 1
 
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh>
 #include <eos/maths/complex.hh>
 #include <eos/models/model.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh>
 #include <eos/utils/parameters.hh>
 #include <eos/utils/transitions.hh>
 
@@ -33,8 +33,7 @@ namespace eos
 {
     using std::sqrt;
 
-    class NoSuchNonleptonicAmplitudeError :
-        public Exception
+    class NoSuchNonleptonicAmplitudeError : public Exception
     {
         public:
             NoSuchNonleptonicAmplitudeError(const std::string & process, const std::string & tag);
@@ -44,25 +43,22 @@ namespace eos
     {
         // Meson SU(3)_F structures
         typedef std::array<std::array<std::array<complex<double>, 3>, 3>, 3> rank3;
-        typedef std::array<std::array<complex<double>, 3>, 3> rank2;
-        typedef std::array<complex<double>, 3> rank1;
+        typedef std::array<std::array<complex<double>, 3>, 3>                rank2;
+        typedef std::array<complex<double>, 3>                               rank1;
 
         void transpose(rank2 &);
 
-        const std::map<QuarkFlavor, rank1> psd_b_triplet
-        {
-            { QuarkFlavor::up,      {{1.0, 0.0, 0.0}}},
-            { QuarkFlavor::down,    {{0.0, 1.0, 0.0}}},
-            { QuarkFlavor::strange, {{0.0, 0.0, 1.0}}},
+        const std::map<QuarkFlavor, rank1> psd_b_triplet{
+            {      QuarkFlavor::up, { { 1.0, 0.0, 0.0 } } },
+            {    QuarkFlavor::down, { { 0.0, 1.0, 0.0 } } },
+            { QuarkFlavor::strange, { { 0.0, 0.0, 1.0 } } },
         };
 
-        extern const std::map<LightMeson, std::function<void (const double &, rank2 &)>> psd_octet;
-    }
+        extern const std::map<LightMeson, std::function<void(const double &, rank2 &)>> psd_octet;
+    } // namespace su3f
 
     /* P -> PP transitions */
-    template <>
-    class NonleptonicAmplitudes<PToPP> :
-        public virtual ParameterUser
+    template <> class NonleptonicAmplitudes<PToPP> : public virtual ParameterUser
     {
         public:
             virtual ~NonleptonicAmplitudes();
@@ -71,40 +67,71 @@ namespace eos
             virtual complex<double> ordered_amplitude() const = 0;
             // Amplitude for B -> P2 P1
             virtual complex<double> inverse_amplitude() const = 0;
+
             // Amplitude for B -> [P2 P1 + P1 P2]
-            complex<double> amplitude() const
+            complex<double>
+            amplitude() const
             {
                 return ordered_amplitude() + inverse_amplitude();
             }
 
             // CP-conserving penguin vs tree correction defined as - |(Vub Vud*) / (Vcb Vcd*)| penguin / (tree - penguin), cf. [FJV:2016A]
-            virtual complex<double> penguin_correction() const
+            virtual complex<double>
+            penguin_correction() const
             {
                 throw InternalError("Not implemented");
                 return 0.0;
             }
 
             // Pseudo-observables given for testing purposes
-            double re_amplitude() const { return real(amplitude()); }
-            double im_amplitude() const { return imag(amplitude()); }
-            double abs_amplitude() const { return abs(amplitude()); }
-            double arg_amplitude() const { return arg(amplitude()); }
-            double abs_penguin_correction() const {return abs(penguin_correction()); }
-            double arg_penguin_correction() const {return arg(penguin_correction()); }
+            double
+            re_amplitude() const
+            {
+                return real(amplitude());
+            }
+
+            double
+            im_amplitude() const
+            {
+                return imag(amplitude());
+            }
+
+            double
+            abs_amplitude() const
+            {
+                return abs(amplitude());
+            }
+
+            double
+            arg_amplitude() const
+            {
+                return arg(amplitude());
+            }
+
+            double
+            abs_penguin_correction() const
+            {
+                return abs(penguin_correction());
+            }
+
+            double
+            arg_penguin_correction() const
+            {
+                return arg(penguin_correction());
+            }
     };
 
-    template <>
-    class NonleptonicAmplitudeFactory<PToPP>
+    template <> class NonleptonicAmplitudeFactory<PToPP>
     {
         public:
-            using KeyType = QualifiedName;
-            using ValueType = std::function<NonleptonicAmplitudes<PToPP> * (const Parameters &, const Options &)>;
+            using KeyType   = QualifiedName;
+            using ValueType = std::function<NonleptonicAmplitudes<PToPP> *(const Parameters &, const Options &)>;
 
             static const std::map<KeyType, ValueType> amplitudes;
 
-            static std::shared_ptr<NonleptonicAmplitudes<PToPP>> create(const QualifiedName & name, const Parameters & parameters, const Options & options = Options{ });
-            static OptionSpecification option_specification(const qnp::Prefix & process);
-            static OptionSpecification option_specification();
+            static std::shared_ptr<NonleptonicAmplitudes<PToPP>> create(const QualifiedName & name, const Parameters & parameters, const Options & options = Options{});
+            static OptionSpecification                           option_specification(const qnp::Prefix & process);
+            static OptionSpecification                           option_specification();
     };
-}
+} // namespace eos
 #endif

--- a/eos/nonleptonic-amplitudes/observables.cc
+++ b/eos/nonleptonic-amplitudes/observables.cc
@@ -17,42 +17,40 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <eos/observable-impl.hh>
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
 #include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-adapter.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
+#include <eos/observable-impl.hh>
 #include <eos/utils/concrete-cacheable-observable.hh>
 #include <eos/utils/concrete_observable.hh>
 
 namespace eos
 {
     /* nonleptonic amplitude as observables */
-    template <typename Transition_, typename Tuple_, typename ... Args_>
-    std::pair<QualifiedName, ObservableEntryPtr> make_nonleptonic_amplitudes_adapter(const char * name,
-            const char * latex,
-            double (NonleptonicAmplitudes<Transition_>::* _function)(const Args_ & ...) const,
-            const Tuple_ & kinematics_names)
+    template <typename Transition_, typename Tuple_, typename... Args_>
+    std::pair<QualifiedName, ObservableEntryPtr>
+    make_nonleptonic_amplitudes_adapter(const char * name, const char * latex, double (NonleptonicAmplitudes<Transition_>::*_function)(const Args_ &...) const,
+                                        const Tuple_ & kinematics_names)
     {
-        QualifiedName qn(name);
-        qnp::Prefix pp = qn.prefix_part();
-        std::function<double (const NonleptonicAmplitudes<Transition_> *, const Args_ & ...)> function(_function);
+        QualifiedName                                                                       qn(name);
+        qnp::Prefix                                                                         pp = qn.prefix_part();
+        std::function<double(const NonleptonicAmplitudes<Transition_> *, const Args_ &...)> function(_function);
 
-        auto result = std::make_pair(qn, std::make_shared<NonleptonicAmplitudesAdapterEntry<Transition_, Args_ ...>>(qn, latex, Unit::None(), pp, function, kinematics_names));
+        auto result = std::make_pair(qn, std::make_shared<NonleptonicAmplitudesAdapterEntry<Transition_, Args_...>>(qn, latex, Unit::None(), pp, function, kinematics_names));
 
         impl::observable_entries.insert(result);
 
         return result;
     }
 
-    template <typename Transition_, typename Tuple_, typename ... Args_>
-    std::pair<QualifiedName, ObservableEntryPtr> make_nonleptonic_amplitudes_adapter(const char * name,
-            double (NonleptonicAmplitudes<Transition_>::* _function)(const Args_ & ...) const,
-            const Tuple_ & kinematics_names)
+    template <typename Transition_, typename Tuple_, typename... Args_>
+    std::pair<QualifiedName, ObservableEntryPtr>
+    make_nonleptonic_amplitudes_adapter(const char * name, double (NonleptonicAmplitudes<Transition_>::*_function)(const Args_ &...) const, const Tuple_ & kinematics_names)
     {
-        QualifiedName qn(name);
-        qnp::Prefix pp = qn.prefix_part();
-        std::function<double (const NonleptonicAmplitudes<Transition_> *, const Args_ & ...)> function(_function);
+        QualifiedName                                                                       qn(name);
+        qnp::Prefix                                                                         pp = qn.prefix_part();
+        std::function<double(const NonleptonicAmplitudes<Transition_> *, const Args_ &...)> function(_function);
 
-        auto result = std::make_pair(qn, std::make_shared<NonleptonicAmplitudesAdapterEntry<Transition_, Args_ ...>>(qn, "", Unit::None(), pp, function, kinematics_names));
+        auto result = std::make_pair(qn, std::make_shared<NonleptonicAmplitudesAdapterEntry<Transition_, Args_...>>(qn, "", Unit::None(), pp, function, kinematics_names));
 
         impl::observable_entries.insert(result);
 
@@ -65,40 +63,32 @@ namespace eos
     make_p_to_p_p_amplitudes_group()
     {
         auto imp = new Implementation<ObservableGroup>(
-            R"(Pseudo-observables related to the $B\to PP$ amplitudes)",
-            R"()",
-            {
-                make_nonleptonic_amplitudes_adapter("B->PP::Re{amplitude}", R"(|\mathcal{A}^{B\to PP}|)",
-                        &NonleptonicAmplitudes<PToPP>::re_amplitude, std::make_tuple()),
-                make_nonleptonic_amplitudes_adapter("B->PP::Im{amplitude}", R"(|\mathcal{A}^{B\to PP}|)",
-                        &NonleptonicAmplitudes<PToPP>::im_amplitude, std::make_tuple()),
-                make_nonleptonic_amplitudes_adapter("B->PP::Abs{amplitude}", R"(|\mathcal{A}^{B\to PP}|)",
-                        &NonleptonicAmplitudes<PToPP>::abs_amplitude, std::make_tuple()),
-                make_nonleptonic_amplitudes_adapter("B->PP::Arg{amplitude}", R"(|\mathcal{A}^{B\to PP}|)",
-                        &NonleptonicAmplitudes<PToPP>::arg_amplitude, std::make_tuple()),
-                make_nonleptonic_amplitudes_adapter("B->PP::r_q", R"(r_q)",
-                        &NonleptonicAmplitudes<PToPP>::abs_penguin_correction, std::make_tuple()),
-                make_nonleptonic_amplitudes_adapter("B->PP::theta_q", R"(\theta_q)",
-                        &NonleptonicAmplitudes<PToPP>::arg_penguin_correction, std::make_tuple()),
-            }
-        );
+                R"(Pseudo-observables related to the $B\to PP$ amplitudes)",
+                R"()",
+                {
+                    make_nonleptonic_amplitudes_adapter("B->PP::Re{amplitude}", R"(|\mathcal{A}^{B\to PP}|)", &NonleptonicAmplitudes<PToPP>::re_amplitude, std::make_tuple()),
+                    make_nonleptonic_amplitudes_adapter("B->PP::Im{amplitude}", R"(|\mathcal{A}^{B\to PP}|)", &NonleptonicAmplitudes<PToPP>::im_amplitude, std::make_tuple()),
+                    make_nonleptonic_amplitudes_adapter("B->PP::Abs{amplitude}", R"(|\mathcal{A}^{B\to PP}|)", &NonleptonicAmplitudes<PToPP>::abs_amplitude, std::make_tuple()),
+                    make_nonleptonic_amplitudes_adapter("B->PP::Arg{amplitude}", R"(|\mathcal{A}^{B\to PP}|)", &NonleptonicAmplitudes<PToPP>::arg_amplitude, std::make_tuple()),
+                    make_nonleptonic_amplitudes_adapter("B->PP::r_q", R"(r_q)", &NonleptonicAmplitudes<PToPP>::abs_penguin_correction, std::make_tuple()),
+                    make_nonleptonic_amplitudes_adapter("B->PP::theta_q", R"(\theta_q)", &NonleptonicAmplitudes<PToPP>::arg_penguin_correction, std::make_tuple()),
+                });
 
         return ObservableGroup(imp);
     }
+
     // }}}
 
     ObservableSection
     make_nonleptonic_amplitudes_section()
     {
-        auto imp = new Implementation<ObservableSection>(
-            "Pseudo-observables in nonleptonic amplitudes",
-            "",
-            {
-                // P -> PP amplitudes
-                make_p_to_p_p_amplitudes_group(),
-            }
-        );
+        auto imp = new Implementation<ObservableSection>("Pseudo-observables in nonleptonic amplitudes",
+                                                         "",
+                                                         {
+                                                             // P -> PP amplitudes
+                                                             make_p_to_p_p_amplitudes_group(),
+                                                         });
 
         return ObservableSection(imp);
     }
-}
+} // namespace eos

--- a/eos/nonleptonic-amplitudes/qcdf-amplitudes.cc
+++ b/eos/nonleptonic-amplitudes/qcdf-amplitudes.cc
@@ -18,8 +18,8 @@
  */
 
 
-#include <eos/nonleptonic-amplitudes/qcdf-amplitudes.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/nonleptonic-amplitudes/qcdf-amplitudes.hh>
 #include <eos/utils/options-impl.hh>
 
 #include <map>
@@ -43,8 +43,8 @@ namespace eos
         opt_B_bar(o, options, "B_bar"),
         theta_18(p["eta::theta_18"], *this),
         B(su3f::psd_b_triplet.find(opt_q.value())->second),
-        P1{{}},
-        P2{{}},
+        P1{ {} },
+        P2{ {} },
         Gfermi(p["WET::G_Fermi"], *this),
         mB(p["mass::B_" + opt_q.str()], *this),
         mB_q_0(p["mass::B_" + opt_q.str() + ",0@BSZ2015"], *this),
@@ -56,48 +56,48 @@ namespace eos
         fP1(p["decay-constant::" + opt_p1.str()], *this),
         fP2(p["decay-constant::" + opt_p2.str()], *this),
 
-        re_alpha1(    p["nonleptonic::Re{alpha1}@QCDF"] , *this),
-        im_alpha1(    p["nonleptonic::Im{alpha1}@QCDF"] , *this),
-        re_alpha2(    p["nonleptonic::Re{alpha2}@QCDF"] , *this),
-        im_alpha2(    p["nonleptonic::Im{alpha2}@QCDF"] , *this),
-        re_b1(     p["nonleptonic::Re{b1}@QCDF"] , *this),
-        im_b1(     p["nonleptonic::Im{b1}@QCDF"] , *this),
-        re_b2(     p["nonleptonic::Re{b2}@QCDF"] , *this),
-        im_b2(     p["nonleptonic::Im{b2}@QCDF"] , *this),
-        re_bS1(    p["nonleptonic::Re{bS1}@QCDF"], *this),
-        im_bS1(    p["nonleptonic::Im{bS1}@QCDF"], *this),
-        re_bS2(    p["nonleptonic::Re{bS2}@QCDF"], *this),
-        im_bS2(    p["nonleptonic::Im{bS2}@QCDF"], *this),
+        re_alpha1(p["nonleptonic::Re{alpha1}@QCDF"], *this),
+        im_alpha1(p["nonleptonic::Im{alpha1}@QCDF"], *this),
+        re_alpha2(p["nonleptonic::Re{alpha2}@QCDF"], *this),
+        im_alpha2(p["nonleptonic::Im{alpha2}@QCDF"], *this),
+        re_b1(p["nonleptonic::Re{b1}@QCDF"], *this),
+        im_b1(p["nonleptonic::Im{b1}@QCDF"], *this),
+        re_b2(p["nonleptonic::Re{b2}@QCDF"], *this),
+        im_b2(p["nonleptonic::Im{b2}@QCDF"], *this),
+        re_bS1(p["nonleptonic::Re{bS1}@QCDF"], *this),
+        im_bS1(p["nonleptonic::Im{bS1}@QCDF"], *this),
+        re_bS2(p["nonleptonic::Re{bS2}@QCDF"], *this),
+        im_bS2(p["nonleptonic::Im{bS2}@QCDF"], *this),
 
-        re_alpha3_u(  p["nonleptonic::Re{alpha3_u}@QCDF"] , *this),
-        im_alpha3_u(  p["nonleptonic::Im{alpha3_u}@QCDF"] , *this),
-        re_alpha3_c(  p["nonleptonic::Re{alpha3_c}@QCDF"] , *this),
-        im_alpha3_c(  p["nonleptonic::Im{alpha3_c}@QCDF"] , *this),
-        re_alpha4_u(  p["nonleptonic::Re{alpha4_u}@QCDF"] , *this),
-        im_alpha4_u(  p["nonleptonic::Im{alpha4_u}@QCDF"] , *this),
-        re_alpha4_c(  p["nonleptonic::Re{alpha4_c}@QCDF"] , *this),
-        im_alpha4_c(  p["nonleptonic::Im{alpha4_c}@QCDF"] , *this),
-        re_b4_u(   p["nonleptonic::Re{b4_u}@QCDF"] , *this),
-        im_b4_u(   p["nonleptonic::Im{b4_u}@QCDF"] , *this),
-        re_b4_c(   p["nonleptonic::Re{b4_c}@QCDF"] , *this),
-        im_b4_c(   p["nonleptonic::Im{b4_c}@QCDF"] , *this),
-        re_bS4_u(  p["nonleptonic::Re{bS4_u}@QCDF"] , *this),
-        im_bS4_u(  p["nonleptonic::Im{bS4_u}@QCDF"] , *this),
-        re_bS4_c(  p["nonleptonic::Re{bS4_c}@QCDF"] , *this),
-        im_bS4_c(  p["nonleptonic::Im{bS4_c}@QCDF"] , *this),
+        re_alpha3_u(p["nonleptonic::Re{alpha3_u}@QCDF"], *this),
+        im_alpha3_u(p["nonleptonic::Im{alpha3_u}@QCDF"], *this),
+        re_alpha3_c(p["nonleptonic::Re{alpha3_c}@QCDF"], *this),
+        im_alpha3_c(p["nonleptonic::Im{alpha3_c}@QCDF"], *this),
+        re_alpha4_u(p["nonleptonic::Re{alpha4_u}@QCDF"], *this),
+        im_alpha4_u(p["nonleptonic::Im{alpha4_u}@QCDF"], *this),
+        re_alpha4_c(p["nonleptonic::Re{alpha4_c}@QCDF"], *this),
+        im_alpha4_c(p["nonleptonic::Im{alpha4_c}@QCDF"], *this),
+        re_b4_u(p["nonleptonic::Re{b4_u}@QCDF"], *this),
+        im_b4_u(p["nonleptonic::Im{b4_u}@QCDF"], *this),
+        re_b4_c(p["nonleptonic::Re{b4_c}@QCDF"], *this),
+        im_b4_c(p["nonleptonic::Im{b4_c}@QCDF"], *this),
+        re_bS4_u(p["nonleptonic::Re{bS4_u}@QCDF"], *this),
+        im_bS4_u(p["nonleptonic::Im{bS4_u}@QCDF"], *this),
+        re_bS4_c(p["nonleptonic::Re{bS4_c}@QCDF"], *this),
+        im_bS4_c(p["nonleptonic::Im{bS4_c}@QCDF"], *this),
 
-        re_alpha3EW_c(p["nonleptonic::Re{alpha3EW_c}@QCDF"] , *this),
-        im_alpha3EW_c(p["nonleptonic::Im{alpha3EW_c}@QCDF"] , *this),
-        re_alpha4EW_c(p["nonleptonic::Re{alpha4EW_c}@QCDF"] , *this),
-        im_alpha4EW_c(p["nonleptonic::Im{alpha4EW_c}@QCDF"] , *this),
-        re_b3EW_c( p["nonleptonic::Re{b3EW_c}@QCDF"], *this),
-        im_b3EW_c( p["nonleptonic::Im{b3EW_c}@QCDF"], *this),
+        re_alpha3EW_c(p["nonleptonic::Re{alpha3EW_c}@QCDF"], *this),
+        im_alpha3EW_c(p["nonleptonic::Im{alpha3EW_c}@QCDF"], *this),
+        re_alpha4EW_c(p["nonleptonic::Re{alpha4EW_c}@QCDF"], *this),
+        im_alpha4EW_c(p["nonleptonic::Im{alpha4EW_c}@QCDF"], *this),
+        re_b3EW_c(p["nonleptonic::Re{b3EW_c}@QCDF"], *this),
+        im_b3EW_c(p["nonleptonic::Im{b3EW_c}@QCDF"], *this),
         re_bS3EW_c(p["nonleptonic::Re{bS3EW_c}@QCDF"], *this),
         im_bS3EW_c(p["nonleptonic::Im{bS3EW_c}@QCDF"], *this),
-        re_b4EW_c(    p["nonleptonic::Re{b4EW_c}@QCDF"] , *this),
-        im_b4EW_c(    p["nonleptonic::Im{b4EW_c}@QCDF"] , *this),
-        re_bS4EW_c(   p["nonleptonic::Re{bS4EW_c}@QCDF"] , *this),
-        im_bS4EW_c(   p["nonleptonic::Im{bS4EW_c}@QCDF"] , *this)
+        re_b4EW_c(p["nonleptonic::Re{b4EW_c}@QCDF"], *this),
+        im_b4EW_c(p["nonleptonic::Im{b4EW_c}@QCDF"], *this),
+        re_bS4EW_c(p["nonleptonic::Re{bS4EW_c}@QCDF"], *this),
+        im_bS4EW_c(p["nonleptonic::Im{bS4EW_c}@QCDF"], *this)
     {
         Context ctx("When constructing B->PP QCD amplitudes");
 
@@ -125,17 +125,15 @@ namespace eos
         Lambda_u[2] = lamsu;
         Lambda_c[1] = lamdc;
         Lambda_c[2] = lamsc;
-    };
+    }
 
-    const std::vector<OptionSpecification>
-    QCDFRepresentation<PToPP>::options
-    {
+    const std::vector<OptionSpecification> QCDFRepresentation<PToPP>::options{
         Model::option_specification(),
-        { "cp-conjugate", { "true", "false"},  "false" },
-        { "B_bar", { "true", "false"},  "false" },
-        { "q", { "u", "d", "s" }, "" },
-        { "P1", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" }, "" },
-        { "P2", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" }, "" },
+        { "cp-conjugate",                                                                     { "true", "false" }, "false" },
+        {        "B_bar",                                                                     { "true", "false" }, "false" },
+        {            "q",                                                                       { "u", "d", "s" },      "" },
+        {           "P1", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" },      "" },
+        {           "P2", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" },      "" },
     };
 
     complex<double>
@@ -143,68 +141,58 @@ namespace eos
     {
         complex<double> A_alpha_qcdf = 0.0;
 
-        complex<double>  alpha1     = complex<double>(this->re_alpha1(),    this->im_alpha1()),
-                         alpha2     = complex<double>(this->re_alpha2(),    this->im_alpha2()),
-                         b1      = complex<double>(this->re_b1(),     this->im_b1()),
-                         b2      = complex<double>(this->re_b2(),     this->im_b2()),
-                         bS1     = complex<double>(this->re_bS1(),    this->im_bS1()),
-                         bS2     = complex<double>(this->re_bS2(),    this->im_bS2()),
+        complex<double> alpha1 = complex<double>(this->re_alpha1(), this->im_alpha1()), alpha2 = complex<double>(this->re_alpha2(), this->im_alpha2()),
+                        b1 = complex<double>(this->re_b1(), this->im_b1()), b2 = complex<double>(this->re_b2(), this->im_b2()),
+                        bS1 = complex<double>(this->re_bS1(), this->im_bS1()), bS2 = complex<double>(this->re_bS2(), this->im_bS2()),
 
-                         alpha3_u = complex<double>(this->re_alpha3_u(),   this->im_alpha3_u()),
-                         alpha3_c = complex<double>(this->re_alpha3_c(),   this->im_alpha3_c()),
-                         alpha4_u = complex<double>(this->re_alpha4_u(),   this->im_alpha4_u()),
-                         alpha4_c = complex<double>(this->re_alpha4_c(),   this->im_alpha4_c()),
-                         b4_u     = complex<double>(this->re_b4_u(),    this->im_b4_u()),
-                         b4_c     = complex<double>(this->re_b4_c(),    this->im_b4_c()),
-                         bS4_u    = complex<double>(this->re_bS4_u(),   this->im_bS4_u()),
-                         bS4_c    = complex<double>(this->re_bS4_c(),   this->im_bS4_c()),
+                        alpha3_u = complex<double>(this->re_alpha3_u(), this->im_alpha3_u()), alpha3_c = complex<double>(this->re_alpha3_c(), this->im_alpha3_c()),
+                        alpha4_u = complex<double>(this->re_alpha4_u(), this->im_alpha4_u()), alpha4_c = complex<double>(this->re_alpha4_c(), this->im_alpha4_c()),
+                        b4_u = complex<double>(this->re_b4_u(), this->im_b4_u()), b4_c = complex<double>(this->re_b4_c(), this->im_b4_c()),
+                        bS4_u = complex<double>(this->re_bS4_u(), this->im_bS4_u()), bS4_c = complex<double>(this->re_bS4_c(), this->im_bS4_c()),
 
-                         alpha3EW_c = complex<double>(this->re_alpha3EW_c(), this->im_alpha3EW_c()),
-                         alpha4EW_c = complex<double>(this->re_alpha4EW_c(), this->im_alpha4EW_c()),
-                         b3EW_c  = complex<double>(this->re_b3EW_c(),  this->im_b3EW_c()),
-                         bS3EW_c = complex<double>(this->re_bS3EW_c(), this->im_bS3EW_c()),
-                         b4EW_c     = complex<double>(this->re_b4EW_c(),     this->im_b4EW_c()),
-                         bS4EW_c    = complex<double>(this->re_bS4EW_c(),    this->im_bS4EW_c());
+                        alpha3EW_c = complex<double>(this->re_alpha3EW_c(), this->im_alpha3EW_c()), alpha4EW_c = complex<double>(this->re_alpha4EW_c(), this->im_alpha4EW_c()),
+                        b3EW_c = complex<double>(this->re_b3EW_c(), this->im_b3EW_c()), bS3EW_c = complex<double>(this->re_bS3EW_c(), this->im_bS3EW_c()),
+                        b4EW_c = complex<double>(this->re_b4EW_c(), this->im_b4EW_c()), bS4EW_c = complex<double>(this->re_bS4EW_c(), this->im_bS4EW_c());
 
         std::array<complex<double>, 6> T, P1_c, P1_u, P2_c;
 
         std::array<std::array<std::array<complex<double>, 6>, 6>, 6> C_u, C_c;
 
-                T[0] = alpha1;
-                T[1] = alpha2;
-                T[2] = b2;
-                T[3] = b1;
-                T[4] = bS2;
-                T[5] = bS1;
+        T[0] = alpha1;
+        T[1] = alpha2;
+        T[2] = b2;
+        T[3] = b1;
+        T[4] = bS2;
+        T[5] = bS1;
 
-                P1_u[0] = alpha4_u;
-                P1_u[1] = alpha3_u;
-                P1_u[3] = b4_u;
-                P1_u[5] = bS4_u;
+        P1_u[0] = alpha4_u;
+        P1_u[1] = alpha3_u;
+        P1_u[3] = b4_u;
+        P1_u[5] = bS4_u;
 
-                P1_c[0] = alpha4_c;
-                P1_c[1] = alpha3_c;
-                P1_c[3] = b4_c;
-                P1_c[5] = bS4_c;
+        P1_c[0] = alpha4_c;
+        P1_c[1] = alpha3_c;
+        P1_c[3] = b4_c;
+        P1_c[5] = bS4_c;
 
-                P2_c[0] = alpha4EW_c;
-                P2_c[1] = alpha3EW_c;
-                P2_c[2] = b3EW_c;
-                P2_c[3] = b4EW_c;
-                P2_c[4] = bS3EW_c;
-                P2_c[5] = bS4EW_c;
+        P2_c[0] = alpha4EW_c;
+        P2_c[1] = alpha3EW_c;
+        P2_c[2] = b3EW_c;
+        P2_c[3] = b4EW_c;
+        P2_c[4] = bS3EW_c;
+        P2_c[5] = bS4EW_c;
 
-                for (unsigned i = 0; i < 3; i++)
+        for (unsigned i = 0; i < 3; i++)
+        {
+            for (unsigned j = 0; j < 3; j++)
+            {
+                for (unsigned a = 0; a < 6; a++)
                 {
-                    for (unsigned j = 0; j < 3; j++)
-                    {
-                        for (unsigned a = 0; a < 6; a++)
-                        {
-                            C_u[a][i][j] = T[a] * U[i][j] + P1_u[a] * I[i][j];
-                            C_c[a][i][j] = 3.0/2.0 * P2_c[a] * U[i][j] + P1_c[a] * I[i][j] ;
-                        }
-                    }
+                    C_u[a][i][j] = T[a] * U[i][j] + P1_u[a] * I[i][j];
+                    C_c[a][i][j] = 3.0 / 2.0 * P2_c[a] * U[i][j] + P1_c[a] * I[i][j];
                 }
+            }
+        }
 
         for (unsigned i = 0; i < 3; i++)
         {
@@ -214,13 +202,11 @@ namespace eos
                 {
                     for (unsigned l = 0; l < 3; l++)
                     {
-
                         A_alpha_qcdf += B[i] * p1[i][j] * C_u[0][j][k] * p2[k][l] * Lambda_u[l];
                         A_alpha_qcdf += B[i] * p1[i][j] * Lambda_u[j] * C_u[1][l][k] * p2[k][l];
 
                         A_alpha_qcdf += B[i] * p1[i][j] * C_c[0][j][k] * p2[k][l] * Lambda_c[l];
                         A_alpha_qcdf += B[i] * p1[i][j] * Lambda_c[j] * C_c[1][l][k] * p2[k][l];
-
                     }
                 }
             }
@@ -234,68 +220,58 @@ namespace eos
     {
         complex<double> A_b_qcdf = 0.0;
 
-        complex<double> alpha1     = complex<double>(this->re_alpha1(),    this->im_alpha1()),
-                        alpha2     = complex<double>(this->re_alpha2(),    this->im_alpha2()),
-                        b1      = complex<double>(this->re_b1(),     this->im_b1()),
-                        b2      = complex<double>(this->re_b2(),     this->im_b2()),
-                        bS1     = complex<double>(this->re_bS1(),    this->im_bS1()),
-                        bS2     = complex<double>(this->re_bS2(),    this->im_bS2()),
+        complex<double> alpha1 = complex<double>(this->re_alpha1(), this->im_alpha1()), alpha2 = complex<double>(this->re_alpha2(), this->im_alpha2()),
+                        b1 = complex<double>(this->re_b1(), this->im_b1()), b2 = complex<double>(this->re_b2(), this->im_b2()),
+                        bS1 = complex<double>(this->re_bS1(), this->im_bS1()), bS2 = complex<double>(this->re_bS2(), this->im_bS2()),
 
-                        alpha3_u = complex<double>(this->re_alpha3_u(),   this->im_alpha3_u()),
-                        alpha3_c = complex<double>(this->re_alpha3_c(),   this->im_alpha3_c()),
-                        alpha4_u = complex<double>(this->re_alpha4_u(),   this->im_alpha4_u()),
-                        alpha4_c = complex<double>(this->re_alpha4_c(),   this->im_alpha4_c()),
-                        b4_u     = complex<double>(this->re_b4_u(),    this->im_b4_u()),
-                        b4_c     = complex<double>(this->re_b4_c(),    this->im_b4_c()),
-                        bS4_u    = complex<double>(this->re_bS4_u(),   this->im_bS4_u()),
-                        bS4_c    = complex<double>(this->re_bS4_c(),   this->im_bS4_c()),
+                        alpha3_u = complex<double>(this->re_alpha3_u(), this->im_alpha3_u()), alpha3_c = complex<double>(this->re_alpha3_c(), this->im_alpha3_c()),
+                        alpha4_u = complex<double>(this->re_alpha4_u(), this->im_alpha4_u()), alpha4_c = complex<double>(this->re_alpha4_c(), this->im_alpha4_c()),
+                        b4_u = complex<double>(this->re_b4_u(), this->im_b4_u()), b4_c = complex<double>(this->re_b4_c(), this->im_b4_c()),
+                        bS4_u = complex<double>(this->re_bS4_u(), this->im_bS4_u()), bS4_c = complex<double>(this->re_bS4_c(), this->im_bS4_c()),
 
-                        alpha3EW_c = complex<double>(this->re_alpha3EW_c(), this->im_alpha3EW_c()),
-                        alpha4EW_c = complex<double>(this->re_alpha4EW_c(), this->im_alpha4EW_c()),
-                        b3EW_c  = complex<double>(this->re_b3EW_c(),  this->im_b3EW_c()),
-                        bS3EW_c = complex<double>(this->re_bS3EW_c(), this->im_bS3EW_c()),
-                        b4EW_c     = complex<double>(this->re_b4EW_c(),     this->im_b4EW_c()),
-                        bS4EW_c    = complex<double>(this->re_bS4EW_c(),    this->im_bS4EW_c());
+                        alpha3EW_c = complex<double>(this->re_alpha3EW_c(), this->im_alpha3EW_c()), alpha4EW_c = complex<double>(this->re_alpha4EW_c(), this->im_alpha4EW_c()),
+                        b3EW_c = complex<double>(this->re_b3EW_c(), this->im_b3EW_c()), bS3EW_c = complex<double>(this->re_bS3EW_c(), this->im_bS3EW_c()),
+                        b4EW_c = complex<double>(this->re_b4EW_c(), this->im_b4EW_c()), bS4EW_c = complex<double>(this->re_bS4EW_c(), this->im_bS4EW_c());
 
         std::array<complex<double>, 6> T, P1_c, P1_u, P2_c;
 
         std::array<std::array<std::array<complex<double>, 6>, 6>, 6> C_u, C_c;
 
-                T[0] = alpha1;
-                T[1] = alpha2;
-                T[2] = b2;
-                T[3] = b1;
-                T[4] = bS2;
-                T[5] = bS1;
+        T[0] = alpha1;
+        T[1] = alpha2;
+        T[2] = b2;
+        T[3] = b1;
+        T[4] = bS2;
+        T[5] = bS1;
 
-                P1_u[0] = alpha4_u;
-                P1_u[1] = alpha3_u;
-                P1_u[3] = b4_u;
-                P1_u[5] = bS4_u;
+        P1_u[0] = alpha4_u;
+        P1_u[1] = alpha3_u;
+        P1_u[3] = b4_u;
+        P1_u[5] = bS4_u;
 
-                P1_c[0] = alpha4_c;
-                P1_c[1] = alpha3_c;
-                P1_c[3] = b4_c;
-                P1_c[5] = bS4_c;
+        P1_c[0] = alpha4_c;
+        P1_c[1] = alpha3_c;
+        P1_c[3] = b4_c;
+        P1_c[5] = bS4_c;
 
-                P2_c[0] = alpha4EW_c;
-                P2_c[1] = alpha3EW_c;
-                P2_c[2] = b3EW_c;
-                P2_c[3] = b4EW_c;
-                P2_c[4] = bS3EW_c;
-                P2_c[5] = bS4EW_c;
+        P2_c[0] = alpha4EW_c;
+        P2_c[1] = alpha3EW_c;
+        P2_c[2] = b3EW_c;
+        P2_c[3] = b4EW_c;
+        P2_c[4] = bS3EW_c;
+        P2_c[5] = bS4EW_c;
 
-                for (unsigned i = 0; i < 3; i++)
+        for (unsigned i = 0; i < 3; i++)
+        {
+            for (unsigned j = 0; j < 3; j++)
+            {
+                for (unsigned a = 0; a < 6; a++)
                 {
-                    for (unsigned j = 0; j < 3; j++)
-                    {
-                        for (unsigned a = 0; a < 6; a++)
-                        {
-                            C_u[a][i][j] = T[a] * U[i][j] + P1_u[a] * I[i][j];
-                            C_c[a][i][j] = 3.0/2.0 * P2_c[a] * U[i][j] + P1_c[a] * I[i][j] ;
-                        }
-                    }
+                    C_u[a][i][j] = T[a] * U[i][j] + P1_u[a] * I[i][j];
+                    C_c[a][i][j] = 3.0 / 2.0 * P2_c[a] * U[i][j] + P1_c[a] * I[i][j];
                 }
+            }
+        }
 
         for (unsigned i = 0; i < 3; i++)
         {
@@ -305,7 +281,6 @@ namespace eos
                 {
                     for (unsigned l = 0; l < 3; l++)
                     {
-
                         A_b_qcdf += B[i] * C_u[2][i][k] * p1[k][l] * p2[l][j] * Lambda_u[j];
                         A_b_qcdf += B[i] * Lambda_u[i] * C_u[3][l][k] * p1[k][j] * p2[j][l];
                         A_b_qcdf += B[i] * C_u[4][i][k] * p1[k][j] * Lambda_u[j] * p2[l][l];
@@ -315,7 +290,6 @@ namespace eos
                         A_b_qcdf += B[i] * Lambda_c[i] * C_c[3][l][k] * p1[k][j] * p2[j][l];
                         A_b_qcdf += B[i] * C_c[4][i][k] * p1[k][j] * Lambda_c[j] * p2[l][l];
                         A_b_qcdf += B[i] * Lambda_c[i] * C_c[5][j][k] * p1[k][j] * p2[l][l];
-
                     }
                 }
             }
@@ -351,4 +325,4 @@ namespace eos
 
         return power_of<2>(mB()) * FP2() * fP1() / (1 - power_of<2>(mP1() / mB_q_0())) * this->alpha_amplitude(P2, P1) + fB() * fP1() * fP2() * this->b_amplitude(P2, P1);
     }
-}
+} // namespace eos

--- a/eos/nonleptonic-amplitudes/qcdf-amplitudes.hh
+++ b/eos/nonleptonic-amplitudes/qcdf-amplitudes.hh
@@ -20,10 +20,10 @@
 #ifndef EOS_GUARD_EOS_NONLEPTONIC_AMPLITUDES_QCDF_AMPLITUDES_HH
 #define EOS_GUARD_EOS_NONLEPTONIC_AMPLITUDES_QCDF_AMPLITUDES_HH 1
 
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh>
 #include <eos/maths/complex.hh>
 #include <eos/models/model.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
 #include <eos/utils/parameters.hh>
 
 #include <array>
@@ -33,23 +33,21 @@ namespace eos
 {
     template <typename Transition_> class QCDFRepresentation;
 
-    template <>
-    class QCDFRepresentation<PToPP> :
-        public NonleptonicAmplitudes<PToPP>
+    template <> class QCDFRepresentation<PToPP> : public NonleptonicAmplitudes<PToPP>
     {
         private:
             std::shared_ptr<Model> model;
-            QuarkFlavorOption opt_q;
-            LightMesonOption opt_p1;
-            LightMesonOption opt_p2;
-            BooleanOption opt_cp_conjugate;
-            BooleanOption opt_B_bar;
+            QuarkFlavorOption      opt_q;
+            LightMesonOption       opt_p1;
+            LightMesonOption       opt_p2;
+            BooleanOption          opt_cp_conjugate;
+            BooleanOption          opt_B_bar;
 
             UsedParameter theta_18;
 
-            su3f::rank1 B;
+            su3f::rank1                    B;
             std::array<complex<double>, 6> Lambda_u, Lambda_c;
-            mutable su3f::rank2 P1, P2, U, I;
+            mutable su3f::rank2            P1, P2, U, I;
 
             UsedParameter Gfermi;
             UsedParameter mB;
@@ -95,9 +93,10 @@ namespace eos
         public:
             QCDFRepresentation(const Parameters & p, const Options & o);
 
-            ~QCDFRepresentation() {};
+            ~QCDFRepresentation() {}
 
-            inline void update() const
+            inline void
+            update() const
             {
                 const double theta_18 = this->theta_18.evaluate();
                 su3f::psd_octet.find(opt_p1.value())->second(theta_18, P1);
@@ -111,13 +110,24 @@ namespace eos
             complex<double> b_amplitude(su3f::rank2 & p1, su3f::rank2 & p2) const;
 
             // Diagnostic functions
-            complex<double> alpha_amplitude() const { update(); return alpha_amplitude(P1, P2); }
-            complex<double> b_amplitude() const { update(); return b_amplitude(P1, P2); };
+            complex<double>
+            alpha_amplitude() const
+            {
+                update();
+                return alpha_amplitude(P1, P2);
+            }
+
+            complex<double>
+            b_amplitude() const
+            {
+                update();
+                return b_amplitude(P1, P2);
+            }
 
             // Amplitude for B -> P1 P2
             complex<double> ordered_amplitude() const;
             // Amplitude for B -> P2 P1
             complex<double> inverse_amplitude() const;
     };
-}
+} // namespace eos
 #endif

--- a/eos/nonleptonic-amplitudes/qcdf-amplitudes_TEST.cc
+++ b/eos/nonleptonic-amplitudes/qcdf-amplitudes_TEST.cc
@@ -17,15 +17,15 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/maths/complex.hh>
 #include <eos/nonleptonic-amplitudes/qcdf-amplitudes.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
 
-class QCDFAmplitudesTest :
-    public TestCase
+class QCDFAmplitudesTest : public TestCase
 {
     public:
         QCDFAmplitudesTest() :
@@ -33,163 +33,155 @@ class QCDFAmplitudesTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-
             {
                 Parameters p = Parameters::Defaults();
 
-                p["nonleptonic::Re{alpha1}@QCDF"]     =  0.1 * std::cos( 0.1);
-                p["nonleptonic::Im{alpha1}@QCDF"]     =  0.1 * std::sin( 0.1);
-                p["nonleptonic::Re{alpha2}@QCDF"]     = -0.2 * std::cos(-0.2);
-                p["nonleptonic::Im{alpha2}@QCDF"]     = -0.2 * std::sin(-0.2);
-                p["nonleptonic::Re{b2}@QCDF"]         =  0.3 * std::cos( 0.3);
-                p["nonleptonic::Im{b2}@QCDF"]         =  0.3 * std::sin( 0.3);
-                p["nonleptonic::Re{b1}@QCDF"]         = -0.4 * std::cos(-0.4);
-                p["nonleptonic::Im{b1}@QCDF"]         = -0.4 * std::sin(-0.4);
-                p["nonleptonic::Re{bS2}@QCDF"]        =  0.5 * std::cos( 0.5);
-                p["nonleptonic::Im{bS2}@QCDF"]        =  0.5 * std::sin( 0.5);
-                p["nonleptonic::Re{bS1}@QCDF"]        = -0.6 * std::cos(-0.6);
-                p["nonleptonic::Im{bS1}@QCDF"]        = -0.6 * std::sin(-0.6);
+                p["nonleptonic::Re{alpha1}@QCDF"] = 0.1 * std::cos(0.1);
+                p["nonleptonic::Im{alpha1}@QCDF"] = 0.1 * std::sin(0.1);
+                p["nonleptonic::Re{alpha2}@QCDF"] = -0.2 * std::cos(-0.2);
+                p["nonleptonic::Im{alpha2}@QCDF"] = -0.2 * std::sin(-0.2);
+                p["nonleptonic::Re{b2}@QCDF"]     = 0.3 * std::cos(0.3);
+                p["nonleptonic::Im{b2}@QCDF"]     = 0.3 * std::sin(0.3);
+                p["nonleptonic::Re{b1}@QCDF"]     = -0.4 * std::cos(-0.4);
+                p["nonleptonic::Im{b1}@QCDF"]     = -0.4 * std::sin(-0.4);
+                p["nonleptonic::Re{bS2}@QCDF"]    = 0.5 * std::cos(0.5);
+                p["nonleptonic::Im{bS2}@QCDF"]    = 0.5 * std::sin(0.5);
+                p["nonleptonic::Re{bS1}@QCDF"]    = -0.6 * std::cos(-0.6);
+                p["nonleptonic::Im{bS1}@QCDF"]    = -0.6 * std::sin(-0.6);
 
-                p["nonleptonic::Re{alpha4_u}@QCDF"]   =  0.7 * std::cos( 0.7);
-                p["nonleptonic::Im{alpha4_u}@QCDF"]   =  0.7 * std::sin( 0.7);
-                p["nonleptonic::Re{alpha3_u}@QCDF"]   = -0.8 * std::cos(-0.8);
-                p["nonleptonic::Im{alpha3_u}@QCDF"]   = -0.8 * std::sin(-0.8);
-                p["nonleptonic::Re{b4_u}@QCDF"]       =  0.9 * std::cos( 0.9);
-                p["nonleptonic::Im{b4_u}@QCDF"]       =  0.9 * std::sin( 0.9);
-                p["nonleptonic::Re{bS4_u}@QCDF"]      = -1.0 * std::cos(-1.0);
-                p["nonleptonic::Im{bS4_u}@QCDF"]      = -1.0 * std::sin(-1.0);
+                p["nonleptonic::Re{alpha4_u}@QCDF"] = 0.7 * std::cos(0.7);
+                p["nonleptonic::Im{alpha4_u}@QCDF"] = 0.7 * std::sin(0.7);
+                p["nonleptonic::Re{alpha3_u}@QCDF"] = -0.8 * std::cos(-0.8);
+                p["nonleptonic::Im{alpha3_u}@QCDF"] = -0.8 * std::sin(-0.8);
+                p["nonleptonic::Re{b4_u}@QCDF"]     = 0.9 * std::cos(0.9);
+                p["nonleptonic::Im{b4_u}@QCDF"]     = 0.9 * std::sin(0.9);
+                p["nonleptonic::Re{bS4_u}@QCDF"]    = -1.0 * std::cos(-1.0);
+                p["nonleptonic::Im{bS4_u}@QCDF"]    = -1.0 * std::sin(-1.0);
 
-                p["nonleptonic::Re{alpha4EW_c}@QCDF"] =  1.1 * std::cos( 1.1);
-                p["nonleptonic::Im{alpha4EW_c}@QCDF"] =  1.1 * std::sin( 1.1);
+                p["nonleptonic::Re{alpha4EW_c}@QCDF"] = 1.1 * std::cos(1.1);
+                p["nonleptonic::Im{alpha4EW_c}@QCDF"] = 1.1 * std::sin(1.1);
                 p["nonleptonic::Re{alpha3EW_c}@QCDF"] = -1.2 * std::cos(-1.2);
                 p["nonleptonic::Im{alpha3EW_c}@QCDF"] = -1.2 * std::sin(-1.2);
-                p["nonleptonic::Re{b3EW_c}@QCDF"]     =  1.3 * std::cos( 1.3);
-                p["nonleptonic::Im{b3EW_c}@QCDF"]     =  1.3 * std::sin( 1.3);
+                p["nonleptonic::Re{b3EW_c}@QCDF"]     = 1.3 * std::cos(1.3);
+                p["nonleptonic::Im{b3EW_c}@QCDF"]     = 1.3 * std::sin(1.3);
                 p["nonleptonic::Re{b4EW_c}@QCDF"]     = -1.4 * std::cos(-1.4);
                 p["nonleptonic::Im{b4EW_c}@QCDF"]     = -1.4 * std::sin(-1.4);
-                p["nonleptonic::Re{bS3EW_c}@QCDF"]    =  1.5 * std::cos( 1.5);
-                p["nonleptonic::Im{bS3EW_c}@QCDF"]    =  1.5 * std::sin( 1.5);
+                p["nonleptonic::Re{bS3EW_c}@QCDF"]    = 1.5 * std::cos(1.5);
+                p["nonleptonic::Im{bS3EW_c}@QCDF"]    = 1.5 * std::sin(1.5);
                 p["nonleptonic::Re{bS4EW_c}@QCDF"]    = -1.6 * std::cos(-1.6);
                 p["nonleptonic::Im{bS4EW_c}@QCDF"]    = -1.6 * std::sin(-1.6);
 
-                p["nonleptonic::Re{alpha4_c}@QCDF"]   =  1.7 * std::cos( 1.7);
-                p["nonleptonic::Im{alpha4_c}@QCDF"]   =  1.7 * std::sin( 1.7);
-                p["nonleptonic::Re{alpha3_c}@QCDF"]   = -1.8 * std::cos(-1.8);
-                p["nonleptonic::Im{alpha3_c}@QCDF"]   = -1.8 * std::sin(-1.8);
-                p["nonleptonic::Re{b4_c}@QCDF"]       =  1.9 * std::cos( 1.9);
-                p["nonleptonic::Im{b4_c}@QCDF"]       =  1.9 * std::sin( 1.9);
-                p["nonleptonic::Re{bS4_c}@QCDF"]      = -2.0 * std::cos(-2.0);
-                p["nonleptonic::Im{bS4_c}@QCDF"]      = -2.0 * std::sin(-2.0);
-                p["eta::theta_18"]                    =  0.0;
+                p["nonleptonic::Re{alpha4_c}@QCDF"] = 1.7 * std::cos(1.7);
+                p["nonleptonic::Im{alpha4_c}@QCDF"] = 1.7 * std::sin(1.7);
+                p["nonleptonic::Re{alpha3_c}@QCDF"] = -1.8 * std::cos(-1.8);
+                p["nonleptonic::Im{alpha3_c}@QCDF"] = -1.8 * std::sin(-1.8);
+                p["nonleptonic::Re{b4_c}@QCDF"]     = 1.9 * std::cos(1.9);
+                p["nonleptonic::Im{b4_c}@QCDF"]     = 1.9 * std::sin(1.9);
+                p["nonleptonic::Re{bS4_c}@QCDF"]    = -2.0 * std::cos(-2.0);
+                p["nonleptonic::Im{bS4_c}@QCDF"]    = -2.0 * std::sin(-2.0);
+                p["eta::theta_18"]                  = 0.0;
 
 
                 static const double eps = 0.1e-6;
 
-                Options o
-                {
-                    { "q", "u" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^+" },
-                    { "model", "CKM" },
+                Options o{
+                    {     "q",    "u" },
+                    {    "P1", "pi^0" },
+                    {    "P2", "pi^+" },
+                    { "model",  "CKM" },
                 };
 
                 QCDFRepresentation<PToPP> d(p, o);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude() , complex<double>( 1.7700615877797436e-7, -3.729986432372129e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude() , complex<double>( 1.824413161575804e-8, 2.9651504220674708e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude() , complex<double>( 1.9525029039373238e-7, -7.648360103046585e-9), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(1.7700615877797436e-7, -3.729986432372129e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>(1.824413161575804e-8, 2.9651504220674708e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(), complex<double>(1.9525029039373238e-7, -7.648360103046585e-9), eps);
 
-                Options o2
-                {
-                    { "q", "d" },
-                    { "P1", "pi^+" },
-                    { "P2", "pi^-" },
-                    { "model", "CKM" },
+                Options o2{
+                    {     "q",    "d" },
+                    {    "P1", "pi^+" },
+                    {    "P2", "pi^-" },
+                    { "model",  "CKM" },
                 };
 
                 QCDFRepresentation<PToPP> d2(p, o2);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d2.ordered_amplitude() , complex<double>(9.28644842045893e-10,1.7567955154889877e-10 ), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d2.inverse_amplitude() , complex<double>( 2.5029133262201755e-7, -5.25160783494036e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d2.amplitude() , complex<double>( 2.5121997746406343e-7, -5.23403987978547e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d2.ordered_amplitude(), complex<double>(9.28644842045893e-10, 1.7567955154889877e-10), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d2.inverse_amplitude(), complex<double>(2.5029133262201755e-7, -5.25160783494036e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d2.amplitude(), complex<double>(2.5121997746406343e-7, -5.23403987978547e-8), eps);
 
 
-                Options o3
-                {
-                    { "q", "d" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^0" },
-                    { "model", "CKM" },
+                Options o3{
+                    {     "q",    "d" },
+                    {    "P1", "pi^0" },
+                    {    "P2", "pi^0" },
+                    { "model",  "CKM" },
                 };
 
                 QCDFRepresentation<PToPP> d3(p, o3);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d3.ordered_amplitude() , complex<double>(-1.24690300570092e-8 ,-2.0761356952422998e-8 ), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d3.inverse_amplitude() , complex<double>( -1.24690300570092e-8, -2.0761356952422998e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d3.amplitude() , complex<double>( -2.49380601140184e-8, -4.1522713904845995e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d3.ordered_amplitude(), complex<double>(-1.24690300570092e-8, -2.0761356952422998e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d3.inverse_amplitude(), complex<double>(-1.24690300570092e-8, -2.0761356952422998e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d3.amplitude(), complex<double>(-2.49380601140184e-8, -4.1522713904845995e-8), eps);
 
-                Options o4
-                {
-                    { "q", "d" },
-                    { "P1", "K_d" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
+                Options o4{
+                    {     "q",      "d" },
+                    {    "P1",    "K_d" },
+                    {    "P2", "Kbar_d" },
+                    { "model",    "CKM" },
                 };
 
                 QCDFRepresentation<PToPP> d4(p, o4);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d4.ordered_amplitude() , complex<double>(1.6400147304326383e-7 ,1.524228015749374e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d4.inverse_amplitude() , complex<double>( 5.463352288201433e-10, 1.6014652984753204e-10), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d4.amplitude() , complex<double>( 1.6454780827208397e-7, 1.540242668734127e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d4.ordered_amplitude(), complex<double>(1.6400147304326383e-7, 1.524228015749374e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d4.inverse_amplitude(), complex<double>(5.463352288201433e-10, 1.6014652984753204e-10), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d4.amplitude(), complex<double>(1.6454780827208397e-7, 1.540242668734127e-8), eps);
 
-                Options o5
-                {
-                    { "q", "s" },
-                    { "P1", "K_d" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "false"}
+                Options o5{
+                    {            "q",      "s" },
+                    {           "P1",    "K_d" },
+                    {           "P2", "Kbar_d" },
+                    {        "model",    "CKM" },
+                    { "cp-conjugate",  "false" }
                 };
 
                 QCDFRepresentation<PToPP> d5(p, o5);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d5.ordered_amplitude() , complex<double>(-3.4371121163743705e-9 ,-1.1816622077486445e-9), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d5.inverse_amplitude() , complex<double>( -7.822191406502231e-7, -1.036958299899132e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d5.amplitude() , complex<double>( -7.856562527665976e-7, -1.0487749219766184e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d5.ordered_amplitude(), complex<double>(-3.4371121163743705e-9, -1.1816622077486445e-9), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d5.inverse_amplitude(), complex<double>(-7.822191406502231e-7, -1.036958299899132e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d5.amplitude(), complex<double>(-7.856562527665976e-7, -1.0487749219766184e-7), eps);
 
 
-                Options o6
-                {
-                    { "q", "s" },
-                    { "P1", "Kbar_d" },
-                    { "P2", "eta" },
-                    { "model", "CKM" },
+                Options o6{
+                    {     "q",      "s" },
+                    {    "P1", "Kbar_d" },
+                    {    "P2",    "eta" },
+                    { "model",    "CKM" },
                 };
 
                 QCDFRepresentation<PToPP> d6(p, o6);
 
 
-                TEST_CHECK_RELATIVE_ERROR_C(d6.ordered_amplitude() , complex<double>( 1.0387328442424082e-7, 2.4381522005734528e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d6.inverse_amplitude() , complex<double>(-8.803841392611456e-8 ,-8.123373428047469e-9), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d6.amplitude() , complex<double>( 1.5834870498126266e-8, 1.625814857768706e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d6.ordered_amplitude(), complex<double>(1.0387328442424082e-7, 2.4381522005734528e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d6.inverse_amplitude(), complex<double>(-8.803841392611456e-8, -8.123373428047469e-9), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d6.amplitude(), complex<double>(1.5834870498126266e-8, 1.625814857768706e-8), eps);
 
-                Options o7
-                {
-                    { "q", "d" },
-                    { "P1", "K_d" },
-                    { "P2", "eta_prime" },
-                    { "model", "CKM" },
+                Options o7{
+                    {     "q",         "d" },
+                    {    "P1",       "K_d" },
+                    {    "P2", "eta_prime" },
+                    { "model",       "CKM" },
                 };
 
                 QCDFRepresentation<PToPP> d7(p, o7);
 
 
-                TEST_CHECK_RELATIVE_ERROR_C(d7.ordered_amplitude() , complex<double>( -7.836971891724648e-7, 2.7757074325068556e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d7.inverse_amplitude() , complex<double>(-1.886061740105515e-7 ,-2.4826978870673098e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d7.amplitude() , complex<double>( -9.723033631830163e-7, 2.930095454395456e-9), eps);
-
+                TEST_CHECK_RELATIVE_ERROR_C(d7.ordered_amplitude(), complex<double>(-7.836971891724648e-7, 2.7757074325068556e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d7.inverse_amplitude(), complex<double>(-1.886061740105515e-7, -2.4826978870673098e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d7.amplitude(), complex<double>(-9.723033631830163e-7, 2.930095454395456e-9), eps);
             }
         }
 } qcdf_amplitudes_test;

--- a/eos/nonleptonic-amplitudes/su3f-amplitudes.cc
+++ b/eos/nonleptonic-amplitudes/su3f-amplitudes.cc
@@ -18,8 +18,8 @@
  */
 
 
-#include <eos/nonleptonic-amplitudes/su3f-amplitudes.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/nonleptonic-amplitudes/su3f-amplitudes.hh>
 #include <eos/utils/options-impl.hh>
 
 #include <map>
@@ -34,7 +34,7 @@ namespace eos
         return new SU3FRepresentation<PToPP>(p, o);
     }
 
-    SU3FRepresentation<PToPP>::SU3FRepresentation(const Parameters & p, const Options & o):
+    SU3FRepresentation<PToPP>::SU3FRepresentation(const Parameters & p, const Options & o) :
         model(Model::make(o.get("model", "SM"), p, o)),
         opt_q(o, options, "q"),
         opt_p1(o, options, "P1"),
@@ -45,53 +45,53 @@ namespace eos
         B(su3f::psd_b_triplet.find(opt_q.value())->second),
         H3bar({}),
         H3tilde({}),
-        P1{{}},
-        P2{{}},
+        P1{ {} },
+        P2{ {} },
         H6bar({}),
         H6tilde({}),
         H15bar({}),
         H15tilde({}),
         Gfermi(p["WET::G_Fermi"], *this),
-        re_AT3( p["nonleptonic::Re{AT3}@SU3F"] , *this),
-        im_AT3( p["nonleptonic::Im{AT3}@SU3F"] , *this),
-        re_CT3( p["nonleptonic::Re{CT3}@SU3F"] , *this),
-        im_CT3( p["nonleptonic::Im{CT3}@SU3F"] , *this),
-        re_AT6( p["nonleptonic::Re{AT6}@SU3F"] , *this),
-        im_AT6( p["nonleptonic::Im{AT6}@SU3F"] , *this),
-        re_CT6( p["nonleptonic::Re{CT6}@SU3F"] , *this),
-        im_CT6( p["nonleptonic::Im{CT6}@SU3F"] , *this),
+        re_AT3(p["nonleptonic::Re{AT3}@SU3F"], *this),
+        im_AT3(p["nonleptonic::Im{AT3}@SU3F"], *this),
+        re_CT3(p["nonleptonic::Re{CT3}@SU3F"], *this),
+        im_CT3(p["nonleptonic::Im{CT3}@SU3F"], *this),
+        re_AT6(p["nonleptonic::Re{AT6}@SU3F"], *this),
+        im_AT6(p["nonleptonic::Im{AT6}@SU3F"], *this),
+        re_CT6(p["nonleptonic::Re{CT6}@SU3F"], *this),
+        im_CT6(p["nonleptonic::Im{CT6}@SU3F"], *this),
         re_AT15(p["nonleptonic::Re{AT15}@SU3F"], *this),
         im_AT15(p["nonleptonic::Im{AT15}@SU3F"], *this),
         re_CT15(p["nonleptonic::Re{CT15}@SU3F"], *this),
         im_CT15(p["nonleptonic::Im{CT15}@SU3F"], *this),
-        re_BT3( p["nonleptonic::Re{BT3}@SU3F"] , *this),
-        im_BT3( p["nonleptonic::Im{BT3}@SU3F"] , *this),
-        re_BT6( p["nonleptonic::Re{BT6}@SU3F"] , *this),
-        im_BT6( p["nonleptonic::Im{BT6}@SU3F"] , *this),
+        re_BT3(p["nonleptonic::Re{BT3}@SU3F"], *this),
+        im_BT3(p["nonleptonic::Im{BT3}@SU3F"], *this),
+        re_BT6(p["nonleptonic::Re{BT6}@SU3F"], *this),
+        im_BT6(p["nonleptonic::Im{BT6}@SU3F"], *this),
         re_BT15(p["nonleptonic::Re{BT15}@SU3F"], *this),
         im_BT15(p["nonleptonic::Im{BT15}@SU3F"], *this),
-        re_DT3( p["nonleptonic::Re{DT3}@SU3F"] , *this),
-        im_DT3( p["nonleptonic::Im{DT3}@SU3F"] , *this),
-        re_AP3( p["nonleptonic::Re{AP3}@SU3F"] , *this),
-        im_AP3( p["nonleptonic::Im{AP3}@SU3F"] , *this),
-        re_CP3( p["nonleptonic::Re{CP3}@SU3F"] , *this),
-        im_CP3( p["nonleptonic::Im{CP3}@SU3F"] , *this),
-        re_AP6( p["nonleptonic::Re{AP6}@SU3F"] , *this),
-        im_AP6( p["nonleptonic::Im{AP6}@SU3F"] , *this),
-        re_CP6( p["nonleptonic::Re{CP6}@SU3F"] , *this),
-        im_CP6( p["nonleptonic::Im{CP6}@SU3F"] , *this),
+        re_DT3(p["nonleptonic::Re{DT3}@SU3F"], *this),
+        im_DT3(p["nonleptonic::Im{DT3}@SU3F"], *this),
+        re_AP3(p["nonleptonic::Re{AP3}@SU3F"], *this),
+        im_AP3(p["nonleptonic::Im{AP3}@SU3F"], *this),
+        re_CP3(p["nonleptonic::Re{CP3}@SU3F"], *this),
+        im_CP3(p["nonleptonic::Im{CP3}@SU3F"], *this),
+        re_AP6(p["nonleptonic::Re{AP6}@SU3F"], *this),
+        im_AP6(p["nonleptonic::Im{AP6}@SU3F"], *this),
+        re_CP6(p["nonleptonic::Re{CP6}@SU3F"], *this),
+        im_CP6(p["nonleptonic::Im{CP6}@SU3F"], *this),
         re_AP15(p["nonleptonic::Re{AP15}@SU3F"], *this),
         im_AP15(p["nonleptonic::Im{AP15}@SU3F"], *this),
         re_CP15(p["nonleptonic::Re{CP15}@SU3F"], *this),
         im_CP15(p["nonleptonic::Im{CP15}@SU3F"], *this),
-        re_BP3( p["nonleptonic::Re{BP3}@SU3F"] , *this),
-        im_BP3( p["nonleptonic::Im{BP3}@SU3F"] , *this),
-        re_BP6( p["nonleptonic::Re{BP6}@SU3F"] , *this),
-        im_BP6( p["nonleptonic::Im{BP6}@SU3F"] , *this),
+        re_BP3(p["nonleptonic::Re{BP3}@SU3F"], *this),
+        im_BP3(p["nonleptonic::Im{BP3}@SU3F"], *this),
+        re_BP6(p["nonleptonic::Re{BP6}@SU3F"], *this),
+        im_BP6(p["nonleptonic::Im{BP6}@SU3F"], *this),
         re_BP15(p["nonleptonic::Re{BP15}@SU3F"], *this),
         im_BP15(p["nonleptonic::Im{BP15}@SU3F"], *this),
-        re_DP3( p["nonleptonic::Re{DP3}@SU3F"] , *this),
-        im_DP3( p["nonleptonic::Im{DP3}@SU3F"] , *this)
+        re_DP3(p["nonleptonic::Re{DP3}@SU3F"], *this),
+        im_DP3(p["nonleptonic::Im{DP3}@SU3F"], *this)
     {
         Context ctx("When constructing B->PP SU3 amplitudes");
 
@@ -160,33 +160,26 @@ namespace eos
         H15tilde[2][2][2] = -2.0 * lamst;
         H15tilde[2][1][1] = -lamst; // Corrected with respect to typo in [HTX:2021A]
         H15tilde[1][2][1] = -lamst; // Corrected with respect to typo in [HTX:2021A]
-    };
+    }
 
-    const std::vector<OptionSpecification>
-    SU3FRepresentation<PToPP>::options
-    {
+    const std::vector<OptionSpecification> SU3FRepresentation<PToPP>::options{
         Model::option_specification(),
-        { "cp-conjugate", { "true", "false" },  "false" },
-        { "B_bar", { "true", "false"},  "false" },
-        { "q", { "u", "d", "s" }, "" },
-        { "P1", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" }, "" },
-        { "P2", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" }, "" },
+        { "cp-conjugate",                                                                     { "true", "false" }, "false" },
+        {        "B_bar",                                                                     { "true", "false" }, "false" },
+        {            "q",                                                                       { "u", "d", "s" },      "" },
+        {           "P1", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" },      "" },
+        {           "P2", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" },      "" },
     };
 
     complex<double>
     SU3FRepresentation<PToPP>::tree_amplitude(su3f::rank2 & p1, su3f::rank2 & p2) const
     {
-        complex<double> T_ira = 0.0;
-        const complex<double> AT3  = complex<double>(this->re_AT3(),  this->im_AT3()),
-                              CT3  = complex<double>(this->re_CT3(),  this->im_CT3()),
-                              AT6  = complex<double>(this->re_AT6(),  this->im_AT6()),
-                              CT6  = complex<double>(this->re_CT6(),  this->im_CT6()),
-                              AT15 = complex<double>(this->re_AT15(), this->im_AT15()),
-                              CT15 = complex<double>(this->re_CT15(), this->im_CT15()),
-                              BT3  = complex<double>(this->re_BT3(),  this->im_BT3()),
-                              BT6  = complex<double>(this->re_BT6(),  this->im_BT6()),
-                              BT15 = complex<double>(this->re_BT15(), this->im_BT15()),
-                              DT3  = complex<double>(this->re_DT3(),  this->im_DT3());
+        complex<double>       T_ira = 0.0;
+        const complex<double> AT3 = complex<double>(this->re_AT3(), this->im_AT3()), CT3 = complex<double>(this->re_CT3(), this->im_CT3()),
+                              AT6 = complex<double>(this->re_AT6(), this->im_AT6()), CT6 = complex<double>(this->re_CT6(), this->im_CT6()),
+                              AT15 = complex<double>(this->re_AT15(), this->im_AT15()), CT15 = complex<double>(this->re_CT15(), this->im_CT15()),
+                              BT3 = complex<double>(this->re_BT3(), this->im_BT3()), BT6 = complex<double>(this->re_BT6(), this->im_BT6()),
+                              BT15 = complex<double>(this->re_BT15(), this->im_BT15()), DT3 = complex<double>(this->re_DT3(), this->im_DT3());
 
         for (unsigned i = 0; i < 3; i++)
         {
@@ -219,17 +212,12 @@ namespace eos
     complex<double>
     SU3FRepresentation<PToPP>::penguin_amplitude(su3f::rank2 & p1, su3f::rank2 & p2) const
     {
-        complex<double> P_ira = 0.0;
-        const complex<double> AP3  = complex<double>(this->re_AP3(),  this->im_AP3()),
-                              CP3  = complex<double>(this->re_CP3(),  this->im_CP3()),
-                              AP6  = complex<double>(this->re_AP6(),  this->im_AP6()),
-                              CP6  = complex<double>(this->re_CP6(),  this->im_CP6()),
-                              AP15 = complex<double>(this->re_AP15(), this->im_AP15()),
-                              CP15 = complex<double>(this->re_CP15(), this->im_CP15()),
-                              BP3  = complex<double>(this->re_BP3(),  this->im_BP3()),
-                              BP6  = complex<double>(this->re_BP6(),  this->im_BP6()),
-                              BP15 = complex<double>(this->re_BP15(), this->im_BP15()),
-                              DP3  = complex<double>(this->re_DP3(),  this->im_DP3());
+        complex<double>       P_ira = 0.0;
+        const complex<double> AP3 = complex<double>(this->re_AP3(), this->im_AP3()), CP3 = complex<double>(this->re_CP3(), this->im_CP3()),
+                              AP6 = complex<double>(this->re_AP6(), this->im_AP6()), CP6 = complex<double>(this->re_CP6(), this->im_CP6()),
+                              AP15 = complex<double>(this->re_AP15(), this->im_AP15()), CP15 = complex<double>(this->re_CP15(), this->im_CP15()),
+                              BP3 = complex<double>(this->re_BP3(), this->im_BP3()), BP6 = complex<double>(this->re_BP6(), this->im_BP6()),
+                              BP15 = complex<double>(this->re_BP15(), this->im_BP15()), DP3 = complex<double>(this->re_DP3(), this->im_DP3());
 
         for (unsigned i = 0; i < 3; i++)
         {
@@ -270,9 +258,7 @@ namespace eos
             su3f::transpose(P2);
         }
 
-        return complex<double>(0.0, 1.0) * Gfermi() / sqrt(2.0) * (
-            this->tree_amplitude(P1, P2) + this->penguin_amplitude(P1, P2)
-        );
+        return complex<double>(0.0, 1.0) * Gfermi() / sqrt(2.0) * (this->tree_amplitude(P1, P2) + this->penguin_amplitude(P1, P2));
     }
 
     complex<double>
@@ -286,9 +272,7 @@ namespace eos
             su3f::transpose(P2);
         }
 
-        return complex<double>(0.0, 1.0) * Gfermi() / sqrt(2.0) * (
-            this->tree_amplitude(P2, P1) + this->penguin_amplitude(P2, P1)
-        );
+        return complex<double>(0.0, 1.0) * Gfermi() / sqrt(2.0) * (this->tree_amplitude(P2, P1) + this->penguin_amplitude(P2, P1));
     }
 
     complex<double>
@@ -297,8 +281,8 @@ namespace eos
         this->update();
 
         auto penguin = (this->penguin_amplitude(P1, P2) + this->penguin_amplitude(P2, P1)) / lamdt;
-        auto tree = (this->tree_amplitude(P1, P2) + this->tree_amplitude(P2, P1)) / lamdu;
+        auto tree    = (this->tree_amplitude(P1, P2) + this->tree_amplitude(P2, P1)) / lamdu;
 
-        return - penguin / (tree - penguin);
+        return -penguin / (tree - penguin);
     }
-}
+} // namespace eos

--- a/eos/nonleptonic-amplitudes/su3f-amplitudes.hh
+++ b/eos/nonleptonic-amplitudes/su3f-amplitudes.hh
@@ -20,10 +20,10 @@
 #ifndef EOS_GUARD_EOS_NONLEPTONIC_AMPLITUDES_SU3_AMPLITUDES_HH
 #define EOS_GUARD_EOS_NONLEPTONIC_AMPLITUDES_SU3_AMPLITUDES_HH 1
 
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh>
 #include <eos/maths/complex.hh>
 #include <eos/models/model.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
 #include <eos/utils/parameters.hh>
 
 #include <array>
@@ -33,21 +33,19 @@ namespace eos
 {
     template <typename Transition_> class SU3FRepresentation;
 
-    template <>
-    class SU3FRepresentation<PToPP> :
-        public NonleptonicAmplitudes<PToPP>
+    template <> class SU3FRepresentation<PToPP> : public NonleptonicAmplitudes<PToPP>
     {
         private:
             std::shared_ptr<Model> model;
-            QuarkFlavorOption opt_q;
-            LightMesonOption opt_p1;
-            LightMesonOption opt_p2;
-            BooleanOption opt_cp_conjugate;
-            BooleanOption opt_B_bar;
+            QuarkFlavorOption      opt_q;
+            LightMesonOption       opt_p1;
+            LightMesonOption       opt_p2;
+            BooleanOption          opt_cp_conjugate;
+            BooleanOption          opt_B_bar;
 
             UsedParameter theta_18;
 
-            su3f::rank1 B;
+            su3f::rank1         B;
             mutable su3f::rank1 H3bar, H3tilde;
             mutable su3f::rank2 P1, P2;
             mutable su3f::rank3 H6bar, H6tilde, H15bar, H15tilde;
@@ -86,9 +84,10 @@ namespace eos
         public:
             SU3FRepresentation(const Parameters & p, const Options & o);
 
-            ~SU3FRepresentation() {};
+            ~SU3FRepresentation() {}
 
-            inline void update() const
+            inline void
+            update() const
             {
                 const double theta_18 = this->theta_18.evaluate();
                 su3f::psd_octet.find(opt_p1.value())->second(theta_18, P1);
@@ -102,8 +101,19 @@ namespace eos
             complex<double> penguin_amplitude(su3f::rank2 & p1, su3f::rank2 & p2) const;
 
             // Diagnostic functions
-            complex<double> tree_amplitude() const { update(); return tree_amplitude(P1, P2); }
-            complex<double> penguin_amplitude() const { update(); return penguin_amplitude(P1, P2); };
+            complex<double>
+            tree_amplitude() const
+            {
+                update();
+                return tree_amplitude(P1, P2);
+            }
+
+            complex<double>
+            penguin_amplitude() const
+            {
+                update();
+                return penguin_amplitude(P1, P2);
+            }
 
             // Amplitude for B -> P1 P2
             complex<double> ordered_amplitude() const;
@@ -112,5 +122,5 @@ namespace eos
             // CP-conserving penguin vs tree correction defined as - |(Vub Vud*) / (Vcb Vcd*)| penguin / (tree - penguin), cf. [FJV:2016A]
             complex<double> penguin_correction() const override;
     };
-}
+} // namespace eos
 #endif

--- a/eos/nonleptonic-amplitudes/su3f-amplitudes_TEST.cc
+++ b/eos/nonleptonic-amplitudes/su3f-amplitudes_TEST.cc
@@ -17,15 +17,15 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/maths/complex.hh>
 #include <eos/nonleptonic-amplitudes/su3f-amplitudes.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
 
-class SU3AmplitudesTest :
-    public TestCase
+class SU3AmplitudesTest : public TestCase
 {
     public:
         SU3AmplitudesTest() :
@@ -33,546 +33,534 @@ class SU3AmplitudesTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-
             /* Test with real amplitudes */
             {
-                Parameters p = Parameters::Defaults();
-                p["nonleptonic::Re{AT3}@SU3F"]  =  0.1;
+                Parameters p                    = Parameters::Defaults();
+                p["nonleptonic::Re{AT3}@SU3F"]  = 0.1;
                 p["nonleptonic::Re{CT3}@SU3F"]  = -0.2;
-                p["nonleptonic::Re{AT6}@SU3F"]  =  0.3;
+                p["nonleptonic::Re{AT6}@SU3F"]  = 0.3;
                 p["nonleptonic::Re{CT6}@SU3F"]  = -0.4;
-                p["nonleptonic::Re{AT15}@SU3F"] =  0.5;
+                p["nonleptonic::Re{AT15}@SU3F"] = 0.5;
                 p["nonleptonic::Re{CT15}@SU3F"] = -0.6;
-                p["nonleptonic::Re{BT3}@SU3F"]  =  0.7;
+                p["nonleptonic::Re{BT3}@SU3F"]  = 0.7;
                 p["nonleptonic::Re{BT6}@SU3F"]  = -0.8;
-                p["nonleptonic::Re{BT15}@SU3F"] =  0.9;
+                p["nonleptonic::Re{BT15}@SU3F"] = 0.9;
                 p["nonleptonic::Re{DT3}@SU3F"]  = -1.0;
-                p["nonleptonic::Re{AP3}@SU3F"]  =  1.1;
+                p["nonleptonic::Re{AP3}@SU3F"]  = 1.1;
                 p["nonleptonic::Re{CP3}@SU3F"]  = -1.2;
-                p["nonleptonic::Re{AP6}@SU3F"]  =  1.3;
+                p["nonleptonic::Re{AP6}@SU3F"]  = 1.3;
                 p["nonleptonic::Re{CP6}@SU3F"]  = -1.4;
-                p["nonleptonic::Re{AP15}@SU3F"] =  1.5;
+                p["nonleptonic::Re{AP15}@SU3F"] = 1.5;
                 p["nonleptonic::Re{CP15}@SU3F"] = -1.6;
-                p["nonleptonic::Re{BP3}@SU3F"]  =  1.7;
+                p["nonleptonic::Re{BP3}@SU3F"]  = 1.7;
                 p["nonleptonic::Re{BP6}@SU3F"]  = -1.8;
-                p["nonleptonic::Re{BP15}@SU3F"] =  1.9;
+                p["nonleptonic::Re{BP15}@SU3F"] = 1.9;
                 p["nonleptonic::Re{DP3}@SU3F"]  = -2.0;
-                p["eta::theta_18"]              =  0.0;
+                p["eta::theta_18"]              = 0.0;
 
                 static const double eps = 1.0e-6;
 
-                Options o
-                {
-                    { "q", "u" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^+" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o{
+                    {            "q",    "u" },
+                    {           "P1", "pi^0" },
+                    {           "P2", "pi^+" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> d(p, o);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(),    complex<double>(-0.003701600698,  0.009833235011), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(), complex<double>(-0.003701600698, 0.009833235011), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(-0.076644441470, -0.030849505280), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>( 1.733325903e-7, -6.626574282e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>(-1.929579753e-8,  1.479410207e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(),         complex<double>( 1.540367927e-7, -6.478633261e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(1.733325903e-7, -6.626574282e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>(-1.929579753e-8, 1.479410207e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(), complex<double>(1.540367927e-7, -6.478633261e-7), eps);
 
-                Options oo
-                {
-                    { "q", "d" },
-                    { "P1", "pi^+" },
-                    { "P2", "pi^-" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oo{
+                    {            "q",    "d" },
+                    {           "P1", "pi^+" },
+                    {           "P2", "pi^-" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> dd(p, oo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(),    complex<double>(-0.001121754409,  0.002979920210), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(), complex<double>(-0.001121754409, 0.002979920210), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(-0.015601822450, -0.006279757473), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>( 2.721554933e-8, -1.379284173e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.inverse_amplitude(), complex<double>( 5.446508563e-8, -2.212538491e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(),         complex<double>( 8.168063496e-8, -3.591822664e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>(2.721554933e-8, -1.379284173e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.inverse_amplitude(), complex<double>(5.446508563e-8, -2.212538491e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(), complex<double>(8.168063496e-8, -3.591822664e-7), eps);
 
-                Options ooo
-                {
-                    { "q", "d" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^0" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options ooo{
+                    {            "q",    "d" },
+                    {           "P1", "pi^0" },
+                    {           "P2", "pi^0" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> ddd(p, ooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(),    complex<double>( 0.001744951303, -0.004635431438), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>( 0.032024793450,  0.012890028500), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(-6.808014322e-8,  2.785174180e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>(-6.808014322e-8,  2.785174180e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(),         complex<double>(-1.361602864e-7,  5.570348360e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(), complex<double>(0.001744951303, -0.004635431438), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>(0.032024793450, 0.012890028500), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(-6.808014322e-8, 2.785174180e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>(-6.808014322e-8, 2.785174180e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(), complex<double>(-1.361602864e-7, 5.570348360e-7), eps);
 
-                Options oooo
-                {
-                    { "q", "s" },
-                    { "P1", "eta" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oooo{
+                    {            "q",      "s" },
+                    {           "P1",    "eta" },
+                    {           "P2", "Kbar_d" },
+                    {        "model",    "CKM" },
+                    { "cp-conjugate",   "true" }
                 };
 
                 SU3FRepresentation<PToPP> dddd(p, oooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.tree_amplitude(),    complex<double>(-0.001221211520,  0.003244126218), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.tree_amplitude(), complex<double>(-0.001221211520, 0.003244126218), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dddd.penguin_amplitude(), complex<double>(-0.021454879470, -0.008635621905), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.ordered_amplitude(), complex<double>( 4.446659188e-8, -1.870220329e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.inverse_amplitude(), complex<double>(-3.336976551e-8,  1.084214168e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.amplitude(),         complex<double>( 1.109682636e-8, -7.860061606e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.ordered_amplitude(), complex<double>(4.446659188e-8, -1.870220329e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.inverse_amplitude(), complex<double>(-3.336976551e-8, 1.084214168e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.amplitude(), complex<double>(1.109682636e-8, -7.860061606e-8), eps);
             }
 
             /* Test with complex amplitudes and theta=0 */
             {
-                Parameters p = Parameters::Defaults();
-                p["nonleptonic::Re{AT3}@SU3F"]  =  0.1 * std::cos( 0.1);
-                p["nonleptonic::Im{AT3}@SU3F"]  =  0.1 * std::sin( 0.1);
+                Parameters p                    = Parameters::Defaults();
+                p["nonleptonic::Re{AT3}@SU3F"]  = 0.1 * std::cos(0.1);
+                p["nonleptonic::Im{AT3}@SU3F"]  = 0.1 * std::sin(0.1);
                 p["nonleptonic::Re{CT3}@SU3F"]  = -0.2 * std::cos(-0.2);
                 p["nonleptonic::Im{CT3}@SU3F"]  = -0.2 * std::sin(-0.2);
-                p["nonleptonic::Re{AT6}@SU3F"]  =  0.3 * std::cos( 0.3);
-                p["nonleptonic::Im{AT6}@SU3F"]  =  0.3 * std::sin( 0.3);
+                p["nonleptonic::Re{AT6}@SU3F"]  = 0.3 * std::cos(0.3);
+                p["nonleptonic::Im{AT6}@SU3F"]  = 0.3 * std::sin(0.3);
                 p["nonleptonic::Re{CT6}@SU3F"]  = -0.4 * std::cos(-0.4);
                 p["nonleptonic::Im{CT6}@SU3F"]  = -0.4 * std::sin(-0.4);
-                p["nonleptonic::Re{AT15}@SU3F"] =  0.5 * std::cos( 0.5);
-                p["nonleptonic::Im{AT15}@SU3F"] =  0.5 * std::sin( 0.5);
+                p["nonleptonic::Re{AT15}@SU3F"] = 0.5 * std::cos(0.5);
+                p["nonleptonic::Im{AT15}@SU3F"] = 0.5 * std::sin(0.5);
                 p["nonleptonic::Re{CT15}@SU3F"] = -0.6 * std::cos(-0.6);
                 p["nonleptonic::Im{CT15}@SU3F"] = -0.6 * std::sin(-0.6);
-                p["nonleptonic::Re{BT3}@SU3F"]  =  0.7 * std::cos( 0.7);
-                p["nonleptonic::Im{BT3}@SU3F"]  =  0.7 * std::sin( 0.7);
+                p["nonleptonic::Re{BT3}@SU3F"]  = 0.7 * std::cos(0.7);
+                p["nonleptonic::Im{BT3}@SU3F"]  = 0.7 * std::sin(0.7);
                 p["nonleptonic::Re{BT6}@SU3F"]  = -0.8 * std::cos(-0.8);
                 p["nonleptonic::Im{BT6}@SU3F"]  = -0.8 * std::sin(-0.8);
-                p["nonleptonic::Re{BT15}@SU3F"] =  0.9 * std::cos( 0.9);
-                p["nonleptonic::Im{BT15}@SU3F"] =  0.9 * std::sin( 0.9);
+                p["nonleptonic::Re{BT15}@SU3F"] = 0.9 * std::cos(0.9);
+                p["nonleptonic::Im{BT15}@SU3F"] = 0.9 * std::sin(0.9);
                 p["nonleptonic::Re{DT3}@SU3F"]  = -1.0 * std::cos(-1.0);
                 p["nonleptonic::Im{DT3}@SU3F"]  = -1.0 * std::sin(-1.0);
-                p["nonleptonic::Re{AP3}@SU3F"]  =  1.1 * std::cos( 1.1);
-                p["nonleptonic::Im{AP3}@SU3F"]  =  1.1 * std::sin( 1.1);
+                p["nonleptonic::Re{AP3}@SU3F"]  = 1.1 * std::cos(1.1);
+                p["nonleptonic::Im{AP3}@SU3F"]  = 1.1 * std::sin(1.1);
                 p["nonleptonic::Re{CP3}@SU3F"]  = -1.2 * std::cos(-1.2);
                 p["nonleptonic::Im{CP3}@SU3F"]  = -1.2 * std::sin(-1.2);
-                p["nonleptonic::Re{AP6}@SU3F"]  =  1.3 * std::cos( 1.3);
-                p["nonleptonic::Im{AP6}@SU3F"]  =  1.3 * std::sin( 1.3);
+                p["nonleptonic::Re{AP6}@SU3F"]  = 1.3 * std::cos(1.3);
+                p["nonleptonic::Im{AP6}@SU3F"]  = 1.3 * std::sin(1.3);
                 p["nonleptonic::Re{CP6}@SU3F"]  = -1.4 * std::cos(-1.4);
                 p["nonleptonic::Im{CP6}@SU3F"]  = -1.4 * std::sin(-1.4);
-                p["nonleptonic::Re{AP15}@SU3F"] =  1.5 * std::cos( 1.5);
-                p["nonleptonic::Im{AP15}@SU3F"] =  1.5 * std::sin( 1.5);
+                p["nonleptonic::Re{AP15}@SU3F"] = 1.5 * std::cos(1.5);
+                p["nonleptonic::Im{AP15}@SU3F"] = 1.5 * std::sin(1.5);
                 p["nonleptonic::Re{CP15}@SU3F"] = -1.6 * std::cos(-1.6);
                 p["nonleptonic::Im{CP15}@SU3F"] = -1.6 * std::sin(-1.6);
-                p["nonleptonic::Re{BP3}@SU3F"]  =  1.7 * std::cos( 1.7);
-                p["nonleptonic::Im{BP3}@SU3F"]  =  1.7 * std::sin( 1.7);
+                p["nonleptonic::Re{BP3}@SU3F"]  = 1.7 * std::cos(1.7);
+                p["nonleptonic::Im{BP3}@SU3F"]  = 1.7 * std::sin(1.7);
                 p["nonleptonic::Re{BP6}@SU3F"]  = -1.8 * std::cos(-1.8);
                 p["nonleptonic::Im{BP6}@SU3F"]  = -1.8 * std::sin(-1.8);
-                p["nonleptonic::Re{BP15}@SU3F"] =  1.9 * std::cos( 1.9);
-                p["nonleptonic::Im{BP15}@SU3F"] =  1.9 * std::sin( 1.9);
+                p["nonleptonic::Re{BP15}@SU3F"] = 1.9 * std::cos(1.9);
+                p["nonleptonic::Im{BP15}@SU3F"] = 1.9 * std::sin(1.9);
                 p["nonleptonic::Re{DP3}@SU3F"]  = -2.0 * std::cos(-2.0);
                 p["nonleptonic::Im{DP3}@SU3F"]  = -2.0 * std::sin(-2.0);
-                p["eta::theta_18"]              =  0.0;
+                p["eta::theta_18"]              = 0.0;
 
                 static const double eps = 1.0e-6;
 
-                Options o
-                {
-                    { "q", "u" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^+" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o{
+                    {            "q",    "u" },
+                    {           "P1", "pi^0" },
+                    {           "P2", "pi^+" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> d(p, o);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(),    complex<double>(-2.273514188e-3,  8.908726610e-3), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(-1.059348845e-2,  6.225628113e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(), complex<double>(-2.273514188e-3, 8.908726610e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(-1.059348845e-2, 6.225628113e-3), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(-1.248212396e-7, -1.061211560e-7), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>(-5.912919404e-7, -9.905965534e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(),         complex<double>(-7.161131800e-7, -2.051808113e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(), complex<double>(-7.161131800e-7, -2.051808113e-7), eps);
 
-                Options oo
-                {
-                    { "q", "d" },
-                    { "P1", "pi^+" },
-                    { "P2", "pi^-" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oo{
+                    {            "q",    "d" },
+                    {           "P1", "pi^+" },
+                    {           "P2", "pi^-" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> dd(p, oo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(),    complex<double>(-2.524130408e-3,  1.991137618e-3), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>( 9.005046361e-3, -1.557506871e-2), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>( 1.120340542e-7,  5.345163223e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(), complex<double>(-2.524130408e-3, 1.991137618e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(9.005046361e-3, -1.557506871e-2), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>(1.120340542e-7, 5.345163223e-8), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dd.inverse_amplitude(), complex<double>(-8.221418647e-7, -2.769768049e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(),         complex<double>(-7.101078106e-7, -2.235251727e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(), complex<double>(-7.101078106e-7, -2.235251727e-7), eps);
 
-                Options ooo
-                {
-                    { "q", "d" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^0" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options ooo{
+                    {            "q",    "d" },
+                    {           "P1", "pi^0" },
+                    {           "P2", "pi^0" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> ddd(p, ooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(),    complex<double>(-7.873850931e-4, -4.573258399e-3), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>( 4.827637712e-3, -1.377336708e-2), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>( 1.513145804e-7,  3.332215673e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>( 1.513145804e-7,  3.332215673e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(),         complex<double>( 3.026291608e-7,  6.664431346e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(), complex<double>(-7.873850931e-4, -4.573258399e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>(4.827637712e-3, -1.377336708e-2), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(1.513145804e-7, 3.332215673e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>(1.513145804e-7, 3.332215673e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(), complex<double>(3.026291608e-7, 6.664431346e-8), eps);
 
-                Options oooo
-                {
-                    { "q", "s" },
-                    { "P1", "eta" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oooo{
+                    {            "q",      "s" },
+                    {           "P1",    "eta" },
+                    {           "P2", "Kbar_d" },
+                    {        "model",    "CKM" },
+                    { "cp-conjugate",   "true" }
                 };
 
                 SU3FRepresentation<PToPP> dddd(p, oooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.tree_amplitude(),    complex<double>(-2.628079667e-4,  3.081147729e-3), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.penguin_amplitude(), complex<double>(-1.199965240e-3,  3.303884344e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.tree_amplitude(), complex<double>(-2.628079667e-4, 3.081147729e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.penguin_amplitude(), complex<double>(-1.199965240e-3, 3.303884344e-3), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dddd.ordered_amplitude(), complex<double>(-5.266082582e-8, -1.206428475e-8), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dddd.inverse_amplitude(), complex<double>(-2.113941987e-7, -2.672089228e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.amplitude(),         complex<double>(-2.640550246e-7, -3.878517703e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.amplitude(), complex<double>(-2.640550246e-7, -3.878517703e-8), eps);
             }
-
 
 
             /* Test with complex amplitudes and theta = 1.0 */
             {
-                Parameters p = Parameters::Defaults();
-                p["nonleptonic::Re{AT3}@SU3F"]  =  0.1 * std::cos( 0.1);
-                p["nonleptonic::Im{AT3}@SU3F"]  =  0.1 * std::sin( 0.1);
+                Parameters p                    = Parameters::Defaults();
+                p["nonleptonic::Re{AT3}@SU3F"]  = 0.1 * std::cos(0.1);
+                p["nonleptonic::Im{AT3}@SU3F"]  = 0.1 * std::sin(0.1);
                 p["nonleptonic::Re{CT3}@SU3F"]  = -0.2 * std::cos(-0.2);
                 p["nonleptonic::Im{CT3}@SU3F"]  = -0.2 * std::sin(-0.2);
-                p["nonleptonic::Re{AT6}@SU3F"]  =  0.3 * std::cos( 0.3);
-                p["nonleptonic::Im{AT6}@SU3F"]  =  0.3 * std::sin( 0.3);
+                p["nonleptonic::Re{AT6}@SU3F"]  = 0.3 * std::cos(0.3);
+                p["nonleptonic::Im{AT6}@SU3F"]  = 0.3 * std::sin(0.3);
                 p["nonleptonic::Re{CT6}@SU3F"]  = -0.4 * std::cos(-0.4);
                 p["nonleptonic::Im{CT6}@SU3F"]  = -0.4 * std::sin(-0.4);
-                p["nonleptonic::Re{AT15}@SU3F"] =  0.5 * std::cos( 0.5);
-                p["nonleptonic::Im{AT15}@SU3F"] =  0.5 * std::sin( 0.5);
+                p["nonleptonic::Re{AT15}@SU3F"] = 0.5 * std::cos(0.5);
+                p["nonleptonic::Im{AT15}@SU3F"] = 0.5 * std::sin(0.5);
                 p["nonleptonic::Re{CT15}@SU3F"] = -0.6 * std::cos(-0.6);
                 p["nonleptonic::Im{CT15}@SU3F"] = -0.6 * std::sin(-0.6);
-                p["nonleptonic::Re{BT3}@SU3F"]  =  0.7 * std::cos( 0.7);
-                p["nonleptonic::Im{BT3}@SU3F"]  =  0.7 * std::sin( 0.7);
+                p["nonleptonic::Re{BT3}@SU3F"]  = 0.7 * std::cos(0.7);
+                p["nonleptonic::Im{BT3}@SU3F"]  = 0.7 * std::sin(0.7);
                 p["nonleptonic::Re{BT6}@SU3F"]  = -0.8 * std::cos(-0.8);
                 p["nonleptonic::Im{BT6}@SU3F"]  = -0.8 * std::sin(-0.8);
-                p["nonleptonic::Re{BT15}@SU3F"] =  0.9 * std::cos( 0.9);
-                p["nonleptonic::Im{BT15}@SU3F"] =  0.9 * std::sin( 0.9);
+                p["nonleptonic::Re{BT15}@SU3F"] = 0.9 * std::cos(0.9);
+                p["nonleptonic::Im{BT15}@SU3F"] = 0.9 * std::sin(0.9);
                 p["nonleptonic::Re{DT3}@SU3F"]  = -1.0 * std::cos(-1.0);
                 p["nonleptonic::Im{DT3}@SU3F"]  = -1.0 * std::sin(-1.0);
-                p["nonleptonic::Re{AP3}@SU3F"]  =  1.1 * std::cos( 1.1);
-                p["nonleptonic::Im{AP3}@SU3F"]  =  1.1 * std::sin( 1.1);
+                p["nonleptonic::Re{AP3}@SU3F"]  = 1.1 * std::cos(1.1);
+                p["nonleptonic::Im{AP3}@SU3F"]  = 1.1 * std::sin(1.1);
                 p["nonleptonic::Re{CP3}@SU3F"]  = -1.2 * std::cos(-1.2);
                 p["nonleptonic::Im{CP3}@SU3F"]  = -1.2 * std::sin(-1.2);
-                p["nonleptonic::Re{AP6}@SU3F"]  =  1.3 * std::cos( 1.3);
-                p["nonleptonic::Im{AP6}@SU3F"]  =  1.3 * std::sin( 1.3);
+                p["nonleptonic::Re{AP6}@SU3F"]  = 1.3 * std::cos(1.3);
+                p["nonleptonic::Im{AP6}@SU3F"]  = 1.3 * std::sin(1.3);
                 p["nonleptonic::Re{CP6}@SU3F"]  = -1.4 * std::cos(-1.4);
                 p["nonleptonic::Im{CP6}@SU3F"]  = -1.4 * std::sin(-1.4);
-                p["nonleptonic::Re{AP15}@SU3F"] =  1.5 * std::cos( 1.5);
-                p["nonleptonic::Im{AP15}@SU3F"] =  1.5 * std::sin( 1.5);
+                p["nonleptonic::Re{AP15}@SU3F"] = 1.5 * std::cos(1.5);
+                p["nonleptonic::Im{AP15}@SU3F"] = 1.5 * std::sin(1.5);
                 p["nonleptonic::Re{CP15}@SU3F"] = -1.6 * std::cos(-1.6);
                 p["nonleptonic::Im{CP15}@SU3F"] = -1.6 * std::sin(-1.6);
-                p["nonleptonic::Re{BP3}@SU3F"]  =  1.7 * std::cos( 1.7);
-                p["nonleptonic::Im{BP3}@SU3F"]  =  1.7 * std::sin( 1.7);
+                p["nonleptonic::Re{BP3}@SU3F"]  = 1.7 * std::cos(1.7);
+                p["nonleptonic::Im{BP3}@SU3F"]  = 1.7 * std::sin(1.7);
                 p["nonleptonic::Re{BP6}@SU3F"]  = -1.8 * std::cos(-1.8);
                 p["nonleptonic::Im{BP6}@SU3F"]  = -1.8 * std::sin(-1.8);
-                p["nonleptonic::Re{BP15}@SU3F"] =  1.9 * std::cos( 1.9);
-                p["nonleptonic::Im{BP15}@SU3F"] =  1.9 * std::sin( 1.9);
+                p["nonleptonic::Re{BP15}@SU3F"] = 1.9 * std::cos(1.9);
+                p["nonleptonic::Im{BP15}@SU3F"] = 1.9 * std::sin(1.9);
                 p["nonleptonic::Re{DP3}@SU3F"]  = -2.0 * std::cos(-2.0);
                 p["nonleptonic::Im{DP3}@SU3F"]  = -2.0 * std::sin(-2.0);
-                p["eta::theta_18"]              =  1.0;
+                p["eta::theta_18"]              = 1.0;
 
                 static const double eps = 1.0e-6;
 
-                Options o
-                {
-                    { "q", "u" },
-                    { "P1", "eta" },
-                    { "P2", "pi^+" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o{
+                    {            "q",    "u" },
+                    {           "P1",  "eta" },
+                    {           "P2", "pi^+" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> d(p, o);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(),    complex<double>(-0.0016259292798226851, -0.0010603290595977166), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(0.011138893126578186,-0.02851323458558204), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(2.439092343376344e-7,7.845857726117909e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(), complex<double>(-0.0016259292798226851, -0.0010603290595977166), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(0.011138893126578186, -0.02851323458558204), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(2.439092343376344e-7, 7.845857726117909e-8), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>(9.893341439632504e-7, 3.13065264103065e-7), eps);
 
                 TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(), complex<double>(1.2332433783008849e-6, 3.9152384136424414e-7), eps);
 
 
-                Options oo
-                {
-                    { "q", "d" },
-                    { "P1", "eta_prime" },
-                    { "P2", "K_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oo{
+                    {            "q",         "d" },
+                    {           "P1", "eta_prime" },
+                    {           "P2",       "K_d" },
+                    {        "model",       "CKM" },
+                    { "cp-conjugate",      "true" }
                 };
 
                 SU3FRepresentation<PToPP> dd(p, oo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(),    complex<double>(0.00007062169107953275, -0.0005939555461374151), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(-0.00029146395565434087,0.007762858389461301), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>(-5.912583361731671e-8,-1.8214060472421337e-9), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(), complex<double>(0.00007062169107953275, -0.0005939555461374151), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(-0.00029146395565434087, 0.007762858389461301), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>(-5.912583361731671e-8, -1.8214060472421337e-9), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dd.inverse_amplitude(), complex<double>(-2.036091029054084e-7, -3.17536373640662e-7), eps);
 
                 TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(), complex<double>(-2.6273493652272477e-7, -3.1935777968790416e-7), eps);
 
 
-                Options ooo
-                {
-                    { "q", "d" },
-                    { "P1", "eta" },
-                    { "P2", "eta" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options ooo{
+                    {            "q",    "d" },
+                    {           "P1",  "eta" },
+                    {           "P2",  "eta" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> ddd(p, ooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(),    complex<double>(0.0031710360721511773, 0.0018016054908118943), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>(-0.004827525253419861,0.04642374433518939), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(-3.9774064069014413e-7,-1.366196555610822e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(), complex<double>(0.0031710360721511773, 0.0018016054908118943), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>(-0.004827525253419861, 0.04642374433518939), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(-3.9774064069014413e-7, -1.366196555610822e-8), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>(-3.9774064069014413e-7, -1.366196555610822e-8), eps);
 
                 TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(), complex<double>(-7.954812813802883e-7, -2.7323931112216412e-8), eps);
 
-                Options o4
-                {
-                    { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "pi^+" },
-                    { "P2", "pi^-" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "false"}
+                Options o4{
+                    { "representation",  "SU3F" },
+                    {              "q",     "d" },
+                    {             "P1",  "pi^+" },
+                    {             "P2",  "pi^-" },
+                    {          "model",   "CKM" },
+                    {   "cp-conjugate", "false" }
                 };
 
                 SU3FRepresentation<PToPP> d4(p, o4);
 
 
-                Options o5
-                {
+                Options o5{
                     { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "pi^+" },
-                    { "P2", "pi^-" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                    {              "q",    "d" },
+                    {             "P1", "pi^+" },
+                    {             "P2", "pi^-" },
+                    {          "model",  "CKM" },
+                    {   "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> d5(p, o5);
 
-                TEST_CHECK_NEARLY_EQUAL(2*(d4.re_amplitude()*d5.im_amplitude() - d4.im_amplitude()*d5.re_amplitude()) / (d4.abs_amplitude()*d4.abs_amplitude() + d5.abs_amplitude()*d5.abs_amplitude()),0.6004206408016731, eps);
+                TEST_CHECK_NEARLY_EQUAL(2 * (d4.re_amplitude() * d5.im_amplitude() - d4.im_amplitude() * d5.re_amplitude())
+                                                / (d4.abs_amplitude() * d4.abs_amplitude() + d5.abs_amplitude() * d5.abs_amplitude()),
+                                        0.6004206408016731,
+                                        eps);
 
 
-                Options o6
-                {
-                    { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "K_d" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "false"}
+                Options o6{
+                    { "representation",   "SU3F" },
+                    {              "q",      "d" },
+                    {             "P1",    "K_d" },
+                    {             "P2", "Kbar_d" },
+                    {          "model",    "CKM" },
+                    {   "cp-conjugate",  "false" }
                 };
 
                 SU3FRepresentation<PToPP> d6(p, o6);
 
 
-                Options o7
-                {
-                    { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "K_d" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o7{
+                    { "representation",   "SU3F" },
+                    {              "q",      "d" },
+                    {             "P1",    "K_d" },
+                    {             "P2", "Kbar_d" },
+                    {          "model",    "CKM" },
+                    {   "cp-conjugate",   "true" }
                 };
 
                 SU3FRepresentation<PToPP> d7(p, o7);
 
-                TEST_CHECK_NEARLY_EQUAL(2*(d6.re_amplitude()*d7.im_amplitude() - d6.im_amplitude()*d7.re_amplitude()) / (d6.abs_amplitude()*d6.abs_amplitude() + d7.abs_amplitude()*d7.abs_amplitude()),0.49395869433764805, eps);
+                TEST_CHECK_NEARLY_EQUAL(2 * (d6.re_amplitude() * d7.im_amplitude() - d6.im_amplitude() * d7.re_amplitude())
+                                                / (d6.abs_amplitude() * d6.abs_amplitude() + d7.abs_amplitude() * d7.abs_amplitude()),
+                                        0.49395869433764805,
+                                        eps);
             }
 
-            //Test with THXs best fit point
+            // Test with THXs best fit point
 
             {
-                Parameters p = Parameters::Defaults();
-                p["nonleptonic::Re{AT3}@SU3F"]  =  0.029 * std::cos( -3.083);
-                p["nonleptonic::Im{AT3}@SU3F"]  =  0.029 * std::sin( -3.083);
-                p["nonleptonic::Re{CT3}@SU3F"]  =  0.258 * std::cos(-0.105);
-                p["nonleptonic::Im{CT3}@SU3F"]  =  0.258 * std::sin(-0.105);
-                p["nonleptonic::Re{AT6}@SU3F"]  =  0. * std::cos( 0.3);
-                p["nonleptonic::Im{AT6}@SU3F"]  =  0. * std::sin( 0.3);
-                p["nonleptonic::Re{CT6}@SU3F"]  =  0.235 * std::cos(-0.079);
-                p["nonleptonic::Im{CT6}@SU3F"]  =  0.235 * std::sin(-0.079);
-                p["nonleptonic::Re{AT15}@SU3F"] =  0.029 * std::cos(-3.083);
-                p["nonleptonic::Im{AT15}@SU3F"] =  0.029 * std::sin(-3.083);
-                p["nonleptonic::Re{CT15}@SU3F"] =  0.151 * std::cos(0.061);
-                p["nonleptonic::Im{CT15}@SU3F"] =  0.151 * std::sin(0.061);
-                p["nonleptonic::Re{BT3}@SU3F"]  =  0.034 * std::cos(3.087);
-                p["nonleptonic::Im{BT3}@SU3F"]  =  0.034 * std::sin(3.087);
-                p["nonleptonic::Re{BT6}@SU3F"]  =  0.033 * std::cos(-0.286);
-                p["nonleptonic::Im{BT6}@SU3F"]  =  0.033 * std::sin(-0.286);
-                p["nonleptonic::Re{BT15}@SU3F"] =  0.008 * std::cos(-1.892);
-                p["nonleptonic::Im{BT15}@SU3F"] =  0.008 * std::sin(-1.892);
-                p["nonleptonic::Re{DT3}@SU3F"]  =  0.055 * std::cos(2.942);
-                p["nonleptonic::Im{DT3}@SU3F"]  =  0.055 * std::sin(2.942);
-                p["nonleptonic::Re{AP3}@SU3F"]  =  0.014 * std::cos(-1.328);
-                p["nonleptonic::Im{AP3}@SU3F"]  =  0.014 * std::sin(-1.328);
-                p["nonleptonic::Re{CP3}@SU3F"]  =  0.008 * std::cos(0.);
-                p["nonleptonic::Im{CP3}@SU3F"]  =  0.008 * std::sin(0.);
-                p["nonleptonic::Re{AP6}@SU3F"]  =  0. * std::cos( 1.3);
-                p["nonleptonic::Im{AP6}@SU3F"]  =  0. * std::sin( 1.3);
-                p["nonleptonic::Re{CP6}@SU3F"]  =  0.145 * std::cos(-2.881);
-                p["nonleptonic::Im{CP6}@SU3F"]  =  0.145 * std::sin(-2.881);
-                p["nonleptonic::Re{AP15}@SU3F"] =  0.003 * std::cos( 2.234);
-                p["nonleptonic::Im{AP15}@SU3F"] =  0.003 * std::sin( 2.234);
-                p["nonleptonic::Re{CP15}@SU3F"] =  0.003 * std::cos(-0.608);
-                p["nonleptonic::Im{CP15}@SU3F"] =  0.003 * std::sin(-0.608);
-                p["nonleptonic::Re{BP3}@SU3F"]  =  0.043 * std::cos( 2.367);
-                p["nonleptonic::Im{BP3}@SU3F"]  =  0.043 * std::sin( 2.367);
-                p["nonleptonic::Re{BP6}@SU3F"]  =  0.099 * std::cos(0.353);
-                p["nonleptonic::Im{BP6}@SU3F"]  =  0.099 * std::sin(0.353);
-                p["nonleptonic::Re{BP15}@SU3F"] =  0.031 * std::cos( -0.690);
-                p["nonleptonic::Im{BP15}@SU3F"] =  0.031 * std::sin( -0.690);
-                p["nonleptonic::Re{DP3}@SU3F"]  =  0.030 * std::cos( 0.477);
-                p["nonleptonic::Im{DP3}@SU3F"]  =  0.030 * std::sin( 0.477);
+                Parameters p                    = Parameters::Defaults();
+                p["nonleptonic::Re{AT3}@SU3F"]  = 0.029 * std::cos(-3.083);
+                p["nonleptonic::Im{AT3}@SU3F"]  = 0.029 * std::sin(-3.083);
+                p["nonleptonic::Re{CT3}@SU3F"]  = 0.258 * std::cos(-0.105);
+                p["nonleptonic::Im{CT3}@SU3F"]  = 0.258 * std::sin(-0.105);
+                p["nonleptonic::Re{AT6}@SU3F"]  = 0. * std::cos(0.3);
+                p["nonleptonic::Im{AT6}@SU3F"]  = 0. * std::sin(0.3);
+                p["nonleptonic::Re{CT6}@SU3F"]  = 0.235 * std::cos(-0.079);
+                p["nonleptonic::Im{CT6}@SU3F"]  = 0.235 * std::sin(-0.079);
+                p["nonleptonic::Re{AT15}@SU3F"] = 0.029 * std::cos(-3.083);
+                p["nonleptonic::Im{AT15}@SU3F"] = 0.029 * std::sin(-3.083);
+                p["nonleptonic::Re{CT15}@SU3F"] = 0.151 * std::cos(0.061);
+                p["nonleptonic::Im{CT15}@SU3F"] = 0.151 * std::sin(0.061);
+                p["nonleptonic::Re{BT3}@SU3F"]  = 0.034 * std::cos(3.087);
+                p["nonleptonic::Im{BT3}@SU3F"]  = 0.034 * std::sin(3.087);
+                p["nonleptonic::Re{BT6}@SU3F"]  = 0.033 * std::cos(-0.286);
+                p["nonleptonic::Im{BT6}@SU3F"]  = 0.033 * std::sin(-0.286);
+                p["nonleptonic::Re{BT15}@SU3F"] = 0.008 * std::cos(-1.892);
+                p["nonleptonic::Im{BT15}@SU3F"] = 0.008 * std::sin(-1.892);
+                p["nonleptonic::Re{DT3}@SU3F"]  = 0.055 * std::cos(2.942);
+                p["nonleptonic::Im{DT3}@SU3F"]  = 0.055 * std::sin(2.942);
+                p["nonleptonic::Re{AP3}@SU3F"]  = 0.014 * std::cos(-1.328);
+                p["nonleptonic::Im{AP3}@SU3F"]  = 0.014 * std::sin(-1.328);
+                p["nonleptonic::Re{CP3}@SU3F"]  = 0.008 * std::cos(0.);
+                p["nonleptonic::Im{CP3}@SU3F"]  = 0.008 * std::sin(0.);
+                p["nonleptonic::Re{AP6}@SU3F"]  = 0. * std::cos(1.3);
+                p["nonleptonic::Im{AP6}@SU3F"]  = 0. * std::sin(1.3);
+                p["nonleptonic::Re{CP6}@SU3F"]  = 0.145 * std::cos(-2.881);
+                p["nonleptonic::Im{CP6}@SU3F"]  = 0.145 * std::sin(-2.881);
+                p["nonleptonic::Re{AP15}@SU3F"] = 0.003 * std::cos(2.234);
+                p["nonleptonic::Im{AP15}@SU3F"] = 0.003 * std::sin(2.234);
+                p["nonleptonic::Re{CP15}@SU3F"] = 0.003 * std::cos(-0.608);
+                p["nonleptonic::Im{CP15}@SU3F"] = 0.003 * std::sin(-0.608);
+                p["nonleptonic::Re{BP3}@SU3F"]  = 0.043 * std::cos(2.367);
+                p["nonleptonic::Im{BP3}@SU3F"]  = 0.043 * std::sin(2.367);
+                p["nonleptonic::Re{BP6}@SU3F"]  = 0.099 * std::cos(0.353);
+                p["nonleptonic::Im{BP6}@SU3F"]  = 0.099 * std::sin(0.353);
+                p["nonleptonic::Re{BP15}@SU3F"] = 0.031 * std::cos(-0.690);
+                p["nonleptonic::Im{BP15}@SU3F"] = 0.031 * std::sin(-0.690);
+                p["nonleptonic::Re{DP3}@SU3F"]  = 0.030 * std::cos(0.477);
+                p["nonleptonic::Im{DP3}@SU3F"]  = 0.030 * std::sin(0.477);
                 p["eta::theta_18"]              = -0.3273166181245092;
-
 
 
                 static const double eps = 1.0e-6;
 
-                Options o1
-                {
-                    { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "pi^+" },
-                    { "P2", "pi^-" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "false"}
+                Options o1{
+                    { "representation",  "SU3F" },
+                    {              "q",     "d" },
+                    {             "P1",  "pi^+" },
+                    {             "P2",  "pi^-" },
+                    {          "model",   "CKM" },
+                    {   "cp-conjugate", "false" }
                 };
 
                 SU3FRepresentation<PToPP> d1(p, o1);
 
 
-                Options o2
-                {
+                Options o2{
                     { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "pi^-" },
-                    { "P2", "pi^+" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                    {              "q",    "d" },
+                    {             "P1", "pi^-" },
+                    {             "P2", "pi^+" },
+                    {          "model",  "CKM" },
+                    {   "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> d2(p, o2);
 
-                TEST_CHECK_NEARLY_EQUAL(2*(d1.re_amplitude()*d2.im_amplitude() - d1.im_amplitude()*d2.re_amplitude()) / (d1.abs_amplitude()*d1.abs_amplitude() + d2.abs_amplitude()*d2.abs_amplitude()),-0.0339696, eps);
+                TEST_CHECK_NEARLY_EQUAL(2 * (d1.re_amplitude() * d2.im_amplitude() - d1.im_amplitude() * d2.re_amplitude())
+                                                / (d1.abs_amplitude() * d1.abs_amplitude() + d2.abs_amplitude() * d2.abs_amplitude()),
+                                        -0.0339696,
+                                        eps);
 
 
-                Options o3
-                {
-                    { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "pi^0" },
-                    { "P2", "K_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "false"}
+                Options o3{
+                    { "representation",  "SU3F" },
+                    {              "q",     "d" },
+                    {             "P1",  "pi^0" },
+                    {             "P2",   "K_d" },
+                    {          "model",   "CKM" },
+                    {   "cp-conjugate", "false" }
                 };
 
                 SU3FRepresentation<PToPP> d3(p, o3);
 
 
-                Options o4
-                {
+                Options o4{
                     { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "K_d" },
-                    { "P2", "pi^0" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                    {              "q",    "d" },
+                    {             "P1",  "K_d" },
+                    {             "P2", "pi^0" },
+                    {          "model",  "CKM" },
+                    {   "cp-conjugate", "true" }
                 };
 
                 SU3FRepresentation<PToPP> d4(p, o4);
 
-                TEST_CHECK_NEARLY_EQUAL(2*(d3.re_amplitude()*d4.im_amplitude() - d3.im_amplitude()*d4.re_amplitude()) / (d3.abs_amplitude()*d3.abs_amplitude() + d4.abs_amplitude()*d4.abs_amplitude()), 0.026275355893312025, eps);
+                TEST_CHECK_NEARLY_EQUAL(2 * (d3.re_amplitude() * d4.im_amplitude() - d3.im_amplitude() * d4.re_amplitude())
+                                                / (d3.abs_amplitude() * d3.abs_amplitude() + d4.abs_amplitude() * d4.abs_amplitude()),
+                                        0.026275355893312025,
+                                        eps);
 
-                Options o5
-                {
-                    { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "K_d" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "false"}
+                Options o5{
+                    { "representation",   "SU3F" },
+                    {              "q",      "d" },
+                    {             "P1",    "K_d" },
+                    {             "P2", "Kbar_d" },
+                    {          "model",    "CKM" },
+                    {   "cp-conjugate",  "false" }
                 };
 
                 SU3FRepresentation<PToPP> d5(p, o5);
 
 
-                Options o6
-                {
-                    { "representation", "SU3F" },
-                    { "q", "d" },
-                    { "P1", "Kbar_d" },
-                    { "P2", "K_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o6{
+                    { "representation",   "SU3F" },
+                    {              "q",      "d" },
+                    {             "P1", "Kbar_d" },
+                    {             "P2",    "K_d" },
+                    {          "model",    "CKM" },
+                    {   "cp-conjugate",   "true" }
                 };
 
                 SU3FRepresentation<PToPP> d6(p, o6);
 
-                TEST_CHECK_NEARLY_EQUAL(2*(d5.re_amplitude()*d6.im_amplitude() - d5.im_amplitude()*d6.re_amplitude()) / (d5.abs_amplitude()*d5.abs_amplitude() + d6.abs_amplitude()*d6.abs_amplitude()), 0.949735305000383, eps);
+                TEST_CHECK_NEARLY_EQUAL(2 * (d5.re_amplitude() * d6.im_amplitude() - d5.im_amplitude() * d6.re_amplitude())
+                                                / (d5.abs_amplitude() * d5.abs_amplitude() + d6.abs_amplitude() * d6.abs_amplitude()),
+                                        0.949735305000383,
+                                        eps);
 
-                Options o7
-                {
-                    { "representation", "SU3F" },
-                    { "q", "s" },
-                    { "P1", "K_u" },
-                    { "P2", "Kbar_u" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "false"}
+                Options o7{
+                    { "representation",   "SU3F" },
+                    {              "q",      "s" },
+                    {             "P1",    "K_u" },
+                    {             "P2", "Kbar_u" },
+                    {          "model",    "CKM" },
+                    {   "cp-conjugate",  "false" }
                 };
 
                 SU3FRepresentation<PToPP> d7(p, o7);
 
 
-                Options o8
-                {
-                    { "representation", "SU3F" },
-                    { "q", "s" },
-                    { "P1", "Kbar_u" },
-                    { "P2", "K_u" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o8{
+                    { "representation",   "SU3F" },
+                    {              "q",      "s" },
+                    {             "P1", "Kbar_u" },
+                    {             "P2",    "K_u" },
+                    {          "model",    "CKM" },
+                    {   "cp-conjugate",   "true" }
                 };
 
                 SU3FRepresentation<PToPP> d8(p, o8);
 
 
-                TEST_CHECK_NEARLY_EQUAL(2*(d7.re_amplitude()*d8.im_amplitude() - d7.im_amplitude()*d8.re_amplitude()) / (d7.abs_amplitude()*d7.abs_amplitude() + d8.abs_amplitude()*d8.abs_amplitude()), -0.22630547119600518, eps);
-
-
+                TEST_CHECK_NEARLY_EQUAL(2 * (d7.re_amplitude() * d8.im_amplitude() - d7.im_amplitude() * d8.re_amplitude())
+                                                / (d7.abs_amplitude() * d7.abs_amplitude() + d8.abs_amplitude() * d8.abs_amplitude()),
+                                        -0.22630547119600518,
+                                        eps);
             }
-
-
-
         }
 } su3_amplitudes_test;

--- a/eos/nonleptonic-amplitudes/topological-amplitudes.cc
+++ b/eos/nonleptonic-amplitudes/topological-amplitudes.cc
@@ -18,8 +18,8 @@
  */
 
 
-#include <eos/nonleptonic-amplitudes/topological-amplitudes.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/nonleptonic-amplitudes/topological-amplitudes.hh>
 #include <eos/utils/options-impl.hh>
 
 #include <map>
@@ -49,38 +49,38 @@ namespace eos
         Hbar({}),
         H3tilde({}),
         Gfermi(p["WET::G_Fermi"], *this),
-        re_T(  p["nonleptonic::Re{T}@Topological"],   *this),
-        im_T(  p["nonleptonic::Im{T}@Topological"],   *this),
-        re_C(  p["nonleptonic::Re{C}@Topological"],   *this),
-        im_C(  p["nonleptonic::Im{C}@Topological"],   *this),
-        re_A(  p["nonleptonic::Re{A}@Topological"],   *this),
-        im_A(  p["nonleptonic::Im{A}@Topological"],   *this),
-        re_E(  p["nonleptonic::Re{E}@Topological"],   *this),
-        im_E(  p["nonleptonic::Im{E}@Topological"],   *this),
+        re_T(p["nonleptonic::Re{T}@Topological"], *this),
+        im_T(p["nonleptonic::Im{T}@Topological"], *this),
+        re_C(p["nonleptonic::Re{C}@Topological"], *this),
+        im_C(p["nonleptonic::Im{C}@Topological"], *this),
+        re_A(p["nonleptonic::Re{A}@Topological"], *this),
+        im_A(p["nonleptonic::Im{A}@Topological"], *this),
+        re_E(p["nonleptonic::Re{E}@Topological"], *this),
+        im_E(p["nonleptonic::Im{E}@Topological"], *this),
         re_TES(p["nonleptonic::Re{TES}@Topological"], *this),
         im_TES(p["nonleptonic::Im{TES}@Topological"], *this),
         re_TAS(p["nonleptonic::Re{TAS}@Topological"], *this),
         im_TAS(p["nonleptonic::Im{TAS}@Topological"], *this),
-        re_TS( p["nonleptonic::Re{TS}@Topological"],  *this),
-        im_TS( p["nonleptonic::Im{TS}@Topological"],  *this),
+        re_TS(p["nonleptonic::Re{TS}@Topological"], *this),
+        im_TS(p["nonleptonic::Im{TS}@Topological"], *this),
         re_TPA(p["nonleptonic::Re{TPA}@Topological"], *this),
         im_TPA(p["nonleptonic::Im{TPA}@Topological"], *this),
-        re_TP( p["nonleptonic::Re{TP}@Topological"],  *this),
-        im_TP( p["nonleptonic::Im{TP}@Topological"],  *this),
+        re_TP(p["nonleptonic::Re{TP}@Topological"], *this),
+        im_TP(p["nonleptonic::Im{TP}@Topological"], *this),
         re_TSS(p["nonleptonic::Re{TSS}@Topological"], *this),
         im_TSS(p["nonleptonic::Im{TSS}@Topological"], *this),
-        re_P(  p["nonleptonic::Re{P}@Topological"],   *this),
-        im_P(  p["nonleptonic::Im{P}@Topological"],   *this),
-        re_PT( p["nonleptonic::Re{PT}@Topological"],  *this),
-        im_PT( p["nonleptonic::Im{PT}@Topological"],  *this),
-        re_S(  p["nonleptonic::Re{S}@Topological"],   *this),
-        im_S(  p["nonleptonic::Im{S}@Topological"],   *this),
-        re_PC( p["nonleptonic::Re{PC}@Topological"],  *this),
-        im_PC( p["nonleptonic::Im{PC}@Topological"],  *this),
+        re_P(p["nonleptonic::Re{P}@Topological"], *this),
+        im_P(p["nonleptonic::Im{P}@Topological"], *this),
+        re_PT(p["nonleptonic::Re{PT}@Topological"], *this),
+        im_PT(p["nonleptonic::Im{PT}@Topological"], *this),
+        re_S(p["nonleptonic::Re{S}@Topological"], *this),
+        im_S(p["nonleptonic::Im{S}@Topological"], *this),
+        re_PC(p["nonleptonic::Re{PC}@Topological"], *this),
+        im_PC(p["nonleptonic::Im{PC}@Topological"], *this),
         re_PTA(p["nonleptonic::Re{PTA}@Topological"], *this),
         im_PTA(p["nonleptonic::Im{PTA}@Topological"], *this),
-        re_PA( p["nonleptonic::Re{PA}@Topological"],  *this),
-        im_PA( p["nonleptonic::Im{PA}@Topological"],  *this),
+        re_PA(p["nonleptonic::Re{PA}@Topological"], *this),
+        im_PA(p["nonleptonic::Im{PA}@Topological"], *this),
         re_PTE(p["nonleptonic::Re{PTE}@Topological"], *this),
         im_PTE(p["nonleptonic::Im{PTE}@Topological"], *this),
         re_PAS(p["nonleptonic::Re{PAS}@Topological"], *this),
@@ -107,38 +107,31 @@ namespace eos
             lamst = conj(model->ckm_tb()) * model->ckm_ts();
         }
 
-        H1tilde[1] = lamdt;
-        H1tilde[2] = lamst;
-        Hbar[0][1][0] = lamdu;
-        Hbar[0][2][0] = lamsu;
+        H1tilde[1]       = lamdt;
+        H1tilde[2]       = lamst;
+        Hbar[0][1][0]    = lamdu;
+        Hbar[0][2][0]    = lamsu;
         H3tilde[0][1][0] = lamdt;
         H3tilde[0][2][0] = lamst;
-    };
+    }
 
-    const std::vector<OptionSpecification>
-    TopologicalRepresentation<PToPP>::options
-    {
+    const std::vector<OptionSpecification> TopologicalRepresentation<PToPP>::options{
         Model::option_specification(),
-        { "cp-conjugate", { "true", "false" },  "false" },
-        { "B_bar", { "true", "false"},  "false" },
-        { "q", { "u", "d", "s" }, "" },
-        { "P1", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" }, "" },
-        { "P2", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" }, "" },
+        { "cp-conjugate",                                                                     { "true", "false" }, "false" },
+        {        "B_bar",                                                                     { "true", "false" }, "false" },
+        {            "q",                                                                       { "u", "d", "s" },      "" },
+        {           "P1", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" },      "" },
+        {           "P2", { "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" },      "" },
     };
 
     complex<double>
     TopologicalRepresentation<PToPP>::tree_amplitude(su3f::rank2 & p1, su3f::rank2 & p2) const
     {
-        complex<double> T_tda = 0.0;
-        const complex<double> T   = complex<double>(this->re_T(),   this->im_T()),
-                              C   = complex<double>(this->re_C(),   this->im_C()),
-                              A   = complex<double>(this->re_A(),   this->im_A()),
-                              E   = complex<double>(this->re_E(),   this->im_E()),
-                              TES = complex<double>(this->re_TES(), this->im_TES()),
-                              TAS = complex<double>(this->re_TAS(), this->im_TAS()),
-                              TS  = complex<double>(this->re_TS(),  this->im_TS()),
-                              TPA = complex<double>(this->re_TPA(), this->im_TPA()),
-                              TP  = complex<double>(this->re_TP(),  this->im_TP()),
+        complex<double>       T_tda = 0.0;
+        const complex<double> T = complex<double>(this->re_T(), this->im_T()), C = complex<double>(this->re_C(), this->im_C()), A = complex<double>(this->re_A(), this->im_A()),
+                              E = complex<double>(this->re_E(), this->im_E()), TES = complex<double>(this->re_TES(), this->im_TES()),
+                              TAS = complex<double>(this->re_TAS(), this->im_TAS()), TS = complex<double>(this->re_TS(), this->im_TS()),
+                              TPA = complex<double>(this->re_TPA(), this->im_TPA()), TP = complex<double>(this->re_TP(), this->im_TP()),
                               TSS = complex<double>(this->re_TSS(), this->im_TSS());
 
         for (unsigned i = 0; i < 3; i++)
@@ -170,16 +163,11 @@ namespace eos
     complex<double>
     TopologicalRepresentation<PToPP>::penguin_amplitude(su3f::rank2 & p1, su3f::rank2 & p2) const
     {
-        complex<double> P_tda = 0.0;
-        const complex<double> P   = complex<double>(this->re_P(),   this->im_P()),
-                              PT  = complex<double>(this->re_PT(),  this->im_PT()),
-                              S   = complex<double>(this->re_S(),   this->im_S()),
-                              PC  = complex<double>(this->re_PC(),  this->im_PC()),
-                              PTA = complex<double>(this->re_PTA(), this->im_PTA()),
-                              PA  = complex<double>(this->re_PA(),  this->im_PA()),
-                              PTE = complex<double>(this->re_PTE(), this->im_PTE()),
-                              PAS = complex<double>(this->re_PAS(), this->im_PAS()),
-                              PSS = complex<double>(this->re_PSS(), this->im_PSS()),
+        complex<double>       P_tda = 0.0;
+        const complex<double> P = complex<double>(this->re_P(), this->im_P()), PT = complex<double>(this->re_PT(), this->im_PT()), S = complex<double>(this->re_S(), this->im_S()),
+                              PC = complex<double>(this->re_PC(), this->im_PC()), PTA = complex<double>(this->re_PTA(), this->im_PTA()),
+                              PA = complex<double>(this->re_PA(), this->im_PA()), PTE = complex<double>(this->re_PTE(), this->im_PTE()),
+                              PAS = complex<double>(this->re_PAS(), this->im_PAS()), PSS = complex<double>(this->re_PSS(), this->im_PSS()),
                               PES = complex<double>(this->re_PES(), this->im_PES());
 
         for (unsigned i = 0; i < 3; i++)
@@ -220,9 +208,7 @@ namespace eos
             su3f::transpose(P2);
         }
 
-        return complex<double>(0.0, 1.0) * Gfermi() / sqrt(2.0) * (
-            this->tree_amplitude(P1, P2) + this->penguin_amplitude(P1, P2)
-        );
+        return complex<double>(0.0, 1.0) * Gfermi() / sqrt(2.0) * (this->tree_amplitude(P1, P2) + this->penguin_amplitude(P1, P2));
     }
 
     complex<double>
@@ -236,9 +222,7 @@ namespace eos
             su3f::transpose(P2);
         }
 
-        return complex<double>(0.0, 1.0) * Gfermi() / sqrt(2.0) * (
-            this->tree_amplitude(P2, P1) + this->penguin_amplitude(P2, P1)
-        );
+        return complex<double>(0.0, 1.0) * Gfermi() / sqrt(2.0) * (this->tree_amplitude(P2, P1) + this->penguin_amplitude(P2, P1));
     }
 
     complex<double>
@@ -247,8 +231,8 @@ namespace eos
         this->update();
 
         auto penguin = (this->penguin_amplitude(P1, P2) + this->penguin_amplitude(P2, P1)) / lamdt;
-        auto tree = (this->tree_amplitude(P1, P2) + this->tree_amplitude(P2, P1)) / lamdu;
+        auto tree    = (this->tree_amplitude(P1, P2) + this->tree_amplitude(P2, P1)) / lamdu;
 
-        return - penguin / (tree - penguin);
+        return -penguin / (tree - penguin);
     }
-}
+} // namespace eos

--- a/eos/nonleptonic-amplitudes/topological-amplitudes.hh
+++ b/eos/nonleptonic-amplitudes/topological-amplitudes.hh
@@ -20,10 +20,10 @@
 #ifndef EOS_GUARD_EOS_NONLEPTONIC_AMPLITUDES_TOPOLOGICAL_AMPLITUDES_HH
 #define EOS_GUARD_EOS_NONLEPTONIC_AMPLITUDES_TOPOLOGICAL_AMPLITUDES_HH 1
 
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
-#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh>
 #include <eos/maths/complex.hh>
 #include <eos/models/model.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes-fwd.hh>
+#include <eos/nonleptonic-amplitudes/nonleptonic-amplitudes.hh>
 #include <eos/utils/parameters.hh>
 
 #include <array>
@@ -33,21 +33,19 @@ namespace eos
 {
     template <typename Transition_> class TopologicalRepresentation;
 
-    template <>
-    class TopologicalRepresentation<PToPP> :
-        public NonleptonicAmplitudes<PToPP>
+    template <> class TopologicalRepresentation<PToPP> : public NonleptonicAmplitudes<PToPP>
     {
         private:
             std::shared_ptr<Model> model;
-            QuarkFlavorOption opt_q;
-            LightMesonOption opt_p1;
-            LightMesonOption opt_p2;
-            BooleanOption opt_cp_conjugate;
-            BooleanOption opt_B_bar;
+            QuarkFlavorOption      opt_q;
+            LightMesonOption       opt_p1;
+            LightMesonOption       opt_p2;
+            BooleanOption          opt_cp_conjugate;
+            BooleanOption          opt_B_bar;
 
             UsedParameter theta_18;
 
-            su3f::rank1 B;
+            su3f::rank1         B;
             mutable su3f::rank1 H1tilde;
             mutable su3f::rank2 P1, P2;
             mutable su3f::rank3 Hbar, H3tilde;
@@ -86,9 +84,10 @@ namespace eos
         public:
             TopologicalRepresentation(const Parameters & p, const Options & o);
 
-            ~TopologicalRepresentation() {};
+            ~TopologicalRepresentation() {}
 
-            inline void update() const
+            inline void
+            update() const
             {
                 const double theta_18 = this->theta_18.evaluate();
                 su3f::psd_octet.find(opt_p1.value())->second(theta_18, P1);
@@ -102,8 +101,19 @@ namespace eos
             complex<double> penguin_amplitude(su3f::rank2 & p1, su3f::rank2 & p2) const;
 
             // Diagnostic functions
-            complex<double> tree_amplitude() const { update(); return tree_amplitude(P1, P2); }
-            complex<double> penguin_amplitude() const { update(); return penguin_amplitude(P1, P2); };
+            complex<double>
+            tree_amplitude() const
+            {
+                update();
+                return tree_amplitude(P1, P2);
+            }
+
+            complex<double>
+            penguin_amplitude() const
+            {
+                update();
+                return penguin_amplitude(P1, P2);
+            }
 
             // Amplitude for B -> P1 P2
             complex<double> ordered_amplitude() const;
@@ -112,5 +122,5 @@ namespace eos
             // CP-conserving penguin vs tree correction defined as - |(Vub Vud*) / (Vcb Vcd*)| penguin / (tree - penguin), cf. [FJV:2016A]
             complex<double> penguin_correction() const override;
     };
-}
+} // namespace eos
 #endif

--- a/eos/nonleptonic-amplitudes/topological-amplitudes_TEST.cc
+++ b/eos/nonleptonic-amplitudes/topological-amplitudes_TEST.cc
@@ -17,15 +17,15 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/maths/complex.hh>
 #include <eos/nonleptonic-amplitudes/topological-amplitudes.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
 
-class TopologicalAmplitudesTest :
-    public TestCase
+class TopologicalAmplitudesTest : public TestCase
 {
     public:
         TopologicalAmplitudesTest() :
@@ -33,322 +33,311 @@ class TopologicalAmplitudesTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-
             /* Test with real amplitudes */
             {
-                Parameters p = Parameters::Defaults();
-                p["nonleptonic::Re{T}@Topological"]    =  0.1;
-                p["nonleptonic::Re{C}@Topological"]    = -0.2;
-                p["nonleptonic::Re{A}@Topological"]    =  0.3;
-                p["nonleptonic::Re{E}@Topological"]    = -0.4;
-                p["nonleptonic::Re{TES}@Topological"]  =  0.5;
-                p["nonleptonic::Re{TAS}@Topological"]  = -0.6;
-                p["nonleptonic::Re{TS}@Topological"]   =  0.7;
-                p["nonleptonic::Re{TPA}@Topological"]  = -0.8;
-                p["nonleptonic::Re{TP}@Topological"]   =  0.9;
-                p["nonleptonic::Re{TSS}@Topological"]  = -1.0;
-                p["nonleptonic::Re{P}@Topological"]    =  1.1;
-                p["nonleptonic::Re{PT}@Topological"]   = -1.2;
-                p["nonleptonic::Re{S}@Topological"]    =  1.3;
-                p["nonleptonic::Re{PC}@Topological"]   = -1.4;
-                p["nonleptonic::Re{PTA}@Topological"]  =  1.5;
-                p["nonleptonic::Re{PA}@Topological"]   = -1.6;
-                p["nonleptonic::Re{PTE}@Topological"]  =  1.7;
-                p["nonleptonic::Re{PAS}@Topological"]  = -1.8;
-                p["nonleptonic::Re{PSS}@Topological"]  =  1.9;
-                p["nonleptonic::Re{PES}@Topological"]  = -2.0;
-                p["eta::theta_18"]                     =  0.0;
+                Parameters p                          = Parameters::Defaults();
+                p["nonleptonic::Re{T}@Topological"]   = 0.1;
+                p["nonleptonic::Re{C}@Topological"]   = -0.2;
+                p["nonleptonic::Re{A}@Topological"]   = 0.3;
+                p["nonleptonic::Re{E}@Topological"]   = -0.4;
+                p["nonleptonic::Re{TES}@Topological"] = 0.5;
+                p["nonleptonic::Re{TAS}@Topological"] = -0.6;
+                p["nonleptonic::Re{TS}@Topological"]  = 0.7;
+                p["nonleptonic::Re{TPA}@Topological"] = -0.8;
+                p["nonleptonic::Re{TP}@Topological"]  = 0.9;
+                p["nonleptonic::Re{TSS}@Topological"] = -1.0;
+                p["nonleptonic::Re{P}@Topological"]   = 1.1;
+                p["nonleptonic::Re{PT}@Topological"]  = -1.2;
+                p["nonleptonic::Re{S}@Topological"]   = 1.3;
+                p["nonleptonic::Re{PC}@Topological"]  = -1.4;
+                p["nonleptonic::Re{PTA}@Topological"] = 1.5;
+                p["nonleptonic::Re{PA}@Topological"]  = -1.6;
+                p["nonleptonic::Re{PTE}@Topological"] = 1.7;
+                p["nonleptonic::Re{PAS}@Topological"] = -1.8;
+                p["nonleptonic::Re{PSS}@Topological"] = 1.9;
+                p["nonleptonic::Re{PES}@Topological"] = -2.0;
+                p["eta::theta_18"]                    = 0.0;
 
                 static const double eps = 1.0e-6;
 
-                Options o
-                {
-                    { "q", "u" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^+" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o{
+                    {            "q",    "u" },
+                    {           "P1", "pi^0" },
+                    {           "P2", "pi^+" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 TopologicalRepresentation<PToPP> d(p, o);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(),    complex<double>( 0.001145733549, -0.003043620361), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>( 0.008128955914,  0.003271917227), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(-1.882888193e-9,  7.649339906e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>( 5.006745077e-8, -2.017304058e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(),         complex<double>( 4.818456257e-8, -1.252370068e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(), complex<double>(0.001145733549, -0.003043620361), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(0.008128955914, 0.003271917227), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(-1.882888193e-9, 7.649339906e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>(5.006745077e-8, -2.017304058e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(), complex<double>(4.818456257e-8, -1.252370068e-7), eps);
 
-                Options oo
-                {
-                    { "q", "d" },
-                    { "P1", "pi^+" },
-                    { "P2", "pi^-" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oo{
+                    {            "q",    "d" },
+                    {           "P1", "pi^+" },
+                    {           "P2", "pi^-" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 TopologicalRepresentation<PToPP> dd(p, oo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(),    complex<double>(-0.001495672546,  0.003973226947), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>( 0.000821148550,  0.000330513551), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(), complex<double>(-0.001495672546, 0.003973226947), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(0.000821148550, 0.000330513551), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>(-3.549528431e-8, -5.563165578e-9), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.inverse_amplitude(), complex<double>( 5.180227961e-8, -1.130758467e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(),         complex<double>( 1.630699530e-8, -1.186390123e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.inverse_amplitude(), complex<double>(5.180227961e-8, -1.130758467e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(), complex<double>(1.630699530e-8, -1.186390123e-7), eps);
 
-                Options ooo
-                {
-                    { "q", "d" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^0" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options ooo{
+                    {            "q",    "d" },
+                    {           "P1", "pi^0" },
+                    {           "P2", "pi^0" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 TopologicalRepresentation<PToPP> ddd(p, ooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(),    complex<double>(-0.000560877204,  0.001489960105), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>( 0.004105742750,  0.001652567756), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(-2.591813329e-8,  2.923643060e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>(-2.591813329e-8,  2.923643060e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(),         complex<double>(-5.183626659e-8,  5.847286120e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(), complex<double>(-0.000560877204, 0.001489960105), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>(0.004105742750, 0.001652567756), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(-2.591813329e-8, 2.923643060e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>(-2.591813329e-8, 2.923643060e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(), complex<double>(-5.183626659e-8, 5.847286120e-8), eps);
 
-                Options oooo
-                {
-                    { "q", "s" },
-                    { "P1", "eta" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oooo{
+                    {            "q",      "s" },
+                    {           "P1",    "eta" },
+                    {           "P2", "Kbar_d" },
+                    {        "model",    "CKM" },
+                    { "cp-conjugate",   "true" }
                 };
 
                 TopologicalRepresentation<PToPP> dddd(p, oooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.tree_amplitude(),    complex<double>(-0.000915908639,  0.002433094663), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.tree_amplitude(), complex<double>(-0.000915908639, 0.002433094663), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dddd.penguin_amplitude(), complex<double>(-0.007375114819, -0.002968495030), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.ordered_amplitude(), complex<double>( 4.415737482e-9, -6.838057151e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.inverse_amplitude(), complex<double>( 1.114241606e-8, -5.356868028e-9), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.amplitude(),         complex<double>( 1.555815354e-8, -7.373743954e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.ordered_amplitude(), complex<double>(4.415737482e-9, -6.838057151e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.inverse_amplitude(), complex<double>(1.114241606e-8, -5.356868028e-9), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.amplitude(), complex<double>(1.555815354e-8, -7.373743954e-8), eps);
             }
 
             /* Test with complex amplitudes and theta = 0*/
             {
-                Parameters p = Parameters::Defaults();
-                p["nonleptonic::Re{T}@Topological"]    =  0.1 * std::cos( 0.1);
-                p["nonleptonic::Im{T}@Topological"]    =  0.1 * std::sin( 0.1);
-                p["nonleptonic::Re{C}@Topological"]    = -0.2 * std::cos(-0.2);
-                p["nonleptonic::Im{C}@Topological"]    = -0.2 * std::sin(-0.2);
-                p["nonleptonic::Re{A}@Topological"]    =  0.3 * std::cos( 0.3);
-                p["nonleptonic::Im{A}@Topological"]    =  0.3 * std::sin( 0.3);
-                p["nonleptonic::Re{E}@Topological"]    = -0.4 * std::cos(-0.4);
-                p["nonleptonic::Im{E}@Topological"]    = -0.4 * std::sin(-0.4);
-                p["nonleptonic::Re{TES}@Topological"]  =  0.5 * std::cos( 0.5);
-                p["nonleptonic::Im{TES}@Topological"]  =  0.5 * std::sin( 0.5);
-                p["nonleptonic::Re{TAS}@Topological"]  = -0.6 * std::cos(-0.6);
-                p["nonleptonic::Im{TAS}@Topological"]  = -0.6 * std::sin(-0.6);
-                p["nonleptonic::Re{TS}@Topological"]   =  0.7 * std::cos( 0.7);
-                p["nonleptonic::Im{TS}@Topological"]   =  0.7 * std::sin( 0.7);
-                p["nonleptonic::Re{TPA}@Topological"]  = -0.8 * std::cos(-0.8);
-                p["nonleptonic::Im{TPA}@Topological"]  = -0.8 * std::sin(-0.8);
-                p["nonleptonic::Re{TP}@Topological"]   =  0.9 * std::cos( 0.9);
-                p["nonleptonic::Im{TP}@Topological"]   =  0.9 * std::sin( 0.9);
-                p["nonleptonic::Re{TSS}@Topological"]  = -1.0 * std::cos(-1.0);
-                p["nonleptonic::Im{TSS}@Topological"]  = -1.0 * std::sin(-1.0);
-                p["nonleptonic::Re{P}@Topological"]    =  1.1 * std::cos( 1.1);
-                p["nonleptonic::Im{P}@Topological"]    =  1.1 * std::sin( 1.1);
-                p["nonleptonic::Re{PT}@Topological"]   = -1.2 * std::cos(-1.2);
-                p["nonleptonic::Im{PT}@Topological"]   = -1.2 * std::sin(-1.2);
-                p["nonleptonic::Re{S}@Topological"]    =  1.3 * std::cos( 1.3);
-                p["nonleptonic::Im{S}@Topological"]    =  1.3 * std::sin( 1.3);
-                p["nonleptonic::Re{PC}@Topological"]   = -1.4 * std::cos(-1.4);
-                p["nonleptonic::Im{PC}@Topological"]   = -1.4 * std::sin(-1.4);
-                p["nonleptonic::Re{PTA}@Topological"]  =  1.5 * std::cos( 1.5);
-                p["nonleptonic::Im{PTA}@Topological"]  =  1.5 * std::sin( 1.5);
-                p["nonleptonic::Re{PA}@Topological"]   = -1.6 * std::cos(-1.6);
-                p["nonleptonic::Im{PA}@Topological"]   = -1.6 * std::sin(-1.6);
-                p["nonleptonic::Re{PTE}@Topological"]  =  1.7 * std::cos( 1.7);
-                p["nonleptonic::Im{PTE}@Topological"]  =  1.7 * std::sin( 1.7);
-                p["nonleptonic::Re{PAS}@Topological"]  = -1.8 * std::cos(-1.8);
-                p["nonleptonic::Im{PAS}@Topological"]  = -1.8 * std::sin(-1.8);
-                p["nonleptonic::Re{PSS}@Topological"]  =  1.9 * std::cos( 1.9);
-                p["nonleptonic::Im{PSS}@Topological"]  =  1.9 * std::sin( 1.9);
-                p["nonleptonic::Re{PES}@Topological"]  = -2.0 * std::cos(-2.0);
-                p["nonleptonic::Im{PES}@Topological"]  = -2.0 * std::sin(-2.0);
-                p["eta::theta_18"]                     =  0.0;
+                Parameters p                          = Parameters::Defaults();
+                p["nonleptonic::Re{T}@Topological"]   = 0.1 * std::cos(0.1);
+                p["nonleptonic::Im{T}@Topological"]   = 0.1 * std::sin(0.1);
+                p["nonleptonic::Re{C}@Topological"]   = -0.2 * std::cos(-0.2);
+                p["nonleptonic::Im{C}@Topological"]   = -0.2 * std::sin(-0.2);
+                p["nonleptonic::Re{A}@Topological"]   = 0.3 * std::cos(0.3);
+                p["nonleptonic::Im{A}@Topological"]   = 0.3 * std::sin(0.3);
+                p["nonleptonic::Re{E}@Topological"]   = -0.4 * std::cos(-0.4);
+                p["nonleptonic::Im{E}@Topological"]   = -0.4 * std::sin(-0.4);
+                p["nonleptonic::Re{TES}@Topological"] = 0.5 * std::cos(0.5);
+                p["nonleptonic::Im{TES}@Topological"] = 0.5 * std::sin(0.5);
+                p["nonleptonic::Re{TAS}@Topological"] = -0.6 * std::cos(-0.6);
+                p["nonleptonic::Im{TAS}@Topological"] = -0.6 * std::sin(-0.6);
+                p["nonleptonic::Re{TS}@Topological"]  = 0.7 * std::cos(0.7);
+                p["nonleptonic::Im{TS}@Topological"]  = 0.7 * std::sin(0.7);
+                p["nonleptonic::Re{TPA}@Topological"] = -0.8 * std::cos(-0.8);
+                p["nonleptonic::Im{TPA}@Topological"] = -0.8 * std::sin(-0.8);
+                p["nonleptonic::Re{TP}@Topological"]  = 0.9 * std::cos(0.9);
+                p["nonleptonic::Im{TP}@Topological"]  = 0.9 * std::sin(0.9);
+                p["nonleptonic::Re{TSS}@Topological"] = -1.0 * std::cos(-1.0);
+                p["nonleptonic::Im{TSS}@Topological"] = -1.0 * std::sin(-1.0);
+                p["nonleptonic::Re{P}@Topological"]   = 1.1 * std::cos(1.1);
+                p["nonleptonic::Im{P}@Topological"]   = 1.1 * std::sin(1.1);
+                p["nonleptonic::Re{PT}@Topological"]  = -1.2 * std::cos(-1.2);
+                p["nonleptonic::Im{PT}@Topological"]  = -1.2 * std::sin(-1.2);
+                p["nonleptonic::Re{S}@Topological"]   = 1.3 * std::cos(1.3);
+                p["nonleptonic::Im{S}@Topological"]   = 1.3 * std::sin(1.3);
+                p["nonleptonic::Re{PC}@Topological"]  = -1.4 * std::cos(-1.4);
+                p["nonleptonic::Im{PC}@Topological"]  = -1.4 * std::sin(-1.4);
+                p["nonleptonic::Re{PTA}@Topological"] = 1.5 * std::cos(1.5);
+                p["nonleptonic::Im{PTA}@Topological"] = 1.5 * std::sin(1.5);
+                p["nonleptonic::Re{PA}@Topological"]  = -1.6 * std::cos(-1.6);
+                p["nonleptonic::Im{PA}@Topological"]  = -1.6 * std::sin(-1.6);
+                p["nonleptonic::Re{PTE}@Topological"] = 1.7 * std::cos(1.7);
+                p["nonleptonic::Im{PTE}@Topological"] = 1.7 * std::sin(1.7);
+                p["nonleptonic::Re{PAS}@Topological"] = -1.8 * std::cos(-1.8);
+                p["nonleptonic::Im{PAS}@Topological"] = -1.8 * std::sin(-1.8);
+                p["nonleptonic::Re{PSS}@Topological"] = 1.9 * std::cos(1.9);
+                p["nonleptonic::Im{PSS}@Topological"] = 1.9 * std::sin(1.9);
+                p["nonleptonic::Re{PES}@Topological"] = -2.0 * std::cos(-2.0);
+                p["nonleptonic::Im{PES}@Topological"] = -2.0 * std::sin(-2.0);
+                p["eta::theta_18"]                    = 0.0;
 
                 static const double eps = 1.0e-6;
 
-                Options o
-                {
-                    { "q", "u" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^+" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o{
+                    {            "q",    "u" },
+                    {           "P1", "pi^0" },
+                    {           "P2", "pi^+" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 TopologicalRepresentation<PToPP> d(p, o);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(),    complex<double>( 2.714849536e-3, -1.505497114e-3), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(-7.413420944e-3,  2.127194598e-2), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(), complex<double>(2.714849536e-3, -1.505497114e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(-7.413420944e-3, 2.127194598e-2), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(-1.630246346e-7, -3.875166918e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>( 5.413850131e-8, -4.135936105e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(),         complex<double>(-1.088861333e-7, -8.011103022e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>(5.413850131e-8, -4.135936105e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(), complex<double>(-1.088861333e-7, -8.011103022e-8), eps);
 
-                Options oo
-                {
-                    { "q", "d" },
-                    { "P1", "pi^+" },
-                    { "P2", "pi^-" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oo{
+                    {            "q",    "d" },
+                    {           "P1", "pi^+" },
+                    {           "P2", "pi^-" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 TopologicalRepresentation<PToPP> dd(p, oo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(),    complex<double>( 1.261996239e-3,  3.974744683e-3), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(-1.227283279e-2,  2.640641563e-2), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(), complex<double>(1.261996239e-3, 3.974744683e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(-1.227283279e-2, 2.640641563e-2), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>(-2.505699225e-7, -9.081234659e-8), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dd.inverse_amplitude(), complex<double>(-2.639484094e-7, -5.705999870e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(),         complex<double>(-5.145183319e-7, -1.478723453e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(), complex<double>(-5.145183319e-7, -1.478723453e-7), eps);
 
-                Options ooo
-                {
-                    { "q", "d" },
-                    { "P1", "pi^0" },
-                    { "P2", "pi^0" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options ooo{
+                    {            "q",    "d" },
+                    {           "P1", "pi^0" },
+                    {           "P2", "pi^0" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 TopologicalRepresentation<PToPP> ddd(p, ooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(),    complex<double>( 2.805870338e-3,  2.431652123e-3), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>(-4.902145577e-3,  1.942516576e-2), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(), complex<double>(2.805870338e-3, 2.431652123e-3), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>(-4.902145577e-3, 1.942516576e-2), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(-1.802650427e-7, -1.728911992e-8), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>(-1.802650427e-7, -1.728911992e-8), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(),         complex<double>(-3.605300854e-7, -3.457823985e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(), complex<double>(-3.605300854e-7, -3.457823985e-8), eps);
 
-                Options oooo
-                {
-                    { "q", "s" },
-                    { "P1", "eta" },
-                    { "P2", "Kbar_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oooo{
+                    {            "q",      "s" },
+                    {           "P1",    "eta" },
+                    {           "P2", "Kbar_d" },
+                    {        "model",    "CKM" },
+                    { "cp-conjugate",   "true" }
                 };
 
                 TopologicalRepresentation<PToPP> dddd(p, oooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.tree_amplitude(),    complex<double>(-2.475246464e-3,  7.949800121e-4), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.tree_amplitude(), complex<double>(-2.475246464e-3, 7.949800121e-4), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dddd.penguin_amplitude(), complex<double>(-6.997788583e-4, -7.919254440e-3), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.ordered_amplitude(), complex<double>( 5.875775885e-8, -2.618615750e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.ordered_amplitude(), complex<double>(5.875775885e-8, -2.618615750e-8), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dddd.inverse_amplitude(), complex<double>(-6.722738747e-8, -9.218878246e-9), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dddd.amplitude(),         complex<double>(-8.469628623e-9, -3.540503574e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dddd.amplitude(), complex<double>(-8.469628623e-9, -3.540503574e-8), eps);
             }
 
             /* Test with complex amplitudes and theta = 1.0 */
             {
-                Parameters p = Parameters::Defaults();
-                p["nonleptonic::Re{T}@Topological"]    =  0.1 * std::cos( 0.1);
-                p["nonleptonic::Im{T}@Topological"]    =  0.1 * std::sin( 0.1);
-                p["nonleptonic::Re{C}@Topological"]    = -0.2 * std::cos(-0.2);
-                p["nonleptonic::Im{C}@Topological"]    = -0.2 * std::sin(-0.2);
-                p["nonleptonic::Re{A}@Topological"]    =  0.3 * std::cos( 0.3);
-                p["nonleptonic::Im{A}@Topological"]    =  0.3 * std::sin( 0.3);
-                p["nonleptonic::Re{E}@Topological"]    = -0.4 * std::cos(-0.4);
-                p["nonleptonic::Im{E}@Topological"]    = -0.4 * std::sin(-0.4);
-                p["nonleptonic::Re{TES}@Topological"]  =  0.5 * std::cos( 0.5);
-                p["nonleptonic::Im{TES}@Topological"]  =  0.5 * std::sin( 0.5);
-                p["nonleptonic::Re{TAS}@Topological"]  = -0.6 * std::cos(-0.6);
-                p["nonleptonic::Im{TAS}@Topological"]  = -0.6 * std::sin(-0.6);
-                p["nonleptonic::Re{TS}@Topological"]   =  0.7 * std::cos( 0.7);
-                p["nonleptonic::Im{TS}@Topological"]   =  0.7 * std::sin( 0.7);
-                p["nonleptonic::Re{TPA}@Topological"]  = -0.8 * std::cos(-0.8);
-                p["nonleptonic::Im{TPA}@Topological"]  = -0.8 * std::sin(-0.8);
-                p["nonleptonic::Re{TP}@Topological"]   =  0.9 * std::cos( 0.9);
-                p["nonleptonic::Im{TP}@Topological"]   =  0.9 * std::sin( 0.9);
-                p["nonleptonic::Re{TSS}@Topological"]  = -1.0 * std::cos(-1.0);
-                p["nonleptonic::Im{TSS}@Topological"]  = -1.0 * std::sin(-1.0);
-                p["nonleptonic::Re{P}@Topological"]    =  1.1 * std::cos( 1.1);
-                p["nonleptonic::Im{P}@Topological"]    =  1.1 * std::sin( 1.1);
-                p["nonleptonic::Re{PT}@Topological"]   = -1.2 * std::cos(-1.2);
-                p["nonleptonic::Im{PT}@Topological"]   = -1.2 * std::sin(-1.2);
-                p["nonleptonic::Re{S}@Topological"]    =  1.3 * std::cos( 1.3);
-                p["nonleptonic::Im{S}@Topological"]    =  1.3 * std::sin( 1.3);
-                p["nonleptonic::Re{PC}@Topological"]   = -1.4 * std::cos(-1.4);
-                p["nonleptonic::Im{PC}@Topological"]   = -1.4 * std::sin(-1.4);
-                p["nonleptonic::Re{PTA}@Topological"]  =  1.5 * std::cos( 1.5);
-                p["nonleptonic::Im{PTA}@Topological"]  =  1.5 * std::sin( 1.5);
-                p["nonleptonic::Re{PA}@Topological"]   = -1.6 * std::cos(-1.6);
-                p["nonleptonic::Im{PA}@Topological"]   = -1.6 * std::sin(-1.6);
-                p["nonleptonic::Re{PTE}@Topological"]  =  1.7 * std::cos( 1.7);
-                p["nonleptonic::Im{PTE}@Topological"]  =  1.7 * std::sin( 1.7);
-                p["nonleptonic::Re{PAS}@Topological"]  = -1.8 * std::cos(-1.8);
-                p["nonleptonic::Im{PAS}@Topological"]  = -1.8 * std::sin(-1.8);
-                p["nonleptonic::Re{PSS}@Topological"]  =  1.9 * std::cos( 1.9);
-                p["nonleptonic::Im{PSS}@Topological"]  =  1.9 * std::sin( 1.9);
-                p["nonleptonic::Re{PES}@Topological"]  = -2.0 * std::cos(-2.0);
-                p["nonleptonic::Im{PES}@Topological"]  = -2.0 * std::sin(-2.0);
-                p["eta::theta_18"]                     =  1.0;
+                Parameters p                          = Parameters::Defaults();
+                p["nonleptonic::Re{T}@Topological"]   = 0.1 * std::cos(0.1);
+                p["nonleptonic::Im{T}@Topological"]   = 0.1 * std::sin(0.1);
+                p["nonleptonic::Re{C}@Topological"]   = -0.2 * std::cos(-0.2);
+                p["nonleptonic::Im{C}@Topological"]   = -0.2 * std::sin(-0.2);
+                p["nonleptonic::Re{A}@Topological"]   = 0.3 * std::cos(0.3);
+                p["nonleptonic::Im{A}@Topological"]   = 0.3 * std::sin(0.3);
+                p["nonleptonic::Re{E}@Topological"]   = -0.4 * std::cos(-0.4);
+                p["nonleptonic::Im{E}@Topological"]   = -0.4 * std::sin(-0.4);
+                p["nonleptonic::Re{TES}@Topological"] = 0.5 * std::cos(0.5);
+                p["nonleptonic::Im{TES}@Topological"] = 0.5 * std::sin(0.5);
+                p["nonleptonic::Re{TAS}@Topological"] = -0.6 * std::cos(-0.6);
+                p["nonleptonic::Im{TAS}@Topological"] = -0.6 * std::sin(-0.6);
+                p["nonleptonic::Re{TS}@Topological"]  = 0.7 * std::cos(0.7);
+                p["nonleptonic::Im{TS}@Topological"]  = 0.7 * std::sin(0.7);
+                p["nonleptonic::Re{TPA}@Topological"] = -0.8 * std::cos(-0.8);
+                p["nonleptonic::Im{TPA}@Topological"] = -0.8 * std::sin(-0.8);
+                p["nonleptonic::Re{TP}@Topological"]  = 0.9 * std::cos(0.9);
+                p["nonleptonic::Im{TP}@Topological"]  = 0.9 * std::sin(0.9);
+                p["nonleptonic::Re{TSS}@Topological"] = -1.0 * std::cos(-1.0);
+                p["nonleptonic::Im{TSS}@Topological"] = -1.0 * std::sin(-1.0);
+                p["nonleptonic::Re{P}@Topological"]   = 1.1 * std::cos(1.1);
+                p["nonleptonic::Im{P}@Topological"]   = 1.1 * std::sin(1.1);
+                p["nonleptonic::Re{PT}@Topological"]  = -1.2 * std::cos(-1.2);
+                p["nonleptonic::Im{PT}@Topological"]  = -1.2 * std::sin(-1.2);
+                p["nonleptonic::Re{S}@Topological"]   = 1.3 * std::cos(1.3);
+                p["nonleptonic::Im{S}@Topological"]   = 1.3 * std::sin(1.3);
+                p["nonleptonic::Re{PC}@Topological"]  = -1.4 * std::cos(-1.4);
+                p["nonleptonic::Im{PC}@Topological"]  = -1.4 * std::sin(-1.4);
+                p["nonleptonic::Re{PTA}@Topological"] = 1.5 * std::cos(1.5);
+                p["nonleptonic::Im{PTA}@Topological"] = 1.5 * std::sin(1.5);
+                p["nonleptonic::Re{PA}@Topological"]  = -1.6 * std::cos(-1.6);
+                p["nonleptonic::Im{PA}@Topological"]  = -1.6 * std::sin(-1.6);
+                p["nonleptonic::Re{PTE}@Topological"] = 1.7 * std::cos(1.7);
+                p["nonleptonic::Im{PTE}@Topological"] = 1.7 * std::sin(1.7);
+                p["nonleptonic::Re{PAS}@Topological"] = -1.8 * std::cos(-1.8);
+                p["nonleptonic::Im{PAS}@Topological"] = -1.8 * std::sin(-1.8);
+                p["nonleptonic::Re{PSS}@Topological"] = 1.9 * std::cos(1.9);
+                p["nonleptonic::Im{PSS}@Topological"] = 1.9 * std::sin(1.9);
+                p["nonleptonic::Re{PES}@Topological"] = -2.0 * std::cos(-2.0);
+                p["nonleptonic::Im{PES}@Topological"] = -2.0 * std::sin(-2.0);
+                p["eta::theta_18"]                    = 1.0;
 
                 static const double eps = 1.0e-6;
 
-                Options o
-                {
-                    { "q", "u" },
-                    { "P1", "eta" },
-                    { "P2", "pi^+" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options o{
+                    {            "q",    "u" },
+                    {           "P1",  "eta" },
+                    {           "P2", "pi^+" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 TopologicalRepresentation<PToPP> d(p, o);
 
-                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(),    complex<double>(-0.001018379427023484, 0.0005647337976274578), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(0.0027808816931099217,-0.007979415385035703), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(6.115290434864023e-8,1.4536313019197382e-8), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.tree_amplitude(), complex<double>(-0.001018379427023484, 0.0005647337976274578), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.penguin_amplitude(), complex<double>(0.0027808816931099217, -0.007979415385035703), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(d.ordered_amplitude(), complex<double>(6.115290434864023e-8, 1.4536313019197382e-8), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(d.inverse_amplitude(), complex<double>(3.9109708177886845e-7, -2.3065477505584753e-8), eps);
 
                 TEST_CHECK_RELATIVE_ERROR_C(d.amplitude(), complex<double>(4.5224998612750857e-7, -8.529164486387376e-9), eps);
 
-                Options oo
-                {
-                    { "q", "d" },
-                    { "P1", "eta_prime" },
-                    { "P2", "K_d" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options oo{
+                    {            "q",         "d" },
+                    {           "P1", "eta_prime" },
+                    {           "P2",       "K_d" },
+                    {        "model",       "CKM" },
+                    { "cp-conjugate",      "true" }
                 };
 
                 TopologicalRepresentation<PToPP> dd(p, oo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(),    complex<double>(0.00045961421670513524, -0.00014761524595177606), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(-0.013955444602458823,-0.026203892903736634), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>(2.1733519347033603e-7,-1.1130743983491132e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.tree_amplitude(), complex<double>(0.00045961421670513524, -0.00014761524595177606), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.penguin_amplitude(), complex<double>(-0.013955444602458823, -0.026203892903736634), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(dd.ordered_amplitude(), complex<double>(2.1733519347033603e-7, -1.1130743983491132e-7), eps);
                 TEST_CHECK_RELATIVE_ERROR_C(dd.inverse_amplitude(), complex<double>(5.80912303675578e-7, -3.216600683041854e-9), eps);
 
                 TEST_CHECK_RELATIVE_ERROR_C(dd.amplitude(), complex<double>(7.98247497145914e-7, -1.1452404051795318e-7), eps);
 
 
-                Options ooo
-                {
-                    { "q", "d" },
-                    { "P1", "eta" },
-                    { "P2", "eta" },
-                    { "model", "CKM" },
-                    { "cp-conjugate", "true"}
+                Options ooo{
+                    {            "q",    "d" },
+                    {           "P1",  "eta" },
+                    {           "P2",  "eta" },
+                    {        "model",  "CKM" },
+                    { "cp-conjugate", "true" }
                 };
 
                 TopologicalRepresentation<PToPP> ddd(p, ooo);
 
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(),    complex<double>( 0.006932851020723416, 0.008997971640539072), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>( -0.03059460579418031, 0.053191625860970544), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>( -5.129113722089845e-7, -1.9515133715782058e-7), eps);
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>( -5.129113722089845e-7, -1.9515133715782058e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.tree_amplitude(), complex<double>(0.006932851020723416, 0.008997971640539072), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.penguin_amplitude(), complex<double>(-0.03059460579418031, 0.053191625860970544), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.ordered_amplitude(), complex<double>(-5.129113722089845e-7, -1.9515133715782058e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.inverse_amplitude(), complex<double>(-5.129113722089845e-7, -1.9515133715782058e-7), eps);
 
-                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(), complex<double>( -1.0258227444179687e-6, -3.90302674315641e-7), eps);
+                TEST_CHECK_RELATIVE_ERROR_C(ddd.amplitude(), complex<double>(-1.0258227444179687e-6, -3.90302674315641e-7), eps);
             }
         }
 } topological_amplitudes_test;


### PR DESCRIPTION
I had to exclude the matrix definition in eos/nonleptonic-amplitudes/nonleptonic-amplitudes.cc as the clang format made no sense.