### PR TITLE
Changes to PToPP form factors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,8 @@ eos/scattering      @mreboud
 
 # @lorenzennio should review commits to pyhf code
 python/eos/*pyhf*   @lorenzennio
+
+# @herren should review commits to:
+eos/b-decays        @Herren
+eos/form-factors    @Herren
+eos/scattering      @Herren

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The main authors are:
  * Christoph Bobeth,
  * Carolina Bolognani <carolinabolognani@gmail.com>,
  * Nico Gubernari <nicogubernari@gmail.com>,
+ * Florian Herren <florian.s.herren@gmail.com>,
  * Meril Reboud <merilreboud@gmail.com>,
 
 with further code contributions by:

--- a/eos/b-decays/b-to-pi-pi-l-nu_TEST.cc
+++ b/eos/b-decays/b-to-pi-pi-l-nu_TEST.cc
@@ -57,6 +57,8 @@ class BToPiPiLeptonNeutrinoTest :
                 Options oo;
                 oo.declare("model"_ok, "CKM");
                 oo.declare("form-factors"_ok, "BFvD2016");
+                oo.declare("I"_ok, "0|1");
+                oo.declare("L"_ok, "S|P|D|F");
 
                 BToPiPiLeptonNeutrino d(p, oo);
 

--- a/eos/b-decays/b-to-psd-l-nu.cc
+++ b/eos/b-decays/b-to-psd-l-nu.cc
@@ -60,7 +60,7 @@ namespace eos
         Parameters parameters;
 
         QuarkFlavorOption opt_q;
-        SpecifiedOption opt_P;
+        RestrictedOption opt_P;
 
         UsedParameter m_B;
 

--- a/eos/b-decays/b-to-psd-psd.cc
+++ b/eos/b-decays/b-to-psd-psd.cc
@@ -43,7 +43,7 @@ namespace eos
         UsedParameter mB;
         UsedParameter mP1;
         UsedParameter mP2;
-        SpecifiedOption opt_rep;
+        RestrictedOption opt_rep;
         std::shared_ptr<NonleptonicAmplitudes<PToPP>> nl_amplitudes;
         std::shared_ptr<NonleptonicAmplitudes<PToPP>> cp_nl_amplitudes;
         std::shared_ptr<NonleptonicAmplitudes<PToPP>> Bbar_nl_amplitudes;

--- a/eos/b-decays/b-to-vec-l-nu.cc
+++ b/eos/b-decays/b-to-vec-l-nu.cc
@@ -50,7 +50,7 @@ namespace eos
         Parameters parameters;
 
         QuarkFlavorOption opt_q;
-        SpecifiedOption opt_V;
+        RestrictedOption opt_V;
 
         UsedParameter hbar;
 

--- a/eos/b-decays/bq-to-dq-psd.cc
+++ b/eos/b-decays/bq-to-dq-psd.cc
@@ -75,7 +75,7 @@ namespace eos
 
         UsedParameter mu;
 
-        SpecifiedOption opt_accuracy;
+        RestrictedOption opt_accuracy;
         double switch_lo;
         double switch_nlo;
         double switch_nlp;

--- a/eos/b-decays/bq-to-dstarq-psd.cc
+++ b/eos/b-decays/bq-to-dstarq-psd.cc
@@ -76,7 +76,7 @@ namespace eos
 
         UsedParameter mu;
 
-        SpecifiedOption opt_accuracy;
+        RestrictedOption opt_accuracy;
         double switch_lo;
         double switch_nlo;
         double switch_nlp;

--- a/eos/c-decays/d-to-psd-l-nu.cc
+++ b/eos/c-decays/d-to-psd-l-nu.cc
@@ -87,7 +87,7 @@ namespace eos
 
         GSL::QAGS::Config int_config;
 
-        SpecifiedOption opt_cp_conjugate;
+        BooleanOption opt_cp_conjugate;
 
         bool cp_conjugate;
 
@@ -173,7 +173,7 @@ namespace eos
             mu(p[opt_Q.str() + "cnu" + opt_l.str() + opt_l.str() + "::mu"], u),
             int_config(GSL::QAGS::Config().epsrel(0.5e-3)),
             opt_cp_conjugate(o, options, "cp-conjugate"_ok),
-            cp_conjugate(destringify<bool>(opt_cp_conjugate.value())),
+            cp_conjugate(opt_cp_conjugate.value()),
             form_factors(FormFactorFactory<PToP>::create(_process() + "::" + o.get("form-factors"_ok, "BSZ2015"), p, o))
         {
             Context ctx("When constructing D->Plnu observable");

--- a/eos/c-decays/dq-to-l-nu.cc
+++ b/eos/c-decays/dq-to-l-nu.cc
@@ -58,7 +58,7 @@ namespace eos
 
         UsedParameter m_l;
 
-        SpecifiedOption opt_cp_conjugate;
+        BooleanOption opt_cp_conjugate;
 
         bool cp_conjugate;
 
@@ -82,7 +82,7 @@ namespace eos
             opt_l(o, options, "l"_ok),
             m_l(p["mass::" + opt_l.str()], u),
             opt_cp_conjugate(o, options, "cp-conjugate"_ok),
-            cp_conjugate(destringify<bool>(opt_cp_conjugate.value())),
+            cp_conjugate(opt_cp_conjugate.value()),
             mu(p[opt_q.str() + "c" + "nu" + opt_l.str() + opt_l.str() + "::mu"], u)
         {
             Context ctx("When constructing D_q^+->l^+nu observable");

--- a/eos/c-decays/dstarq-to-l-nu.cc
+++ b/eos/c-decays/dstarq-to-l-nu.cc
@@ -58,7 +58,7 @@ namespace eos
 
         UsedParameter m_l;
 
-        SpecifiedOption opt_cp_conjugate;
+        BooleanOption opt_cp_conjugate;
 
         bool cp_conjugate;
 
@@ -83,7 +83,7 @@ namespace eos
             opt_l(o, options, "l"_ok),
             m_l(p["mass::" + opt_l.str()], u),
             opt_cp_conjugate(o, options, "cp-conjugate"_ok),
-            cp_conjugate(destringify<bool>(opt_cp_conjugate.value())),
+            cp_conjugate(opt_cp_conjugate.value()),
             mu(p[opt_q.str() + "c" + "nu" + opt_l.str() + opt_l.str() + "::mu"], u)
         {
             Context ctx("When constructing D_q^*+->l^+nu observable");

--- a/eos/form-factors/analytic-b-to-pi-pi.cc
+++ b/eos/form-factors/analytic-b-to-pi-pi.cc
@@ -560,38 +560,6 @@ namespace eos
         return _imp->ff_lo_tw2(tr, q2, k2, z) + _imp->ff_lo_tw3(tr, q2, k2, z);
     }
 
-    double
-    AnalyticFormFactorBToPiPiBFvD2016::f_perp_im_res_qhat2(const double & /*q2*/, const double & /*k2*/) const
-    {
-        throw InternalError("Not yet implemented");
-
-        return 0.0;
-    }
-
-    double
-    AnalyticFormFactorBToPiPiBFvD2016::f_para_im_res_qhat2(const double & /*q2*/, const double & /*k2*/) const
-    {
-        throw InternalError("Not yet implemented");
-
-        return 0.0;
-    }
-
-    double
-    AnalyticFormFactorBToPiPiBFvD2016::f_long_im_res_qhat2(const double & /*q2*/, const double & /*k2*/) const
-    {
-        throw InternalError("Not yet implemented");
-
-        return 0.0;
-    }
-
-    double
-    AnalyticFormFactorBToPiPiBFvD2016::f_time_im_res_qhat2(const double & /*q2*/, const double & /*k2*/) const
-    {
-        throw InternalError("Not yet implemented");
-
-        return 0.0;
-    }
-
     Diagnostics
     AnalyticFormFactorBToPiPiBFvD2016::diagnostics() const
     {
@@ -692,6 +660,11 @@ namespace eos
         {
             Diagnostics results;
 
+            results.add({ f_time_im_res_qhat2(0.05, 13.0),   "f_time_im_res_qhat2(q2 = 0.05, k2 = 13.0)" });
+            results.add({ f_long_im_res_qhat2(0.05, 13.0),   "f_long_im_res_qhat2(q2 = 0.05, k2 = 13.0)" });
+            results.add({ f_perp_im_res_qhat2(0.05, 13.0),   "f_perp_im_res_qhat2(q2 = 0.05, k2 = 13.0)" });
+            results.add({ f_para_im_res_qhat2(0.05, 13.0),   "f_para_im_res_qhat2(q2 = 0.05, k2 = 13.0)" });
+
             return results;
         }
     };
@@ -770,6 +743,11 @@ namespace eos
         return _imp->diagnostics();
     }
 
+    const std::set<ReferenceName> AnalyticFormFactorBToPiPiFvDV2018::references
+    {
+        "FvDV:2018A"_rn
+    };
+
     std::vector<OptionSpecification>::const_iterator
     AnalyticFormFactorBToPiPiFvDV2018::begin_options()
     {
@@ -781,4 +759,8 @@ namespace eos
     {
         return Implementation<AnalyticFormFactorBToPiPiFvDV2018>::options.cend();
     }
+
+    const std::vector<OptionSpecification> AnalyticFormFactorBToPiPiFvDV2018::options
+    {
+    };
 }

--- a/eos/form-factors/analytic-b-to-pi-pi.hh
+++ b/eos/form-factors/analytic-b-to-pi-pi.hh
@@ -24,6 +24,7 @@
 #include <eos/utils/diagnostics.hh>
 #include <eos/utils/parameters.hh>
 #include <eos/utils/options.hh>
+#include <eos/utils/reference-name.hh>
 
 namespace eos
 {
@@ -57,12 +58,6 @@ namespace eos
             double re_f_time(const double & q2, const double & k2, const double & z) const;
             double im_f_time(const double & q2, const double & k2, const double & z) const;
 
-            /* Form factors */
-            virtual double f_perp_im_res_qhat2(const double & q2, const double & k2) const override;
-            virtual double f_para_im_res_qhat2(const double & q2, const double & k2) const override;
-            virtual double f_long_im_res_qhat2(const double & q2, const double & k2) const override;
-            virtual double f_time_im_res_qhat2(const double & q2, const double & k2) const override;
-
             /* Diagnostics for unit tests */
             Diagnostics diagnostics() const;
 
@@ -91,19 +86,25 @@ namespace eos
             virtual complex<double> f_time(const double & q2, const double & k2, const double & z) const;
 
             /* Form factor residues */
-            virtual double f_perp_im_res_qhat2(const double & q2, const double & k2) const;
-            virtual double f_para_im_res_qhat2(const double & q2, const double & k2) const;
-            virtual double f_long_im_res_qhat2(const double & q2, const double & k2) const;
-            virtual double f_time_im_res_qhat2(const double & q2, const double & k2) const;
+            double f_perp_im_res_qhat2(const double & q2, const double & k2) const;
+            double f_para_im_res_qhat2(const double & q2, const double & k2) const;
+            double f_long_im_res_qhat2(const double & q2, const double & k2) const;
+            double f_time_im_res_qhat2(const double & q2, const double & k2) const;
 
             /* Diagnostics for unit tests */
             Diagnostics diagnostics() const;
+
+            /*!
+             * References used in the computation of our observables.
+             */
+            static const std::set<ReferenceName> references;
 
             /*!
              * Options used in the computation of our observables.
              */
             static std::vector<OptionSpecification>::const_iterator begin_options();
             static std::vector<OptionSpecification>::const_iterator end_options();
+            static const std::vector<OptionSpecification> options;
     };
 }
 

--- a/eos/form-factors/analytic-b-to-pi-pi.hh
+++ b/eos/form-factors/analytic-b-to-pi-pi.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2016 Danny van Dyk
+ * Copyright (c) 2025 Florian Herren
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -43,6 +44,12 @@ namespace eos
             complex<double> F_perp_lo_tw2(const double & q2, const double & k2, const double & z) const;
             complex<double> F_perp_lo_tw3(const double & q2, const double & k2, const double & z) const;
 
+            // Partial waves
+            virtual std::array<complex<double>, 4> f_perp(const double & q2, const double & k2) const override;
+            virtual std::array<complex<double>, 4> f_para(const double & q2, const double & k2) const override;
+            virtual std::array<complex<double>, 4> f_long(const double & q2, const double & k2) const override;
+            virtual std::array<complex<double>, 4> f_time(const double & q2, const double & k2) const override;
+
             /* Form factors */
             virtual complex<double> f_perp(const double & q2, const double & k2, const double & z) const override;
             virtual complex<double> f_para(const double & q2, const double & k2, const double & z) const override;
@@ -78,6 +85,12 @@ namespace eos
             ~AnalyticFormFactorBToPiPiFvDV2018();
 
             static FormFactors<PToPP> * make(const Parameters &, const Options &);
+
+            // Partial waves
+            virtual std::array<complex<double>, 4> f_perp(const double & q2, const double & k2) const;
+            virtual std::array<complex<double>, 4> f_para(const double & q2, const double & k2) const;
+            virtual std::array<complex<double>, 4> f_long(const double & q2, const double & k2) const;
+            virtual std::array<complex<double>, 4> f_time(const double & q2, const double & k2) const;
 
             /* Form factors */
             virtual complex<double> f_perp(const double & q2, const double & k2, const double & z) const;

--- a/eos/form-factors/analytic-b-to-pi-pi_TEST.cc
+++ b/eos/form-factors/analytic-b-to-pi-pi_TEST.cc
@@ -276,7 +276,7 @@ class AnalyticFormFactorBToPiPiFvDV2018Test :
 
         virtual void run() const
         {
-            static const double eps = 1.0e-5;
+            static const double eps = 1.0e-3;
 
             /* Factory */
             {
@@ -285,13 +285,25 @@ class AnalyticFormFactorBToPiPiFvDV2018Test :
                 p["mass::B_d^*"] = 5.32465;
 
                 std::shared_ptr<FormFactors<PToPP>> ff = FormFactorFactory<PToPP>::create("B->pipi::FvDV2018-Dispersive", p, Options{ });
-
                 TEST_CHECK(0 != ff.get());
+            }
 
-                TEST_CHECK_RELATIVE_ERROR(ff->f_time_im_res_qhat2(0.05, 13.0), 2910.308, eps);
-                TEST_CHECK_RELATIVE_ERROR(ff->f_long_im_res_qhat2(0.05, 13.0), 2927.843, eps);
-                TEST_CHECK_RELATIVE_ERROR(ff->f_perp_im_res_qhat2(0.05, 13.0),  -46.067, eps);
-                TEST_CHECK_RELATIVE_ERROR(ff->f_para_im_res_qhat2(0.05, 13.0),  129.103, eps);
+            /* Internal Diagnostics */
+            {
+                Parameters p = Parameters::Defaults();
+                p["mass::B_d"] = 5.27958;
+                p["mass::B_d^*"] = 5.32465;
+
+                AnalyticFormFactorBToPiPiFvDV2018 ff(p, Options{ });
+                Diagnostics diagnostics = ff.diagnostics();
+                static const std::vector<std::pair<double, double>> reference
+                {
+                    std::make_pair(  2910.308,  eps), // f_time_im_res_qhat2(q2 = 0.05, k2 = 13.0)
+                    std::make_pair(  2927.843,  eps), // f_long_im_res_qhat2(q2 = 0.05, k2 = 13.0)
+                    std::make_pair(   -46.067,  eps), // f_perp_im_res_qhat2(q2 = 0.05, k2 = 13.0)
+                    std::make_pair(   129.103,  eps), // f_para_im_res_qhat2(q2 = 0.05, k2 = 13.0)
+                };
+                TEST_CHECK_DIAGNOSTICS(diagnostics, reference);
             }
         }
 } analytic_form_factor_b_to_pi_pi_FvDV2018_test;

--- a/eos/form-factors/analytic-b-to-psd-dkmmo2008-impl.hh
+++ b/eos/form-factors/analytic-b-to-psd-dkmmo2008-impl.hh
@@ -327,7 +327,7 @@ namespace eos
         UsedParameter _s0_zero, _s0_zero_p, _s0_zero_pp;
         UsedParameter _s0_T,    _s0_T_p,    _s0_T_pp;
         // Decays constant: option govens whether to use the QCDSR or a parameter for the decay constant
-        SpecifiedOption opt_decay_constant;
+        RestrictedOption opt_decay_constant;
         std::function<double ()> decay_constant;
 
         // Parameter for the estimation of NNLO corrections

--- a/eos/form-factors/heavy-meson-lcdas-exponential.hh
+++ b/eos/form-factors/heavy-meson-lcdas-exponential.hh
@@ -52,7 +52,7 @@ namespace eos
             private:
                 QuarkFlavorOption opt_Q;
                 QuarkFlavorOption opt_q;
-                SpecifiedOption opt_gminus;
+                RestrictedOption opt_gminus;
 
                 UsedParameter lambda_B_inv;
                 UsedParameter lambda_E2;

--- a/eos/form-factors/heavy-meson-lcdas-flvd2022.hh
+++ b/eos/form-factors/heavy-meson-lcdas-flvd2022.hh
@@ -51,10 +51,10 @@ namespace eos
 
                 QuarkFlavorOption opt_Q;
                 QuarkFlavorOption opt_q;
-                SpecifiedOption opt_gminus;
+                RestrictedOption opt_gminus;
                 double switch_gminus;
 
-                SpecifiedOption opt_alpha_s;
+                RestrictedOption opt_alpha_s;
                 std::function<double(const double &)> alpha_s;
 
                 UsedParameter mu_0;

--- a/eos/form-factors/mesonic.hh
+++ b/eos/form-factors/mesonic.hh
@@ -219,12 +219,6 @@ namespace eos
             double im_f_para(const double & q2, const double & k2, const double & z) const { return std::imag(f_para(q2, k2, z)); }
             double im_f_long(const double & q2, const double & k2, const double & z) const { return std::imag(f_long(q2, k2, z)); }
             double im_f_time(const double & q2, const double & k2, const double & z) const { return std::imag(f_time(q2, k2, z)); }
-
-            // residues
-            virtual double f_perp_im_res_qhat2(const double & q2, const double & k2) const = 0;
-            virtual double f_para_im_res_qhat2(const double & q2, const double & k2) const = 0;
-            virtual double f_long_im_res_qhat2(const double & q2, const double & k2) const = 0;
-            virtual double f_time_im_res_qhat2(const double & q2, const double & k2) const = 0;
     };
 
     template <>

--- a/eos/form-factors/mesonic.hh
+++ b/eos/form-factors/mesonic.hh
@@ -7,6 +7,7 @@
  * Copyright (c) 2022 Philip Lüghausen
  * Copyright (c) 2010 Christian Wacker
  * Copyright (c) 2024 Matthew J. Kirk
+ * Copyright (c) 2025 Florian Herren
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -32,6 +33,7 @@
 #include <eos/utils/qualified-name.hh>
 #include <eos/utils/transitions.hh>
 
+#include <array>
 #include <map>
 #include <memory>
 #include <string>
@@ -208,6 +210,12 @@ namespace eos
     {
         public:
             virtual ~FormFactors();
+
+            // Partial waves
+            virtual std::array<complex<double>, 4> f_perp(const double & q2, const double & k2) const = 0;
+            virtual std::array<complex<double>, 4> f_para(const double & q2, const double & k2) const = 0;
+            virtual std::array<complex<double>, 4> f_long(const double & q2, const double & k2) const = 0;
+            virtual std::array<complex<double>, 4> f_time(const double & q2, const double & k2) const = 0;
 
             // form factors
             virtual complex<double> f_perp(const double & q2, const double & k2, const double & z) const = 0;

--- a/eos/form-factors/observables.cc
+++ b/eos/form-factors/observables.cc
@@ -31,6 +31,7 @@
 #include <eos/form-factors/parametric-bgl1997.hh>
 #include <eos/form-factors/parametric-bfw2010.hh>
 #include <eos/form-factors/parametric-bmrvd2022.hh>
+#include <eos/form-factors/parametric-fvdv2018.hh>
 #include <eos/form-factors/parametric-kkrvd2024.hh>
 #include <eos/form-factors/parametric-kkvdz2022.hh>
 #include <eos/form-factors/parametric-ksvd2025.hh>
@@ -1924,17 +1925,53 @@ namespace eos
                 make_form_factor_adapter("B->pipi::Im{F_time}(q2,k2,z)", R"(\mathrm{Im}\,F_t^{B\to \pi\pi}(q^2,k^2,z))",
                         &FormFactors<PToPP>::im_f_time, std::make_tuple("q2", "k2", "z")),
 
-                make_form_factor_adapter("B->pipi::Im{Res{F_perp}}(q2,k2)", R"(\mathrm{Res}\,\mathrm{Im}\,F_\perp^{B\to \pi\pi}(q^2,k^2,z))",
-                        &FormFactors<PToPP>::f_perp_im_res_qhat2, std::make_tuple("q2", "k2")),
+                make_observable("B->pipi::Im{Res{F_perp}}(q2,k2)@FvDV2018A", R"(\mathrm{Res}\,\mathrm{Im}\,F_\perp^{B\to \pi\pi}(q^2,k^2,z))",
+                        Unit::None(),
+                        &AnalyticFormFactorBToPiPiFvDV2018::f_perp_im_res_qhat2,
+                        std::make_tuple("q2", "k2")
+                        ),
 
-                make_form_factor_adapter("B->pipi::Im{Res{F_para}}(q2,k2)", R"(\mathrm{Res}\,\mathrm{Im}\,F_\parallel^{B\to \pi\pi}(q^2,k^2,z))",
-                        &FormFactors<PToPP>::f_para_im_res_qhat2, std::make_tuple("q2", "k2")),
+                make_observable("B->pipi::Im{Res{F_para}}(q2,k2)@FvDV2018A", R"(\mathrm{Res}\,\mathrm{Im}\,F_\parallel^{B\to \pi\pi}(q^2,k^2,z))",
+                        Unit::None(),
+                        &AnalyticFormFactorBToPiPiFvDV2018::f_para_im_res_qhat2,
+                        std::make_tuple("q2", "k2")
+                        ),
 
-                make_form_factor_adapter("B->pipi::Im{Res{F_long}}(q2,k2)", R"(\mathrm{Res}\,\mathrm{Im}\,F_0^{B\to \pi\pi}(q^2,k^2,z))",
-                        &FormFactors<PToPP>::f_long_im_res_qhat2, std::make_tuple("q2", "k2")),
+                make_observable("B->pipi::Im{Res{F_long}}(q2,k2)@FvDV2018A", R"(\mathrm{Res}\,\mathrm{Im}\,F_0^{B\to \pi\pi}(q^2,k^2,z))",
+                        Unit::None(),
+                        &AnalyticFormFactorBToPiPiFvDV2018::f_long_im_res_qhat2,
+                        std::make_tuple("q2", "k2")
+                        ),
 
-                make_form_factor_adapter("B->pipi::Im{Res{F_time}}(q2,k2)", R"(\mathrm{Res}\,\mathrm{Im}\,F_t^{B\to \pi\pi}(q^2,k^2,z))",
-                        &FormFactors<PToPP>::f_time_im_res_qhat2, std::make_tuple("q2", "k2")),
+                make_observable("B->pipi::Im{Res{F_time}}(q2,k2)@FvDV2018A", R"(\mathrm{Res}\,\mathrm{Im}\,F_t^{B\to \pi\pi}(q^2,k^2,z))",
+                        Unit::None(),
+                        &AnalyticFormFactorBToPiPiFvDV2018::f_time_im_res_qhat2,
+                        std::make_tuple("q2", "k2")
+                        ),
+
+                make_observable("B->pipi::Im{Res{F_perp}}(q2,k2)@FvDV2018D", R"(\mathrm{Res}\,\mathrm{Im}\,F_\perp^{B\to \pi\pi}(q^2,k^2,z))",
+                        Unit::None(),
+                        &FvDV2018FormFactors<BToPiPi>::f_perp_im_res_qhat2,
+                        std::make_tuple("q2", "k2")
+                        ),
+
+                make_observable("B->pipi::Im{Res{F_para}}(q2,k2)@FvDV2018D", R"(\mathrm{Res}\,\mathrm{Im}\,F_\parallel^{B\to \pi\pi}(q^2,k^2,z))",
+                        Unit::None(),
+                        &FvDV2018FormFactors<BToPiPi>::f_para_im_res_qhat2,
+                        std::make_tuple("q2", "k2")
+                        ),
+
+                make_observable("B->pipi::Im{Res{F_long}}(q2,k2)@FvDV2018D", R"(\mathrm{Res}\,\mathrm{Im}\,F_0^{B\to \pi\pi}(q^2,k^2,z))",
+                        Unit::None(),
+                        &FvDV2018FormFactors<BToPiPi>::f_long_im_res_qhat2,
+                        std::make_tuple("q2", "k2")
+                        ),
+
+                make_observable("B->pipi::Im{Res{F_time}}(q2,k2)@FvDV2018D", R"(\mathrm{Res}\,\mathrm{Im}\,F_t^{B\to \pi\pi}(q^2,k^2,z))",
+                        Unit::None(),
+                        &FvDV2018FormFactors<BToPiPi>::f_time_im_res_qhat2,
+                        std::make_tuple("q2", "k2")
+                        ),
             }
         );
 

--- a/eos/form-factors/parametric-fvdv2018-impl.hh
+++ b/eos/form-factors/parametric-fvdv2018-impl.hh
@@ -383,6 +383,31 @@ namespace eos
 
         return result;
     }
+
+    template<typename Process_>
+    const std::set<ReferenceName> FvDV2018FormFactors<Process_>::references
+    {
+        "FvDV:2018A"_rn
+    };
+
+    template<typename Process_>
+    const std::vector<OptionSpecification> FvDV2018FormFactors<Process_>::options
+    {
+    };
+
+    template<typename Process_>
+    std::vector<OptionSpecification>::const_iterator
+    FvDV2018FormFactors<Process_>::begin_options()
+    {
+        return options.cbegin();
+    }
+
+    template<typename Process_>
+    std::vector<OptionSpecification>::const_iterator
+    FvDV2018FormFactors<Process_>::end_options()
+    {
+        return options.cend();
+    }
 }
 
 #endif

--- a/eos/form-factors/parametric-fvdv2018.hh
+++ b/eos/form-factors/parametric-fvdv2018.hh
@@ -23,7 +23,9 @@
 
 #include <eos/form-factors/mesonic.hh>
 #include <eos/form-factors/mesonic-processes.hh>
+#include <eos/utils/options.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/utils/reference-name.hh>
 
 namespace eos
 {
@@ -64,10 +66,22 @@ namespace eos
             virtual complex<double> f_long(const double & q2, const double & k2, const double & ctheta) const override;
             virtual complex<double> f_time(const double & q2, const double & k2, const double & ctheta) const override;
 
-            virtual double f_perp_im_res_qhat2(const double & q2, const double & k2) const override;
-            virtual double f_para_im_res_qhat2(const double & q2, const double & k2) const override;
-            virtual double f_long_im_res_qhat2(const double & q2, const double & k2) const override;
-            virtual double f_time_im_res_qhat2(const double & q2, const double & k2) const override;
+            double f_perp_im_res_qhat2(const double & q2, const double & k2) const;
+            double f_para_im_res_qhat2(const double & q2, const double & k2) const;
+            double f_long_im_res_qhat2(const double & q2, const double & k2) const;
+            double f_time_im_res_qhat2(const double & q2, const double & k2) const;
+
+            /*!
+             * References used in the computation of our observables.
+             */
+            static const std::set<ReferenceName> references;
+
+            /*!
+             * Options used in the computation of our observables.
+             */
+            static std::vector<OptionSpecification>::const_iterator begin_options();
+            static std::vector<OptionSpecification>::const_iterator end_options();
+            static const std::vector<OptionSpecification> options;
     };
 
     extern template class FvDV2018FormFactors<BToPiPi>;

--- a/eos/form-factors/parametric-fvdv2018.hh
+++ b/eos/form-factors/parametric-fvdv2018.hh
@@ -2,7 +2,8 @@
 
 /*
  * Copyright (c) 2010-2022 Danny van Dyk
- * Copyright (c) 2018 Keri Vos
+ * Copyright (c) 2018      Keri Vos
+ * Copyright (c) 2025      Florian Herren
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -49,6 +50,9 @@ namespace eos
             UsedParameter _b_Ftime_0_0, _b_Ftime_0_1, _b_Ftime_0_2, _b_Ftime_0_3, _b_Ftime_1_0, _b_Ftime_1_1, _b_Ftime_1_2;
             UsedParameter _c_Ftime_0_0, _c_Ftime_0_1, _c_Ftime_0_2, _c_Ftime_0_3, _c_Ftime_1_0, _c_Ftime_1_1, _c_Ftime_1_2;
 
+            PartialWaveOption opt_L;
+            double _S_switch, _P_switch, _D_switch, _F_switch;
+
             static double _calc_z(const double & t, const double & t_p, const double & t_0);
             inline double _z(const double & t) const;
             inline double _zhat(const double & that) const;
@@ -56,10 +60,15 @@ namespace eos
             inline double _blaschke_res_qhat2(const double & z) const;
 
           public:
-            FvDV2018FormFactors(const Parameters & p, const Options &);
+            FvDV2018FormFactors(const Parameters & p, const Options & o);
             ~FvDV2018FormFactors();
 
             static FormFactors<PToPP> * make(const Parameters & parameters, const Options & options);
+
+            virtual std::array<complex<double>, 4> f_perp(const double & q2, const double & k2) const override;
+            virtual std::array<complex<double>, 4> f_para(const double & q2, const double & k2) const override;
+            virtual std::array<complex<double>, 4> f_long(const double & q2, const double & k2) const override;
+            virtual std::array<complex<double>, 4> f_time(const double & q2, const double & k2) const override;
 
             virtual complex<double> f_perp(const double & q2, const double & k2, const double & ctheta) const override;
             virtual complex<double> f_para(const double & q2, const double & k2, const double & ctheta) const override;

--- a/eos/form-factors/parametric-fvdv2018_TEST.cc
+++ b/eos/form-factors/parametric-fvdv2018_TEST.cc
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2010-2022 Danny van Dyk
  * Copyright (c) 2018 Keri Vos
+ * Copyright (c) 2025 Florian Herren
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -152,5 +153,18 @@ class BToPiPiFvDV2018FormFactorsTest :
             TEST_CHECK_NEARLY_EQUAL(imag(ff->f_perp(0.60, 19.0, +0.5)), 0.001048, eps);
             TEST_CHECK_NEARLY_EQUAL(real(ff->f_perp(0.05, 16.0, -0.5)), 0.0,      eps);
             TEST_CHECK_NEARLY_EQUAL(imag(ff->f_perp(0.05, 16.0, -0.5)), 0.001215, eps);
+
+            // partial waves
+            auto time_pw = ff->f_time(0.60, 19.0);
+            TEST_CHECK_NEARLY_EQUAL(imag(ff->f_time(0.60, 19.0, 1.0)) - imag(time_pw[0] + std::sqrt(3.0) * time_pw[1] + std::sqrt(5.0) * time_pw[2] + std::sqrt(7.0) * time_pw[3]), 0.0, eps);
+
+            auto long_pw = ff->f_long(0.60, 19.0);
+            TEST_CHECK_NEARLY_EQUAL(imag(ff->f_long(0.60, 19.0, 1.0)) - imag(long_pw[0] + std::sqrt(3.0) * long_pw[1] + std::sqrt(5.0) * long_pw[2] + std::sqrt(7.0) * long_pw[3]), 0.0, eps);
+
+            auto perp_pw = ff->f_perp(0.60, 19.0);
+            TEST_CHECK_NEARLY_EQUAL(imag(ff->f_perp(0.60, 19.0, 0.0)) - imag(std::sqrt(3.0) * perp_pw[1] - 1.5 * std::sqrt(7.0) * perp_pw[3]), 0.0, eps);
+
+            auto para_pw = ff->f_para(0.60, 19.0);
+            TEST_CHECK_NEARLY_EQUAL(imag(ff->f_para(0.60, 19.0, 0.0)) - imag(std::sqrt(3.0) * para_pw[1] - 1.5 * std::sqrt(7.0) * para_pw[3]), 0.0, eps);
         }
 } b_to_pi_pi_fvdv2018_form_factors_test;

--- a/eos/form-factors/parametric-ksvd2025.hh
+++ b/eos/form-factors/parametric-ksvd2025.hh
@@ -38,8 +38,8 @@ namespace eos
         public FormFactors<VacuumToPP>
     {
         private:
-            SpecifiedOption n_resonances_1m;
-            SpecifiedOption n_resonances_0p;
+            RestrictedOption n_resonances_1m;
+            RestrictedOption n_resonances_0p;
 
             // parameters for form factor f_+
             std::array<UsedParameter, 9u> _b_fp;

--- a/eos/nonlocal-form-factors/charm-loops.cc
+++ b/eos/nonlocal-form-factors/charm-loops.cc
@@ -1486,7 +1486,7 @@ namespace eos
     template <>
     struct Implementation<CharmLoopsAdapter>
     {
-        SpecifiedOption opt_contribution;
+        RestrictedOption opt_contribution;
 
         UsedParameter m_b;
         UsedParameter m_c;

--- a/eos/rare-b-decays/b-to-psd-nu-nu.cc
+++ b/eos/rare-b-decays/b-to-psd-nu-nu.cc
@@ -43,7 +43,7 @@ namespace eos
 
         QuarkFlavorOption opt_D;
         QuarkFlavorOption opt_q;
-        SpecifiedOption opt_I;
+        RestrictedOption opt_I;
 
         UsedParameter m_B;
 

--- a/eos/rare-b-decays/b-to-vec-nu-nu.cc
+++ b/eos/rare-b-decays/b-to-vec-nu-nu.cc
@@ -44,7 +44,7 @@ namespace eos
 
         QuarkFlavorOption opt_D;
         QuarkFlavorOption opt_q;
-        SpecifiedOption opt_I;
+        RestrictedOption opt_I;
 
         UsedParameter m_B;
 

--- a/eos/utils/destringify.hh
+++ b/eos/utils/destringify.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2010-2025 Danny van Dyk
+ * Copyright (c) 2025      Florian Herren
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -94,7 +95,7 @@ namespace eos
                 std::string::size_type i = 0, j = input.find('|');
                 do
                 {
-                    const auto value = input.substr(i, j);
+                    const auto value = input.substr(i, j - i);
 
                     const auto k = isospins.find(value);
                     if (isospins.cend() == k)
@@ -135,7 +136,7 @@ namespace eos
                 std::string::size_type i = 0, j = input.find('|');
                 do
                 {
-                    const auto value = input.substr(i, j);
+                    const auto value = input.substr(i, j - i);
 
                     const auto k = partial_waves.find(value);
                     if (partial_waves.cend() == k)

--- a/eos/utils/options.cc
+++ b/eos/utils/options.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2010-2025 Danny van Dyk
+ * Copyright (c) 2025      Florian Herren
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -431,6 +432,50 @@ namespace eos
 
     const std::string &
     LightMesonOption::str() const
+    {
+        return _value;
+    }
+
+    IsospinOption::IsospinOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key) :
+        SpecifiedOption(options, specifications, key),
+        _isospin_value(destringify<Isospin>(_value))
+    {
+        if (((_isospin_value ^ destringify<Isospin>(this->_specification.allowed_values.front())) & _isospin_value) != Isospin::none)
+            throw InvalidOptionValueError(_specification.key, _value, join(_specification.allowed_values.cbegin(), _specification.allowed_values.cend()));
+    }
+
+    IsospinOption::~IsospinOption() = default;
+
+    Isospin
+    IsospinOption::value() const
+    {
+        return _isospin_value;
+    }
+
+    const std::string &
+    IsospinOption::str() const
+    {
+        return _value;
+    }
+
+    PartialWaveOption::PartialWaveOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key) :
+        SpecifiedOption(options, specifications, key),
+        _partial_wave_value(destringify<PartialWave>(_value))
+    {
+        if (((_partial_wave_value ^ destringify<PartialWave>(this->_specification.allowed_values.front())) & _partial_wave_value) != PartialWave::none)
+            throw InvalidOptionValueError(_specification.key, _value, join(_specification.allowed_values.cbegin(), _specification.allowed_values.cend()));
+    }
+
+    PartialWaveOption::~PartialWaveOption() = default;
+
+    PartialWave
+    PartialWaveOption::value() const
+    {
+        return _partial_wave_value;
+    }
+
+    const std::string &
+    PartialWaveOption::str() const
     {
         return _value;
     }

--- a/eos/utils/options.hh
+++ b/eos/utils/options.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2010-2025 Danny van Dyk
+ * Copyright (c) 2025      Florian Herren
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -235,6 +236,34 @@ namespace eos
             ~LightMesonOption();
 
             LightMeson value() const;
+            const std::string & str() const;
+    };
+
+    class IsospinOption :
+        public SpecifiedOption
+    {
+        private:
+            Isospin _isospin_value;
+
+        public:
+            IsospinOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "I"_ok);
+            ~IsospinOption();
+
+            Isospin value() const;
+            const std::string & str() const;
+    };
+
+    class PartialWaveOption :
+        public SpecifiedOption
+    {
+        private:
+            PartialWave _partial_wave_value;
+
+        public:
+            PartialWaveOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "L"_ok);
+            ~PartialWaveOption();
+
+            PartialWave value() const;
             const std::string & str() const;
     };
 }

--- a/eos/utils/options.hh
+++ b/eos/utils/options.hh
@@ -128,6 +128,10 @@ namespace eos
      */
     struct OptionSpecification
     {
+        OptionSpecification(const OptionSpecification &);
+        OptionSpecification(const qnp::OptionKey & key_in, const std::vector<std::string> & allowed_values_in);
+        OptionSpecification(const qnp::OptionKey & key_in, const std::vector<std::string> & allowed_values_in, const std::string & default_value_in);
+
         qnp::OptionKey key;
         std::vector<std::string> allowed_values;
         std::string default_value;
@@ -135,15 +139,28 @@ namespace eos
 
     class SpecifiedOption
     {
+        private:
+            SpecifiedOption & operator= (const SpecifiedOption &);
+
         protected:
+            OptionSpecification _specification;
             std::string _value;
 
         public:
+            SpecifiedOption(const SpecifiedOption &);
             SpecifiedOption(const Options & options, const OptionSpecification & specification);
             SpecifiedOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key);
             ~SpecifiedOption();
 
             const std::string & value() const;
+    };
+
+    class RestrictedOption :
+        public SpecifiedOption
+    {
+        public:
+            RestrictedOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key);
+            ~RestrictedOption();
     };
 
     class BooleanOption :
@@ -189,7 +206,7 @@ namespace eos
     };
 
     class LeptonFlavorOption :
-        public SpecifiedOption
+        public RestrictedOption
     {
         public:
             LeptonFlavorOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "l"_ok);
@@ -200,7 +217,7 @@ namespace eos
     };
 
     class QuarkFlavorOption :
-        public SpecifiedOption
+        public RestrictedOption
     {
         public:
             QuarkFlavorOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "q"_ok);
@@ -211,7 +228,7 @@ namespace eos
     };
 
     class LightMesonOption :
-        public SpecifiedOption
+        public RestrictedOption
     {
         public:
             LightMesonOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key);

--- a/eos/utils/options_TEST.cc
+++ b/eos/utils/options_TEST.cc
@@ -316,3 +316,188 @@ class SwitchOptionTest :
             }
         }
 } switch_option_test;
+
+class SpecifiedOptionTest :
+    public TestCase
+{
+    public:
+        SpecifiedOptionTest() :
+            TestCase("specified_option_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // specify permitted options
+            std::vector<OptionSpecification> specifications
+            {
+                { "key-with-full-specification"_ok,   { "value1", "value2", "value4" }, "value1" },
+                { "key-without-default"_ok,           { "value1", "value2", "value4" }           }
+            };
+
+            // Creation of fully specified option, with value
+            {
+                SpecifiedOption so
+                {
+                    Options{
+                        { "key-with-full-specification"_ok, "value1" }, { "unused"_ok, "foo" }
+                    },
+                    specifications,
+                    "key-with-full-specification"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), "value1");
+            }
+
+            // Creation of fully specified option, without value
+            {
+                SpecifiedOption so
+                {
+                    Options{
+                        { "unused"_ok, "foo" }
+                    },
+                    specifications,
+                    "key-with-full-specification"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), "value1");
+            }
+
+            // Creation of specified option without default value, with value
+            {
+                SpecifiedOption so
+                {
+                    Options{
+                        { "key-without-default"_ok, "value4" }, { "unused"_ok, "foo" }
+                    },
+                    specifications,
+                    "key-without-default"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), "value4");
+            }
+            // Creation of specified option without default value, without value
+            {
+                auto test = [specifications] ()
+                {
+                    SpecifiedOption so
+                    {
+                        Options{
+                            { "unused"_ok, "foo" }
+                        },
+                        specifications,
+                        "key-without-default"_ok
+                    };
+                };
+                TEST_CHECK_THROWS(UnspecifiedOptionError, test());
+            }
+        }
+} specified_option_test;
+
+class RestrictedOptionTest :
+    public TestCase
+{
+    public:
+        RestrictedOptionTest() :
+            TestCase("restricted_option_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // specify permitted options
+            std::vector<OptionSpecification> specifications
+            {
+                { "key-with-default"_ok,              { "value1", "value2", "value4" }, "value1" },
+                { "key-without-value"_ok,             { "foo", "bar" },                 "foo"    },
+                { "key-without-default"_ok,           { "value1", "value2", "value4" }           },
+                { "key-without-value-and-default"_ok, { "foo", "bar" }                           },
+                { "key-with-invalid-default"_ok,      { "value1", "value2", "value4" }, "value3" },
+                { "key-with-invalid-value"_ok,        { "value1", "value2", "value4" }, "value1" },
+            };
+
+            // Creation of option with valid default value, with value = default value
+            {
+                RestrictedOption so
+                {
+                    Options{
+                        { "key-with-default"_ok, "value1" }, { "unused"_ok, "foo" }
+                    },
+                    specifications,
+                    "key-with-default"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), "value1");
+            }
+
+            // Creation of option with valid default value, with unspecified value
+            {
+                RestrictedOption so
+                {
+                    Options{
+                        { "unused"_ok, "foo" }
+                    },
+                    specifications,
+                    "key-without-value"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), "foo");
+            }
+
+            // Creation of option without default valuee, with valid value
+            {
+                RestrictedOption so
+                {
+                    Options{
+                        { "key-without-default"_ok, "value4" }, { "unused"_ok, "foo" }
+                    },
+                    specifications,
+                    "key-without-default"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), "value4");
+            }
+
+            // Creation of option without default value, with unspecified valu
+            {
+                auto test = [specifications] ()
+                {
+                    RestrictedOption so
+                    {
+                        Options{
+                            { "unused"_ok, "foo" }
+                        },
+                        specifications,
+                        "key-without-value-and-default"_ok
+                    };
+                };
+                TEST_CHECK_THROWS(UnspecifiedOptionError, test());
+            }
+
+            // Creation with invalid value
+            {
+                auto test = [specifications] ()
+                {
+                    RestrictedOption so
+                    {
+                        Options{
+                            { "unused"_ok, "foo" }
+                        },
+                        specifications,
+                        "key-with-invalid-default"_ok
+                    };
+                };
+                TEST_CHECK_THROWS(InvalidOptionValueError, test());
+            }
+
+            // Creation with invalid value
+            {
+                auto test = [specifications] ()
+                {
+                    RestrictedOption so
+                    {
+                        Options{
+                            { "key-with-invalid-value"_ok, "value3"}, { "unused"_ok, "foo" }
+                        },
+                        specifications,
+                        "key-with-invalid-value"_ok
+                    };
+                };
+                TEST_CHECK_THROWS(InvalidOptionValueError, test());
+            }
+        }
+} restricted_option_test;

--- a/eos/utils/options_TEST.cc
+++ b/eos/utils/options_TEST.cc
@@ -501,3 +501,183 @@ class RestrictedOptionTest :
             }
         }
 } restricted_option_test;
+
+class IsospinOptionTest :
+    public TestCase
+{
+    public:
+        IsospinOptionTest() :
+            TestCase("isospin_option_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // specify permitted options
+            std::vector<OptionSpecification> specifications
+            {
+                { "I"_ok,              { "0|2" }, "0" },
+            };
+
+            // Creation of option with valid default value, with value = default value
+            {
+                IsospinOption so
+                {
+                    Options{
+                        { "I"_ok, "0" }
+                    },
+                    specifications,
+                    "I"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), Isospin::zero);
+            }
+
+            // Creation of option with valid default value, with value != default value
+            {
+                IsospinOption so
+                {
+                    Options{
+                        { "I"_ok, "2" }
+                    },
+                    specifications,
+                    "I"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), Isospin::two);
+            }
+
+            // Creation of option with valid default value, with value != default value but containing default value
+            {
+                IsospinOption so
+                {
+                    Options{
+                        { "I"_ok, "0|2" }
+                    },
+                    specifications,
+                    "I"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), Isospin::zero | Isospin::two);
+            }
+
+            // Creation with invalid value
+            {
+                auto test = [specifications] ()
+                {
+                    IsospinOption so
+                    {
+                        Options{
+                            { "I"_ok, "1"}
+                        },
+                        specifications,
+                        "I"_ok
+                    };
+                };
+                TEST_CHECK_THROWS(InvalidOptionValueError, test());
+            }
+
+            // Creation with invalid value but containing a valid value
+            {
+                auto test = [specifications] ()
+                {
+                    IsospinOption so
+                    {
+                        Options{
+                            { "I"_ok, "0|1"}
+                        },
+                        specifications,
+                        "I"_ok
+                    };
+                };
+                TEST_CHECK_THROWS(InvalidOptionValueError, test());
+            }
+        }
+} isospin_option_test;
+
+class PartialWaveOptionTest :
+    public TestCase
+{
+    public:
+        PartialWaveOptionTest() :
+            TestCase("partial_wave_option_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // specify permitted options
+            std::vector<OptionSpecification> specifications
+            {
+                { "L"_ok,              { "S|P|D" }, "S|P" },
+            };
+
+            // Creation of option with valid default value, with value = default value
+            {
+                PartialWaveOption so
+                {
+                    Options{
+                        { "L"_ok, "S|P" }
+                    },
+                    specifications,
+                    "L"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), PartialWave::S | PartialWave::P);
+            }
+
+            // Creation of option with valid default value, with value != default value but part of default value
+            {
+                PartialWaveOption so
+                {
+                    Options{
+                        { "L"_ok, "P" }
+                    },
+                    specifications,
+                    "L"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), PartialWave::P);
+            }
+
+            // Creation of option with valid default value, with value != default value but containing default value
+            {
+                PartialWaveOption so
+                {
+                    Options{
+                        { "L"_ok, "S|P|D" }
+                    },
+                    specifications,
+                    "L"_ok
+                };
+                TEST_CHECK_EQUAL(so.value(), PartialWave::S | PartialWave::P | PartialWave::D);
+            }
+
+            // Creation with invalid value
+            {
+                auto test = [specifications] ()
+                {
+                    PartialWaveOption so
+                    {
+                        Options{
+                            { "L"_ok, "F"}
+                        },
+                        specifications,
+                        "L"_ok
+                    };
+                };
+                TEST_CHECK_THROWS(InvalidOptionValueError, test());
+            }
+
+            // Creation with invalid value but containing a valid value
+            {
+                auto test = [specifications] ()
+                {
+                    PartialWaveOption so
+                    {
+                        Options{
+                            { "L"_ok, "P|F"}
+                        },
+                        specifications,
+                        "L"_ok
+                    };
+                };
+                TEST_CHECK_THROWS(InvalidOptionValueError, test());
+            }
+        }
+} partial_wave_option_test;

--- a/eos/utils/quantum-numbers.hh
+++ b/eos/utils/quantum-numbers.hh
@@ -83,6 +83,18 @@ namespace eos
         return lhs;
     }
 
+    inline Isospin operator ^ (Isospin lhs, Isospin rhs)
+    {
+        using T = std::underlying_type_t<Isospin>;
+        return static_cast<Isospin>(static_cast<T>(lhs) ^ static_cast<T>(rhs));
+    }
+
+    inline Isospin & operator ^= (Isospin & lhs, Isospin rhs)
+    {
+        lhs = lhs ^ rhs;
+        return lhs;
+    }
+
     inline bool operator && (Isospin lhs, Isospin rhs)
     {
         return (lhs & rhs) != Isospin::none;
@@ -147,6 +159,18 @@ namespace eos
     inline PartialWave & operator &= (PartialWave & lhs, PartialWave rhs)
     {
         lhs = lhs & rhs;
+        return lhs;
+    }
+
+    inline PartialWave operator ^ (PartialWave lhs, PartialWave rhs)
+    {
+        using T = std::underlying_type_t<PartialWave>;
+        return static_cast<PartialWave>(static_cast<T>(lhs) ^ static_cast<T>(rhs));
+    }
+
+    inline PartialWave & operator ^= (PartialWave & lhs, PartialWave rhs)
+    {
+        lhs = lhs ^ rhs;
         return lhs;
     }
 

--- a/eos/utils/quantum-numbers_TEST.cc
+++ b/eos/utils/quantum-numbers_TEST.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2021-2025 Danny van Dyk
+ * Copyright (c) 2025 Florian Herren
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -87,6 +88,7 @@ class IsospinTest :
             TEST_CHECK_EQUAL(destringify<Isospin>("0|1"),   Isospin::zero | Isospin::one);
             TEST_CHECK_EQUAL(destringify<Isospin>("0|3/2"), Isospin::zero | Isospin::threehalves);
             TEST_CHECK_EQUAL(destringify<Isospin>("1|2"),   Isospin::one | Isospin::two);
+            TEST_CHECK_EQUAL(destringify<Isospin>("0|1|2"), Isospin::zero | Isospin::one | Isospin::two);
         }
 } isospin_test;
 
@@ -151,12 +153,14 @@ class PartialWaveTest :
             TEST_CHECK_EQUAL_STR("D",    stringify(PartialWave::D));
             TEST_CHECK_EQUAL_STR("F",    stringify(PartialWave::F));
 
-            TEST_CHECK_EQUAL_STR("S|D",  stringify(PartialWave::S | PartialWave::D));
-            TEST_CHECK_EQUAL_STR("S|P",  stringify(PartialWave::S | PartialWave::P));
-            TEST_CHECK_EQUAL_STR("P|F",  stringify(PartialWave::P | PartialWave::F));
+            TEST_CHECK_EQUAL_STR("S|D",    stringify(PartialWave::S | PartialWave::D));
+            TEST_CHECK_EQUAL_STR("S|P",    stringify(PartialWave::S | PartialWave::P));
+            TEST_CHECK_EQUAL_STR("P|F",    stringify(PartialWave::P | PartialWave::F));
+            TEST_CHECK_EQUAL_STR("S|P|D",  stringify(PartialWave::S | PartialWave::P | PartialWave::D));
 
-            TEST_CHECK_EQUAL(destringify<PartialWave>("S|D"), PartialWave::S | PartialWave::D);
-            TEST_CHECK_EQUAL(destringify<PartialWave>("S|P"), PartialWave::S | PartialWave::P);
-            TEST_CHECK_EQUAL(destringify<PartialWave>("P|F"), PartialWave::P | PartialWave::F);
+            TEST_CHECK_EQUAL(destringify<PartialWave>("S|D"),     PartialWave::S | PartialWave::D);
+            TEST_CHECK_EQUAL(destringify<PartialWave>("S|P"),     PartialWave::S | PartialWave::P);
+            TEST_CHECK_EQUAL(destringify<PartialWave>("P|F"),     PartialWave::P | PartialWave::F);
+            TEST_CHECK_EQUAL(destringify<PartialWave>("S|P|D|F"), PartialWave::S | PartialWave::P | PartialWave::D | PartialWave::F);
         }
 } partial_wave_test;


### PR DESCRIPTION
Simple changes to make existing PToPP form factors compatible with partial-wave based parameterizations.
Nothing speaks against keeping the (q2,k2,costheta)-dependent implementation, as going from partial waves to
full form factors is trivial. The partial waves are normalized as in FFKMvD:2013A.

Furthermore, we introduce an IsospinOption, allowing to specify combinations of isospin-configurations.