### PR TITLE
Add arguments for minimal number of iterations to ``sample-nested`` tasks and CLI script

### DIFF
--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -593,7 +593,7 @@ class DynestyResultLogger:
 
 # Nested sampling
 @task('sample-nested', '{posterior}/nested')
-def sample_nested(analysis_file:str, posterior:str, base_directory:str='./', bound:str='multi', nlive:int=250, dlogz:float=1.0, maxiter:int=None, seed:int=10, sample:str='auto'):
+def sample_nested(analysis_file:str, posterior:str, base_directory:str='./', bound:str='multi', nlive:int=250, dlogz:float=1.0, maxiter:int=None, miniter:int=None, seed:int=10, sample:str='auto'):
     """
     Samples from a likelihood associated with a named posterior using dynamic nested sampling.
 
@@ -614,6 +614,8 @@ def sample_nested(analysis_file:str, posterior:str, base_directory:str='./', bou
     :type dlogz: float, optional
     :param maxiter: The maximum number of iterations. Iterations may stop earlier if the termination condition is reached.
     :type maxiter: int, optional
+    :param miniter: The minimum number of iterations. If not provided, the sampler will run until the termination condition is reached.
+    :type miniter: int, optional
     :param seed: The seed used to initialize the Mersenne Twister pseudo-random number generator.
     :type seed: int, optional
     :param sample: The method used for sampling within the likelihood constraints. For valid values, see dynesty documentation. Defaults to 'auto'.
@@ -621,7 +623,7 @@ def sample_nested(analysis_file:str, posterior:str, base_directory:str='./', bou
     """
     analysis = analysis_file.analysis(posterior)
     logger = DynestyResultLogger()
-    results = analysis.sample_nested(bound=bound, nlive=nlive, dlogz=dlogz, maxiter=maxiter, print_function=logger.print_function, seed=seed, sample=sample)
+    results = analysis.sample_nested(bound=bound, nlive=nlive, dlogz=dlogz, maxiter=maxiter, miniter=miniter, print_function=logger.print_function, seed=seed, sample=sample)
     samples = results.samples
     posterior_values = results.logwt - results.logz[-1]
     weights = _np.exp(posterior_values)

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -260,6 +260,10 @@ In addition, an ImportanceSamples object is exported to EOS_BASE_DIRECTORY/POSTE
         help = 'The maximum number of iterations. Iterations may stop earlier if the termination condition is reached.',
         dest = 'maxiter', action = 'store', type = int, default = None
     )
+    parser_sample_nested.add_argument('-l', '--min-number-iterations',
+        help = 'The minimum number of iterations. If not provided, the sampler will run until the termination condition is reached.',
+        dest = 'miniter', action = 'store', type = int, default = None
+    )
     parser_sample_nested.add_argument('-s', '--use-random-seed',
         help = 'The seed used to initialize the Mersenne Twister pseudo-random number generator.',
         dest = 'seed', action = 'store', type = int, default = 10


### PR DESCRIPTION
- a299fba963a293aa6739413838646dfe83b3daf5 Add ``miniter`` argument to the ``sample-nested`` task. This simply pipe the argument through to ``eos.Analysis.sample_nested``.
- 2e667f6e77eb31743846b0b4d0904b14e43d3121 Add ``--min-number-iterations`` argument to the ``eos-analysis`` script. Since both ``-m`` and ``-M`` are already used as short cuts, I decided to use ``-l``.