### PR TITLE
Update build images for PyPI workflow and start building for Python 3.13

### DIFF
--- a/.github/workflows/pypi-build+check+deploy.yaml
+++ b/.github/workflows/pypi-build+check+deploy.yaml
@@ -21,7 +21,11 @@ jobs:
                   - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 310, version: cp310, runner: ubuntu-24.04     }
                   - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 311, version: cp311, runner: ubuntu-24.04     }
                   - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 312, version: cp312, runner: ubuntu-24.04     }
+                  - { arch: x86_64,  cxxflags: '-march=x86-64',    boost_python_suffix: 313, version: cp313, runner: ubuntu-24.04     }
                   - { arch: aarch64, cxxflags: '-march=armv8.5-a', boost_python_suffix: 310, version: cp310, runner: ubuntu-24.04-arm }
+                  - { arch: aarch64, cxxflags: '-march=armv8.5-a', boost_python_suffix: 311, version: cp311, runner: ubuntu-24.04-arm }
+                  - { arch: aarch64, cxxflags: '-march=armv8.5-a', boost_python_suffix: 312, version: cp312, runner: ubuntu-24.04-arm }
+                  - { arch: aarch64, cxxflags: '-march=armv8.5-a', boost_python_suffix: 313, version: cp313, runner: ubuntu-24.04-arm }
         runs-on: ${{ matrix.runner }}
         name: Build and check EOS wheels on ${{ matrix.arch }} for Python version ${{ matrix.version }}
         steps:
@@ -41,15 +45,15 @@ jobs:
                 fi
 
             - name: Build EOS, run tests, and create wheels
-              uses: pypa/cibuildwheel@v2.16.5
+              uses: pypa/cibuildwheel@v2.23.3
               with:
                 package-dir: eoshep
               env:
                 CIBW_BUILD: ${{ matrix.version}}-*
                 CIBW_SKIP: \*-musllinux_*
                 CIBW_ARCHS: ${{ matrix.arch}}
-                CIBW_MANYLINUX_X86_64_IMAGE: eoshep/manylinux_2_28@sha256:03c63bfb48c45c10915262740c1633fa6970485d4395ecb99bfdfe7fc3b12290
-                CIBW_MANYLINUX_AARCH64_IMAGE: eoshep/manylinux_2_28@sha256:0a27b0ae8f0394f48ed5b89bed523d20a3c1de96e2af4f6de987c2e5d752b52e
+                CIBW_MANYLINUX_X86_64_IMAGE: eoshep/manylinux_2_28@sha256:3f78a8f83445748224746aefac910b4ad3f1e6920edd2f97896e08d7315ec6f8
+                CIBW_MANYLINUX_AARCH64_IMAGE: eoshep/manylinux_2_28@sha256:4aaf8ef51bcd9fd90d9eb35f80484f3790e532ef13d45a9663eba89bb734b27b
                 CIBW_BEFORE_BUILD_LINUX: |
                   pushd {project}
                   ./autogen.bash


### PR DESCRIPTION
- update to EOS manylinux_2_28 build images with tag 2025-05-19-95bbb72
- update pyp/cibuildwheel action to v2.23.3
- start building the x86_64 wheels for Python version 3.13
- start building the aarch64 wheels for Python version 3.12 & 3.13

GitHub: resolves #1014