### PR TITLE
Improve handling of log messages across tasks, notebook, and the eos-analysis script

### DIFF
--- a/python/eos/__init__.py
+++ b/python/eos/__init__.py
@@ -1,6 +1,6 @@
-# Copyright (c) 2018 Frederik Beaujean
-# Copyright (c) 2017, 2018, 2020 Danny van Dyk
-# Copyright (c) 2021 Philip Lueghausen
+# Copyright (c) 2018      Frederik Beaujean
+# Copyright (c) 2017-2025 Danny van Dyk
+# Copyright (c) 2021      Philip Lueghausen
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -60,7 +60,13 @@ setattr(logging, 'COMPLETED', logging.INFO + 2)
 logging.addLevelName(logging.WARNING - 1, 'SUCCESS')
 setattr(logging, 'SUCCESS', logging.WARNING - 1)
 logger = logging.getLogger('EOS')
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
+logger.propagate = False
+# log to stderr by default
+stderr_handler = logging.StreamHandler(stream=sys.stderr)
+stderr_handler.setLevel(logging.INFO)
+logger.addHandler(stderr_handler)
+
 from _eos import _register_log_callback, _set_native_log_level, _NativeLogLevel
 _set_native_log_level(_NativeLogLevel.INFO) # default native log level
 
@@ -123,13 +129,6 @@ def _log_callback(id, level, msg):
         raise RuntimeError(f'Cannot handle log level: {level}. Log message: {full_msg}')
 
 _register_log_callback(_log_callback)
-
-# log to stderr by default in non-interactive Python code
-if not __ipython__:
-    import logging
-    logger = logging.getLogger('EOS')
-    logger.setLevel(logging.INFO)
-    logger.addHandler(logging.StreamHandler(stream=sys.stderr))
 
 import time as _time
 import os as _os

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -40,6 +40,7 @@ class LogfileHandler:
         self.mode = mode
         self.formatter = logging.Formatter('%(asctime)-15s %(levelname)-10s %(message)s')
         self.handler = logging.FileHandler(os.path.join(path, name), mode=mode)
+        self.handler.setLevel(logging.DEBUG)
         self.handler.setFormatter(self.formatter)
 
     def __enter__(self):

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -1,7 +1,7 @@
 # vim: set sw=4 sts=4 et tw=120 :
 
-# Copyright (c) 2020-2023 Danny van Dyk
-# Copyright (c) 2023 Philip Lüghausen
+# Copyright (c) 2020-2025 Danny van Dyk
+# Copyright (c) 2023      Philip Lüghausen
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -624,6 +624,7 @@ def sample_nested(analysis_file:str, posterior:str, base_directory:str='./', bou
     samples = results.samples
     posterior_values = results.logwt - results.logz[-1]
     weights = _np.exp(posterior_values)
+    eos.info(f'Finished sampling with {len(samples)} samples and evidence estimate {results.logz[-1]:.2f} +/- {results.logzerr[-1]:.2f}')
     eos.data.DynestyResults.create(os.path.join(base_directory, posterior, 'nested'), analysis.varied_parameters, results)
     eos.data.ImportanceSamples.create(os.path.join(base_directory, posterior, 'samples'), analysis.varied_parameters,
                                       samples, weights, posterior_values=posterior_values)

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 
-# Copyright (c) 2020-2024 Danny van Dyk
+# Copyright (c) 2020-2025 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -661,11 +661,8 @@ def main():
                 5: logging.DEBUG
             }
 
-            eos.logger.setLevel(levels[args.verbose])
-            eos.logger.removeHandler(eos.logger.handlers[0])
-            handler = logging.StreamHandler(stream=sys.stderr)
-            handler.setFormatter(CustomLogFormatter())
-            eos.logger.addHandler(handler)
+            eos.stderr_handler.setLevel(levels[args.verbose])
+            eos.stderr_handler.setFormatter(CustomLogFormatter())
 
             args.cmd(args)
     except Exception as e:


### PR DESCRIPTION
- Log messages are saved to a task's log file, using log level ``DEBUG``.
- Log messages are output to standard error, using log level ``INFO``.
- If running in eos-analysis, log messages to standard error start only at level ERROR. Appending ``--verbose``/``-v`` to the command line increase this log level up to ``DEBUG``.

@mreboud Let me know if you are happy with this, and please check it with your notebooks.