### PR TITLE
Adapt ``eos/utils`` to ``clang-format``-based coding style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
    hooks:
     - id: clang-format
       types_or: [ 'c++' ]
-      exclude: ^(eos/b-decays/|eos/c-decays/|eos/form-factors/|eos/maths/|eos/meson-mixing/|eos/nonlocal-form-factors/|eos/rare-b-decays/|eos/scattering/|eos/statistics/|eos/utils/)
+      exclude: ^(eos/b-decays/|eos/c-decays/|eos/form-factors/|eos/maths/|eos/meson-mixing/|eos/nonlocal-form-factors/|eos/rare-b-decays/|eos/scattering/|eos/statistics/)
 
  - repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.4.0

--- a/eos/utils/cacheable_observable_TEST.cc
+++ b/eos/utils/cacheable_observable_TEST.cc
@@ -15,18 +15,19 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
-#include <eos/utils/private_implementation_pattern-impl.hh>
-#include <eos/utils/options-impl.hh>
-#include <eos/observable.hh>
-#include <eos/utils/options.hh>
 #include "eos/utils/kinematic.hh"
-#include <eos/utils/parameters.hh>
-#include <eos/utils/private_implementation_pattern.hh>
-#include <eos/utils/reference-name.hh>
+#include <eos/observable.hh>
 #include <eos/utils/concrete-cacheable-observable.hh>
 #include <eos/utils/concrete_observable.hh>
 #include <eos/utils/observable_cache.hh>
+#include <eos/utils/options-impl.hh>
+#include <eos/utils/options.hh>
+#include <eos/utils/parameters.hh>
+#include <eos/utils/private_implementation_pattern-impl.hh>
+#include <eos/utils/private_implementation_pattern.hh>
+#include <eos/utils/reference-name.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
@@ -34,20 +35,17 @@ using namespace eos;
 namespace eos
 {
 
-    class TestCacheableObservableProvider :
-        public ParameterUser,
-        public PrivateImplementationPattern<TestCacheableObservableProvider>
+    class TestCacheableObservableProvider : public ParameterUser, public PrivateImplementationPattern<TestCacheableObservableProvider>
     {
         public:
-            struct IntermediateResult :
-                public CacheableObservable::IntermediateResult
+            struct IntermediateResult : public CacheableObservable::IntermediateResult
             {
-                // e.g. amplitudes
-                double a;
-                double b;
+                    // e.g. amplitudes
+                    double a;
+                    double b;
 
-                // e.g. kinematical variables
-                double q2;
+                    // e.g. kinematical variables
+                    double q2;
             };
 
             TestCacheableObservableProvider(const Parameters & parameters, const Options & options);
@@ -65,45 +63,43 @@ namespace eos
             static const std::set<ReferenceName> references;
     };
 
-    const std::set<ReferenceName>
-    TestCacheableObservableProvider::references
+    const std::set<ReferenceName> TestCacheableObservableProvider::references{};
+
+    template <> struct Implementation<TestCacheableObservableProvider>
     {
-    };
+            UsedParameter m_B;
 
-    template <>
-    struct Implementation<TestCacheableObservableProvider>
-    {
+            using IntermediateResult = TestCacheableObservableProvider::IntermediateResult;
 
-        UsedParameter m_B;
+            IntermediateResult _intermediate_result;
 
-        using IntermediateResult = TestCacheableObservableProvider::IntermediateResult;
+            Implementation(const Parameters & p, const Options & /* o */, ParameterUser & u) :
+                m_B(p["mass::B_u"], u)
+            {
+            }
 
-        IntermediateResult _intermediate_result;
+            const IntermediateResult *
+            prepare(const double & q2)
+            {
+                _intermediate_result.a = 2.0;
+                _intermediate_result.b = m_B;
 
-        Implementation(const Parameters & p, const Options & /* o */, ParameterUser & u) :
-            m_B(p["mass::B_u"], u)
-        {
-        }
+                _intermediate_result.q2 = q2;
 
-        const IntermediateResult * prepare(const double & q2)
-        {
-            _intermediate_result.a = 2.0;
-            _intermediate_result.b = m_B;
+                return &_intermediate_result;
+            }
 
-            _intermediate_result.q2 = q2;
+            double
+            evaluate1(const IntermediateResult * intermediate_result)
+            {
+                return intermediate_result->b - intermediate_result->a * intermediate_result->q2;
+            }
 
-            return &_intermediate_result;
-        }
-
-        double evaluate1(const IntermediateResult * intermediate_result)
-        {
-            return intermediate_result->b - intermediate_result->a * intermediate_result->q2;
-        }
-
-        double evaluate2(const IntermediateResult * intermediate_result)
-        {
-            return pow(intermediate_result->q2, 2);
-        }
+            double
+            evaluate2(const IntermediateResult * intermediate_result)
+            {
+                return pow(intermediate_result->q2, 2);
+            }
     };
 
     TestCacheableObservableProvider::TestCacheableObservableProvider(const Parameters & parameters, const Options & options) :
@@ -111,9 +107,7 @@ namespace eos
     {
     }
 
-    TestCacheableObservableProvider::~TestCacheableObservableProvider()
-    {
-    }
+    TestCacheableObservableProvider::~TestCacheableObservableProvider() {}
 
     const TestCacheableObservableProvider::IntermediateResult *
     TestCacheableObservableProvider::prepare(const double & q2) const
@@ -134,11 +128,9 @@ namespace eos
     }
 
     /*!
-    * Construct the same observable as a regular observable
-    */
-    class TestRegularObservableProvider :
-        public ParameterUser,
-        public PrivateImplementationPattern<TestRegularObservableProvider>
+     * Construct the same observable as a regular observable
+     */
+    class TestRegularObservableProvider : public ParameterUser, public PrivateImplementationPattern<TestRegularObservableProvider>
     {
         public:
             TestRegularObservableProvider(const Parameters & parameters, const Options & options);
@@ -154,36 +146,33 @@ namespace eos
             static const std::set<ReferenceName> references;
     };
 
-    const std::set<ReferenceName>
-    TestRegularObservableProvider::references
+    const std::set<ReferenceName> TestRegularObservableProvider::references{};
+
+    template <> struct Implementation<TestRegularObservableProvider>
     {
-    };
+            UsedParameter m_B;
 
-    template <>
-    struct Implementation<TestRegularObservableProvider>
-    {
+            double a;
+            double b;
 
-        UsedParameter m_B;
+            Implementation(const Parameters & p, const Options & /* o */, ParameterUser & u) :
+                m_B(p["mass::B_u"], u)
+            {
+                a = 2.0;
+                b = m_B;
+            }
 
-        double a;
-        double b;
+            double
+            evaluate1(const double & q2)
+            {
+                return b - a * q2;
+            }
 
-        Implementation(const Parameters & p, const Options & /* o */, ParameterUser & u) :
-            m_B(p["mass::B_u"], u)
-        {
-            a = 2.0;
-            b = m_B;
-        }
-
-        double evaluate1(const double & q2)
-        {
-            return b - a * q2;
-        }
-
-        double evaluate2(const double & q2)
-        {
-            return pow(q2, 2);
-        }
+            double
+            evaluate2(const double & q2)
+            {
+                return pow(q2, 2);
+            }
     };
 
     TestRegularObservableProvider::TestRegularObservableProvider(const Parameters & parameters, const Options & options) :
@@ -191,9 +180,7 @@ namespace eos
     {
     }
 
-    TestRegularObservableProvider::~TestRegularObservableProvider()
-    {
-    }
+    TestRegularObservableProvider::~TestRegularObservableProvider() {}
 
     double
     TestRegularObservableProvider::evaluate1(const double & q2) const
@@ -206,104 +193,111 @@ namespace eos
     {
         return _imp->evaluate2(q2);
     }
-}
+} // namespace eos
 
-
-
-
-
-
-
-
-class CacheableObservableTest :
-    public TestCase
+class CacheableObservableTest : public TestCase
 {
     public:
-    CacheableObservableTest() :
-        TestCase("cacheable_observable_test")
-    {
-    }
-
-    virtual void run() const
-    {
+        CacheableObservableTest() :
+            TestCase("cacheable_observable_test")
         {
-            Parameters p = Parameters::Defaults();
-            p["mass::B_u"] = 5.27934;
-
-            Options oo;
-
-            TestCacheableObservableProvider tcop(p, oo);
-
-            // Test the observable implementation
-            TEST_CHECK_EQUAL(tcop.evaluate1(tcop.prepare(2.0)),  5.27934 - 2.0*2.0);
-            TEST_CHECK_EQUAL(tcop.evaluate2(tcop.prepare(2.0)),  4.0);
-
-
-            // Try to create a cacheable observable
-            using TestCacheableObservable = class ConcreteCacheableObservable<TestCacheableObservableProvider, double>;
-
-            ObservablePtr cacheable_observable(new TestCacheableObservable("test::cacheable_observable1(q2)", p, Kinematics({{"q2", 2.0}}), Options(),
-                &TestCacheableObservableProvider::prepare,
-                &TestCacheableObservableProvider::evaluate1,
-                std::make_tuple("q2")
-            ));
-
-            TEST_CHECK_NEARLY_EQUAL(cacheable_observable->evaluate(),  5.27934 - 2.0*2.0, 1.e-5);
-
-            // Try to add the observable to the cache...
-            ObservableCache cache(p);
-            ObservableCache::Id cacheable_observable_id;
-
-            TEST_CHECK_NO_THROW(cacheable_observable_id = cache.add(cacheable_observable));
-
-            // ..twice
-            TEST_CHECK_EQUAL(cacheable_observable_id,  cache.add(cacheable_observable));
-
-            // Cache the observable by adding the same observable with a different name
-            ObservablePtr cacheable_observable2(new TestCacheableObservable("test::cacheable_observable2(q2)", p, Kinematics({{"q2", 2.0}}), Options(),
-                &TestCacheableObservableProvider::prepare,
-                &TestCacheableObservableProvider::evaluate1,
-                std::make_tuple("q2")
-            ));
-            ObservableCache::Id cacheable_observable2_id;
-            unsigned cache_size = cache.size();
-
-            TEST_CHECK_NO_THROW(cacheable_observable2_id = cache.add(cacheable_observable2));
-            TEST_CHECK_EQUAL(cache.size(),  cache_size + 1);
-
-
-            // Create a regular observable
-            using TestRegularObservable = class ConcreteObservable<TestRegularObservableProvider, double>;
-
-            ObservablePtr regular_observable(new TestRegularObservable("test::regular_observable(q2)", p, Kinematics({{"q2", 2.0}}), Options(),
-                &TestRegularObservableProvider::evaluate1,
-                std::make_tuple("q2")
-            ));
-            ObservableCache::Id regular_observable_id [[maybe_unused]];
-
-            TEST_CHECK_NO_THROW(regular_observable_id = cache.add(regular_observable));
-
-
-            // Add a third, different, cacheable observable
-            ObservablePtr cacheable_observable3(new TestCacheableObservable("test::cacheable_observable3(q2)", p, Kinematics({{"q2", 6.0}}), Options(),
-                &TestCacheableObservableProvider::prepare,
-                &TestCacheableObservableProvider::evaluate2,
-                std::make_tuple("q2")
-            ));
-            ObservableCache::Id cacheable_observable3_id [[maybe_unused]];
-
-            TEST_CHECK_NO_THROW(cacheable_observable3_id = cache.add(cacheable_observable3));
-
-
-            // Test cache evaluation
-            TEST_CHECK_NO_THROW(cache.update());
-            TEST_CHECK_EQUAL(cache[cacheable_observable_id],  cache[cacheable_observable2_id]);
-
-            // Test cache cloning
-            ObservableCache cache2(p);
-            TEST_CHECK_NO_THROW(cache2 = cache.clone(p));
-
         }
 
-    }
+        virtual void
+        run() const
+        {
+            {
+                Parameters p   = Parameters::Defaults();
+                p["mass::B_u"] = 5.27934;
+
+                Options oo;
+
+                TestCacheableObservableProvider tcop(p, oo);
+
+                // Test the observable implementation
+                TEST_CHECK_EQUAL(tcop.evaluate1(tcop.prepare(2.0)), 5.27934 - 2.0 * 2.0);
+                TEST_CHECK_EQUAL(tcop.evaluate2(tcop.prepare(2.0)), 4.0);
+
+
+                // Try to create a cacheable observable
+                using TestCacheableObservable = class ConcreteCacheableObservable<TestCacheableObservableProvider, double>;
+
+                ObservablePtr cacheable_observable(new TestCacheableObservable("test::cacheable_observable1(q2)",
+                                                                               p,
+                                                                               Kinematics({
+                                                                                   { "q2", 2.0 }
+                }),
+                                                                               Options(),
+                                                                               &TestCacheableObservableProvider::prepare,
+                                                                               &TestCacheableObservableProvider::evaluate1,
+                                                                               std::make_tuple("q2")));
+
+                TEST_CHECK_NEARLY_EQUAL(cacheable_observable->evaluate(), 5.27934 - 2.0 * 2.0, 1.e-5);
+
+                // Try to add the observable to the cache...
+                ObservableCache     cache(p);
+                ObservableCache::Id cacheable_observable_id;
+
+                TEST_CHECK_NO_THROW(cacheable_observable_id = cache.add(cacheable_observable));
+
+                // ..twice
+                TEST_CHECK_EQUAL(cacheable_observable_id, cache.add(cacheable_observable));
+
+                // Cache the observable by adding the same observable with a different name
+                ObservablePtr       cacheable_observable2(new TestCacheableObservable("test::cacheable_observable2(q2)",
+                                                                                p,
+                                                                                Kinematics({
+                                                                                    { "q2", 2.0 }
+                }),
+                                                                                Options(),
+                                                                                &TestCacheableObservableProvider::prepare,
+                                                                                &TestCacheableObservableProvider::evaluate1,
+                                                                                std::make_tuple("q2")));
+                ObservableCache::Id cacheable_observable2_id;
+                unsigned            cache_size = cache.size();
+
+                TEST_CHECK_NO_THROW(cacheable_observable2_id = cache.add(cacheable_observable2));
+                TEST_CHECK_EQUAL(cache.size(), cache_size + 1);
+
+
+                // Create a regular observable
+                using TestRegularObservable = class ConcreteObservable<TestRegularObservableProvider, double>;
+
+                ObservablePtr       regular_observable(new TestRegularObservable("test::regular_observable(q2)",
+                                                                           p,
+                                                                           Kinematics({
+                                                                               { "q2", 2.0 }
+                }),
+                                                                           Options(),
+                                                                           &TestRegularObservableProvider::evaluate1,
+                                                                           std::make_tuple("q2")));
+                ObservableCache::Id regular_observable_id [[maybe_unused]];
+
+                TEST_CHECK_NO_THROW(regular_observable_id = cache.add(regular_observable));
+
+
+                // Add a third, different, cacheable observable
+                ObservablePtr       cacheable_observable3(new TestCacheableObservable("test::cacheable_observable3(q2)",
+                                                                                p,
+                                                                                Kinematics({
+                                                                                    { "q2", 6.0 }
+                }),
+                                                                                Options(),
+                                                                                &TestCacheableObservableProvider::prepare,
+                                                                                &TestCacheableObservableProvider::evaluate2,
+                                                                                std::make_tuple("q2")));
+                ObservableCache::Id cacheable_observable3_id [[maybe_unused]];
+
+                TEST_CHECK_NO_THROW(cacheable_observable3_id = cache.add(cacheable_observable3));
+
+
+                // Test cache evaluation
+                TEST_CHECK_NO_THROW(cache.update());
+                TEST_CHECK_EQUAL(cache[cacheable_observable_id], cache[cacheable_observable2_id]);
+
+                // Test cache cloning
+                ObservableCache cache2(p);
+                TEST_CHECK_NO_THROW(cache2 = cache.clone(p));
+            }
+        }
 } cacheable_observable_test;

--- a/eos/utils/cartesian-product.hh
+++ b/eos/utils/cartesian-product.hh
@@ -21,8 +21,8 @@
 #ifndef EOS_GUARD_EOS_UTILS_CARTESIAN_PRODUCT_HH
 #define EOS_GUARD_EOS_UTILS_CARTESIAN_PRODUCT_HH 1
 
-#include <vector>
 #include <cstddef>
+#include <vector>
 
 namespace eos
 {
@@ -52,14 +52,12 @@ namespace eos
                 private:
                     using IteratorState = std::vector<typename U_::const_iterator>;
 
-                    IteratorState _state;
-                    Sizes _sizes;
-                    bool _at_end;
+                    IteratorState     _state;
+                    Sizes             _sizes;
+                    bool              _at_end;
                     std::vector<long> _values;
 
-                    _Iterator(const IteratorState & state,
-                              const Sizes& sizes,
-                              bool  atEnd) :
+                    _Iterator(const IteratorState & state, const Sizes & sizes, bool atEnd) :
                         _state(state),
                         _sizes(sizes),
                         _at_end(atEnd),
@@ -70,62 +68,76 @@ namespace eos
                 public:
                     friend class CartesianProduct<U_>;
 
-                    bool operator== (const _Iterator & other) const
+                    bool
+                    operator== (const _Iterator & other) const
                     {
                         if (_at_end && other._at_end)
+                        {
                             return true;
+                        }
 
                         // compare each element
                         auto i = _state.cbegin();
                         auto j = other._state.cbegin();
-                        for ( ; i != _state.end(); ++i, ++j)
+                        for (; i != _state.end(); ++i, ++j)
                         {
                             if (*i != *j)
+                            {
                                 return false;
+                            }
                         }
 
                         return true;
                     }
 
-                    bool operator!= (const _Iterator& other) const
+                    bool
+                    operator!= (const _Iterator & other) const
                     {
-                        return !(*this == other);
+                        return ! (*this == other);
                     }
 
-                    _Iterator & operator+= (long increment)
+                    _Iterator &
+                    operator+= (long increment)
                     {
                         // Already at the last element?
                         if (_at_end)
+                        {
                             return *this;
+                        }
 
-                        auto size_it = _sizes.rbegin();
+                        auto size_it  = _sizes.rbegin();
                         auto state_it = _state.rbegin();
                         auto value_it = _values.rbegin();
-                        for ( ; size_it != _sizes.rend(); ++size_it, ++state_it, ++value_it)
+                        for (; size_it != _sizes.rend(); ++size_it, ++state_it, ++value_it)
                         {
-                            long new_value = (*value_it + increment) % *size_it;;
-                            long difference = new_value - *value_it;
-                            *value_it = new_value;
-                            increment -= difference;
-                            increment /= *size_it;
-                            *state_it += difference;
+                            long new_value = (*value_it + increment) % *size_it;
+                            ;
+                            long difference  = new_value - *value_it;
+                            *value_it        = new_value;
+                            increment       -= difference;
+                            increment       /= *size_it;
+                            *state_it       += difference;
                         }
 
                         if (increment != 0)
+                        {
                             _at_end = true;
+                        }
 
                         return *this;
                     }
 
-                    _Iterator & operator++ ()
+                    _Iterator &
+                    operator++ ()
                     {
                         return (*this += 1);
                     }
 
-                    std::vector<typename U_::value_type> operator* () const
+                    std::vector<typename U_::value_type>
+                    operator* () const
                     {
                         std::vector<typename U_::value_type> result;
-                        for (auto i = _state.begin() ; _state.end() != i ; ++i)
+                        for (auto i = _state.begin(); _state.end() != i; ++i)
                         {
                             result.push_back(*(*i));
                         }
@@ -153,7 +165,8 @@ namespace eos
              * with new_container.
              * @param new_container The new container to be added.
              */
-            void over(const T_ & new_container)
+            void
+            over(const T_ & new_container)
             {
                 // Store the new container and its iterators
                 _data.push_back(new_container);
@@ -162,9 +175,13 @@ namespace eos
 
                 // Update the size of CartesianProduct
                 if (0 == _size)
+                {
                     _size = new_container.size();
+                }
                 else
+                {
                     _size *= new_container.size();
+                }
 
                 _sizes.push_back(new_container.size());
             }
@@ -172,7 +189,8 @@ namespace eos
             /*!
              * Returns an iterator for the first element.
              */
-            Iterator begin() const
+            Iterator
+            begin() const
             {
                 return Iterator(_begin, _sizes, false);
             }
@@ -180,7 +198,8 @@ namespace eos
             /*!
              * Returns an iterator for the position after the last element.
              */
-            Iterator end() const
+            Iterator
+            end() const
             {
                 return Iterator(_end, _sizes, true);
             }
@@ -189,11 +208,12 @@ namespace eos
              * Returns the number of elements stored in CartesianProduct. This is the product of the
              * sizes of each stored container.
              */
-            size_t size() const
+            size_t
+            size() const
             {
                 return _size;
             }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/cartesian-product_TEST.cc
+++ b/eos/utils/cartesian-product_TEST.cc
@@ -18,18 +18,17 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/cartesian-product.hh>
 
-#include <complex>
+#include <test/test.hh>
 
+#include <complex>
 #include <iostream>
 
 using namespace test;
 using namespace eos;
 
-class CartesianProductTest :
-    public TestCase
+class CartesianProductTest : public TestCase
 {
     public:
         CartesianProductTest() :
@@ -37,48 +36,40 @@ class CartesianProductTest :
         {
         }
 
-        static void check_tuples(const std::vector<double> & a, const std::vector<double> & b)
+        static void
+        check_tuples(const std::vector<double> & a, const std::vector<double> & b)
         {
-            for (auto i = a.cbegin(), i_end = a.cend(), j = b.cbegin() ; i != i_end; ++i, ++j)
+            for (auto i = a.cbegin(), i_end = a.cend(), j = b.cbegin(); i != i_end; ++i, ++j)
             {
                 TEST_CHECK_EQUAL(*i, *j);
             }
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             /* No Product at all */
             {
-                static const std::vector<double> input = { -0.5, -0.4, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5 };
+                static const std::vector<double>              input  = { -0.5, -0.4, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5 };
                 static const std::vector<std::vector<double>> result = {
-                    { -0.5 },
-                    { -0.4 },
-                    { -0.3 },
-                    { -0.2 },
-                    { -0.1 },
-                    {  0.0 },
-                    {  0.1 },
-                    {  0.2 },
-                    {  0.3 },
-                    {  0.4 },
-                    {  0.5 },
+                    { -0.5 }, { -0.4 }, { -0.3 }, { -0.2 }, { -0.1 }, { 0.0 }, { 0.1 }, { 0.2 }, { 0.3 }, { 0.4 }, { 0.5 },
                 };
 
                 CartesianProduct<std::vector<double>> cp;
                 cp.over(input);
 
                 auto j = result.cbegin();
-                for (auto i = cp.begin() ; cp.end() != i ; ++i, ++j)
+                for (auto i = cp.begin(); cp.end() != i; ++i, ++j)
                 {
                     check_tuples(*i, *j);
                 }
             }
 
             {
-                static const std::vector<double> input1 = {    1.0,    2.0                 };
-                static const std::vector<double> input2 = {   10.0,   20.0,   30.0         };
-                static const std::vector<double> input3 = {  100.0,  200.0,  300.0,  400.0 };
-                static const std::vector<double> input4 = { 1000.0, 2000.0                 };
+                static const std::vector<double> input1 = { 1.0, 2.0 };
+                static const std::vector<double> input2 = { 10.0, 20.0, 30.0 };
+                static const std::vector<double> input3 = { 100.0, 200.0, 300.0, 400.0 };
+                static const std::vector<double> input4 = { 1000.0, 2000.0 };
 
                 CartesianProduct<std::vector<double>> cp;
                 cp.over(input1);
@@ -97,20 +88,26 @@ class CartesianProductTest :
                 static const std::vector<double> result2 = { 1.0, 10.0, 100.0, 2000.0 };
                 TEST_CHECK_EQUAL(*cp_it, result2);
 
-                cp_it += 10;
-                static const std::vector<double> result3 = { 1.0, 20.0, 200.0, 2000.0 };
+                cp_it                                    += 10;
+                static const std::vector<double> result3  = { 1.0, 20.0, 200.0, 2000.0 };
                 TEST_CHECK_EQUAL(*cp_it, result3);
 
                 if (cp_it == cp.begin())
+                {
                     TEST_CHECK_FAILED("cp_it should not be equal cp.begin()");
+                }
 
                 if (cp_it == cp.end())
+                {
                     TEST_CHECK_FAILED("cp_it should not be equal cp.end()");
+                }
 
                 cp_it += 35;
 
                 if (cp_it == cp.end())
+                {
                     TEST_CHECK_FAILED("cp_it should not be equal cp.end()");
+                }
 
                 static const std::vector<double> result4 = { 2.0, 30.0, 400.0, 1000.0 };
                 TEST_CHECK_EQUAL(*cp_it, result4);

--- a/eos/utils/concrete-cacheable-observable.hh
+++ b/eos/utils/concrete-cacheable-observable.hh
@@ -33,12 +33,9 @@
 
 namespace eos
 {
-    template <typename Decay_, typename ... Args_>
-    class ConcreteCacheableObservable;
+    template <typename Decay_, typename... Args_> class ConcreteCacheableObservable;
 
-    template <typename Decay_, typename ... Args_>
-    class ConcreteCachedObservable :
-        public Observable
+    template <typename Decay_, typename... Args_> class ConcreteCachedObservable : public Observable
     {
         private:
             QualifiedName _name;
@@ -53,22 +50,18 @@ namespace eos
 
             const typename Decay_::IntermediateResult * _intermediate_result;
 
-            std::function<const typename Decay_::IntermediateResult * (const Decay_ *, const Args_ & ...)> _prepare_fn;
+            std::function<const typename Decay_::IntermediateResult *(const Decay_ *, const Args_ &...)> _prepare_fn;
 
-            std::function<double (const Decay_ *, const typename Decay_::IntermediateResult *)> _evaluate_fn;
+            std::function<double(const Decay_ *, const typename Decay_::IntermediateResult *)> _evaluate_fn;
 
-            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> _kinematics_names;
+            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> _kinematics_names;
 
         public:
-            ConcreteCachedObservable(const QualifiedName & name,
-                    const Parameters & parameters,
-                    const Kinematics & kinematics,
-                    const Options & options,
-                    const std::shared_ptr<Decay_> & decay,
-                    const typename Decay_::IntermediateResult * intermediate_result,
-                    const std::function<const typename Decay_::IntermediateResult * (const Decay_ *, const Args_ & ...)> & prepare_fn,
-                    const std::function<double (const Decay_ *, const typename Decay_::IntermediateResult *)> & evaluate_fn,
-                    const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> & kinematics_names) :
+            ConcreteCachedObservable(const QualifiedName & name, const Parameters & parameters, const Kinematics & kinematics, const Options & options,
+                                     const std::shared_ptr<Decay_> & decay, const typename Decay_::IntermediateResult * intermediate_result,
+                                     const std::function<const typename Decay_::IntermediateResult *(const Decay_ *, const Args_ &...)> & prepare_fn,
+                                     const std::function<double(const Decay_ *, const typename Decay_::IntermediateResult *)> &           evaluate_fn,
+                                     const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> &                           kinematics_names) :
                 _name(name),
                 _parameters(parameters),
                 _kinematics(kinematics),
@@ -85,45 +78,52 @@ namespace eos
 
             ~ConcreteCachedObservable() = default;
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual double evaluate() const
+            virtual double
+            evaluate() const
             {
                 return _evaluate_fn(_decay.get(), _intermediate_result);
-            };
+            }
 
-            virtual Parameters parameters()
+            virtual Parameters
+            parameters()
             {
                 return _parameters;
-            };
+            }
 
-            virtual Kinematics kinematics()
+            virtual Kinematics
+            kinematics()
             {
                 return _kinematics;
-            };
+            }
 
-            virtual Options options()
+            virtual Options
+            options()
             {
                 return _options;
             }
 
-            virtual ObservablePtr clone() const
+            virtual ObservablePtr
+            clone() const
             {
-                return ObservablePtr(new ConcreteCacheableObservable<Decay_, Args_ ...>(_name, _parameters.clone(), _kinematics.clone(), _options, _prepare_fn, _evaluate_fn, _kinematics_names));
+                return ObservablePtr(
+                        new ConcreteCacheableObservable<Decay_, Args_...>(_name, _parameters.clone(), _kinematics.clone(), _options, _prepare_fn, _evaluate_fn, _kinematics_names));
             }
 
-            virtual ObservablePtr clone(const Parameters & parameters) const
+            virtual ObservablePtr
+            clone(const Parameters & parameters) const
             {
-                return ObservablePtr(new ConcreteCacheableObservable<Decay_, Args_ ...>(_name, parameters, _kinematics.clone(), _options, _prepare_fn, _evaluate_fn, _kinematics_names));
+                return ObservablePtr(
+                        new ConcreteCacheableObservable<Decay_, Args_...>(_name, parameters, _kinematics.clone(), _options, _prepare_fn, _evaluate_fn, _kinematics_names));
             }
     };
 
-    template <typename Decay_, typename ... Args_>
-    class ConcreteCacheableObservable :
-        public CacheableObservable
+    template <typename Decay_, typename... Args_> class ConcreteCacheableObservable : public CacheableObservable
     {
         private:
             QualifiedName _name;
@@ -136,22 +136,19 @@ namespace eos
 
             std::shared_ptr<Decay_> _decay;
 
-            std::function<const typename Decay_::IntermediateResult * (const Decay_ *, const Args_ & ...)> _prepare_fn;
+            std::function<const typename Decay_::IntermediateResult *(const Decay_ *, const Args_ &...)> _prepare_fn;
 
-            std::function<double (const Decay_ *, const typename Decay_::IntermediateResult *)> _evaluate_fn;
+            std::function<double(const Decay_ *, const typename Decay_::IntermediateResult *)> _evaluate_fn;
 
-            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> _kinematics_names;
+            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> _kinematics_names;
 
-            std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, KinematicVariable>::Type ...> _argument_tuple;
+            std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, KinematicVariable>::Type...> _argument_tuple;
 
         public:
-            ConcreteCacheableObservable(const QualifiedName & name,
-                    const Parameters & parameters,
-                    const Kinematics & kinematics,
-                    const Options & options,
-                    const std::function<const typename Decay_::IntermediateResult * (const Decay_ *, const Args_ & ...)> & prepare_fn,
-                    const std::function<double (const Decay_ *, const typename Decay_::IntermediateResult *)> & evaluate_fn,
-                    const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> & kinematics_names) :
+            ConcreteCacheableObservable(const QualifiedName & name, const Parameters & parameters, const Kinematics & kinematics, const Options & options,
+                                        const std::function<const typename Decay_::IntermediateResult *(const Decay_ *, const Args_ &...)> & prepare_fn,
+                                        const std::function<double(const Decay_ *, const typename Decay_::IntermediateResult *)> &           evaluate_fn,
+                                        const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> &                           kinematics_names) :
                 _name(name),
                 _parameters(parameters),
                 _kinematics(kinematics),
@@ -168,86 +165,110 @@ namespace eos
 
             ~ConcreteCacheableObservable() = default;
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual double evaluate() const
+            virtual double
+            evaluate() const
             {
-                std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, double>::Type ...> values = _argument_tuple;
+                std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, double>::Type...> values = _argument_tuple;
 
                 const typename Decay_::IntermediateResult * intermediate_result = std::apply(_prepare_fn, values);
 
                 return _evaluate_fn(_decay.get(), intermediate_result);
-            };
+            }
 
-            virtual const CacheableObservable::IntermediateResult * prepare() const
+            virtual const CacheableObservable::IntermediateResult *
+            prepare() const
             {
-                std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, double>::Type ...> values = _argument_tuple;
+                std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, double>::Type...> values = _argument_tuple;
 
                 return std::apply(_prepare_fn, values);
             }
 
-            virtual double evaluate(const CacheableObservable::IntermediateResult * intermediate_result) const
+            virtual double
+            evaluate(const CacheableObservable::IntermediateResult * intermediate_result) const
             {
                 return _evaluate_fn(_decay.get(), static_cast<const typename Decay_::IntermediateResult *>(intermediate_result));
             }
 
-            virtual Parameters parameters()
+            virtual Parameters
+            parameters()
             {
                 return _parameters;
-            };
+            }
 
-            virtual Kinematics kinematics()
+            virtual Kinematics
+            kinematics()
             {
                 return _kinematics;
-            };
+            }
 
-            virtual Options options()
+            virtual Options
+            options()
             {
                 return _options;
             }
 
-            virtual ObservablePtr make_cached_observable(const CacheableObservable * _other) const
+            virtual ObservablePtr
+            make_cached_observable(const CacheableObservable * _other) const
             {
                 auto other = dynamic_cast<decltype(this)>(_other);
                 if (nullptr == other)
+                {
                     return { nullptr };
+                }
 
                 if (other->_parameters != this->_parameters)
+                {
                     return { nullptr };
+                }
 
                 if (other->_kinematics != this->_kinematics)
+                {
                     return { nullptr };
+                }
 
                 if (other->_options != this->_options)
+                {
                     return { nullptr };
+                }
 
                 /*
                  * The values tuple contains a pointer to the Decay_ object, which owns the persistent pointer
                  * to the intermediate result. We make sure to use _other->_argument tuples, to ensure that
                  * the correct pointer to the intermediate result is used.
                  */
-                std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, double>::Type ...> values = other->_argument_tuple;
+                std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, double>::Type...> values = other->_argument_tuple;
 
-                return ObservablePtr(new ConcreteCachedObservable<Decay_, Args_ ...>(_name, _parameters, _kinematics, _options, other->_decay, std::apply(other->_prepare_fn, values), _prepare_fn, _evaluate_fn, _kinematics_names));
+                return ObservablePtr(new ConcreteCachedObservable<Decay_, Args_...>(_name,
+                                                                                    _parameters,
+                                                                                    _kinematics,
+                                                                                    _options,
+                                                                                    other->_decay,
+                                                                                    std::apply(other->_prepare_fn, values),
+                                                                                    _prepare_fn,
+                                                                                    _evaluate_fn,
+                                                                                    _kinematics_names));
             }
 
-            virtual ObservablePtr clone() const
+            virtual ObservablePtr
+            clone() const
             {
                 return ObservablePtr(new ConcreteCacheableObservable(_name, _parameters.clone(), _kinematics.clone(), _options, _prepare_fn, _evaluate_fn, _kinematics_names));
             }
 
-            virtual ObservablePtr clone(const Parameters & parameters) const
+            virtual ObservablePtr
+            clone(const Parameters & parameters) const
             {
                 return ObservablePtr(new ConcreteCacheableObservable(_name, parameters, _kinematics.clone(), _options, _prepare_fn, _evaluate_fn, _kinematics_names));
             }
     };
 
-    template <typename Decay_, typename ... Args_>
-    class ConcreteCacheableObservableEntry :
-        public ObservableEntry
+    template <typename Decay_, typename... Args_> class ConcreteCacheableObservableEntry : public ObservableEntry
     {
         private:
             QualifiedName _name;
@@ -256,11 +277,11 @@ namespace eos
 
             Unit _unit;
 
-            std::function<const typename Decay_::IntermediateResult * (const Decay_ *, const Args_ & ...)> _prepare_fn;
+            std::function<const typename Decay_::IntermediateResult *(const Decay_ *, const Args_ &...)> _prepare_fn;
 
-            std::function<double (const Decay_ *, const typename Decay_::IntermediateResult *)> _evaluate_fn;
+            std::function<double(const Decay_ *, const typename Decay_::IntermediateResult *)> _evaluate_fn;
 
-            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> _kinematics_names;
+            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> _kinematics_names;
 
             std::array<const std::string, sizeof...(Args_)> _kinematics_names_array;
 
@@ -268,10 +289,9 @@ namespace eos
 
         public:
             ConcreteCacheableObservableEntry(const QualifiedName & name, const std::string & latex, const Unit & unit,
-                    const std::function<const typename Decay_::IntermediateResult * (const Decay_ *, const Args_ & ...)> & prepare_fn,
-                    const std::function<double (const Decay_ *, const typename Decay_::IntermediateResult *)> & evaluate_fn,
-                    const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> & kinematics_names,
-                    const Options & forced_options) :
+                                             const std::function<const typename Decay_::IntermediateResult *(const Decay_ *, const Args_ &...)> & prepare_fn,
+                                             const std::function<double(const Decay_ *, const typename Decay_::IntermediateResult *)> &           evaluate_fn,
+                                             const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> & kinematics_names, const Options & forced_options) :
                 _name(name),
                 _latex(latex),
                 _unit(unit),
@@ -283,46 +303,52 @@ namespace eos
             {
             }
 
-            ~ConcreteCacheableObservableEntry()
-            {
-            }
+            ~ConcreteCacheableObservableEntry() {}
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual const std::string & latex() const
+            virtual const std::string &
+            latex() const
             {
                 return _latex;
             }
 
-            virtual const Unit & unit() const
+            virtual const Unit &
+            unit() const
             {
                 return _unit;
             }
 
-            virtual ObservableEntry::KinematicVariableIterator begin_kinematic_variables() const
+            virtual ObservableEntry::KinematicVariableIterator
+            begin_kinematic_variables() const
             {
                 return _kinematics_names_array.begin();
             }
 
-            virtual ObservableEntry::KinematicVariableIterator end_kinematic_variables() const
+            virtual ObservableEntry::KinematicVariableIterator
+            end_kinematic_variables() const
             {
                 return _kinematics_names_array.end();
             }
 
-            virtual ObservableEntry::OptionIterator begin_options() const
+            virtual ObservableEntry::OptionIterator
+            begin_options() const
             {
                 return Decay_::begin_options();
             }
 
-            virtual ObservableEntry::OptionIterator end_options() const
+            virtual ObservableEntry::OptionIterator
+            end_options() const
             {
                 return Decay_::end_options();
             }
 
-            virtual ObservablePtr make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
+            virtual ObservablePtr
+            make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
             {
                 for (const auto & fo : _forced_options)
                 {
@@ -330,13 +356,16 @@ namespace eos
                     if (options.has(key))
                     {
                         Log::instance()->message("[ConcreteCacheableObservableEntry.make]", ll_warning)
-                            << "Observable '" << _name << "' forces option key '" << key << "' to value '" << _forced_options[key] << "', overriding user-provided value '" << options[key] << "'";
+                                << "Observable '" << _name << "' forces option key '" << key << "' to value '" << _forced_options[key] << "', overriding user-provided value '"
+                                << options[key] << "'";
                     }
                 }
-                return ObservablePtr(new ConcreteCacheableObservable<Decay_, Args_ ...>(_name, parameters, kinematics, options + _forced_options, _prepare_fn, _evaluate_fn, _kinematics_names));
+                return ObservablePtr(
+                        new ConcreteCacheableObservable<Decay_, Args_...>(_name, parameters, kinematics, options + _forced_options, _prepare_fn, _evaluate_fn, _kinematics_names));
             }
 
-            virtual std::ostream & insert(std::ostream & os) const
+            virtual std::ostream &
+            insert(std::ostream & os) const
             {
                 os << "    type: cacheable observable" << std::endl;
 
@@ -349,23 +378,25 @@ namespace eos
             }
     };
 
-    template <typename Decay_, typename Tuple_, typename ... Args_>
-    ObservableEntryPtr make_concrete_cacheable_observable_entry(const QualifiedName & name, const std::string & latex,
-            const Unit & unit,
-            const typename Decay_::IntermediateResult * (Decay_::* prepare_fn)(const Args_ & ...) const,
-            double (Decay_::* evaluate_fn)(const typename Decay_::IntermediateResult *) const,
-            const Tuple_ & kinematics_names,
-            const Options & forced_options)
+    template <typename Decay_, typename Tuple_, typename... Args_>
+    ObservableEntryPtr
+    make_concrete_cacheable_observable_entry(const QualifiedName & name, const std::string & latex, const Unit & unit,
+                                             const typename Decay_::IntermediateResult * (Decay_::*prepare_fn)(const Args_ &...) const,
+                                             double (Decay_::*evaluate_fn)(const typename Decay_::IntermediateResult *) const, const Tuple_ & kinematics_names,
+                                             const Options & forced_options)
     {
         static_assert(sizeof...(Args_) == impl::TupleSize<Tuple_>::size, "Need as many function arguments as kinematics names!");
 
-        return std::make_shared<ConcreteCacheableObservableEntry<Decay_, Args_ ...>>(name, latex,
+        return std::make_shared<ConcreteCacheableObservableEntry<Decay_, Args_...>>(
+                name,
+                latex,
                 unit,
-                std::function<const typename Decay_::IntermediateResult * (const Decay_ *, const Args_ & ...)>(std::mem_fn(prepare_fn)),
-                std::function<double (const Decay_ *, const typename Decay_::IntermediateResult *)>(std::mem_fn(evaluate_fn)),
-                kinematics_names, forced_options);
+                std::function<const typename Decay_::IntermediateResult *(const Decay_ *, const Args_ &...)>(std::mem_fn(prepare_fn)),
+                std::function<double(const Decay_ *, const typename Decay_::IntermediateResult *)>(std::mem_fn(evaluate_fn)),
+                kinematics_names,
+                forced_options);
     }
-}
+} // namespace eos
 
 
 #endif

--- a/eos/utils/concrete-signal-pdf.hh
+++ b/eos/utils/concrete-signal-pdf.hh
@@ -26,11 +26,10 @@
 
 #include <cmath>
 #include <functional>
+#include <iostream>
 #include <limits>
 #include <string>
 #include <vector>
-
-#include <iostream>
 
 namespace eos
 {
@@ -38,112 +37,124 @@ namespace eos
     {
         template <unsigned i_, typename Tuple_> struct DescriptionFiller
         {
-            static std::vector<ParameterDescription> fill(Kinematics & k, const Tuple_ & kinematic_ranges)
-            {
-                auto result = DescriptionFiller<i_ - 1, Tuple_>::fill(k, kinematic_ranges);
+                static std::vector<ParameterDescription>
+                fill(Kinematics & k, const Tuple_ & kinematic_ranges)
+                {
+                    auto result = DescriptionFiller<i_ - 1, Tuple_>::fill(k, kinematic_ranges);
 
-                auto & kinematic_range = std::get<i_ - 1>(kinematic_ranges);
-                std::string kname = std::string(kinematic_range.name);
-                double kvalue = (kinematic_range.max - kinematic_range.min) / 2.0;
-                MutablePtr kvar(new KinematicVariable(k.declare(kname, kvalue)));
-                result.push_back(ParameterDescription{ kvar, kinematic_range.min, kinematic_range.max, false });
+                    auto &      kinematic_range = std::get<i_ - 1>(kinematic_ranges);
+                    std::string kname           = std::string(kinematic_range.name);
+                    double      kvalue          = (kinematic_range.max - kinematic_range.min) / 2.0;
+                    MutablePtr  kvar(new KinematicVariable(k.declare(kname, kvalue)));
+                    result.push_back(ParameterDescription{ kvar, kinematic_range.min, kinematic_range.max, false });
 
-                return result;
-            }
+                    return result;
+                }
         };
 
         template <typename Tuple_> struct DescriptionFiller<1u, Tuple_>
         {
-            static std::vector<ParameterDescription> fill(Kinematics & k, const Tuple_ & kinematic_ranges)
-            {
-                std::vector<ParameterDescription> result;
+                static std::vector<ParameterDescription>
+                fill(Kinematics & k, const Tuple_ & kinematic_ranges)
+                {
+                    std::vector<ParameterDescription> result;
 
-                auto & kinematic_range = std::get<0u>(kinematic_ranges);
-                std::string kname = std::string(kinematic_range.name);
-                double kvalue = (kinematic_range.max - kinematic_range.min) / 2.0;
-                MutablePtr kvar(new KinematicVariable(k.declare(kname, kvalue)));
-                result.push_back(ParameterDescription{ kvar, kinematic_range.min, kinematic_range.max, false });
+                    auto &      kinematic_range = std::get<0u>(kinematic_ranges);
+                    std::string kname           = std::string(kinematic_range.name);
+                    double      kvalue          = (kinematic_range.max - kinematic_range.min) / 2.0;
+                    MutablePtr  kvar(new KinematicVariable(k.declare(kname, kvalue)));
+                    result.push_back(ParameterDescription{ kvar, kinematic_range.min, kinematic_range.max, false });
 
-                return std::move(result);
-            }
+                    return std::move(result);
+                }
         };
 
         template <unsigned i_, typename Tuple_> struct KinematicRangePrinter
         {
-            static void print(std::ostream & os, const Tuple_ & kinematic_ranges)
-            {
-                KinematicRangePrinter<i_ - 1, Tuple_>::print(os, kinematic_ranges);
-                auto & kinematic_range = std::get<i_ - 1>(kinematic_ranges);
+                static void
+                print(std::ostream & os, const Tuple_ & kinematic_ranges)
+                {
+                    KinematicRangePrinter<i_ - 1, Tuple_>::print(os, kinematic_ranges);
+                    auto & kinematic_range = std::get<i_ - 1>(kinematic_ranges);
 
-                os << "    " << kinematic_range.name << "\t" << kinematic_range.description << std::endl;
-            }
+                    os << "    " << kinematic_range.name << "\t" << kinematic_range.description << std::endl;
+                }
         };
 
         template <typename Tuple_> struct KinematicRangePrinter<1u, Tuple_>
         {
-            static void print(std::ostream & os, const Tuple_ & kinematic_ranges)
-            {
-                auto & kinematic_range = std::get<0u>(kinematic_ranges);
+                static void
+                print(std::ostream & os, const Tuple_ & kinematic_ranges)
+                {
+                    auto & kinematic_range = std::get<0u>(kinematic_ranges);
 
-                os << "    " << kinematic_range.name << "\t" << kinematic_range.description << std::endl;
-            }
+                    os << "    " << kinematic_range.name << "\t" << kinematic_range.description << std::endl;
+                }
         };
 
         template <typename Result_, unsigned n_> struct ArgumentFromRange
         {
-            template <typename Ranges_, typename ... TempArgs_>
-            static Result_ make(Kinematics & k, const Ranges_ & r, TempArgs_ ... args)
-            {
-                return ArgumentFromRange<Result_, n_ - 1>::make(k, r, k[r[n_ - 1].name], args ...);
-            }
+                template <typename Ranges_, typename... TempArgs_>
+                static Result_
+                make(Kinematics & k, const Ranges_ & r, TempArgs_... args)
+                {
+                    return ArgumentFromRange<Result_, n_ - 1>::make(k, r, k[r[n_ - 1].name], args...);
+                }
         };
 
         template <typename Result_> struct ArgumentFromRange<Result_, 0>
         {
-            template <typename Ranges_, typename ... TempArgs_>
-            static Result_ make(Kinematics &, const Ranges_ &, TempArgs_ ... args)
-            {
-                return Result_{ args ... };
-            }
+                template <typename Ranges_, typename... TempArgs_>
+                static Result_
+                make(Kinematics &, const Ranges_ &, TempArgs_... args)
+                {
+                    return Result_{ args... };
+                }
         };
 
-        template <unsigned long n_> auto make_arguments(Kinematics & kinematics, const std::array<KinematicRange, n_> & kinematic_ranges)
-             -> std::array<KinematicVariable, n_>
+        template <unsigned long n_>
+        auto
+        make_arguments(Kinematics & kinematics, const std::array<KinematicRange, n_> & kinematic_ranges) -> std::array<KinematicVariable, n_>
         {
             return ArgumentFromRange<std::array<KinematicVariable, n_>, n_>::make(kinematics, kinematic_ranges);
         }
 
         template <typename Result_, unsigned n_> struct ArgumentFromName
         {
-            template <typename Names_, typename ... TempArgs_>
-            static Result_ make(Kinematics & k, const Names_ & n, TempArgs_ ... args)
-            {
-                return ArgumentFromName<Result_, n_ - 1>::make(k, n, k[n[n_ - 1]], args ...);
-            }
+                template <typename Names_, typename... TempArgs_>
+                static Result_
+                make(Kinematics & k, const Names_ & n, TempArgs_... args)
+                {
+                    return ArgumentFromName<Result_, n_ - 1>::make(k, n, k[n[n_ - 1]], args...);
+                }
         };
 
         template <typename Result_> struct ArgumentFromName<Result_, 0>
         {
-            template <typename Names_, typename ... TempArgs_>
-            static Result_ make(Kinematics &, const Names_ &, TempArgs_ ... args)
-            {
-                return Result_{ args ... };
-            }
+                template <typename Names_, typename... TempArgs_>
+                static Result_
+                make(Kinematics &, const Names_ &, TempArgs_... args)
+                {
+                    return Result_{ args... };
+                }
         };
 
-        template <unsigned long n_> auto make_arguments(Kinematics & kinematics, const std::array<std::string, n_> & kinematic_names)
-             -> std::array<KinematicVariable, n_>
+        template <unsigned long n_>
+        auto
+        make_arguments(Kinematics & kinematics, const std::array<std::string, n_> & kinematic_names) -> std::array<KinematicVariable, n_>
         {
             return ArgumentFromName<std::array<KinematicVariable, n_>, n_>::make(kinematics, kinematic_names);
         }
 
-        template <unsigned long n_> std::vector<ParameterDescription> make_descriptions(Kinematics & kinematics, const std::array<KinematicRange, n_> & kinematic_ranges)
+        template <unsigned long n_>
+        std::vector<ParameterDescription>
+        make_descriptions(Kinematics & kinematics, const std::array<KinematicRange, n_> & kinematic_ranges)
         {
             std::vector<ParameterDescription> result;
 
             for (auto krange : kinematic_ranges)
             {
-                auto kname = std::string(krange.name);
+                auto kname  = std::string(krange.name);
                 auto kvalue = (krange.max - krange.min) / 2.0;
 
                 MutablePtr kvar(new KinematicVariable(kinematics.declare(kname, kvalue)));
@@ -156,91 +167,90 @@ namespace eos
 
         template <typename Result_, unsigned n_> struct Evaluator
         {
-            template <typename Variables_, typename ... TempArgs_>
-            static Result_ evaluate(const Variables_ & v, TempArgs_ ... args)
-            {
-                return Evaluator<Result_, n_ - 1>::evaluate(v, v[n_ - 1].evaluate(), args ...);
-            }
+                template <typename Variables_, typename... TempArgs_>
+                static Result_
+                evaluate(const Variables_ & v, TempArgs_... args)
+                {
+                    return Evaluator<Result_, n_ - 1>::evaluate(v, v[n_ - 1].evaluate(), args...);
+                }
         };
 
         template <typename Result_> struct Evaluator<Result_, 0>
         {
-            template <typename Variables_, typename ... TempArgs_>
-            static Result_ evaluate(const Variables_ &, TempArgs_ ... args)
-            {
-                return Result_{ args ... };
-            }
+                template <typename Variables_, typename... TempArgs_>
+                static Result_
+                evaluate(const Variables_ &, TempArgs_... args)
+                {
+                    return Result_{ args... };
+                }
         };
 
-        template <unsigned long n_> auto evaluate(const std::array<KinematicVariable, n_> & kinematic_variables)
-             -> std::array<double, n_>
+        template <unsigned long n_>
+        auto
+        evaluate(const std::array<KinematicVariable, n_> & kinematic_variables) -> std::array<double, n_>
         {
             return Evaluator<std::array<double, n_>, n_>::evaluate(kinematic_variables);
         }
 
         // convert std::tuple to std::array
-        template<int... Indices_>
-        struct indices {
-            using next = indices<Indices_ ..., sizeof...(Indices_)>;
+        template <int... Indices_> struct indices
+        {
+                using next = indices<Indices_..., sizeof...(Indices_)>;
         };
 
-        template<int Size_>
-        struct build_indices {
-            using type = typename build_indices<Size_ - 1>::type::next;
+        template <int Size_> struct build_indices
+        {
+                using type = typename build_indices<Size_ - 1>::type::next;
         };
 
-        template<>
-        struct build_indices<0> {
-            using type = indices<>;
+        template <> struct build_indices<0>
+        {
+                using type = indices<>;
         };
 
-        template<typename T_>
-        using Bare = typename std::remove_cv<typename std::remove_reference<T_>::type>::type;
+        template <typename T_> using Bare = typename std::remove_cv<typename std::remove_reference<T_>::type>::type;
 
-        template<typename Tuple_>
-        constexpr
-        typename build_indices<std::tuple_size<Bare<Tuple_>>::value>::type
+        template <typename Tuple_>
+        constexpr typename build_indices<std::tuple_size<Bare<Tuple_>>::value>::type
         make_indices()
-        { return {}; }
+        {
+            return {};
+        }
 
-        template <typename Tuple_, int ... Indices_>
-        std::array<
-          typename std::tuple_element<0, Bare<Tuple_>>::type,
-            std::tuple_size<Bare<Tuple_>>::value
-        >
-        to_array(Tuple_ && tuple, indices<Indices_ ...>)
+        template <typename Tuple_, int... Indices_>
+        std::array<typename std::tuple_element<0, Bare<Tuple_>>::type, std::tuple_size<Bare<Tuple_>>::value>
+        to_array(Tuple_ && tuple, indices<Indices_...>)
         {
             using std::get;
-            return {{ get<Indices_>(std::forward<Tuple_>(tuple)) ... }};
+            return { { get<Indices_>(std::forward<Tuple_>(tuple))... } };
         }
 
         template <typename Tuple_>
-        auto to_array(Tuple_ && tuple)
-        -> decltype( to_array(std::declval<Tuple_>(), make_indices<Tuple_>()) )
+        auto
+        to_array(Tuple_ && tuple) -> decltype(to_array(std::declval<Tuple_>(), make_indices<Tuple_>()))
         {
             return to_array(std::forward<Tuple_>(tuple), make_indices<Tuple_>());
         }
 
         // convert Decay_ + std::array to std::tuple such that std::apply can be used
-        template <typename T_, std::size_t N_, std::size_t ... indices_>
-        auto make_tuple(const T_ * t, const std::array<double, N_> & a, std::index_sequence<indices_ ...>)
+        template <typename T_, std::size_t N_, std::size_t... indices_>
+        auto
+        make_tuple(const T_ * t, const std::array<double, N_> & a, std::index_sequence<indices_...>)
         {
-            return std::make_tuple(t, std::get<indices_>(a) ...);
+            return std::make_tuple(t, std::get<indices_>(a)...);
         }
 
         template <typename T_, std::size_t N_>
-        auto convert_to_tuple(const T_ * t, const std::array<double, N_> & args)
+        auto
+        convert_to_tuple(const T_ * t, const std::array<double, N_> & args)
         {
-            return make_tuple(t , args, std::make_index_sequence<N_>());
+            return make_tuple(t, args, std::make_index_sequence<N_>());
         }
-    }
+    } // namespace impl
 
-    template <typename Decay_, typename PDFSignature_, unsigned pdf_args_, typename NormSignature_, unsigned norm_args_>
-    class ConcreteSignalPDF :
-        public SignalPDF
+    template <typename Decay_, typename PDFSignature_, unsigned pdf_args_, typename NormSignature_, unsigned norm_args_> class ConcreteSignalPDF : public SignalPDF
     {
         public:
-
         private:
             QualifiedName _name;
 
@@ -265,15 +275,11 @@ namespace eos
             std::array<std::string, norm_args_> _norm_kinematic_names;
 
             std::array<KinematicVariable, norm_args_> _norm_arguments;
+
         public:
-            ConcreteSignalPDF(const QualifiedName & name,
-                    const Parameters & parameters,
-                    const Kinematics & kinematics,
-                    const Options & options,
-                    const std::function<PDFSignature_> & pdf,
-                    const std::array<KinematicRange, pdf_args_> & pdf_kinematic_ranges,
-                    const std::function<NormSignature_> & norm,
-                    const std::array<std::string, norm_args_> & norm_kinematic_names) :
+            ConcreteSignalPDF(const QualifiedName & name, const Parameters & parameters, const Kinematics & kinematics, const Options & options,
+                              const std::function<PDFSignature_> & pdf, const std::array<KinematicRange, pdf_args_> & pdf_kinematic_ranges,
+                              const std::function<NormSignature_> & norm, const std::array<std::string, norm_args_> & norm_kinematic_names) :
                 _name(name),
                 _parameters(parameters),
                 _kinematics(kinematics),
@@ -289,68 +295,76 @@ namespace eos
             {
             }
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual double evaluate() const
+            virtual double
+            evaluate() const
             {
                 std::array<double, pdf_args_> pdf_arguments = impl::evaluate(_pdf_arguments);
 
                 double result = std::apply(_pdf, impl::convert_to_tuple(&_decay, pdf_arguments));
 
                 return (result > 0 ? std::log(result) : -std::numeric_limits<double>::max());
-            };
+            }
 
-            virtual double normalization() const
+            virtual double
+            normalization() const
             {
                 std::array<double, norm_args_> norm_arguments = impl::evaluate(_norm_arguments);
 
                 double result = std::apply(_norm, impl::convert_to_tuple(&_decay, norm_arguments));
 
                 return (result > 0 ? std::log(result) : -std::numeric_limits<double>::max());
-            };
+            }
 
-            virtual Parameters parameters()
+            virtual Parameters
+            parameters()
             {
                 return _parameters;
-            };
+            }
 
-            virtual Kinematics kinematics()
+            virtual Kinematics
+            kinematics()
             {
                 return _kinematics;
-            };
+            }
 
-            virtual Options options()
+            virtual Options
+            options()
             {
                 return _options;
             }
 
-            virtual DensityPtr clone() const
+            virtual DensityPtr
+            clone() const
             {
                 return DensityPtr(new ConcreteSignalPDF(_name, _parameters.clone(), _kinematics.clone(), _options, _pdf, _pdf_kinematic_ranges, _norm, _norm_kinematic_names));
             }
 
-            virtual DensityPtr clone(const Parameters & parameters) const
+            virtual DensityPtr
+            clone(const Parameters & parameters) const
             {
                 return DensityPtr(new ConcreteSignalPDF(_name, parameters, _kinematics.clone(), _options, _pdf, _pdf_kinematic_ranges, _norm, _norm_kinematic_names));
             }
 
-            virtual Density::Iterator begin() const
+            virtual Density::Iterator
+            begin() const
             {
                 return Density::Iterator(_descriptions.cbegin());
             }
 
-            virtual Density::Iterator end() const
+            virtual Density::Iterator
+            end() const
             {
                 return Density::Iterator(_descriptions.cend());
             }
     };
 
-    template <typename Decay_, typename PDFSignature_, unsigned pdf_args_, typename NormSignature_, unsigned norm_args_>
-    class ConcreteSignalPDFEntry :
-        public SignalPDFEntry
+    template <typename Decay_, typename PDFSignature_, unsigned pdf_args_, typename NormSignature_, unsigned norm_args_> class ConcreteSignalPDFEntry : public SignalPDFEntry
     {
         private:
             QualifiedName _name;
@@ -366,12 +380,9 @@ namespace eos
             std::array<std::string, norm_args_> _norm_kinematic_names;
 
         public:
-            ConcreteSignalPDFEntry(const QualifiedName & name,
-                    const Options & default_options,
-                    const std::function<PDFSignature_> & pdf,
-                    const std::array<KinematicRange, pdf_args_> & pdf_kinematic_ranges,
-                    const std::function<NormSignature_> & norm,
-                    const std::array<std::string, norm_args_> & norm_kinematic_names) :
+            ConcreteSignalPDFEntry(const QualifiedName & name, const Options & default_options, const std::function<PDFSignature_> & pdf,
+                                   const std::array<KinematicRange, pdf_args_> & pdf_kinematic_ranges, const std::function<NormSignature_> & norm,
+                                   const std::array<std::string, norm_args_> & norm_kinematic_names) :
                 _name(name),
                 _default_options(default_options),
                 _pdf(pdf),
@@ -381,68 +392,78 @@ namespace eos
             {
             }
 
-            ~ConcreteSignalPDFEntry()
-            {
-            }
+            ~ConcreteSignalPDFEntry() {}
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual const std::string & description() const
+            virtual const std::string &
+            description() const
             {
                 return Decay_::description;
             }
 
-            virtual SignalPDFEntry::KinematicRangeIterator begin_kinematic_ranges() const
+            virtual SignalPDFEntry::KinematicRangeIterator
+            begin_kinematic_ranges() const
             {
                 return _pdf_kinematic_ranges.begin();
             }
 
-            virtual SignalPDFEntry::KinematicRangeIterator end_kinematic_ranges() const
+            virtual SignalPDFEntry::KinematicRangeIterator
+            end_kinematic_ranges() const
             {
                 return _pdf_kinematic_ranges.end();
             }
 
-            virtual SignalPDFPtr make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
+            virtual SignalPDFPtr
+            make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
             {
-
-                return SignalPDFPtr(new ConcreteSignalPDF<Decay_, PDFSignature_, pdf_args_, NormSignature_, norm_args_>(_name, parameters, kinematics, _default_options + options, _pdf, _pdf_kinematic_ranges, _norm, _norm_kinematic_names));
+                return SignalPDFPtr(new ConcreteSignalPDF<Decay_, PDFSignature_, pdf_args_, NormSignature_, norm_args_>(_name,
+                                                                                                                        parameters,
+                                                                                                                        kinematics,
+                                                                                                                        _default_options + options,
+                                                                                                                        _pdf,
+                                                                                                                        _pdf_kinematic_ranges,
+                                                                                                                        _norm,
+                                                                                                                        _norm_kinematic_names));
             }
 
-            virtual std::ostream & insert(std::ostream & os) const
+            virtual std::ostream &
+            insert(std::ostream & os) const
             {
                 return os;
             }
     };
 
-    template <typename Decay_, typename ... PDFArgs_, typename ... PDFKinematicRanges_, typename ... NormArgs_, typename ... NormKinematicNames_>
-    SignalPDFEntry * make_concrete_signal_pdf_entry(const QualifiedName & name,
-            const Options & default_options,
-            const std::function<double (const Decay_ *, const PDFArgs_ & ...)> & pdf,
-            const std::tuple<PDFKinematicRanges_ ...> & _pdf_kinematic_ranges,
-            const std::function<double (const Decay_ *, const NormArgs_ & ...)> & norm,
-            const std::tuple<NormKinematicNames_ ...> & _norm_kinematic_names)
+    template <typename Decay_, typename... PDFArgs_, typename... PDFKinematicRanges_, typename... NormArgs_, typename... NormKinematicNames_>
+    SignalPDFEntry *
+    make_concrete_signal_pdf_entry(const QualifiedName & name, const Options & default_options, const std::function<double(const Decay_ *, const PDFArgs_ &...)> & pdf,
+                                   const std::tuple<PDFKinematicRanges_...> & _pdf_kinematic_ranges, const std::function<double(const Decay_ *, const NormArgs_ &...)> & norm,
+                                   const std::tuple<NormKinematicNames_...> & _norm_kinematic_names)
     {
         static_assert(sizeof...(PDFArgs_) == sizeof...(PDFKinematicRanges_), "Need as many function arguments as kinematics ranges!");
         static_assert(sizeof...(NormArgs_) == sizeof...(NormKinematicNames_), "Need as many function arguments for the normalization as kinematics names!");
 
-        using PDFSignature = double (const Decay_ *, const PDFArgs_ & ...);
-        using NormSignature = double (const Decay_ *, const NormArgs_ & ...);
+        using PDFSignature  = double(const Decay_ *, const PDFArgs_ &...);
+        using NormSignature = double(const Decay_ *, const NormArgs_ &...);
         std::array<KinematicRange, sizeof...(PDFArgs_)> pdf_kinematic_ranges(impl::to_array(_pdf_kinematic_ranges));
-        std::array<std::string, sizeof...(NormArgs_)> norm_kinematic_names;
-        std::array<const char *, sizeof...(NormArgs_)> __norm_kinematic_names(impl::to_array(_norm_kinematic_names));
-        for (auto i = 0u ; i < sizeof...(NormArgs_) ; ++i)
+        std::array<std::string, sizeof...(NormArgs_)>   norm_kinematic_names;
+        std::array<const char *, sizeof...(NormArgs_)>  __norm_kinematic_names(impl::to_array(_norm_kinematic_names));
+        for (auto i = 0u; i < sizeof...(NormArgs_); ++i)
+        {
             norm_kinematic_names[i] = std::string(__norm_kinematic_names[i]);
+        }
 
         return new ConcreteSignalPDFEntry<Decay_, PDFSignature, sizeof...(PDFArgs_), NormSignature, sizeof...(NormArgs_)>(name,
-                default_options,
-                pdf,
-                pdf_kinematic_ranges,
-                norm,
-                norm_kinematic_names);
+                                                                                                                          default_options,
+                                                                                                                          pdf,
+                                                                                                                          pdf_kinematic_ranges,
+                                                                                                                          norm,
+                                                                                                                          norm_kinematic_names);
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/concrete_observable.cc
+++ b/eos/utils/concrete_observable.cc
@@ -24,4 +24,4 @@ namespace eos
 {
     template class WrappedForwardIterator<ObservableEntry::KinematicVariableIteratorTag, const std::string &>;
     template class WrappedForwardIterator<ObservableEntry::OptionIteratorTag, const OptionSpecification &>;
-}
+} // namespace eos

--- a/eos/utils/concrete_observable.hh
+++ b/eos/utils/concrete_observable.hh
@@ -34,12 +34,9 @@
 
 namespace eos
 {
-    template <typename Decay_, typename ... Args_>
-    class ConcreteObservable :
-        public Observable
+    template <typename Decay_, typename... Args_> class ConcreteObservable : public Observable
     {
         public:
-
         private:
             QualifiedName _name;
 
@@ -51,19 +48,16 @@ namespace eos
 
             Decay_ _decay;
 
-            std::function<double (const Decay_ *, const Args_ & ...)> _function;
+            std::function<double(const Decay_ *, const Args_ &...)> _function;
 
-            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> _kinematics_names;
+            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> _kinematics_names;
 
-            std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, KinematicVariable>::Type ...> _argument_tuple;
+            std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, KinematicVariable>::Type...> _argument_tuple;
 
         public:
-            ConcreteObservable(const QualifiedName & name,
-                    const Parameters & parameters,
-                    const Kinematics & kinematics,
-                    const Options & options,
-                    const std::function<double (const Decay_ *, const Args_ & ...)> & function,
-                    const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> & kinematics_names) :
+            ConcreteObservable(const QualifiedName & name, const Parameters & parameters, const Kinematics & kinematics, const Options & options,
+                               const std::function<double(const Decay_ *, const Args_ &...)> &            function,
+                               const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> & kinematics_names) :
                 _name(name),
                 _parameters(parameters),
                 _kinematics(kinematics),
@@ -77,47 +71,52 @@ namespace eos
                 uses(Decay_::references);
             }
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual double evaluate() const
+            virtual double
+            evaluate() const
             {
-                std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, double>::Type ...> values = _argument_tuple;
+                std::tuple<const Decay_ *, typename impl::ConvertTo<Args_, double>::Type...> values = _argument_tuple;
 
                 return std::apply(_function, values);
-            };
+            }
 
-            virtual Parameters parameters()
+            virtual Parameters
+            parameters()
             {
                 return _parameters;
-            };
+            }
 
-            virtual Kinematics kinematics()
+            virtual Kinematics
+            kinematics()
             {
                 return _kinematics;
-            };
+            }
 
-            virtual Options options()
+            virtual Options
+            options()
             {
                 return _options;
             }
 
-            virtual ObservablePtr clone() const
+            virtual ObservablePtr
+            clone() const
             {
                 return ObservablePtr(new ConcreteObservable(_name, _parameters.clone(), _kinematics.clone(), _options, _function, _kinematics_names));
             }
 
-            virtual ObservablePtr clone(const Parameters & parameters) const
+            virtual ObservablePtr
+            clone(const Parameters & parameters) const
             {
                 return ObservablePtr(new ConcreteObservable(_name, parameters, _kinematics.clone(), _options, _function, _kinematics_names));
             }
     };
 
-    template <typename Decay_, typename ... Args_>
-    class ConcreteObservableEntry :
-        public ObservableEntry
+    template <typename Decay_, typename... Args_> class ConcreteObservableEntry : public ObservableEntry
     {
         private:
             QualifiedName _name;
@@ -126,20 +125,18 @@ namespace eos
 
             Unit _unit;
 
-            std::function<double (const Decay_ *, const Args_ & ...)> _function;
+            std::function<double(const Decay_ *, const Args_ &...)> _function;
 
-            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> _kinematics_names;
+            std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> _kinematics_names;
 
             std::array<const std::string, sizeof...(Args_)> _kinematics_names_array;
 
             Options _forced_options;
 
         public:
-            ConcreteObservableEntry(const QualifiedName & name, const std::string & latex,
-                    const Unit & unit,
-                    const std::function<double (const Decay_ *, const Args_ & ...)> & function,
-                    const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type ...> & kinematics_names,
-                    const Options & forced_options) :
+            ConcreteObservableEntry(const QualifiedName & name, const std::string & latex, const Unit & unit,
+                                    const std::function<double(const Decay_ *, const Args_ &...)> &            function,
+                                    const std::tuple<typename impl::ConvertTo<Args_, const char *>::Type...> & kinematics_names, const Options & forced_options) :
                 _name(name),
                 _latex(latex),
                 _unit(unit),
@@ -150,74 +147,80 @@ namespace eos
             {
             }
 
-            ~ConcreteObservableEntry()
-            {
-            }
+            ~ConcreteObservableEntry() {}
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual const std::string & latex() const
+            virtual const std::string &
+            latex() const
             {
                 return _latex;
             }
 
-            virtual const Unit & unit() const
+            virtual const Unit &
+            unit() const
             {
                 return _unit;
             }
 
-            virtual ObservableEntry::KinematicVariableIterator begin_kinematic_variables() const
+            virtual ObservableEntry::KinematicVariableIterator
+            begin_kinematic_variables() const
             {
                 return _kinematics_names_array.begin();
             }
 
-            virtual ObservableEntry::KinematicVariableIterator end_kinematic_variables() const
+            virtual ObservableEntry::KinematicVariableIterator
+            end_kinematic_variables() const
             {
                 return _kinematics_names_array.end();
             }
 
-            virtual ObservableEntry::OptionIterator begin_options() const
+            virtual ObservableEntry::OptionIterator
+            begin_options() const
             {
                 return Decay_::begin_options();
             }
 
-            virtual ObservableEntry::OptionIterator end_options() const
+            virtual ObservableEntry::OptionIterator
+            end_options() const
             {
                 return Decay_::end_options();
             }
 
-            virtual ObservablePtr make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
+            virtual ObservablePtr
+            make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const
             {
                 for (const auto & [key, forced_value] : _forced_options)
                 {
                     if (options.has(key) && (options[key] != forced_value))
                     {
-                        Log::instance()->message("[ConcreteObservableEntry.make]", ll_error)
-                            << "Observable '" << _name << "' forces option key '" << key << "' to value '" << forced_value << "', overriding user-provided value '" << options[key] << "'";
+                        Log::instance()->message("[ConcreteObservableEntry.make]", ll_error) << "Observable '" << _name << "' forces option key '" << key << "' to value '"
+                                                                                             << forced_value << "', overriding user-provided value '" << options[key] << "'";
                     }
                 }
-                return ObservablePtr(new ConcreteObservable<Decay_, Args_ ...>(_name, parameters, kinematics, options + _forced_options, _function, _kinematics_names));
+                return ObservablePtr(new ConcreteObservable<Decay_, Args_...>(_name, parameters, kinematics, options + _forced_options, _function, _kinematics_names));
             }
     };
 
-    template <typename Decay_, typename Tuple_, typename ... Args_>
-    ObservableEntryPtr make_concrete_observable_entry(const QualifiedName & name, const std::string & latex,
-            const Unit & unit,
-            double (Decay_::* function)(const Args_ & ...) const,
-            const Tuple_ & kinematics_names,
-            const Options & forced_options)
+    template <typename Decay_, typename Tuple_, typename... Args_>
+    ObservableEntryPtr
+    make_concrete_observable_entry(const QualifiedName & name, const std::string & latex, const Unit & unit, double (Decay_::*function)(const Args_ &...) const,
+                                   const Tuple_ & kinematics_names, const Options & forced_options)
     {
         static_assert(sizeof...(Args_) == impl::TupleSize<Tuple_>::size, "Need as many function arguments as kinematics names!");
 
-        return std::make_shared<ConcreteObservableEntry<Decay_, Args_ ...>>(name, latex,
-                unit,
-                std::function<double (const Decay_ *, const Args_ & ...)>(std::mem_fn(function)),
-                kinematics_names, forced_options);
+        return std::make_shared<ConcreteObservableEntry<Decay_, Args_...>>(name,
+                                                                           latex,
+                                                                           unit,
+                                                                           std::function<double(const Decay_ *, const Args_ &...)>(std::mem_fn(function)),
+                                                                           kinematics_names,
+                                                                           forced_options);
     }
-}
+} // namespace eos
 
 
 #endif

--- a/eos/utils/condition_variable.cc
+++ b/eos/utils/condition_variable.cc
@@ -54,4 +54,4 @@ namespace eos
     {
         pthread_cond_wait(_cond, m.mutex());
     }
-}
+} // namespace eos

--- a/eos/utils/condition_variable.hh
+++ b/eos/utils/condition_variable.hh
@@ -30,8 +30,7 @@
 
 namespace eos
 {
-    class ConditionVariable :
-        public InstantiationPolicy<ConditionVariable, NonCopyable>
+    class ConditionVariable : public InstantiationPolicy<ConditionVariable, NonCopyable>
     {
         private:
             /// Our pthread condition variable.
@@ -56,6 +55,6 @@ namespace eos
             /// Wait until condition is met.
             void wait(Mutex &);
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/density-fwd.hh
+++ b/eos/utils/density-fwd.hh
@@ -29,6 +29,6 @@ namespace eos
     class Density;
 
     using DensityPtr = std::shared_ptr<Density>;
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/density-impl.hh
+++ b/eos/utils/density-impl.hh
@@ -27,11 +27,10 @@
 
 namespace eos
 {
-    template <>
-    struct WrappedForwardIteratorTraits<Density::IteratorTag>
+    template <> struct WrappedForwardIteratorTraits<Density::IteratorTag>
     {
-        using UnderlyingIterator = std::vector<ParameterDescription>::const_iterator;
+            using UnderlyingIterator = std::vector<ParameterDescription>::const_iterator;
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/density.cc
+++ b/eos/utils/density.cc
@@ -25,9 +25,7 @@
 
 namespace eos
 {
-    Density::~Density()
-    {
-    }
+    Density::~Density() {}
 
     template class WrappedForwardIterator<Density::IteratorTag, const ParameterDescription>;
-}
+} // namespace eos

--- a/eos/utils/density.hh
+++ b/eos/utils/density.hh
@@ -48,11 +48,11 @@ namespace eos
             using Iterator = WrappedForwardIterator<IteratorTag, const ParameterDescription>;
 
             virtual Iterator begin() const = 0;
-            virtual Iterator end() const = 0;
+            virtual Iterator end() const   = 0;
             ///@}
     };
 
     extern template class WrappedForwardIterator<Density::IteratorTag, const ParameterDescription>;
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/destringify.cc
+++ b/eos/utils/destringify.cc
@@ -25,4 +25,4 @@ namespace eos
         Exception("Could not destringify '" + str + "'")
     {
     }
-}
+} // namespace eos

--- a/eos/utils/destringify.hh
+++ b/eos/utils/destringify.hh
@@ -34,8 +34,7 @@ namespace eos
     /**
      * Exception thrown when destringification fails.
      */
-    class DestringifyError :
-        public Exception
+    class DestringifyError : public Exception
     {
         public:
             DestringifyError(const std::string & str);
@@ -43,123 +42,133 @@ namespace eos
 
     namespace impl
     {
-        template <typename T_>
-        struct SimpleDestringify
+        template <typename T_> struct SimpleDestringify
         {
-            static T_ destringify(const std::string & input)
-            {
-                std::stringstream ss(input);
-                T_ value;
-
-                ss >> value;
-                if (! ss.eof() || ss.fail())
+                static T_
+                destringify(const std::string & input)
                 {
-                    throw DestringifyError(input);
-                }
+                    std::stringstream ss(input);
+                    T_                value;
 
-                return value;
-            }
+                    ss >> value;
+                    if (! ss.eof() || ss.fail())
+                    {
+                        throw DestringifyError(input);
+                    }
+
+                    return value;
+                }
         };
 
-        template <typename T_> struct DoDestringify : public SimpleDestringify<T_> {};
+        template <typename T_> struct DoDestringify : public SimpleDestringify<T_>
+        {};
 
         template <> struct DoDestringify<bool>
         {
-            static bool destringify(const std::string & input)
-            {
-                if ("true" == input)
-                    return true;
+                static bool
+                destringify(const std::string & input)
+                {
+                    if ("true" == input)
+                    {
+                        return true;
+                    }
 
-                if ("false" == input)
-                    return false;
+                    if ("false" == input)
+                    {
+                        return false;
+                    }
 
-                throw DestringifyError(input + ": 'true' or 'false' was expected");
-            }
+                    throw DestringifyError(input + ": 'true' or 'false' was expected");
+                }
         };
 
         template <> struct DoDestringify<Isospin>
         {
-            static Isospin destringify(const std::string & input)
-            {
-                static const std::map<std::string, Isospin> isospins
+                static Isospin
+                destringify(const std::string & input)
                 {
-                    { "0",   Isospin::zero        },
-                    { "1",   Isospin::one         },
-                    { "1/2", Isospin::onehalf     },
-                    { "2",   Isospin::two         },
-                    { "3/2", Isospin::threehalves }
-                };
+                    static const std::map<std::string, Isospin> isospins{
+                        {   "0",        Isospin::zero },
+                        {   "1",         Isospin::one },
+                        { "1/2",     Isospin::onehalf },
+                        {   "2",         Isospin::two },
+                        { "3/2", Isospin::threehalves }
+                    };
 
-                Isospin result = Isospin::none;
+                    Isospin result = Isospin::none;
 
-                std::string::size_type i = 0, j = input.find('|');
-                do
-                {
-                    const auto value = input.substr(i, j - i);
-
-                    const auto k = isospins.find(value);
-                    if (isospins.cend() == k)
-                        throw DestringifyError(std::string("'") + value + "' is not a valid Isospin value");
-
-                    result |= k->second;
-
-                    if (std::string::npos != j)
+                    std::string::size_type i = 0, j = input.find('|');
+                    do
                     {
-                        i = j + 1;
-                        j = input.find('|', i);
+                        const auto value = input.substr(i, j - i);
+
+                        const auto k = isospins.find(value);
+                        if (isospins.cend() == k)
+                        {
+                            throw DestringifyError(std::string("'") + value + "' is not a valid Isospin value");
+                        }
+
+                        result |= k->second;
+
+                        if (std::string::npos != j)
+                        {
+                            i = j + 1;
+                            j = input.find('|', i);
+                        }
+                        else
+                        {
+                            i = std::string::npos;
+                        }
                     }
-                    else
-                    {
-                        i = std::string::npos;
-                    }
+                    while (std::string::npos != i);
+
+                    return result;
                 }
-                while (std::string::npos != i);
-
-                return result;
-            }
         };
 
         template <> struct DoDestringify<PartialWave>
         {
-            static PartialWave destringify(const std::string & input)
-            {
-                static const std::map<std::string, PartialWave> partial_waves
+                static PartialWave
+                destringify(const std::string & input)
                 {
-                    { "S", PartialWave::S },
-                    { "P", PartialWave::P },
-                    { "D", PartialWave::D },
-                    { "F", PartialWave::F }
-                };
+                    static const std::map<std::string, PartialWave> partial_waves{
+                        { "S", PartialWave::S },
+                        { "P", PartialWave::P },
+                        { "D", PartialWave::D },
+                        { "F", PartialWave::F }
+                    };
 
-                PartialWave result = PartialWave::none;
+                    PartialWave result = PartialWave::none;
 
-                std::string::size_type i = 0, j = input.find('|');
-                do
-                {
-                    const auto value = input.substr(i, j - i);
-
-                    const auto k = partial_waves.find(value);
-                    if (partial_waves.cend() == k)
-                        throw DestringifyError(std::string("'") + value + "' is not a valid PartialWave value");
-
-                    result |= k->second;
-
-                    if (std::string::npos != j)
+                    std::string::size_type i = 0, j = input.find('|');
+                    do
                     {
-                        i = j + 1;
-                        j = input.find('|', i);
+                        const auto value = input.substr(i, j - i);
+
+                        const auto k = partial_waves.find(value);
+                        if (partial_waves.cend() == k)
+                        {
+                            throw DestringifyError(std::string("'") + value + "' is not a valid PartialWave value");
+                        }
+
+                        result |= k->second;
+
+                        if (std::string::npos != j)
+                        {
+                            i = j + 1;
+                            j = input.find('|', i);
+                        }
+                        else
+                        {
+                            i = std::string::npos;
+                        }
                     }
-                    else
-                    {
-                        i = std::string::npos;
-                    }
+                    while (std::string::npos != i);
+
+                    return result;
                 }
-                while (std::string::npos != i);
-
-                return result;
-            }
         };
-    }
+    } // namespace impl
 
     template <typename T_>
     T_
@@ -167,6 +176,6 @@ namespace eos
     {
         return impl::DoDestringify<T_>::destringify(input);
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/diagnostics.cc
+++ b/eos/utils/diagnostics.cc
@@ -25,17 +25,15 @@
 
 namespace eos
 {
-    template <>
-    struct WrappedForwardIteratorTraits<Diagnostics::IteratorTag>
+    template <> struct WrappedForwardIteratorTraits<Diagnostics::IteratorTag>
     {
-        using UnderlyingIterator = std::vector<Diagnostics::Entry>::const_iterator;
+            using UnderlyingIterator = std::vector<Diagnostics::Entry>::const_iterator;
     };
     template class WrappedForwardIterator<Diagnostics::IteratorTag, const Diagnostics::Entry>;
 
-    template <>
-    struct Implementation<Diagnostics>
+    template <> struct Implementation<Diagnostics>
     {
-        std::vector<Diagnostics::Entry> entries;
+            std::vector<Diagnostics::Entry> entries;
     };
 
     Diagnostics::Diagnostics() :
@@ -43,9 +41,7 @@ namespace eos
     {
     }
 
-    Diagnostics::~Diagnostics()
-    {
-    }
+    Diagnostics::~Diagnostics() {}
 
     void
     Diagnostics::add(const Entry & entry)
@@ -70,4 +66,4 @@ namespace eos
     {
         return _imp->entries.size();
     }
-}
+} // namespace eos

--- a/eos/utils/diagnostics.hh
+++ b/eos/utils/diagnostics.hh
@@ -31,8 +31,7 @@ namespace eos
      * Container for diagnostic values and corresponding metadata.
      * Used as part of the unit tests.
      */
-    class Diagnostics :
-        public PrivateImplementationPattern<Diagnostics>
+    class Diagnostics : public PrivateImplementationPattern<Diagnostics>
     {
         public:
             struct Entry;
@@ -74,12 +73,12 @@ namespace eos
      */
     struct Diagnostics::Entry
     {
-        /// Numeric value for this entry.
-        double value;
+            /// Numeric value for this entry.
+            double value;
 
-        /// Description for this entry, e.g. a reference to the underlying formula.
-        std::string description;
+            /// Description for this entry, e.g. a reference to the underlying formula.
+            std::string description;
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/exception.cc
+++ b/eos/utils/exception.cc
@@ -35,13 +35,14 @@ namespace eos
 
     Context::Context(const Context & other) = default;
 
-    Context &
-    Context::operator= (const Context & other) = default;
+    Context & Context::operator= (const Context & other) = default;
 
     Context::~Context() noexcept(false)
     {
         if (impl::context.empty())
+        {
             throw InternalError("empty context");
+        }
 
         impl::context.pop_back();
     }
@@ -50,17 +51,20 @@ namespace eos
     Context::backtrace(const std::string & delimiter) const
     {
         if (impl::context.empty())
+        {
             return "";
+        }
 
         std::string result;
 
         auto append = [&](const std::tuple<source_location, std::string> & entry)
         {
-            result += std::get<1>(entry) + "[" + std::get<0>(entry).file_name() + ":" + std::to_string(std::get<0>(entry).line()) + " -> " + std::get<0>(entry).function_name() + "]";
+            result +=
+                    std::get<1>(entry) + "[" + std::get<0>(entry).file_name() + ":" + std::to_string(std::get<0>(entry).line()) + " -> " + std::get<0>(entry).function_name() + "]";
             result += delimiter;
         };
 
-        for (auto c = impl::context.cbegin(), c_end = impl::context.cend() ; c != c_end ; ++c)
+        for (auto c = impl::context.cbegin(), c_end = impl::context.cend(); c != c_end; ++c)
         {
             append(*c);
         }
@@ -80,7 +84,7 @@ namespace eos
             }
 
             ContextData(const ContextData &) = default;
-            ~ContextData() = default;
+            ~ContextData()                   = default;
     };
 
     Exception::Exception(const std::string & message) noexcept :
@@ -96,25 +100,26 @@ namespace eos
     {
     }
 
-    Exception::~Exception() noexcept
-    {
-    }
+    Exception::~Exception() noexcept {}
 
     std::string
     Exception::backtrace(const std::string & delimiter) const
     {
         if (_context_data->local_context.empty())
+        {
             return "";
+        }
 
         std::string result;
 
         auto append = [&](const std::tuple<source_location, std::string> & entry)
         {
-            result += std::get<1>(entry) + " [" + std::get<0>(entry).file_name() + ":" + std::to_string(std::get<0>(entry).line()) + " -> " + std::get<0>(entry).function_name() + "]";
+            result += std::get<1>(entry) + " [" + std::get<0>(entry).file_name() + ":" + std::to_string(std::get<0>(entry).line()) + " -> " + std::get<0>(entry).function_name()
+                      + "]";
             result += delimiter;
         };
 
-        for (auto c = _context_data->local_context.cbegin(), c_end = _context_data->local_context.cend() ; c != c_end ; ++c)
+        for (auto c = _context_data->local_context.cbegin(), c_end = _context_data->local_context.cend(); c != c_end; ++c)
         {
             append(*c);
         }
@@ -123,28 +128,28 @@ namespace eos
     }
 
     const char *
-    Exception::what() const throw ()
+    Exception::what() const throw()
     {
         return _message.c_str();
     }
 
-    InternalError::InternalError(const std::string & message) throw () :
+    InternalError::InternalError(const std::string & message) throw() :
         Exception("Internal Error: " + message)
     {
     }
 
-    UnknownObservableError::UnknownObservableError(const std::string & message) throw () :
+    UnknownObservableError::UnknownObservableError(const std::string & message) throw() :
         Exception("Unknown Observable Error: " + message)
     {
     }
 
-    GSLError::GSLError(const std::string & message) throw () :
+    GSLError::GSLError(const std::string & message) throw() :
         Exception("GSL Error: " + message)
     {
     }
 
-    ParsingError::ParsingError(const std::string & message) throw () :
+    ParsingError::ParsingError(const std::string & message) throw() :
         Exception("Parsing Error: " + message)
     {
     }
-}
+} // namespace eos

--- a/eos/utils/exception.hh
+++ b/eos/utils/exception.hh
@@ -50,13 +50,12 @@ namespace eos
             std::string backtrace(const std::string & delimiter) const;
     };
 
-    class Exception :
-        public std::exception
+    class Exception : public std::exception
     {
         private:
             class ContextData;
 
-            std::string _message;
+            std::string                        _message;
             const std::unique_ptr<ContextData> _context_data;
 
         protected:
@@ -71,33 +70,29 @@ namespace eos
             virtual const char * what() const noexcept override;
     };
 
-    class InternalError :
-        public Exception
+    class InternalError : public Exception
     {
         public:
-            InternalError(const std::string & message) throw ();
+            InternalError(const std::string & message) throw();
     };
 
-    class UnknownObservableError :
-        public Exception
+    class UnknownObservableError : public Exception
     {
         public:
-            UnknownObservableError(const std::string & message) throw ();
+            UnknownObservableError(const std::string & message) throw();
     };
 
-    class GSLError :
-        public Exception
+    class GSLError : public Exception
     {
         public:
-            GSLError(const std::string & message) throw ();
+            GSLError(const std::string & message) throw();
     };
 
-    class ParsingError :
-        public Exception
+    class ParsingError : public Exception
     {
         public:
-            ParsingError(const std::string & message) throw ();
+            ParsingError(const std::string & message) throw();
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/expression-cacher.hh
+++ b/eos/utils/expression-cacher.hh
@@ -53,6 +53,6 @@ namespace eos::exp
 
             Expression visit(const CachedObservableExpression & e);
     };
-}
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/expression-cloner.hh
+++ b/eos/utils/expression-cloner.hh
@@ -57,6 +57,6 @@ namespace eos::exp
 
             Expression visit(const CachedObservableExpression & e);
     };
-}
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/expression-evaluator.hh
+++ b/eos/utils/expression-evaluator.hh
@@ -27,7 +27,7 @@ namespace eos::exp
     class ExpressionEvaluator
     {
         public:
-            ExpressionEvaluator() = default;
+            ExpressionEvaluator()  = default;
             ~ExpressionEvaluator() = default;
 
             double visit(BinaryExpression & e);
@@ -49,8 +49,7 @@ namespace eos::exp
             double visit(KinematicVariableExpression & e);
 
             double visit(CachedObservableExpression & e);
-
     };
-}
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/expression-fwd.hh
+++ b/eos/utils/expression-fwd.hh
@@ -34,18 +34,8 @@ namespace eos::exp
     class ParameterNameExpression;
     class ParameterExpression;
 
-    using Expression = OneOf<
-        BinaryExpression,
-        FunctionExpression,
-        ConstantExpression,
-        ObservableNameExpression,
-        ObservableExpression,
-        KinematicVariableNameExpression,
-        KinematicVariableExpression,
-        CachedObservableExpression,
-        ParameterNameExpression,
-        ParameterExpression
-    >;
-}
+    using Expression = OneOf<BinaryExpression, FunctionExpression, ConstantExpression, ObservableNameExpression, ObservableExpression, KinematicVariableNameExpression,
+                             KinematicVariableExpression, CachedObservableExpression, ParameterNameExpression, ParameterExpression>;
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/expression-kinematic-reader.hh
+++ b/eos/utils/expression-kinematic-reader.hh
@@ -30,11 +30,10 @@ namespace eos::exp
     class ExpressionKinematicReader
     {
         public:
-
             std::set<std::string> kinematics;
             std::set<std::string> aliases;
 
-            ExpressionKinematicReader() = default;
+            ExpressionKinematicReader()  = default;
             ~ExpressionKinematicReader() = default;
 
             // Clear the sets of kinematics and aliases
@@ -60,6 +59,6 @@ namespace eos::exp
 
             void visit(const CachedObservableExpression & e);
     };
-}
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/expression-maker.hh
+++ b/eos/utils/expression-maker.hh
@@ -57,6 +57,6 @@ namespace eos::exp
 
             Expression visit(const CachedObservableExpression & e);
     };
-}
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/expression-observable.cc
+++ b/eos/utils/expression-observable.cc
@@ -33,11 +33,8 @@ namespace eos
 {
     using eos::exp::Expression;
 
-    ExpressionObservable::ExpressionObservable(const QualifiedName & name,
-            const Parameters & parameters,
-            const Kinematics & kinematics,
-            const Options & options,
-            const Expression & expression) :
+    ExpressionObservable::ExpressionObservable(const QualifiedName & name, const Parameters & parameters, const Kinematics & kinematics, const Options & options,
+                                               const Expression & expression) :
         _name(name),
         _parameters(parameters),
         _kinematics(kinematics),
@@ -60,12 +57,8 @@ namespace eos
         }
     }
 
-    ExpressionObservable::ExpressionObservable(const QualifiedName & name,
-            const ObservableCache & cache,
-            const Kinematics & kinematics,
-            const Options & options,
-            const Expression & expression
-            ) :
+    ExpressionObservable::ExpressionObservable(const QualifiedName & name, const ObservableCache & cache, const Kinematics & kinematics, const Options & options,
+                                               const Expression & expression) :
         _name(name),
         _parameters(cache.parameters()),
         _kinematics(kinematics),
@@ -101,7 +94,6 @@ namespace eos
         return _expression.accept_returning<double>(evaluator);
     }
 
-
     ObservablePtr
     ExpressionObservable::clone() const
     {
@@ -123,11 +115,8 @@ namespace eos
         return ObservablePtr(new ExpressionObservable(_name, parameters, kinematics, _options, _expression.accept_returning<Expression>(cloner)));
     }
 
-
-    ExpressionObservableEntry::ExpressionObservableEntry(const QualifiedName & name, const std::string & latex,
-            const Unit & unit,
-            const Expression & expression,
-            const Options & forced_options) :
+    ExpressionObservableEntry::ExpressionObservableEntry(const QualifiedName & name, const std::string & latex, const Unit & unit, const Expression & expression,
+                                                         const Options & forced_options) :
         _name(name),
         _latex(latex),
         _unit(unit),
@@ -145,11 +134,11 @@ namespace eos
 
         // Check the absence of overlap between the used kinematic variables and the aliased variables
         std::set<std::string> intersection;
-        std::set_intersection(
-            kinematic_reader.kinematics.begin(), kinematic_reader.kinematics.end(),
-            kinematic_reader.aliases.begin(), kinematic_reader.aliases.end(),
-            std::inserter(intersection, intersection.begin())
-        );
+        std::set_intersection(kinematic_reader.kinematics.begin(),
+                              kinematic_reader.kinematics.end(),
+                              kinematic_reader.aliases.begin(),
+                              kinematic_reader.aliases.end(),
+                              std::inserter(intersection, intersection.begin()));
 
         if (! intersection.empty())
         {
@@ -196,11 +185,11 @@ namespace eos
             const auto & key = std::get<0>(fo);
             if (options.has(key))
             {
-                Log::instance()->message("[ExpressionObservableEntry.make]", ll_warning)
-                    << "Observable '" << _name << "' forces option key '" << key << "' to value '" << _forced_options[key] << "', overriding user-provided value '" << options[key] << "'";
+                Log::instance()->message("[ExpressionObservableEntry.make]", ll_warning) << "Observable '" << _name << "' forces option key '" << key << "' to value '"
+                                                                                         << _forced_options[key] << "', overriding user-provided value '" << options[key] << "'";
             }
         }
 
         return ObservablePtr(new ExpressionObservable(_name, parameters, kinematics, options + _forced_options, _expression));
     }
-}
+} // namespace eos

--- a/eos/utils/expression-observable.hh
+++ b/eos/utils/expression-observable.hh
@@ -31,8 +31,7 @@ namespace eos
 {
     using eos::exp::Expression;
 
-    class ExpressionObservable :
-        public Observable
+    class ExpressionObservable : public Observable
     {
         private:
             QualifiedName _name;
@@ -46,54 +45,48 @@ namespace eos
             Expression _expression;
 
         public:
-            ExpressionObservable(const QualifiedName & name,
-                    const Parameters & parameters,
-                    const Kinematics & kinematics,
-                    const Options & options,
-                    const Expression & expression);
+            ExpressionObservable(const QualifiedName & name, const Parameters & parameters, const Kinematics & kinematics, const Options & options, const Expression & expression);
 
-            ExpressionObservable(const QualifiedName & name,
-                    const ObservableCache & cache,
-                    const Kinematics & kinematics,
-                    const Options & options,
-                    const Expression & expression);
+            ExpressionObservable(const QualifiedName & name, const ObservableCache & cache, const Kinematics & kinematics, const Options & options, const Expression & expression);
 
-            ~ExpressionObservable()
-            {
-            }
+            ~ExpressionObservable() {}
 
-            virtual double evaluate() const;
+            virtual double        evaluate() const;
             virtual ObservablePtr clone() const;
             virtual ObservablePtr clone(const Parameters & parameters) const;
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual Parameters parameters()
+            virtual Parameters
+            parameters()
             {
                 return _parameters;
-            };
+            }
 
-            virtual Kinematics kinematics()
+            virtual Kinematics
+            kinematics()
             {
                 return _kinematics;
-            };
+            }
 
-            virtual Options options()
+            virtual Options
+            options()
             {
                 return _options;
             }
 
-            const Expression & expression() const
+            const Expression &
+            expression() const
             {
                 return _expression;
             }
     };
 
-    class ExpressionObservableEntry :
-        public ObservableEntry
+    class ExpressionObservableEntry : public ObservableEntry
     {
         private:
             QualifiedName _name;
@@ -111,14 +104,9 @@ namespace eos
             std::vector<OptionSpecification> _option_specifications;
 
         public:
-            ExpressionObservableEntry(const QualifiedName & name, const std::string & latex,
-                    const Unit & unit,
-                    const Expression & expression,
-                    const Options & forced_options);
+            ExpressionObservableEntry(const QualifiedName & name, const std::string & latex, const Unit & unit, const Expression & expression, const Options & forced_options);
 
-            ~ExpressionObservableEntry()
-            {
-            }
+            ~ExpressionObservableEntry() {}
 
             virtual ObservableEntry::KinematicVariableIterator begin_kinematic_variables() const;
             virtual ObservableEntry::KinematicVariableIterator end_kinematic_variables() const;
@@ -128,21 +116,24 @@ namespace eos
 
             virtual ObservablePtr make(const Parameters & parameters, const Kinematics & kinematics, const Options & options) const;
 
-            virtual const QualifiedName & name() const
+            virtual const QualifiedName &
+            name() const
             {
                 return _name;
             }
 
-            virtual const std::string & latex() const
+            virtual const std::string &
+            latex() const
             {
                 return _latex;
             }
 
-            virtual const Unit & unit() const
+            virtual const Unit &
+            unit() const
             {
                 return _unit;
             }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/expression-parser-impl.hh
+++ b/eos/utils/expression-parser-impl.hh
@@ -19,11 +19,11 @@
 #ifndef EOS_GUARD_EOS_UTILS_EXPRESSION_PARSER_IMPL_HH
 #define EOS_GUARD_EOS_UTILS_EXPRESSION_PARSER_IMPL_HH 1
 
-#include <boost/spirit/include/qi.hpp>
-#include <boost/fusion/adapted.hpp>
-
-#include <eos/utils/expression.hh>
 #include <eos/utils/expression-parser.hh>
+#include <eos/utils/expression.hh>
+
+#include <boost/fusion/adapted.hpp>
+#include <boost/spirit/include/qi.hpp>
 
 #include <utility>
 
@@ -35,128 +35,50 @@ namespace eos
     {
         using namespace boost::spirit::qi;
 
-        expression =
-            additive_expr                                [ _val = _1]
-            ;
+        expression = additive_expr[_val = _1];
 
-        auto make_binary = [] (char op, const auto & lhs, const auto & rhs)
-        {
-            return eos::exp::BinaryExpression(op, lhs, rhs);
-        };
+        auto make_binary = [](char op, const auto & lhs, const auto & rhs) { return eos::exp::BinaryExpression(op, lhs, rhs); };
 
-        additive_expr =
-            multiplicative_expr                            [ _val = _1]
-            >> *(   (char_("+") >> multiplicative_expr)    [ _val = phx::bind(make_binary, _1, _val, _2)]
-                  | (char_("-") >> multiplicative_expr)    [ _val = phx::bind(make_binary, _1, _val, _2)]
-                )
-            ;
+        additive_expr = multiplicative_expr[_val = _1] >> *((char_("+") >> multiplicative_expr)[_val = phx::bind(make_binary, _1, _val, _2)]
+                                                            | (char_("-") >> multiplicative_expr)[_val = phx::bind(make_binary, _1, _val, _2)]);
 
-        multiplicative_expr =
-            exponential_expr                               [ _val = _1]
-            >> *(   (char_("*") >> exponential_expr)       [ _val = phx::bind(make_binary, _1, _val, _2)]
-                  | (char_("/") >> exponential_expr)       [ _val = phx::bind(make_binary, _1, _val, _2)]
-                )
-            ;
+        multiplicative_expr = exponential_expr[_val = _1] >> *((char_("*") >> exponential_expr)[_val = phx::bind(make_binary, _1, _val, _2)]
+                                                               | (char_("/") >> exponential_expr)[_val = phx::bind(make_binary, _1, _val, _2)]);
 
-        exponential_expr =
-            primary_expr                                   [ _val = _1 ]
-            >> -( char_("^") >> primary_expr )             [ _val = phx::bind(make_binary, _1, _val, _2) ]
-            ;
+        exponential_expr = primary_expr[_val = _1] >> -(char_("^") >> primary_expr)[_val = phx::bind(make_binary, _1, _val, _2)];
 
-        auto make_observable = [] (const std::string & name, const KinematicsSpecification & spec)
-        {
-            return eos::exp::Expression(eos::exp::ObservableNameExpression(name, spec));
-        };
+        auto make_observable = [](const std::string & name, const KinematicsSpecification & spec) { return eos::exp::Expression(eos::exp::ObservableNameExpression(name, spec)); };
 
-        auto make_parameter = [] (const std::string & name)
-        {
-            return eos::exp::Expression(eos::exp::ParameterNameExpression(name));
-        };
+        auto make_parameter = [](const std::string & name) { return eos::exp::Expression(eos::exp::ParameterNameExpression(name)); };
 
-        auto make_kinematic_variable = [] (const std::string & name)
-        {
-            return eos::exp::Expression(eos::exp::KinematicVariableNameExpression(name));
-        };
+        auto make_kinematic_variable = [](const std::string & name) { return eos::exp::Expression(eos::exp::KinematicVariableNameExpression(name)); };
 
-        primary_expr =
-              ('(' >> expression >> ')')                   [ _val = _1 ]
-            | constant                                     [ _val = _1 ]
-            | (observable_name >> kinematics)              [ _val = phx::bind(make_observable, _1, _2) ]
-            | observable_name                              [ _val = phx::bind(make_observable, _1, KinematicsSpecification()) ]
-            | parameter_name                               [ _val = phx::bind(make_parameter, _1)]
-            | kinematic_variable_name                      [ _val = phx::bind(make_kinematic_variable, _1) ]
-            | function_expr                                [ _val = _1 ]
-            ;
+        primary_expr = ('(' >> expression >> ')')[_val = _1] | constant[_val = _1] | (observable_name >> kinematics)[_val = phx::bind(make_observable, _1, _2)]
+                       | observable_name[_val = phx::bind(make_observable, _1, KinematicsSpecification())] | parameter_name[_val = phx::bind(make_parameter, _1)]
+                       | kinematic_variable_name[_val = phx::bind(make_kinematic_variable, _1)] | function_expr[_val = _1];
 
         constant = double_ | int_;
 
-        kinematic_variable_name =
-              "{"
-            >> as_string [ lexeme [ *(char_ - "}")  ] ] [ _val = _1 ]
-            >> "}"
-            ;
+        kinematic_variable_name = "{" >> as_string[lexeme[*(char_ - "}")]][_val = _1] >> "}";
 
-        observable_name =
-              "<<"
-            >> as_string [ lexeme [ *(char_ - ">>")  ] ] [ _val = _1 ]
-            >> ">>"
-            ;
+        observable_name = "<<" >> as_string[lexeme[*(char_ - ">>")]][_val = _1] >> ">>";
 
-        parameter_name =
-              "[["
-            >> as_string [ lexeme [ *(char_ - "]]")  ] ] [ _val = _1 ]
-            >> "]]"
-            ;
+        parameter_name = "[[" >> as_string[lexeme[*(char_ - "]]")]][_val = _1] >> "]]";
 
-        kinematics =
-              '['
-            >> (   kinematics_alias                      [ phx::bind(_val, _1) ]
-                 | kinematics_value                      [ phx::bind(_val, _1) ]
-               ) % ','
-            >> ']'
-            ;
+        kinematics = '[' >> (kinematics_alias[phx::bind(_val, _1)] | kinematics_value[phx::bind(_val, _1)]) % ',' >> ']';
 
-        kinematics_alias =
-            (
-            as_string [ lexeme [ *~char_(",=>]") ] ]
-            >> "=>"
-            >> as_string [ lexeme [ *~char_(",=]") ] ]
-            )
-            ;
+        kinematics_alias = (as_string[lexeme[*~char_(",=>]")]] >> "=>" >> as_string[lexeme[*~char_(",=]")]]);
 
-        kinematics_value =
-            (
-            as_string [ lexeme [ *~char_(",=>]") ] ]
-            >> '='
-            >> double_
-            )
-            ;
+        kinematics_value = (as_string[lexeme[*~char_(",=>]")]] >> '=' >> double_);
 
-        auto make_function = [] (const std::string & f, const auto & arg)
-        {
-            return eos::exp::FunctionExpression(f, arg);
-        };
+        auto make_function = [](const std::string & f, const auto & arg) { return eos::exp::FunctionExpression(f, arg); };
 
-        function_expr =
-            (
-            function_name
-            >> '('
-            >> primary_expr
-            >> ')'
-            ) [ _val = phx::bind(make_function, _1, _2)]
-            ;
+        function_expr = (function_name >> '(' >> primary_expr >> ')')[_val = phx::bind(make_function, _1, _2)];
 
-        function_name =
-            *(
-                string("exp") | string("cos") | string("sin")
-            )
-            ;
+        function_name = *(string("exp") | string("cos") | string("sin"));
     }
 
-    template <typename Iterator>
-    ExpressionParser<Iterator>::~ExpressionParser()
-    {
-    }
-}
+    template <typename Iterator> ExpressionParser<Iterator>::~ExpressionParser() {}
+} // namespace eos
 
 #endif

--- a/eos/utils/expression-parser.cc
+++ b/eos/utils/expression-parser.cc
@@ -19,7 +19,7 @@
 
 #include <string>
 
- namespace eos
- {
-     template struct ExpressionParser<std::string::const_iterator>;
- }
+namespace eos
+{
+    template struct ExpressionParser<std::string::const_iterator>;
+}

--- a/eos/utils/expression-parser.hh
+++ b/eos/utils/expression-parser.hh
@@ -19,11 +19,11 @@
 #ifndef EOS_GUARD_EOS_UTILS_EXPRESSION_PARSER_HH
 #define EOS_GUARD_EOS_UTILS_EXPRESSION_PARSER_HH 1
 
-#include <boost/spirit/include/qi.hpp>
-#include <boost/phoenix.hpp>
-#include <boost/fusion/adapted.hpp>
-
 #include <eos/utils/expression.hh>
+
+#include <boost/fusion/adapted.hpp>
+#include <boost/phoenix.hpp>
+#include <boost/spirit/include/qi.hpp>
 
 namespace eos
 {
@@ -31,37 +31,35 @@ namespace eos
     namespace ascii = boost::spirit::ascii;
     namespace phx   = boost::phoenix;
 
-    template <typename Iterator>
-    struct ExpressionParser :
-        qi::grammar<Iterator, eos::exp::Expression(), ascii::space_type>
+    template <typename Iterator> struct ExpressionParser : qi::grammar<Iterator, eos::exp::Expression(), ascii::space_type>
     {
-        // Constructor
-        ExpressionParser();
+            // Constructor
+            ExpressionParser();
 
-        qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> expression;
-        qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> additive_expr;
-        qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> multiplicative_expr;
-        qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> exponential_expr;
-        qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> function_expr;
+            qi::rule<Iterator, eos::exp::Expression(), ascii::space_type> expression;
+            qi::rule<Iterator, eos::exp::Expression(), ascii::space_type> additive_expr;
+            qi::rule<Iterator, eos::exp::Expression(), ascii::space_type> multiplicative_expr;
+            qi::rule<Iterator, eos::exp::Expression(), ascii::space_type> exponential_expr;
+            qi::rule<Iterator, eos::exp::Expression(), ascii::space_type> function_expr;
 
-        qi::rule<Iterator, eos::exp::Expression()               , ascii::space_type> primary_expr;
-        qi::rule<Iterator, eos::exp::ConstantExpression()       , ascii::space_type> constant;
-        qi::rule<Iterator, std::string()                        , ascii::space_type> observable_name;
-        qi::rule<Iterator, std::string()                        , ascii::space_type> parameter_name;
-        qi::rule<Iterator, std::string()                        , ascii::space_type> kinematic_variable_name;
-        qi::rule<Iterator, std::string()                        , ascii::space_type> function_name;
+            qi::rule<Iterator, eos::exp::Expression(), ascii::space_type>         primary_expr;
+            qi::rule<Iterator, eos::exp::ConstantExpression(), ascii::space_type> constant;
+            qi::rule<Iterator, std::string(), ascii::space_type>                  observable_name;
+            qi::rule<Iterator, std::string(), ascii::space_type>                  parameter_name;
+            qi::rule<Iterator, std::string(), ascii::space_type>                  kinematic_variable_name;
+            qi::rule<Iterator, std::string(), ascii::space_type>                  function_name;
 
-        using KinematicsSpecification = eos::exp::KinematicsSpecification;
+            using KinematicsSpecification = eos::exp::KinematicsSpecification;
 
-        qi::rule<Iterator, KinematicsSpecification()            , ascii::space_type> kinematics;
-        qi::rule<Iterator, std::pair<std::string, std::string>(), ascii::space_type> kinematics_alias;
-        qi::rule<Iterator, std::pair<std::string, double>       , ascii::space_type> kinematics_value;
+            qi::rule<Iterator, KinematicsSpecification(), ascii::space_type>             kinematics;
+            qi::rule<Iterator, std::pair<std::string, std::string>(), ascii::space_type> kinematics_alias;
+            qi::rule<Iterator, std::pair<std::string, double>, ascii::space_type>        kinematics_value;
 
-        // Destuctor
-        ~ExpressionParser();
+            // Destuctor
+            ~ExpressionParser();
     };
 
     extern template struct ExpressionParser<std::string::const_iterator>;
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/expression-parser_TEST.cc
+++ b/eos/utils/expression-parser_TEST.cc
@@ -16,20 +16,20 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
-
-#include <eos/utils/expression.hh>
-#include <eos/utils/expression-fwd.hh>
 #include <eos/utils/expression-cloner.hh>
 #include <eos/utils/expression-evaluator.hh>
+#include <eos/utils/expression-fwd.hh>
 #include <eos/utils/expression-kinematic-reader.hh>
 #include <eos/utils/expression-maker.hh>
 #include <eos/utils/expression-parser-impl.hh>
 #include <eos/utils/expression-printer.hh>
 #include <eos/utils/expression-used-parameter-reader.hh>
+#include <eos/utils/expression.hh>
 #include <eos/utils/kinematic.hh>
 #include <eos/utils/options.hh>
 #include <eos/utils/parameters.hh>
+
+#include <test/test.hh>
 
 #include <iostream>
 
@@ -44,7 +44,7 @@ class ExpressionTest
 
     public:
         Expression e;
-        bool completed;
+        bool       completed;
 
         using It = std::string::const_iterator;
         ExpressionParser<It> parser;
@@ -57,17 +57,16 @@ class ExpressionTest
         }
 };
 
-
-class ExpressionParserTest :
-    public TestCase
+class ExpressionParserTest : public TestCase
 {
     public:
         ExpressionParserTest() :
-        TestCase("expression_parser_test")
+            TestCase("expression_parser_test")
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // testing parser failure
             {
@@ -121,12 +120,10 @@ class ExpressionParserTest :
                 ExpressionEvaluator evaluator;
 
                 TEST_CHECK(test.completed);
-                TEST_CHECK_EQUAL_STR(
-                    "BinaryExpression(KinematicVariableNameExpression(q2_mu)"
-                    " - "
-                    "KinematicVariableNameExpression(q2_e))",
-                    out.str()
-                );
+                TEST_CHECK_EQUAL_STR("BinaryExpression(KinematicVariableNameExpression(q2_mu)"
+                                     " - "
+                                     "KinematicVariableNameExpression(q2_e))",
+                                     out.str());
 
                 // Cannot evaluate expression with KinematicVariableNameExpression objects
                 TEST_CHECK_THROWS(InternalError, test.e.accept_returning<double>(evaluator));
@@ -135,24 +132,25 @@ class ExpressionParserTest :
                 ExpressionKinematicReader kinematic_reader;
                 test.e.accept(kinematic_reader);
 
-                std::set<std::string> expected_kinematic{"q2_mu", "q2_e"};
+                std::set<std::string> expected_kinematic{ "q2_mu", "q2_e" };
                 TEST_CHECK_EQUAL(expected_kinematic, kinematic_reader.kinematics);
 
                 // Make and evaluate expression
-                Kinematics k = Kinematics({{"q2_mu", 4.0},  {"q2_e", 3.0}});
+                Kinematics      k = Kinematics({
+                    { "q2_mu", 4.0 },
+                    {  "q2_e", 3.0 }
+                });
                 ExpressionMaker maker(Parameters::Defaults(), k, Options());
-                Expression assessable_test = test.e.accept_returning<Expression>(maker);
+                Expression      assessable_test = test.e.accept_returning<Expression>(maker);
 
                 std::stringstream out2;
                 ExpressionPrinter printer2(out2);
                 assessable_test.accept(printer2);
 
-                TEST_CHECK_EQUAL_STR(
-                    "BinaryExpression(KinematicVariableExpression(q2_mu)"
-                    " - "
-                    "KinematicVariableExpression(q2_e))",
-                    out2.str()
-                );
+                TEST_CHECK_EQUAL_STR("BinaryExpression(KinematicVariableExpression(q2_mu)"
+                                     " - "
+                                     "KinematicVariableExpression(q2_e))",
+                                     out2.str());
 
                 TEST_CHECK_EQUAL(assessable_test.accept_returning<double>(evaluator), 1.0);
             }
@@ -170,12 +168,10 @@ class ExpressionParserTest :
                 ExpressionEvaluator evaluator;
 
                 TEST_CHECK(test.completed);
-                TEST_CHECK_EQUAL_STR(
-                    "BinaryExpression(ObservableNameExpression(test::obs1;multiplier=2, aliases=[q2_min=>q2_min_num])"
-                    " / "
-                    "ObservableNameExpression(test::obs1, values=[q2_min=0]))",
-                    out.str()
-                );
+                TEST_CHECK_EQUAL_STR("BinaryExpression(ObservableNameExpression(test::obs1;multiplier=2, aliases=[q2_min=>q2_min_num])"
+                                     " / "
+                                     "ObservableNameExpression(test::obs1, values=[q2_min=0]))",
+                                     out.str());
 
                 // Cannot evaluate expression with ObservableNameExpression objects
                 TEST_CHECK_THROWS(InternalError, test.e.accept_returning<double>(evaluator));
@@ -184,7 +180,7 @@ class ExpressionParserTest :
                 ExpressionKinematicReader kinematic_reader;
                 test.e.accept(kinematic_reader);
 
-                std::set<std::string> expected_kinematic{"q2_max", "q2_min_num"};
+                std::set<std::string> expected_kinematic{ "q2_max", "q2_min_num" };
                 TEST_CHECK_EQUAL(expected_kinematic, kinematic_reader.kinematics);
 
                 // Check the aliased kinematics are correctly aliased
@@ -205,12 +201,10 @@ class ExpressionParserTest :
                 ExpressionEvaluator evaluator;
 
                 TEST_CHECK(test.completed);
-                TEST_CHECK_EQUAL_STR(
-                    "BinaryExpression(ParameterNameExpression(mass::c)"
-                    " / "
-                    "ParameterNameExpression(mass::b(MSbar)))",
-                    out.str()
-                );
+                TEST_CHECK_EQUAL_STR("BinaryExpression(ParameterNameExpression(mass::c)"
+                                     " / "
+                                     "ParameterNameExpression(mass::b(MSbar)))",
+                                     out.str());
 
                 // Cannot evaluate expression with ObservableNameExpression objects
                 TEST_CHECK_THROWS(InternalError, test.e.accept_returning<double>(evaluator));
@@ -223,19 +217,15 @@ class ExpressionParserTest :
                 TEST_CHECK_EQUAL(expected_kinematic, kinematic_reader.kinematics);
 
                 // Create a usable expression
-                Parameters p = Parameters::Defaults();
+                Parameters      p = Parameters::Defaults();
                 ExpressionMaker maker(p, Kinematics(), Options());
-                Expression e = test.e.accept_returning<Expression>(maker);
+                Expression      e = test.e.accept_returning<Expression>(maker);
 
                 // Extract used parameters from an expression
                 ExpressionUsedParameterReader used_parameter_reader;
                 e.accept(used_parameter_reader);
 
-                std::set<Parameter::Id> expected_used_parameters
-                {
-                    p["mass::c"].id(),
-                    p["mass::b(MSbar)"].id()
-                };
+                std::set<Parameter::Id> expected_used_parameters{ p["mass::c"].id(), p["mass::b(MSbar)"].id() };
                 TEST_CHECK_EQUAL(expected_used_parameters, used_parameter_reader.parameter_ids);
             }
 
@@ -246,31 +236,38 @@ class ExpressionParserTest :
                 Parameters p = Parameters::Defaults();
                 p["mass::c"] = 1.2;
 
-                Kinematics k       = Kinematics({{"q2_min_num", 4.0}, {"q2_min_denom", 3.0}, {"q2_max", 10.0}});
-                Kinematics k_num   = Kinematics({{"q2_min", 4.0},  {"q2_max", 10.0}});
-                Kinematics k_denom = Kinematics({{"q2_min", 3.0},  {"q2_max", 10.0}});
+                Kinematics k       = Kinematics({
+                    {   "q2_min_num",  4.0 },
+                    { "q2_min_denom",  3.0 },
+                    {       "q2_max", 10.0 }
+                });
+                Kinematics k_num   = Kinematics({
+                    { "q2_min",  4.0 },
+                    { "q2_max", 10.0 }
+                });
+                Kinematics k_denom = Kinematics({
+                    { "q2_min",  3.0 },
+                    { "q2_max", 10.0 }
+                });
 
-                auto obs_num   = Observable::make("test::obs1;multiplier=2", p, k_num,   Options());
-                auto obs_denom = Observable::make("test::obs1",              p, k_denom, Options());
+                auto obs_num   = Observable::make("test::obs1;multiplier=2", p, k_num, Options());
+                auto obs_denom = Observable::make("test::obs1", p, k_denom, Options());
 
-                TEST_CHECK_RELATIVE_ERROR(obs_num->evaluate(),   14.4,  1e-10);
-                TEST_CHECK_RELATIVE_ERROR(obs_denom->evaluate(),  8.4,  1e-10);
+                TEST_CHECK_RELATIVE_ERROR(obs_num->evaluate(), 14.4, 1e-10);
+                TEST_CHECK_RELATIVE_ERROR(obs_denom->evaluate(), 8.4, 1e-10);
 
                 // Make and evaluate expression
                 ExpressionMaker maker(p, k, Options());
-                Expression assessable_test = test.e.accept_returning<Expression>(maker);
+                Expression      assessable_test = test.e.accept_returning<Expression>(maker);
 
                 ExpressionEvaluator evaluator;
 
-                TEST_CHECK_RELATIVE_ERROR(
-                    assessable_test.accept_returning<double>(evaluator),
-                    obs_num->evaluate() / obs_denom->evaluate(),
-                    1e-3);
+                TEST_CHECK_RELATIVE_ERROR(assessable_test.accept_returning<double>(evaluator), obs_num->evaluate() / obs_denom->evaluate(), 1e-3);
 
 
                 // Observable with exponentiation
                 ExpressionTest test2("[[mass::tau]]^2 - <<mass::mu>>^2");
-                Expression assessable_test2 = test2.e.accept_returning<Expression>(maker);
+                Expression     assessable_test2 = test2.e.accept_returning<Expression>(maker);
 
                 TEST_CHECK(test2.completed);
                 TEST_CHECK_RELATIVE_ERROR(assessable_test2.accept_returning<double>(evaluator), 3.14592, 1e-3);
@@ -285,45 +282,47 @@ class ExpressionParserTest :
                 test.e.accept(printer);
 
                 TEST_CHECK(test.completed);
-                TEST_CHECK_EQUAL_STR(
-                    "BinaryExpression("
-                        "KinematicVariableNameExpression(q2) - "
-                        "BinaryExpression("
-                            "BinaryExpression(ConstantExpression(4) * ParameterNameExpression(mass::mu))"
-                            " * ObservableNameExpression(mass::tau)"
-                        ")"
-                    ")",
-                    out.str()
-                );
+                TEST_CHECK_EQUAL_STR("BinaryExpression("
+                                     "KinematicVariableNameExpression(q2) - "
+                                     "BinaryExpression("
+                                     "BinaryExpression(ConstantExpression(4) * ParameterNameExpression(mass::mu))"
+                                     " * ObservableNameExpression(mass::tau)"
+                                     ")"
+                                     ")",
+                                     out.str());
 
-                Options o;
-                Kinematics k = Kinematics({{"q2", 10.0}});
-                Parameters p = Parameters::Defaults();
-                p["mass::mu"]     =  1.0;
-                p["mass::tau"]    =  2.0;
+                Options    o;
+                Kinematics k   = Kinematics({
+                    { "q2", 10.0 }
+                });
+                Parameters p   = Parameters::Defaults();
+                p["mass::mu"]  = 1.0;
+                p["mass::tau"] = 2.0;
 
                 ExpressionMaker maker(p, k, o);
-                Expression assessable_test = test.e.accept_returning<Expression>(maker);
+                Expression      assessable_test = test.e.accept_returning<Expression>(maker);
 
-                Kinematics k2 = Kinematics({{"q2", 20.0}});
-                Parameters p2 = Parameters::Defaults();
-                p2["mass::mu"]     =  2.0;
-                p2["mass::tau"]    =  2.0;
+                Kinematics k2   = Kinematics({
+                    { "q2", 20.0 }
+                });
+                Parameters p2   = Parameters::Defaults();
+                p2["mass::mu"]  = 2.0;
+                p2["mass::tau"] = 2.0;
 
                 ExpressionCloner cloner(p2, k2, o);
-                Expression cloned_test = assessable_test.accept_returning<Expression>(cloner);
+                Expression       cloned_test = assessable_test.accept_returning<Expression>(cloner);
 
                 ExpressionEvaluator evaluator;
 
-                TEST_CHECK_EQUAL(assessable_test.accept_returning<double>(evaluator),    2.0);
-                TEST_CHECK_EQUAL(cloned_test.accept_returning<double>(evaluator),        4.0);
+                TEST_CHECK_EQUAL(assessable_test.accept_returning<double>(evaluator), 2.0);
+                TEST_CHECK_EQUAL(cloned_test.accept_returning<double>(evaluator), 4.0);
 
                 // Test that parameters are considered as used
-                ParameterUser parameter_user;
+                ParameterUser   parameter_user;
                 ExpressionMaker maker_user(p, k, o, &parameter_user);
                 assessable_test = test.e.accept_returning<Expression>(maker_user);
                 std::set<Parameter::Id> used_ids(parameter_user.begin(), parameter_user.end());
-                std::set<Parameter::Id> expected_ids{p["mass::mu"].id(), p["mass::tau"].id()};
+                std::set<Parameter::Id> expected_ids{ p["mass::mu"].id(), p["mass::tau"].id() };
 
                 TEST_CHECK_EQUAL(used_ids, expected_ids);
             }
@@ -334,7 +333,7 @@ class ExpressionParserTest :
                 TEST_CHECK_THROWS(QualifiedNameSyntaxError, ExpressionTest test("<<{test::obs1}>>"));
 
                 // { } are allowed in the prefix of QualifiedNames (but test::obs1{} is not an existing obervable)
-                ExpressionTest test("<<test::obs1{}>>");
+                ExpressionTest    test("<<test::obs1{}>>");
                 std::stringstream out;
                 ExpressionPrinter printer(out);
                 test.e.accept(printer);
@@ -354,20 +353,20 @@ class ExpressionParserTest :
             // testing the compatibility of kinematic variables and aliases
             {
                 // Simple case, no conflict
-                ExpressionTest test("<<test::obs1>>[q2_min=>q2_min_num] * {q2_min_num}");
+                ExpressionTest            test("<<test::obs1>>[q2_min=>q2_min_num] * {q2_min_num}");
                 ExpressionKinematicReader kinematic_reader;
                 test.e.accept(kinematic_reader);
-                std::set<std::string> expected_kinematic{"q2_max", "q2_min_num"};
+                std::set<std::string> expected_kinematic{ "q2_max", "q2_min_num" };
 
                 TEST_CHECK_EQUAL(expected_kinematic, kinematic_reader.kinematics);
 
                 // Check the overlap between the set of used kinematic variables and the set of aliased variables
                 std::set<std::string> intersection;
-                std::set_intersection(
-                    kinematic_reader.kinematics.begin(), kinematic_reader.kinematics.end(),
-                    kinematic_reader.aliases.begin(), kinematic_reader.aliases.end(),
-                    std::inserter(intersection, intersection.begin())
-                );
+                std::set_intersection(kinematic_reader.kinematics.begin(),
+                                      kinematic_reader.kinematics.end(),
+                                      kinematic_reader.aliases.begin(),
+                                      kinematic_reader.aliases.end(),
+                                      std::inserter(intersection, intersection.begin()));
                 TEST_CHECK(intersection.empty());
 
                 // Problematic case, conflict between the alias and the kinematic variable
@@ -376,11 +375,11 @@ class ExpressionParserTest :
                 test2.e.accept(kinematic_reader);
 
                 intersection.clear();
-                std::set_intersection(
-                    kinematic_reader.kinematics.begin(), kinematic_reader.kinematics.end(),
-                    kinematic_reader.aliases.begin(), kinematic_reader.aliases.end(),
-                    std::inserter(intersection, intersection.begin())
-                );
+                std::set_intersection(kinematic_reader.kinematics.begin(),
+                                      kinematic_reader.kinematics.end(),
+                                      kinematic_reader.aliases.begin(),
+                                      kinematic_reader.aliases.end(),
+                                      std::inserter(intersection, intersection.begin()));
                 TEST_CHECK(! intersection.empty());
             }
 
@@ -396,7 +395,7 @@ class ExpressionParserTest :
 
                 // test with default parameters as stored on disk
                 {
-                    Parameters p = Parameters::Defaults();
+                    Parameters      p = Parameters::Defaults();
                     ExpressionMaker maker(p, Kinematics(), Options());
 
                     TEST_CHECK_THROWS(UnknownParameterError, test.e.accept_returning<Expression>(maker));
@@ -405,7 +404,7 @@ class ExpressionParserTest :
                 // test after declaring "undeclared::parameter"
                 {
                     Parameters::declare("undeclared::parameter", "", Unit::Undefined(), 1.0, 0.0, 2.0);
-                    Parameters p = Parameters::Defaults();
+                    Parameters      p = Parameters::Defaults();
                     ExpressionMaker maker(p, Kinematics(), Options());
 
                     Expression e;

--- a/eos/utils/expression-printer.hh
+++ b/eos/utils/expression-printer.hh
@@ -54,6 +54,6 @@ namespace eos::exp
 
             void visit(CachedObservableExpression & e);
     };
-}
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/expression-used-parameter-reader.hh
+++ b/eos/utils/expression-used-parameter-reader.hh
@@ -30,7 +30,7 @@ namespace eos::exp
         public:
             std::set<Parameter::Id> parameter_ids;
 
-            ExpressionUsedParameterReader() = default;
+            ExpressionUsedParameterReader()  = default;
             ~ExpressionUsedParameterReader() = default;
 
             void visit(const BinaryExpression & e);
@@ -53,6 +53,6 @@ namespace eos::exp
 
             void visit(const CachedObservableExpression & e);
     };
-}
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/expression-visitors.cc
+++ b/eos/utils/expression-visitors.cc
@@ -16,10 +16,9 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <eos/observable.hh>
 #include <eos/observable-impl.hh>
+#include <eos/observable.hh>
 #include <eos/utils/exception.hh>
-#include <eos/utils/expression.hh>
 #include <eos/utils/expression-cacher.hh>
 #include <eos/utils/expression-cloner.hh>
 #include <eos/utils/expression-evaluator.hh>
@@ -27,6 +26,7 @@
 #include <eos/utils/expression-maker.hh>
 #include <eos/utils/expression-printer.hh>
 #include <eos/utils/expression-used-parameter-reader.hh>
+#include <eos/utils/expression.hh>
 #include <eos/utils/join.hh>
 #include <eos/utils/kinematic.hh>
 #include <eos/utils/options.hh>
@@ -47,7 +47,8 @@ namespace eos::exp
     {
     }
 
-    void ExpressionPrinter::visit(BinaryExpression & e)
+    void
+    ExpressionPrinter::visit(BinaryExpression & e)
     {
         _os << "BinaryExpression(";
         e.lhs.accept(*this);
@@ -56,7 +57,8 @@ namespace eos::exp
         _os << ")";
     }
 
-    void ExpressionPrinter::visit(FunctionExpression & e)
+    void
+    ExpressionPrinter::visit(FunctionExpression & e)
     {
         _os << "FunctionExpression(";
         _os << e.fname << ", ";
@@ -64,12 +66,14 @@ namespace eos::exp
         _os << ")";
     }
 
-    void ExpressionPrinter::visit(ConstantExpression & e)
+    void
+    ExpressionPrinter::visit(ConstantExpression & e)
     {
         _os << "ConstantExpression(" << e.value << ")";
     }
 
-    void ExpressionPrinter::visit(ObservableNameExpression & e)
+    void
+    ExpressionPrinter::visit(ObservableNameExpression & e)
     {
         _os << "ObservableNameExpression(" << e.observable_name.full();
         if (! e.kinematics_specification.aliases.empty())
@@ -77,7 +81,7 @@ namespace eos::exp
             auto a = e.kinematics_specification.aliases.cbegin();
             _os << ", aliases=[" << a->first << "=>" << a->second;
             ++a;
-            for (auto a_end = e.kinematics_specification.aliases.cend() ; a != a_end ; ++a)
+            for (auto a_end = e.kinematics_specification.aliases.cend(); a != a_end; ++a)
             {
                 _os << "," << a->first << "=>" << a->second;
             }
@@ -88,7 +92,7 @@ namespace eos::exp
             auto v = e.kinematics_specification.values.cbegin();
             _os << ", values=[" << v->first << "=" << v->second;
             ++v;
-            for (auto v_end = e.kinematics_specification.values.cend() ; v != v_end ; ++v)
+            for (auto v_end = e.kinematics_specification.values.cend(); v != v_end; ++v)
             {
                 _os << "," << v->first << "=" << v->second;
             }
@@ -97,7 +101,8 @@ namespace eos::exp
         _os << ")";
     }
 
-    void ExpressionPrinter::visit(ObservableExpression & e)
+    void
+    ExpressionPrinter::visit(ObservableExpression & e)
     {
         _os << "ObservableExpression(" << e.observable->name() << ")";
         if (! e.kinematics_specification.aliases.empty())
@@ -105,7 +110,7 @@ namespace eos::exp
             auto a = e.kinematics_specification.aliases.cbegin();
             _os << ", aliases=[" << a->first << "=>" << a->second;
             ++a;
-            for (auto a_end = e.kinematics_specification.aliases.cend() ; a != a_end ; ++a)
+            for (auto a_end = e.kinematics_specification.aliases.cend(); a != a_end; ++a)
             {
                 _os << "," << a->first << "=>" << a->second;
             }
@@ -116,7 +121,7 @@ namespace eos::exp
             auto v = e.kinematics_specification.values.cbegin();
             _os << ", values=[" << v->first << "=" << v->second;
             ++v;
-            for (auto v_end = e.kinematics_specification.values.cend() ; v != v_end ; ++v)
+            for (auto v_end = e.kinematics_specification.values.cend(); v != v_end; ++v)
             {
                 _os << "," << v->first << "=" << v->second;
             }
@@ -125,27 +130,32 @@ namespace eos::exp
         _os << ")";
     }
 
-    void ExpressionPrinter::visit(ParameterNameExpression & e)
+    void
+    ExpressionPrinter::visit(ParameterNameExpression & e)
     {
         _os << "ParameterNameExpression(" << e.parameter_name.full() << ")";
     }
 
-    void ExpressionPrinter::visit(ParameterExpression & e)
+    void
+    ExpressionPrinter::visit(ParameterExpression & e)
     {
         _os << "ParameterExpression(" << e.parameter.name() << ")";
     }
 
-    void ExpressionPrinter::visit(KinematicVariableNameExpression & e)
+    void
+    ExpressionPrinter::visit(KinematicVariableNameExpression & e)
     {
         _os << "KinematicVariableNameExpression(" << e.variable_name << ")";
     }
 
-    void ExpressionPrinter::visit(KinematicVariableExpression & e)
+    void
+    ExpressionPrinter::visit(KinematicVariableExpression & e)
     {
         _os << "KinematicVariableExpression(" << e.kinematic_variable.name() << ")";
     }
 
-    void ExpressionPrinter::visit(CachedObservableExpression & e)
+    void
+    ExpressionPrinter::visit(CachedObservableExpression & e)
     {
         _os << "CachedObservableExpression(id=" << e.id;
         _os << ", name='" << e.cache.observable(e.id)->name().full() << "'";
@@ -262,7 +272,7 @@ namespace eos::exp
     Expression
     ExpressionCloner::visit(const ObservableExpression & e)
     {
-        const auto & kinematics_values = e.kinematics_specification.values;
+        const auto & kinematics_values  = e.kinematics_specification.values;
         const auto & kinematics_aliases = e.kinematics_specification.aliases;
 
         // Set or alias kinematic specifications
@@ -276,12 +286,7 @@ namespace eos::exp
         }
 
         // Make observable
-        auto observable = Observable::make(
-            e.observable->name(),
-            this->_parameters,
-            this->_kinematics,
-            this->_options + e.observable->options()
-            );
+        auto observable = Observable::make(e.observable->name(), this->_parameters, this->_kinematics, this->_options + e.observable->options());
         // Clear alias map
         _kinematics.clear_aliases();
 
@@ -317,7 +322,7 @@ namespace eos::exp
     Expression
     ExpressionCloner::visit(const CachedObservableExpression & e)
     {
-        const auto & kinematics_values = e.kinematics_specification.values;
+        const auto & kinematics_values  = e.kinematics_specification.values;
         const auto & kinematics_aliases = e.kinematics_specification.aliases;
 
         // Set or alias kinematic specifications
@@ -331,12 +336,7 @@ namespace eos::exp
         }
 
         // Make observable
-        auto observable = Observable::make(
-            e.cache.observable(e.id)->name(),
-            this->_parameters,
-            this->_kinematics,
-            this->_options + e.cache.observable(e.id)->options()
-            );
+        auto observable = Observable::make(e.cache.observable(e.id)->name(), this->_parameters, this->_kinematics, this->_options + e.cache.observable(e.id)->options());
         // Clear alias map
         _kinematics.clear_aliases();
 
@@ -376,7 +376,7 @@ namespace eos::exp
     Expression
     ExpressionMaker::visit(const ObservableNameExpression & e)
     {
-        const auto & kinematics_values = e.kinematics_specification.values;
+        const auto & kinematics_values  = e.kinematics_specification.values;
         const auto & kinematics_aliases = e.kinematics_specification.aliases;
 
         // Set or alias kinematic specifications
@@ -390,15 +390,10 @@ namespace eos::exp
         }
 
         // Make observable
-        auto observable = Observable::make(
-            e.observable_name,
-            this->_parameters,
-            this->_kinematics,
-            this->_options
-            );
+        auto observable = Observable::make(e.observable_name, this->_parameters, this->_kinematics, this->_options);
 
         // Clear aliases installed as part of this expression
-        for (const auto & alias: kinematics_aliases)
+        for (const auto & alias : kinematics_aliases)
         {
             _kinematics.remove_alias(alias.first);
         }
@@ -417,7 +412,7 @@ namespace eos::exp
     {
         // Rebuild the observable expression with the local set of parameters
 
-        const auto & kinematics_values = e.kinematics_specification.values;
+        const auto & kinematics_values  = e.kinematics_specification.values;
         const auto & kinematics_aliases = e.kinematics_specification.aliases;
 
         // Set or alias kinematic specifications
@@ -431,15 +426,10 @@ namespace eos::exp
         }
 
         // Make observable
-        auto observable = Observable::make(
-            e.observable->name(),
-            this->_parameters,
-            this->_kinematics,
-            this->_options + e.observable->options()
-            );
+        auto observable = Observable::make(e.observable->name(), this->_parameters, this->_kinematics, this->_options + e.observable->options());
 
         // Clear aliases installed as part of this expression
-        for (const auto & alias: kinematics_aliases)
+        for (const auto & alias : kinematics_aliases)
         {
             _kinematics.remove_alias(alias.first);
         }
@@ -539,7 +529,7 @@ namespace eos::exp
         std::set<std::string> alias_set;
 
         const auto & entries = impl::observable_entries;
-        const auto & it = entries.find(e.observable_name);
+        const auto & it      = entries.find(e.observable_name);
 
         // check if 'e' matches the name of a known observable
         if (it != entries.end())
@@ -548,7 +538,7 @@ namespace eos::exp
 
             kinematic_set.insert(entry->begin_kinematic_variables(), entry->end_kinematic_variables());
 
-            const auto & kinematics_values = e.kinematics_specification.values;
+            const auto & kinematics_values  = e.kinematics_specification.values;
             const auto & kinematics_aliases = e.kinematics_specification.aliases;
 
             // Set or alias kinematic specifications
@@ -576,7 +566,7 @@ namespace eos::exp
             auto parameters = eos::Parameters::Defaults();
 
             // observable_name.full() is used below because if the observable has options, it cannot be a parameter
-            auto i = std::find_if(parameters.begin(), parameters.end(), [&] (const Parameter & p) { return p.name() == e.observable_name.full(); });
+            auto i = std::find_if(parameters.begin(), parameters.end(), [&](const Parameter & p) { return p.name() == e.observable_name.full(); });
             if (parameters.end() != i)
             {
                 return;
@@ -592,7 +582,7 @@ namespace eos::exp
         std::set<std::string> kinematic_set;
         std::set<std::string> alias_set;
 
-        const auto & kinematics_values = e.kinematics_specification.values;
+        const auto & kinematics_values  = e.kinematics_specification.values;
         const auto & kinematics_aliases = e.kinematics_specification.aliases;
 
         // Set or alias kinematic specifications
@@ -640,7 +630,7 @@ namespace eos::exp
         std::set<std::string> kinematic_set;
         std::set<std::string> alias_set;
 
-        const auto & kinematics_values = e.kinematics_specification.values;
+        const auto & kinematics_values  = e.kinematics_specification.values;
         const auto & kinematics_aliases = e.kinematics_specification.aliases;
 
         // Set or alias kinematic specifications
@@ -805,4 +795,4 @@ namespace eos::exp
             this->parameter_ids.insert(parameter_id);
         }
     }
-}
+} // namespace eos::exp

--- a/eos/utils/expression.cc
+++ b/eos/utils/expression.cc
@@ -19,6 +19,7 @@
 #include <eos/utils/exception.hh>
 #include <eos/utils/expression.hh>
 #include <eos/utils/stringify.hh>
+
 #include <math.h>
 
 namespace eos::exp
@@ -28,24 +29,47 @@ namespace eos::exp
     {
     }
 
-    double BinaryExpression::sum(const double & a, const double & b)        { return a + b; }
-    double BinaryExpression::difference(const double & a, const double & b) { return a - b; }
-    double BinaryExpression::product(const double & a, const double & b)    { return a * b; }
-    double BinaryExpression::ratio(const double & a, const double & b)      { return a / b; }
-    double BinaryExpression::power(const double & a, const double & b)      { return pow(a, b); }
+    double
+    BinaryExpression::sum(const double & a, const double & b)
+    {
+        return a + b;
+    }
+
+    double
+    BinaryExpression::difference(const double & a, const double & b)
+    {
+        return a - b;
+    }
+
+    double
+    BinaryExpression::product(const double & a, const double & b)
+    {
+        return a * b;
+    }
+
+    double
+    BinaryExpression::ratio(const double & a, const double & b)
+    {
+        return a / b;
+    }
+
+    double
+    BinaryExpression::power(const double & a, const double & b)
+    {
+        return pow(a, b);
+    }
 
     BinaryExpression::func
     BinaryExpression::Method(char op)
     {
-        switch(op) {
+        switch (op)
+        {
             case '+': return BinaryExpression::sum;
             case '-': return BinaryExpression::difference;
             case '*': return BinaryExpression::product;
             case '/': return BinaryExpression::ratio;
             case '^': return BinaryExpression::power;
-            default:
-                InternalError("Unknown binary operator '" + stringify(op) + "' encountered");
-                return nullptr;
+            default:  InternalError("Unknown binary operator '" + stringify(op) + "' encountered"); return nullptr;
         }
     }
 
@@ -54,17 +78,18 @@ namespace eos::exp
         fname(f),
         arg(arg)
     {
-        static const std::map<std::string, FunctionType> function_table
-        {
-            { std::string("exp"), FunctionType([] (const double & x) -> double { return std::exp(x); }) },
-            { std::string("sin"), FunctionType([] (const double & x) -> double { return std::sin(x); }) },
-            { std::string("cos"), FunctionType([] (const double & x) -> double { return std::cos(x); }) }
+        static const std::map<std::string, FunctionType> function_table{
+            { std::string("exp"), FunctionType([](const double & x) -> double { return std::exp(x); }) },
+            { std::string("sin"), FunctionType([](const double & x) -> double { return std::sin(x); }) },
+            { std::string("cos"), FunctionType([](const double & x) -> double { return std::cos(x); }) }
         };
 
         auto it = function_table.find(f);
         if (function_table.end() == it)
+        {
             throw ExpressionError("unknown function name " + f);
+        }
 
         this->f = it->second;
     }
-}
+} // namespace eos::exp

--- a/eos/utils/expression.hh
+++ b/eos/utils/expression.hh
@@ -26,14 +26,13 @@
 #include <eos/utils/qualified-name.hh>
 
 #include <cassert>
-#include <memory>
 #include <iostream>
 #include <map>
+#include <memory>
 
 namespace eos::exp
 {
-    class ExpressionError :
-        public eos::Exception
+    class ExpressionError : public eos::Exception
     {
         public:
             ExpressionError(const std::string & msg);
@@ -42,10 +41,10 @@ namespace eos::exp
     class BinaryExpression
     {
         public:
-            char op;
+            char       op;
             Expression lhs, rhs;
 
-            using func = double(*)(const double &, const double &);
+            using func = double (*)(const double &, const double &);
 
             static double sum(const double &, const double &);
             static double difference(const double &, const double &);
@@ -58,7 +57,9 @@ namespace eos::exp
             BinaryExpression() {}
 
             BinaryExpression(char op, const Expression & l, const Expression & r) :
-                op(op), lhs(l), rhs(r)
+                op(op),
+                lhs(l),
+                rhs(r)
             {
             }
     };
@@ -66,13 +67,13 @@ namespace eos::exp
     class FunctionExpression
     {
         public:
-            using FunctionType = double(*)(const double &);
+            using FunctionType = double (*)(const double &);
 
             FunctionType f;
-            std::string fname;
-            Expression arg;
+            std::string  fname;
+            Expression   arg;
 
-            FunctionExpression() {};
+            FunctionExpression() {}
 
             FunctionExpression(const std::string & f, const Expression & arg);
     };
@@ -82,7 +83,7 @@ namespace eos::exp
         public:
             double value;
 
-            ConstantExpression(const double& v = 0) :
+            ConstantExpression(const double & v = 0) :
                 value(v)
             {
             }
@@ -91,11 +92,20 @@ namespace eos::exp
     class KinematicsSpecification
     {
         public:
-            std::map<std::string, double> values;
+            std::map<std::string, double>      values;
             std::map<std::string, std::string> aliases;
 
-            void operator() (const std::pair<std::string, double> & value) { values.insert(value); }
-            void operator() (const std::pair<std::string, std::string> & alias) { aliases.insert(alias); }
+            void
+            operator() (const std::pair<std::string, double> & value)
+            {
+                values.insert(value);
+            }
+
+            void
+            operator() (const std::pair<std::string, std::string> & alias)
+            {
+                aliases.insert(alias);
+            }
     };
 
     class KinematicVariableNameExpression
@@ -104,7 +114,7 @@ namespace eos::exp
             std::string variable_name;
 
             KinematicVariableNameExpression(const std::string & variable_name) :
-                 variable_name(variable_name)
+                variable_name(variable_name)
             {
             }
     };
@@ -123,12 +133,12 @@ namespace eos::exp
     class ObservableNameExpression
     {
         public:
-            QualifiedName observable_name;
+            QualifiedName           observable_name;
             KinematicsSpecification kinematics_specification;
 
             ObservableNameExpression(const QualifiedName & observable_name, const KinematicsSpecification & kinematics_specification) :
-                 observable_name(observable_name),
-                 kinematics_specification(kinematics_specification)
+                observable_name(observable_name),
+                kinematics_specification(kinematics_specification)
             {
             }
     };
@@ -136,12 +146,12 @@ namespace eos::exp
     class ObservableExpression
     {
         public:
-            ObservablePtr observable;
+            ObservablePtr           observable;
             KinematicsSpecification kinematics_specification;
 
             ObservableExpression(ObservablePtr observable, const KinematicsSpecification & kinematics_specification) :
-                 observable(observable),
-                 kinematics_specification(kinematics_specification)
+                observable(observable),
+                kinematics_specification(kinematics_specification)
             {
             }
     };
@@ -149,8 +159,8 @@ namespace eos::exp
     class CachedObservableExpression
     {
         public:
-            ObservableCache cache;
-            ObservableCache::Id id;
+            ObservableCache         cache;
+            ObservableCache::Id     id;
             KinematicsSpecification kinematics_specification;
 
             CachedObservableExpression(const ObservableCache & cache, const ObservableCache::Id & id, const KinematicsSpecification & kinematics_specification) :
@@ -182,6 +192,6 @@ namespace eos::exp
             {
             }
     };
-}
+} // namespace eos::exp
 
 #endif

--- a/eos/utils/gsl-hacks.cc
+++ b/eos/utils/gsl-hacks.cc
@@ -35,7 +35,8 @@ namespace eos
 
     namespace gsl_cblas_hack
     {
-        void gsl_cblas_hack()
+        void
+        gsl_cblas_hack()
         {
             int lda = 3;
 
@@ -51,7 +52,7 @@ namespace eos
 
             cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, 2, 2, 3, 1.0, A, lda, B, ldb, 0.0, C, ldc);
         }
-    }
+    } // namespace gsl_cblas_hack
 
     /*
      * Disable GSL default error handler and register our own handler, which
@@ -59,16 +60,18 @@ namespace eos
      */
     namespace gsl_error_handler
     {
-        void gsl_error_handler(const char * reason, const char * /*file*/, int /*line*/, int gsl_errno)
+        void
+        gsl_error_handler(const char * reason, const char * /*file*/, int /*line*/, int gsl_errno)
         {
             throw GSLError(stringify(reason) + " (error code: " + stringify(gsl_errno) + ")");
         }
 
         void gsl_error_handler_hack() __attribute__((constructor));
 
-        void gsl_error_handler_hack()
+        void
+        gsl_error_handler_hack()
         {
-            gsl_error_handler_t * previous_gsl_error_handler __attribute__ ((unused)) = gsl_set_error_handler(&gsl_error_handler);
+            gsl_error_handler_t * previous_gsl_error_handler __attribute__((unused)) = gsl_set_error_handler(&gsl_error_handler);
         }
-    }
-}
+    } // namespace gsl_error_handler
+} // namespace eos

--- a/eos/utils/gsl-hacks_TEST.cc
+++ b/eos/utils/gsl-hacks_TEST.cc
@@ -17,16 +17,16 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/exception.hh>
+
+#include <test/test.hh>
 
 #include <gsl/gsl_sf.h>
 
 using namespace test;
 using namespace eos;
 
-class GSLErrorHandlerTest :
-    public TestCase
+class GSLErrorHandlerTest : public TestCase
 {
     public:
         GSLErrorHandlerTest() :
@@ -34,14 +34,12 @@ class GSLErrorHandlerTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-	    gsl_sf_result result;
-	    int status;
+            gsl_sf_result result;
+            int           status;
 
-	    TEST_CHECK_THROWS(GSLError,
-	    {
-            status = gsl_sf_expint_3_e(-1.0, &result);
-	    });
+            TEST_CHECK_THROWS(GSLError, { status = gsl_sf_expint_3_e(-1.0, &result); });
         }
 } gsl_error_handler_test;

--- a/eos/utils/indirect-iterator-fwd.hh
+++ b/eos/utils/indirect-iterator-fwd.hh
@@ -27,27 +27,19 @@
 
 namespace eos
 {
-    template <typename>
-    struct IndirectIteratorValueType;
+    template <typename> struct IndirectIteratorValueType;
 
-    template <typename Iter_, typename Value_ = typename IndirectIteratorValueType<
-        typename std::iterator_traits<Iter_>::value_type>::Type>
-    class IndirectIterator;
+    template <typename Iter_, typename Value_ = typename IndirectIteratorValueType<typename std::iterator_traits<Iter_>::value_type>::Type> class IndirectIterator;
 
-    template <typename Iter_>
-    IndirectIterator<Iter_> indirect_iterator(const Iter_ &);
+    template <typename Iter_> IndirectIterator<Iter_> indirect_iterator(const Iter_ &);
 
-    template <typename Iter_, typename Value_>
-    bool operator== (const IndirectIterator<Iter_, Value_> &, const IndirectIterator<Iter_, Value_> &);
+    template <typename Iter_, typename Value_> bool operator== (const IndirectIterator<Iter_, Value_> &, const IndirectIterator<Iter_, Value_> &);
 
-    template <typename Iter_, typename Value_>
-    bool operator!= (const IndirectIterator<Iter_, Value_> &, const IndirectIterator<Iter_, Value_> &);
+    template <typename Iter_, typename Value_> bool operator!= (const IndirectIterator<Iter_, Value_> &, const IndirectIterator<Iter_, Value_> &);
 
-    template <typename Iter_, typename Value_>
-    bool operator< (const IndirectIterator<Iter_, Value_> &, const IndirectIterator<Iter_, Value_> &);
+    template <typename Iter_, typename Value_> bool operator< (const IndirectIterator<Iter_, Value_> &, const IndirectIterator<Iter_, Value_> &);
 
-    template <typename Iter_, typename Value_>
-    bool operator> (const IndirectIterator<Iter_, Value_> &, const IndirectIterator<Iter_, Value_> &);
-}
+    template <typename Iter_, typename Value_> bool operator> (const IndirectIterator<Iter_, Value_> &, const IndirectIterator<Iter_, Value_> &);
+} // namespace eos
 
 #endif

--- a/eos/utils/indirect-iterator-impl.hh
+++ b/eos/utils/indirect-iterator-impl.hh
@@ -72,7 +72,7 @@ namespace eos
 
     template <typename Iter_, typename Value_>
     typename IndirectIterator<Iter_, Value_>::pointer
-    IndirectIterator<Iter_, Value_>::operator-> () const
+    IndirectIterator<Iter_, Value_>::operator->() const
     {
         return &**_iter;
     }
@@ -92,25 +92,29 @@ namespace eos
     }
 
     template <typename Iter_, typename Value_>
-    bool operator== (const IndirectIterator<Iter_, Value_> & lhs, const IndirectIterator<Iter_, Value_> & rhs)
+    bool
+    operator== (const IndirectIterator<Iter_, Value_> & lhs, const IndirectIterator<Iter_, Value_> & rhs)
     {
         return lhs._iter == rhs._iter;
     }
 
     template <typename Iter_, typename Value_>
-    bool operator!= (const IndirectIterator<Iter_, Value_> & lhs, const IndirectIterator<Iter_, Value_> & rhs)
+    bool
+    operator!= (const IndirectIterator<Iter_, Value_> & lhs, const IndirectIterator<Iter_, Value_> & rhs)
     {
         return lhs._iter != rhs._iter;
     }
 
     template <typename Iter_, typename Value_>
-    bool operator< (const IndirectIterator<Iter_, Value_> & lhs, const IndirectIterator<Iter_, Value_> & rhs)
+    bool
+    operator< (const IndirectIterator<Iter_, Value_> & lhs, const IndirectIterator<Iter_, Value_> & rhs)
     {
         return lhs._iter < rhs._iter;
     }
 
     template <typename Iter_, typename Value_>
-    bool operator> (const IndirectIterator<Iter_, Value_> & lhs, const IndirectIterator<Iter_, Value_> & rhs)
+    bool
+    operator> (const IndirectIterator<Iter_, Value_> & lhs, const IndirectIterator<Iter_, Value_> & rhs)
     {
         return rhs._iter < lhs._iter;
     }
@@ -121,6 +125,6 @@ namespace eos
     {
         return IndirectIterator<Iter_>(i);
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/indirect-iterator.hh
+++ b/eos/utils/indirect-iterator.hh
@@ -31,53 +31,46 @@
 
 namespace eos
 {
-    template <typename T_>
-    struct IndirectIteratorValueType
+    template <typename T_> struct IndirectIteratorValueType
     {
-        using Type = typename std::iterator_traits<T_>::value_type;
+            using Type = typename std::iterator_traits<T_>::value_type;
     };
 
-    template <typename T_>
-    struct IndirectIteratorValueType<T_ *>
+    template <typename T_> struct IndirectIteratorValueType<T_ *>
     {
-        using Type = T_;
+            using Type = T_;
     };
 
-    template <typename T_>
-    struct IndirectIteratorValueType<std::shared_ptr<T_> >
+    template <typename T_> struct IndirectIteratorValueType<std::shared_ptr<T_>>
     {
-        using Type = T_;
+            using Type = T_;
     };
 
-    template <typename T_>
-    struct IndirectIteratorValueType<std::shared_ptr<const T_> >
+    template <typename T_> struct IndirectIteratorValueType<std::shared_ptr<const T_>>
     {
-        using Type = const T_;
+            using Type = const T_;
     };
 
-    template <typename T_>
-    struct IndirectIteratorValueType<const T_>
+    template <typename T_> struct IndirectIteratorValueType<const T_>
     {
-        using Type = typename IndirectIteratorValueType<T_>::Type;
+            using Type = typename IndirectIteratorValueType<T_>::Type;
     };
 
-    template <typename T_>
-    struct IndirectIteratorValueType<T_ &>
+    template <typename T_> struct IndirectIteratorValueType<T_ &>
     {
-        using Type = typename IndirectIteratorValueType<T_>::Type;
+            using Type = typename IndirectIteratorValueType<T_>::Type;
     };
 
     /**
      * An IndirectIterator turns an iterator over T_ * or std::shared_ptr<T_> into an iterator
      * over T_.
      */
-    template <typename Iter_, typename Value_>
-    class IndirectIterator
+    template <typename Iter_, typename Value_> class IndirectIterator
     {
-        friend bool operator== <> (const IndirectIterator &, const IndirectIterator &);
-        friend bool operator!= <> (const IndirectIterator &, const IndirectIterator &);
-        friend bool operator< <> (const IndirectIterator &, const IndirectIterator &);
-        friend bool operator> <> (const IndirectIterator &, const IndirectIterator &);
+            friend bool operator== <>(const IndirectIterator &, const IndirectIterator &);
+            friend bool operator!= <>(const IndirectIterator &, const IndirectIterator &);
+            friend bool operator< <>(const IndirectIterator &, const IndirectIterator &);
+            friend bool operator><> (const IndirectIterator &, const IndirectIterator &);
 
         private:
             Iter_ _iter;
@@ -100,7 +93,7 @@ namespace eos
             typedef typename std::remove_reference<Value_>::type & value_type;
             typedef typename std::remove_reference<Value_>::type & reference;
             typedef typename std::remove_reference<Value_>::type * pointer;
-            using difference_type = std::ptrdiff_t;
+            using difference_type   = std::ptrdiff_t;
             using iterator_category = std::forward_iterator_tag;
 
             ///@}
@@ -116,14 +109,14 @@ namespace eos
             ///@{
 
             IndirectIterator & operator++ ();
-            IndirectIterator operator++ (int);
+            IndirectIterator   operator++ (int);
 
             ///@}
 
             ///@name Dereference
             ///@{
 
-            pointer operator-> () const;
+            pointer   operator->() const;
             reference operator* () const;
 
             underlying_iterator_type underlying_iterator();
@@ -134,8 +127,7 @@ namespace eos
     /**
      * Construct an IndirectIterator from another iterator.
      */
-    template <typename Iter_>
-    IndirectIterator<Iter_> indirect_iterator(const Iter_ & t);
-}
+    template <typename Iter_> IndirectIterator<Iter_> indirect_iterator(const Iter_ & t);
+} // namespace eos
 
 #endif

--- a/eos/utils/indirect-iterator_TEST.cc
+++ b/eos/utils/indirect-iterator_TEST.cc
@@ -21,13 +21,14 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/indirect-iterator-impl.hh>
 #include <eos/utils/stringify.hh>
 
+#include <test/test.hh>
+
 #include <algorithm>
-#include <vector>
 #include <list>
+#include <vector>
 
 using namespace test;
 using namespace eos;
@@ -36,17 +37,16 @@ namespace
 {
     struct Deleter
     {
-        template <typename T_>
-        void operator() (T_ t)
-        {
-            delete t;
-        }
+            template <typename T_>
+            void
+            operator() (T_ t)
+            {
+                delete t;
+            }
     };
-}
+} // namespace
 
-
-class IndirectIteratorTest :
-    public TestCase
+class IndirectIteratorTest : public TestCase
 {
     public:
         IndirectIteratorTest() :
@@ -54,14 +54,15 @@ class IndirectIteratorTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-            //TEST(IndirectIterator, VectorSharedInt)
+            // TEST(IndirectIterator, VectorSharedInt)
             {
-                std::vector<std::shared_ptr<int> > v;
+                std::vector<std::shared_ptr<int>> v;
                 v.push_back(std::shared_ptr<int>(std::make_shared<int>(5)));
                 v.push_back(std::shared_ptr<int>(std::make_shared<int>(10)));
-                IndirectIterator<std::vector<std::shared_ptr<int> >::iterator, int> vi(v.begin()), vi_end(v.end());
+                IndirectIterator<std::vector<std::shared_ptr<int>>::iterator, int> vi(v.begin()), vi_end(v.end());
                 TEST_CHECK(vi != vi_end);
                 TEST_CHECK(vi < vi_end);
                 TEST_CHECK(! (vi > vi_end));
@@ -73,12 +74,12 @@ class IndirectIteratorTest :
                 TEST_CHECK(++vi == vi_end);
             }
 
-            //TEST(IndirectIterator, ListSharedInt)
+            // TEST(IndirectIterator, ListSharedInt)
             {
-                std::list<std::shared_ptr<int> > v;
+                std::list<std::shared_ptr<int>> v;
                 v.push_back(std::shared_ptr<int>(std::make_shared<int>(5)));
                 v.push_back(std::shared_ptr<int>(std::make_shared<int>(10)));
-                IndirectIterator<std::list<std::shared_ptr<int> >::iterator> vi(v.begin()), vi_end(v.end());
+                IndirectIterator<std::list<std::shared_ptr<int>>::iterator> vi(v.begin()), vi_end(v.end());
                 TEST_CHECK(vi != vi_end);
                 TEST_CHECK_EQUAL(5, *vi);
                 TEST_CHECK(++vi != vi_end);
@@ -86,7 +87,7 @@ class IndirectIteratorTest :
                 TEST_CHECK(++vi == vi_end);
             }
 
-            //TEST(IndirectIterator, VectorIntStar)
+            // TEST(IndirectIterator, VectorIntStar)
             {
                 std::vector<int *> v;
                 v.push_back(new int(5));
@@ -105,7 +106,7 @@ class IndirectIteratorTest :
                 std::for_each(v.begin(), v.end(), Deleter());
             }
 
-            //TEST(IndirectIterator, ListIntStar)
+            // TEST(IndirectIterator, ListIntStar)
             {
                 std::list<int *> v;
                 v.push_back(new int(5));
@@ -120,7 +121,7 @@ class IndirectIteratorTest :
                 std::for_each(v.begin(), v.end(), Deleter());
             }
 
-            //TEST(IndirectIterator, ListIntListIterator)
+            // TEST(IndirectIterator, ListIntListIterator)
             {
                 std::list<int> v;
                 v.push_back(5);

--- a/eos/utils/instantiation_policy-impl.hh
+++ b/eos/utils/instantiation_policy-impl.hh
@@ -36,14 +36,13 @@ namespace eos
         delete ptr;
     }
 
-    template <typename T_>
-    class InstantiationPolicy<T_, Singleton>::DeleteOnDestruction
+    template <typename T_> class InstantiationPolicy<T_, Singleton>::DeleteOnDestruction
     {
         private:
-            T_ * * const _ptr;
+            T_ ** const _ptr;
 
         public:
-            DeleteOnDestruction(T_ * * const ptr) :
+            DeleteOnDestruction(T_ ** const ptr) :
                 _ptr(ptr)
             {
             }
@@ -57,10 +56,10 @@ namespace eos
     };
 
     template <typename T_>
-    T_ * *
+    T_ **
     InstantiationPolicy<T_, Singleton>::_instance_ptr()
     {
-        static T_ * instance(0);
+        static T_ *                instance(0);
         static DeleteOnDestruction delete_instance(&instance);
 
         return &instance;
@@ -70,12 +69,12 @@ namespace eos
     T_ *
     InstantiationPolicy<T_, Singleton>::instance()
     {
-        T_ * * instance_ptr(_instance_ptr());
+        T_ ** instance_ptr(_instance_ptr());
 
         if (0 == *instance_ptr)
         {
             static Mutex m;
-            Lock l(m);
+            Lock         l(m);
 
             instance_ptr = _instance_ptr();
 
@@ -87,6 +86,6 @@ namespace eos
 
         return *instance_ptr;
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/instantiation_policy.hh
+++ b/eos/utils/instantiation_policy.hh
@@ -69,9 +69,7 @@ namespace eos
 
         public:
             /// Default constructor.
-            InstantiationPolicy()
-            {
-            }
+            InstantiationPolicy() {}
     };
 
     template <typename T_> class InstantiationPolicy<T_, NonInstantiable>
@@ -95,7 +93,7 @@ namespace eos
             friend class DeleteOnDestruction;
 
             /// Returns a pointer to our instance pointer.
-            static T_ * * _instance_ptr();
+            static T_ ** _instance_ptr();
 
             /// Deletes the object of T_ that is pointed at by ptr.
             static void _delete(T_ * const ptr);
@@ -108,17 +106,14 @@ namespace eos
 
         protected:
             /// Default constructor.
-            InstantiationPolicy()
-            {
-            }
+            InstantiationPolicy() {}
 
         public:
             /// Returns the instance.
             static T_ * instance();
-
     };
 
     /// \}
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/iterator-range.hh
+++ b/eos/utils/iterator-range.hh
@@ -41,9 +41,18 @@ namespace eos
 
             ~IteratorRange() = default;
 
-            Iterator_ begin() { return _begin; }
-            Iterator_ end() { return _end; }
+            Iterator_
+            begin()
+            {
+                return _begin;
+            }
+
+            Iterator_
+            end()
+            {
+                return _end;
+            }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/join.hh
+++ b/eos/utils/join.hh
@@ -28,8 +28,8 @@ namespace eos
      * Join a range of iterators [it, end) with the separator sep.
      */
     template <typename Iter_>
-    std::string join(Iter_ it, const Iter_ & end,
-            const std::string & sep = ", ")
+    std::string
+    join(Iter_ it, const Iter_ & end, const std::string & sep = ", ")
     {
         if (it == end)
         {
@@ -40,13 +40,13 @@ namespace eos
 
         ss << *(it++);
 
-        for ( ; it != end ; ++it)
+        for (; it != end; ++it)
         {
             ss << sep << *it;
         }
 
         return ss.str();
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/join_TEST.cc
+++ b/eos/utils/join_TEST.cc
@@ -17,19 +17,18 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/join.hh>
 
-#include <list>
-#include <vector>
+#include <test/test.hh>
 
 #include <iostream>
+#include <list>
+#include <vector>
 
 using namespace test;
 using namespace eos;
 
-class JoinTest :
-    public TestCase
+class JoinTest : public TestCase
 {
     public:
         JoinTest() :
@@ -37,7 +36,8 @@ class JoinTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // filled vector
             {
@@ -46,7 +46,7 @@ class JoinTest :
                 std::cout << join(items.begin(), items.end()) << std::endl;
                 TEST_CHECK_EQUAL("1, 4, 7", join(items.begin(), items.end()));
                 TEST_CHECK_EQUAL("1, 4, 7", join(items.begin(), items.end(), ", "));
-                TEST_CHECK_EQUAL("1:4:7",   join(items.begin(), items.end(), ":"));
+                TEST_CHECK_EQUAL("1:4:7", join(items.begin(), items.end(), ":"));
             }
 
             // empty list

--- a/eos/utils/kinematic.cc
+++ b/eos/utils/kinematic.cc
@@ -27,25 +27,23 @@
 
 namespace eos
 {
-    template <>
-    struct WrappedForwardIteratorTraits<Kinematics::KinematicVariableIteratorTag>
+    template <> struct WrappedForwardIteratorTraits<Kinematics::KinematicVariableIteratorTag>
     {
-        using UnderlyingIterator = std::vector<KinematicVariable>::iterator;
+            using UnderlyingIterator = std::vector<KinematicVariable>::iterator;
     };
     template class WrappedForwardIterator<Kinematics::KinematicVariableIteratorTag, const KinematicVariable>;
 
-    template <>
-    struct Implementation<Kinematics>
+    template <> struct Implementation<Kinematics>
     {
-        std::vector<double> variables_data;
+            std::vector<double> variables_data;
 
-        std::map<std::string, unsigned> variables_map;
+            std::map<std::string, unsigned> variables_map;
 
-        std::vector<std::string> variables_names;
+            std::vector<std::string> variables_names;
 
-        std::map<std::string, unsigned> alias_map;
+            std::map<std::string, unsigned> alias_map;
 
-        std::vector<KinematicVariable> variables;
+            std::vector<KinematicVariable> variables;
     };
 
     Kinematics::Kinematics() :
@@ -62,7 +60,7 @@ namespace eos
 
             if (_imp->variables_map.end() == i)
             {
-                int index = _imp->variables_data.size();
+                int index                    = _imp->variables_data.size();
                 _imp->variables_map[v.first] = index;
                 _imp->variables_data.push_back(v.second);
                 _imp->variables_names.push_back(v.first);
@@ -70,15 +68,13 @@ namespace eos
             }
             else
             {
-                _imp->variables_data[i->second] = v.second;
+                _imp->variables_data[i->second]  = v.second;
                 _imp->variables_names[i->second] = v.first;
             }
         }
     }
 
-    Kinematics::~Kinematics()
-    {
-    }
+    Kinematics::~Kinematics() {}
 
     Kinematics
     Kinematics::clone() const
@@ -91,7 +87,7 @@ namespace eos
     }
 
     Kinematics
-    Kinematics::operator+(const Kinematics & rhs) const
+    Kinematics::operator+ (const Kinematics & rhs) const
     {
         Kinematics result = this->clone();
 
@@ -112,24 +108,34 @@ namespace eos
     Kinematics::operator== (const Kinematics & rhs) const
     {
         if (_imp->variables_map.size() != rhs._imp->variables_map.size())
+        {
             return false;
+        }
 
-        for (auto l = _imp->variables_map.cbegin(), l_end = _imp->variables_map.cend(), r = rhs._imp->variables_map.cbegin() ; l != l_end ; ++l, ++r)
+        for (auto l = _imp->variables_map.cbegin(), l_end = _imp->variables_map.cend(), r = rhs._imp->variables_map.cbegin(); l != l_end; ++l, ++r)
         {
             if (l->first != r->first)
+            {
                 return false;
+            }
 
             if (_imp->variables_data[l->second] != rhs._imp->variables_data[r->second])
+            {
                 return false;
+            }
         }
 
         if (_imp->alias_map.size() != rhs._imp->alias_map.size())
+        {
             return false;
+        }
 
-        for (auto l = _imp->alias_map.cbegin() , l_end = _imp->alias_map.cend(), r = rhs._imp->alias_map.cbegin() ; l != l_end ; ++l, ++r)
+        for (auto l = _imp->alias_map.cbegin(), l_end = _imp->alias_map.cend(), r = rhs._imp->alias_map.cbegin(); l != l_end; ++l, ++r)
         {
             if (l->first != r->first)
+            {
                 return false;
+            }
         }
 
         return true;
@@ -147,18 +153,22 @@ namespace eos
         auto i(_imp->variables_map.find(name));
 
         if (_imp->variables_map.end() != i)
+        {
             return KinematicVariable(_imp, i->second, false);
+        }
 
         auto j(_imp->alias_map.find(name));
 
         if (_imp->alias_map.end() != j)
+        {
             return KinematicVariable(_imp, j->second, true);
+        }
 
         throw UnknownKinematicVariableError(name);
     }
 
     std::string
-    Kinematics::as_string () const
+    Kinematics::as_string() const
     {
         std::string result;
 
@@ -169,13 +179,13 @@ namespace eos
             ++i;
         }
 
-        for ( ; i != i_end ; ++i)
+        for (; i != i_end; ++i)
         {
             result += ", " + i->first + '=' + stringify(_imp->variables_data[i->second]);
         }
 
         auto j(_imp->alias_map.cbegin()), j_end(_imp->alias_map.cend());
-        for ( ; j != j_end ; ++j)
+        for (; j != j_end; ++j)
         {
             result += ", " + j->first + "->" + _imp->variables_names[j->second];
         }
@@ -189,11 +199,13 @@ namespace eos
     {
         const auto i(_imp->variables_map.find(name));
         const auto j(_imp->alias_map.find(name));
-        bool name_exists  = (_imp->variables_map.end() != i);
-        bool alias_exists = (_imp->alias_map.end() != j);
+        bool       name_exists  = (_imp->variables_map.end() != i);
+        bool       alias_exists = (_imp->alias_map.end() != j);
 
         if (! name_exists)
+        {
             throw UnknownKinematicVariableError(name);
+        }
 
         if (alias_exists)
         {
@@ -209,7 +221,9 @@ namespace eos
         const auto i(_imp->alias_map.find(alias));
 
         if (_imp->alias_map.end() == i)
+        {
             throw UnknownKinematicAliasError(alias);
+        }
 
         _imp->alias_map.erase(i);
     }
@@ -225,13 +239,13 @@ namespace eos
     {
         const auto i(_imp->variables_map.find(name));
         const auto j(_imp->alias_map.find(name));
-        bool regular    = (_imp->variables_map.end() != i);
-        bool alias      = (_imp->alias_map.end() != j);
-        bool undeclared = (! regular) && (! alias);
+        bool       regular    = (_imp->variables_map.end() != i);
+        bool       alias      = (_imp->alias_map.end() != j);
+        bool       undeclared = (! regular) && (! alias);
 
         if (undeclared)
         {
-            int index = _imp->variables_data.size();
+            int index                 = _imp->variables_data.size();
             _imp->variables_map[name] = index;
             _imp->variables_data.push_back(value);
             _imp->variables_names.push_back(name);
@@ -258,17 +272,23 @@ namespace eos
     {
         const auto i(_imp->variables_map.find(name));
         const auto j(_imp->alias_map.find(name));
-        bool regular    = (_imp->variables_map.end() != i);
-        bool alias      = (_imp->alias_map.end() == j);
-        bool undeclared = (! regular) && (! alias);
+        bool       regular    = (_imp->variables_map.end() != i);
+        bool       alias      = (_imp->alias_map.end() == j);
+        bool       undeclared = (! regular) && (! alias);
 
         if (undeclared)
+        {
             throw UnknownKinematicVariableError(name);
+        }
 
         if (regular)
+        {
             _imp->variables_data[i->second] = value;
+        }
         else // alias
+        {
             _imp->variables_data[j->second] = value;
+        }
     }
 
     Kinematics::KinematicVariableIterator
@@ -290,9 +310,7 @@ namespace eos
     {
     }
 
-    KinematicVariable::~KinematicVariable()
-    {
-    }
+    KinematicVariable::~KinematicVariable() {}
 
     MutablePtr
     KinematicVariable::clone() const
@@ -337,18 +355,18 @@ namespace eos
         return _imp->variables_names[_index];
     }
 
-    UnknownKinematicVariableError::UnknownKinematicVariableError(const std::string & variable) throw () :
+    UnknownKinematicVariableError::UnknownKinematicVariableError(const std::string & variable) throw() :
         Exception("Unknown kinematic variable: '" + variable + "'")
     {
     }
 
-    DuplicateKinematicAliasError::DuplicateKinematicAliasError(const std::string & alias, const std::string & variable) throw () :
+    DuplicateKinematicAliasError::DuplicateKinematicAliasError(const std::string & alias, const std::string & variable) throw() :
         Exception("Alias: '" + alias + "' cannot be used for variable: '" + variable + "' since it was already defined")
     {
     }
 
-    UnknownKinematicAliasError::UnknownKinematicAliasError(const std::string & alias) throw () :
+    UnknownKinematicAliasError::UnknownKinematicAliasError(const std::string & alias) throw() :
         Exception("Unknown kinematic alias: '" + alias + "'")
     {
     }
-}
+} // namespace eos

--- a/eos/utils/kinematic.hh
+++ b/eos/utils/kinematic.hh
@@ -31,29 +31,26 @@ namespace eos
      * UnknownKinematicVariableError is thrown when no parameter of a given
      * name could be found.
      */
-    struct UnknownKinematicVariableError :
-        public Exception
+    struct UnknownKinematicVariableError : public Exception
     {
-        UnknownKinematicVariableError(const std::string & variable) throw ();
+            UnknownKinematicVariableError(const std::string & variable) throw();
     };
 
     /*!
      * DuplicateKinematicAliasError is thrown when an alias is defined twice.
      */
-    struct DuplicateKinematicAliasError :
-        public Exception
+    struct DuplicateKinematicAliasError : public Exception
     {
-        DuplicateKinematicAliasError(const std::string & alias, const std::string & variable) throw ();
+            DuplicateKinematicAliasError(const std::string & alias, const std::string & variable) throw();
     };
 
     /*!
      * UnknownKinematicAliasError is thrown when no alias of a given
      * name could be found.
      */
-    struct UnknownKinematicAliasError :
-        public Exception
+    struct UnknownKinematicAliasError : public Exception
     {
-        UnknownKinematicAliasError(const std::string & alias) throw ();
+            UnknownKinematicAliasError(const std::string & alias) throw();
     };
 
     // Forward declaration.
@@ -66,8 +63,7 @@ namespace eos
      * a KinematicVariable object will propagate to every other object with the same
      * parent Kinematics and which handle the same variable by name.
      */
-    class Kinematics :
-        public PrivateImplementationPattern<Kinematics>
+    class Kinematics : public PrivateImplementationPattern<Kinematics>
     {
         public:
             ///@name Basic Functions
@@ -93,7 +89,7 @@ namespace eos
              */
             Kinematics clone() const;
 
-            Kinematics operator+(const Kinematics & rhs) const;
+            Kinematics operator+ (const Kinematics & rhs) const;
 
             /// Equality comparison operator.
             bool operator== (const Kinematics & rhs) const;
@@ -173,8 +169,7 @@ namespace eos
     /*!
      * KinematicVariable is the class that holds all information of one of KinematicVariables' parameters.
      */
-    class KinematicVariable :
-        public Mutable
+    class KinematicVariable : public Mutable
     {
         private:
             ///@name Internal Data
@@ -226,14 +221,14 @@ namespace eos
             /// Retrieve the Parameter's name.
             virtual const std::string & name() const;
             ///@}
-
     };
 
     template <typename T>
-    inline T lambda(const T & a, const T & b, const T & c)
+    inline T
+    lambda(const T & a, const T & b, const T & c)
     {
         return a * a + b * b + c * c - 2.0 * (a * b + a * c + b * c);
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/kinematic_TEST.cc
+++ b/eos/utils/kinematic_TEST.cc
@@ -17,16 +17,16 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/kinematic.hh>
+
+#include <test/test.hh>
 
 #include <cmath>
 
 using namespace test;
 using namespace eos;
 
-class KinematicsTest :
-    public TestCase
+class KinematicsTest : public TestCase
 {
     public:
         KinematicsTest() :
@@ -34,12 +34,12 @@ class KinematicsTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // Creation from initializer list
             {
-                Kinematics kinematics
-                {
+                Kinematics kinematics{
                     { "s_min", 1.0 },
                     { "s_max", 6.0 },
                 };
@@ -50,8 +50,7 @@ class KinematicsTest :
 
             // Creation from initializer list and aliasing
             {
-                Kinematics kinematics
-                {
+                Kinematics kinematics{
                     { "s_min", 1.0 },
                     { "s_max", 6.0 },
                 };
@@ -125,10 +124,9 @@ class KinematicsTest :
 
             // Iteration (check for names, values, and order)
             {
-                Kinematics k
-                {
-                    { "s_min",       1.0 },
-                    { "s_max",       6.0 },
+                Kinematics k{
+                    {      "s_min",  1.0 },
+                    {      "s_max",  6.0 },
                     { "cos(theta)", -0.5 },
                 };
 
@@ -150,10 +148,9 @@ class KinematicsTest :
 
             // Iteration (check for names, values, and order, in presence of an alias)
             {
-                Kinematics k
-                {
-                    { "s_min",       1.0 },
-                    { "s_max",       6.0 },
+                Kinematics k{
+                    {      "s_min",  1.0 },
+                    {      "s_max",  6.0 },
                     { "cos(theta)", -0.5 },
                 };
                 k.alias("z", "cos(theta)");

--- a/eos/utils/kmatrix.cc
+++ b/eos/utils/kmatrix.cc
@@ -17,14 +17,15 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <eos/utils/kmatrix.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/utils/kmatrix.hh>
 
 namespace eos
 {
     namespace kmatrix_utils
     {
-        complex<double> blatt_weisskopf_factor(const unsigned & l, const complex<double> & z)
+        complex<double>
+        blatt_weisskopf_factor(const unsigned & l, const complex<double> & z)
         {
             const complex<double> z2 = z * z;
 
@@ -32,19 +33,13 @@ namespace eos
             {
                 // We use the definitions of the PDG's resonance review
                 // they agree with [CBHKSS:1995A], keeping only the denominator (numerators are accounted for in the K matrix definition)
-                case 0:
-                    return 1.0;
-                case 1:
-                    return std::sqrt(1.0 / (z2 + 1.0));
-                case 2:
-                    return std::sqrt(1.0 / (9.0 + z2 * (3.0 + z2)));
-                case 3:
-                    return std::sqrt(1.0 / (z2 * power_of<2>(z2 - 15.0) + 9.0 * power_of<2>(2.0 * z2 - 5.0))); // This one is wrong in [CBHKSS:1995A]
-                case 4:
-                    return std::sqrt(1.0 / (power_of<2>(power_of<2>(z2) - 45.0 * z2 + 105.0) + 25.0 * z2 * power_of<2>(2.0 * z2 - 21.0)));
-                default:
-                    throw InternalError("Blatt-Weisskopf factors are not implemented for l > 4.");
+                case 0:  return 1.0;
+                case 1:  return std::sqrt(1.0 / (z2 + 1.0));
+                case 2:  return std::sqrt(1.0 / (9.0 + z2 * (3.0 + z2)));
+                case 3:  return std::sqrt(1.0 / (z2 * power_of<2>(z2 - 15.0) + 9.0 * power_of<2>(2.0 * z2 - 5.0))); // This one is wrong in [CBHKSS:1995A]
+                case 4:  return std::sqrt(1.0 / (power_of<2>(power_of<2>(z2) - 45.0 * z2 + 105.0) + 25.0 * z2 * power_of<2>(2.0 * z2 - 21.0)));
+                default: throw InternalError("Blatt-Weisskopf factors are not implemented for l > 4.");
             }
         }
-    }
-}
+    } // namespace kmatrix_utils
+} // namespace eos

--- a/eos/utils/kmatrix.hh
+++ b/eos/utils/kmatrix.hh
@@ -36,18 +36,16 @@
 
 namespace eos
 {
-    template <unsigned nchannels_, unsigned nresonances_>
-    class KMatrix
+    template <unsigned nchannels_, unsigned nresonances_> class KMatrix
     {
         public:
-
             struct Channel;
             struct Resonance;
 
-            std::array<std::shared_ptr<KMatrix::Channel>, nchannels_> _channels;
+            std::array<std::shared_ptr<KMatrix::Channel>, nchannels_>     _channels;
             std::array<std::shared_ptr<KMatrix::Resonance>, nresonances_> _resonances;
             // The non-resonant contribution is described with a set of constants
-            std::array<std::array<Parameter, nchannels_>, nchannels_> _bkgcst;
+            std::array<std::array<Parameter, nchannels_>, nchannels_>     _bkgcst;
 
             const std::string & _prefix;
 
@@ -61,13 +59,11 @@ namespace eos
             gsl_matrix_complex * _tmp_1;
             gsl_matrix_complex * _tmp_2;
             gsl_matrix_complex * _tmp_3;
-            gsl_permutation * _perm;
+            gsl_permutation *    _perm;
 
             // Constructor
-            KMatrix(std::array<std::shared_ptr<KMatrix::Channel>, nchannels_> channels,
-                std::array<std::shared_ptr<KMatrix::Resonance>, nresonances_> resonances,
-                std::array<std::array<Parameter, nchannels_>, nchannels_> bkgcst,
-                const std::string & prefix);
+            KMatrix(std::array<std::shared_ptr<KMatrix::Channel>, nchannels_> channels, std::array<std::shared_ptr<KMatrix::Resonance>, nresonances_> resonances,
+                    std::array<std::array<Parameter, nchannels_>, nchannels_> bkgcst, const std::string & prefix);
 
             // Destructor
             ~KMatrix();
@@ -91,65 +87,67 @@ namespace eos
             double spectral_function(unsigned resonance, const double & s) const;
     };
 
-
-    template <unsigned nchannels_, unsigned nresonances_>
-    struct KMatrix<nchannels_, nresonances_>::Channel
+    template <unsigned nchannels_, unsigned nresonances_> struct KMatrix<nchannels_, nresonances_>::Channel
     {
-        std::string _name;
-        //Masses of the two final state particles
-        Parameter _m1;
-        Parameter _m2;
+            std::string _name;
+            // Masses of the two final state particles
+            Parameter   _m1;
+            Parameter   _m2;
 
-        // Properties of the centrifugal barrier factors, cf (50.26)
-        unsigned _l_orbital;
-        Parameter _q0;
+            // Properties of the centrifugal barrier factors, cf (50.26)
+            unsigned  _l_orbital;
+            Parameter _q0;
 
-        std::array<Parameter, nresonances_> _g0s;
+            std::array<Parameter, nresonances_> _g0s;
 
-        Channel(std::string name, Parameter m1, Parameter m2, unsigned l_orbital, Parameter q0, std::array<Parameter, nresonances_> g0s) :
-            _name(name),
-            _m1(m1),
-            _m2(m2),
-            _l_orbital(l_orbital),
-            _q0(q0),
-            _g0s(g0s)
-        {
-            if (m1.evaluate() < 0 || m2.evaluate() < 0)
-                throw InternalError("Masses of channel '" + _name + "' must be positive");
-            if (q0.evaluate() < 0)
-                throw InternalError("Scale parameter of the channel'" + _name + "' must be positive");
-        };
+            Channel(std::string name, Parameter m1, Parameter m2, unsigned l_orbital, Parameter q0, std::array<Parameter, nresonances_> g0s) :
+                _name(name),
+                _m1(m1),
+                _m2(m2),
+                _l_orbital(l_orbital),
+                _q0(q0),
+                _g0s(g0s)
+            {
+                if (m1.evaluate() < 0 || m2.evaluate() < 0)
+                {
+                    throw InternalError("Masses of channel '" + _name + "' must be positive");
+                }
+                if (q0.evaluate() < 0)
+                {
+                    throw InternalError("Scale parameter of the channel'" + _name + "' must be positive");
+                }
+            }
 
-        // Phase space factor
-        virtual complex<double> rho(const complex<double> & s) = 0;
+            // Phase space factor
+            virtual complex<double> rho(const complex<double> & s) = 0;
 
-        // Analytic continuation of the phase space factor
-        virtual complex<double> chew_mandelstam(const complex<double> & s) = 0;
+            // Analytic continuation of the phase space factor
+            virtual complex<double> chew_mandelstam(const complex<double> & s) = 0;
     };
 
-
-    template <unsigned nchannels_, unsigned nresonances_>
-    struct KMatrix<nchannels_, nresonances_>::Resonance
+    template <unsigned nchannels_, unsigned nresonances_> struct KMatrix<nchannels_, nresonances_>::Resonance
     {
-        std::string _name;
+            std::string _name;
 
-        // Mass of the resonance
-        Parameter _m;
+            // Mass of the resonance
+            Parameter _m;
 
-        Resonance(std::string name, Parameter m) :
-            _name(name),
-            _m(m)
-        {
-            if (m.evaluate() < 0)
-                throw InternalError("Mass of resonance '" + _name + "' must be positive");
-        };
+            Resonance(std::string name, Parameter m) :
+                _name(name),
+                _m(m)
+            {
+                if (m.evaluate() < 0)
+                {
+                    throw InternalError("Mass of resonance '" + _name + "' must be positive");
+                }
+            }
     };
 
     namespace kmatrix_utils
     {
         // We follow the notation of the PDG's resonance review, i.e. z = (q / q0)
         complex<double> blatt_weisskopf_factor(const unsigned & l, const complex<double> & z);
-    }
-}
+    } // namespace kmatrix_utils
+} // namespace eos
 
 #endif

--- a/eos/utils/kmatrix_TEST.cc
+++ b/eos/utils/kmatrix_TEST.cc
@@ -15,11 +15,12 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/maths/complex.hh>
 #include <eos/maths/power-of.hh>
 #include <eos/utils/kmatrix-impl.hh>
 #include <eos/utils/parameters.hh>
+
+#include <test/test.hh>
 
 #include <cmath>
 #include <memory>
@@ -31,97 +32,97 @@ using namespace eos;
 /// Generic channel with two Pseudoscalars
 //////////////////////////////////////////
 template <typename T, T... indices>
-auto _parameter_names(const Parameters & p, std::integer_sequence<T, indices...>)
-    -> std::array<eos::Parameter, sizeof...(indices)>
+auto
+_parameter_names(const Parameters & p, std::integer_sequence<T, indices...>) -> std::array<eos::Parameter, sizeof...(indices)>
 {
-    return std::array<eos::Parameter, sizeof...(indices)>
-    {{
-        p["test::g0_" + std::to_string(indices + 1) + ""]...
-    }};
+    return std::array<eos::Parameter, sizeof...(indices)>{ { p["test::g0_" + std::to_string(indices + 1) + ""]... } };
 }
 
-template <unsigned nchannels_, unsigned nresonances_>
-struct PPchannel:
-    public KMatrix<nchannels_, nresonances_>::Channel
+template <unsigned nchannels_, unsigned nresonances_> struct PPchannel : public KMatrix<nchannels_, nresonances_>::Channel
 {
-    PPchannel(std::string name, Parameter m1, Parameter m2, unsigned l_orbital, const Parameters & p) :
-        KMatrix<nchannels_, nresonances_>::Channel(name, m1, m2, l_orbital, p["test::q0"], _parameter_names(p, std::make_index_sequence<nresonances_>()))
-    {
-    };
-
-    double mm = this->_m1 - this->_m2;
-    double mp = this->_m1 + this->_m2;
-    // sqrt of the Källen factor, defined with an absolute value
-    double sqlk(const complex<double> & s)
-    {
-        return std::sqrt(std::abs((s - mp * mp) * (s - mm * mm)));
-    }
-    const double pi = M_PI;
-    const complex<double> i = complex<double>(0.0, 1.0);
-
-    complex<double> rho(const complex<double> & s)
-    {
-        if (real(s) < mp * mp)
-            return 0.;
-        else
-            return sqlk(s) / abs(s) / 16.0 / pi;
-    }
-
-    complex<double> chew_mandelstam(const complex<double> & S)
-    {
-        double s = real(S);
-
-        complex<double> result = 0.0;
-        if (s < mm * mm)
+        PPchannel(std::string name, Parameter m1, Parameter m2, unsigned l_orbital, const Parameters & p) :
+            KMatrix<nchannels_, nresonances_>::Channel(name, m1, m2, l_orbital, p["test::q0"], _parameter_names(p, std::make_index_sequence<nresonances_>()))
         {
-            result += mm * (mp * mp - s) * std::log((mm + mp) / (mp - mm));
-            result += mp * sqlk(s) * std::log((mm * mm + mp * mp - 2 * s - 2 * sqlk(s)) / (mp * mp - mm * mm));
-            result *= -1.0 / (mp * pi * s);
-
-            return result / 16.0 / pi;
         }
-        else if (s < mp * mp)
+
+        double mm = this->_m1 - this->_m2;
+        double mp = this->_m1 + this->_m2;
+
+        // sqrt of the Källen factor, defined with an absolute value
+        double
+        sqlk(const complex<double> & s)
         {
-            result += mm * (mp * mp - s) * std::log((mm + mp) / (mp - mm));
-            result += 2 * mp * sqlk(s) * std::atan(std::sqrt((s - mm * mm) / (mp * mp - s)));
-            result *= -1.0 / (mp * pi * s);
-
-            return result / 16.0 / pi;
+            return std::sqrt(std::abs((s - mp * mp) * (s - mm * mm)));
         }
-        else
+
+        const double          pi = M_PI;
+        const complex<double> i  = complex<double>(0.0, 1.0);
+
+        complex<double>
+        rho(const complex<double> & s)
         {
-            result += mm * (mp * mp - s) * std::log((mm + mp) / (mp - mm));
-            result += mp * sqlk(s) * std::log((2 * s + 2 * sqlk(s) - mm * mm - mp * mp) / (mp * mp - mm * mm));
-            result *= -1.0 / (mp * pi * s);
-            result += i * sqlk(s) / s;
-
-            return result / 16.0 / pi;
+            if (real(s) < mp * mp)
+            {
+                return 0.;
+            }
+            else
+            {
+                return sqlk(s) / abs(s) / 16.0 / pi;
+            }
         }
-    }
 
+        complex<double>
+        chew_mandelstam(const complex<double> & S)
+        {
+            double s = real(S);
+
+            complex<double> result = 0.0;
+            if (s < mm * mm)
+            {
+                result += mm * (mp * mp - s) * std::log((mm + mp) / (mp - mm));
+                result += mp * sqlk(s) * std::log((mm * mm + mp * mp - 2 * s - 2 * sqlk(s)) / (mp * mp - mm * mm));
+                result *= -1.0 / (mp * pi * s);
+
+                return result / 16.0 / pi;
+            }
+            else if (s < mp * mp)
+            {
+                result += mm * (mp * mp - s) * std::log((mm + mp) / (mp - mm));
+                result += 2 * mp * sqlk(s) * std::atan(std::sqrt((s - mm * mm) / (mp * mp - s)));
+                result *= -1.0 / (mp * pi * s);
+
+                return result / 16.0 / pi;
+            }
+            else
+            {
+                result += mm * (mp * mp - s) * std::log((mm + mp) / (mp - mm));
+                result += mp * sqlk(s) * std::log((2 * s + 2 * sqlk(s) - mm * mm - mp * mp) / (mp * mp - mm * mm));
+                result *= -1.0 / (mp * pi * s);
+                result += i * sqlk(s) / s;
+
+                return result / 16.0 / pi;
+            }
+        }
 };
 
-template <unsigned nchannels_, unsigned nresonances_>
-struct resonance :
-    public KMatrix<nchannels_, nresonances_>::Resonance
+template <unsigned nchannels_, unsigned nresonances_> struct resonance : public KMatrix<nchannels_, nresonances_>::Resonance
 {
-    resonance(std::string name, Parameter m) :
-        KMatrix<nchannels_, nresonances_>::Resonance(name, m)
-    {
-    };
+        resonance(std::string name, Parameter m) :
+            KMatrix<nchannels_, nresonances_>::Resonance(name, m)
+        {
+        }
 };
 
-complex<double> BreitWigner(complex<double> const s, complex<double> const M, complex<double> const Ga)
+complex<double>
+BreitWigner(const complex<double> s, const complex<double> M, const complex<double> Ga)
 {
     return M * M * Ga * Ga / (power_of<2>(s - M * M) + M * M * Ga * Ga);
 }
 
-
 /////////
 /// TESTS
 /////////
-class KMatrixTest :
-    public TestCase
+class KMatrixTest : public TestCase
 {
     public:
         KMatrixTest() :
@@ -129,19 +130,19 @@ class KMatrixTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-
             constexpr double eps = 1e-4;
 
-            Parameters::declare("test::g0_1", "g_0^1", Unit::None(),  1.0);
-            Parameters::declare("test::g0_2", "g_0^2", Unit::None(),  2.2);
-            Parameters::declare("test::c_1",  "c_1",   Unit::None(),  0.0);
-            Parameters::declare("test::m_1",  "m_1",   Unit::GeV(),  20.0);
-            Parameters::declare("test::m_2",  "m_2",   Unit::GeV(),   2.0);
-            Parameters::declare("test::m_a",  "m_a",   Unit::GeV(),   0.7);
-            Parameters::declare("test::m_b",  "m_b",   Unit::GeV(),   0.8);
-            Parameters::declare("test::q0",   "q0",    Unit::GeV(),   0.2);
+            Parameters::declare("test::g0_1", "g_0^1", Unit::None(), 1.0);
+            Parameters::declare("test::g0_2", "g_0^2", Unit::None(), 2.2);
+            Parameters::declare("test::c_1", "c_1", Unit::None(), 0.0);
+            Parameters::declare("test::m_1", "m_1", Unit::GeV(), 20.0);
+            Parameters::declare("test::m_2", "m_2", Unit::GeV(), 2.0);
+            Parameters::declare("test::m_a", "m_a", Unit::GeV(), 0.7);
+            Parameters::declare("test::m_b", "m_b", Unit::GeV(), 0.8);
+            Parameters::declare("test::q0", "q0", Unit::GeV(), 0.2);
 
             Parameters p = Parameters::Defaults();
 
@@ -149,46 +150,48 @@ class KMatrixTest :
             // In the limit where the resonance mass is much larger
             // than the channel masses, one recover a simple Breit-Wigner distribution
             {
-                auto res = std::make_shared<resonance<1, 1>>("res", p["test::m_1"]);
+                auto res  = std::make_shared<resonance<1, 1>>("res", p["test::m_1"]);
                 auto chan = std::make_shared<PPchannel<1, 1>>("chan", p["test::m_a"], p["test::m_b"], 1, p);
 
-                KMatrix<1,1> simplest_kmatrix({chan}, {res}, {{p["test::c_1"]}}, "simplest_kmatrix");
+                KMatrix<1, 1> simplest_kmatrix({ chan }, { res }, { { p["test::c_1"] } }, "simplest_kmatrix");
 
                 TEST_CHECK_EQUAL(res->_m, 20.0);
 
-                auto qres = 0.5 * std::sqrt(std::abs(eos::lambda(power_of<2>((double)res->_m), power_of<2>((double)chan->_m1), power_of<2>((double)chan->_m2)) / power_of<2>((double)res->_m)));
-                auto q300 = 0.5 * std::sqrt(std::abs(eos::lambda(300., power_of<2>((double)chan->_m1), power_of<2>((double)chan->_m2)) / 300.));
+                auto qres = 0.5
+                            * std::sqrt(std::abs(eos::lambda(power_of<2>((double) res->_m), power_of<2>((double) chan->_m1), power_of<2>((double) chan->_m2))
+                                                 / power_of<2>((double) res->_m)));
+                auto q300 = 0.5 * std::sqrt(std::abs(eos::lambda(300., power_of<2>((double) chan->_m1), power_of<2>((double) chan->_m2)) / 300.));
 
-                const complex<double> BWfactorat300  = kmatrix_utils::blatt_weisskopf_factor(chan->_l_orbital, q300/chan->_q0);
-                const complex<double> BWfactoratmres = kmatrix_utils::blatt_weisskopf_factor(chan->_l_orbital, qres/chan->_q0);
+                const complex<double> BWfactorat300  = kmatrix_utils::blatt_weisskopf_factor(chan->_l_orbital, q300 / chan->_q0);
+                const complex<double> BWfactoratmres = kmatrix_utils::blatt_weisskopf_factor(chan->_l_orbital, qres / chan->_q0);
 
                 // Check that the barrier factors are 1 at large q^2 = 300 GeV^2
-                TEST_CHECK_NEARLY_EQUAL( std::abs(pow(q300 / qres, chan->_l_orbital) * BWfactorat300 / BWfactoratmres), 1., eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(pow(q300 / qres, chan->_l_orbital) * BWfactorat300 / BWfactoratmres), 1., eps);
 
                 // Check |T-Matrix|^2 against Breit-Wigner
                 // The mass of the BW gets correction from the channels loop
-                const double m = res->_m;
-                const complex<double> M = m * (1.0 - 0.5 * chan->chew_mandelstam(m*m) / m / m);
+                const double          m = res->_m;
+                const complex<double> M = m * (1.0 - 0.5 * chan->chew_mandelstam(m * m) / m / m);
 
                 // s = 100. (everybody is ~zero there)
                 double Trowsq = std::norm(simplest_kmatrix.tmatrix_row(0, 100.)[0]);
-                TEST_CHECK_NEARLY_EQUAL(std::abs(BreitWigner(100., M, 1./M)),        Trowsq,        eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(BreitWigner(100., M, 1. / M)), Trowsq, eps);
 
                 // s = 380. (resonance region)
                 Trowsq = std::norm(simplest_kmatrix.tmatrix_row(0, 380.)[0]);
-                TEST_CHECK_NEARLY_EQUAL(std::abs(BreitWigner(380., M, 1./M)),        Trowsq,        eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(BreitWigner(380., M, 1. / M)), Trowsq, eps);
 
                 // s = 420. (resonance region)
                 Trowsq = std::norm(simplest_kmatrix.tmatrix_row(0, 420.)[0]);
-                TEST_CHECK_NEARLY_EQUAL(std::abs(BreitWigner(420., M, 1./M)),        Trowsq,        eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(BreitWigner(420., M, 1. / M)), Trowsq, eps);
 
                 // s = 800. (everybody is ~zero there)
                 Trowsq = std::norm(simplest_kmatrix.tmatrix_row(0, 800.)[0]);
-                TEST_CHECK_NEARLY_EQUAL(std::abs(BreitWigner(800., M, 1./M)),        Trowsq,        eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(BreitWigner(800., M, 1. / M)), Trowsq, eps);
             }
 
             p["test::g0_1"] = 1.1;
-            p["test::m_1"] = 1.0;
+            p["test::m_1"]  = 1.0;
 
             // One channel, two resonances
             {
@@ -198,18 +201,18 @@ class KMatrixTest :
                 auto chan_12 = std::make_shared<PPchannel<1, 2>>("chan_12", p["test::m_a"], p["test::m_b"], 1, p);
 
                 // Test the phase space and Chew-Mandelstam functions for a PP channel
-                TEST_CHECK_NEARLY_EQUAL(std::abs(chan_12->rho(9.0)),          0.0172195,  eps);
-                TEST_CHECK_NEARLY_EQUAL(std::abs(chan_12->rho(1.5)),          0.,         eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(chan_12->rho(9.0)), 0.0172195, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::abs(chan_12->rho(1.5)), 0., eps);
 
-                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(9.0).real(),   -0.0144157,  eps);
-                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(9.0).imag(),    0.0172195,  eps);
-                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(1.5).real(),   -0.00854099, eps);
-                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(1.5).imag(),    0.,         eps);
-                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(0.001).real(), -0.0126445,  eps);
-                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(0.001).imag(),  0.,         eps);
+                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(9.0).real(), -0.0144157, eps);
+                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(9.0).imag(), 0.0172195, eps);
+                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(1.5).real(), -0.00854099, eps);
+                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(1.5).imag(), 0., eps);
+                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(0.001).real(), -0.0126445, eps);
+                TEST_CHECK_NEARLY_EQUAL(chan_12->chew_mandelstam(0.001).imag(), 0., eps);
 
                 // Test K matrix inversion into T matrix
-                KMatrix<1,2> kmatrix_12({chan_12}, {res1, res2}, {{p["test::c_1"]}}, "kmatrix_12");
+                KMatrix<1, 2> kmatrix_12({ chan_12 }, { res1, res2 }, { { p["test::c_1"] } }, "kmatrix_12");
 
                 auto kmatrix_12_ats0 = kmatrix_12.tmatrix_row(0, 9.0);
                 auto kmatrix_12_ats1 = kmatrix_12.tmatrix_row(0, 1.5);
@@ -217,16 +220,16 @@ class KMatrixTest :
                 auto kmatrix_12_ats2 = kmatrix_12.tmatrix_row(0, 1.0);
                 auto kmatrix_12_ats3 = kmatrix_12.tmatrix_row(0, 0.001);
 
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats0[0].real(), -1.11080,   eps);
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats0[0].imag(),  0.0217595, eps);
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats1[0].real(), -0.618935,  eps);
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats1[0].imag(),  0,         eps);
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats2[0].real(),  111.325,   eps);
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats2[0].imag(),  0,         eps);
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats3[0].real(),  2.33115,   eps);
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats3[0].imag(),  0,         eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats0[0].real(), -1.11080, eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats0[0].imag(), 0.0217595, eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats1[0].real(), -0.618935, eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats1[0].imag(), 0, eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats2[0].real(), 111.325, eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats2[0].imag(), 0, eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats3[0].real(), 2.33115, eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12_ats3[0].imag(), 0, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(kmatrix_12.width(1),        0.0318047, eps);
+                TEST_CHECK_NEARLY_EQUAL(kmatrix_12.width(1), 0.0318047, eps);
             }
-    }
+        }
 } kmatrix_test;

--- a/eos/utils/lock.cc
+++ b/eos/utils/lock.cc
@@ -40,12 +40,16 @@ namespace eos
         _mutex(&m)
     {
         if (0 != pthread_mutex_trylock(_mutex->mutex()))
+        {
             _mutex = 0;
+        }
     }
 
     TryLock::~TryLock()
     {
         if (_mutex)
+        {
             pthread_mutex_unlock(_mutex->mutex());
+        }
     }
-}
+} // namespace eos

--- a/eos/utils/lock.hh
+++ b/eos/utils/lock.hh
@@ -28,8 +28,7 @@
 
 namespace eos
 {
-    class Lock :
-        public InstantiationPolicy<Lock, NonCopyable>
+    class Lock : public InstantiationPolicy<Lock, NonCopyable>
     {
         private:
             /// Our mutex.
@@ -43,8 +42,7 @@ namespace eos
             ~Lock();
     };
 
-    class TryLock :
-        public InstantiationPolicy<TryLock, NonCopyable>
+    class TryLock : public InstantiationPolicy<TryLock, NonCopyable>
     {
         private:
             /// Our mutex.
@@ -58,11 +56,12 @@ namespace eos
             ~TryLock();
 
             /// Return true if the lock worked.
-            bool operator() () const
+            bool
+            operator() () const
             {
                 return 0 != _mutex;
             }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/log.cc
+++ b/eos/utils/log.cc
@@ -30,9 +30,8 @@
 
 #include <iostream>
 #include <set>
-#include <vector>
-
 #include <time.h>
+#include <vector>
 
 namespace eos
 {
@@ -45,40 +44,23 @@ namespace eos
         {
             switch (rhs)
             {
-                case ll_silent:
-                    lhs << "silent";
-                    continue;
+                case ll_silent: lhs << "silent"; continue;
 
-                case ll_error:
-                    lhs << "error";
-                    continue;
+                case ll_error: lhs << "error"; continue;
 
-                case ll_warning:
-                    lhs << "warning";
-                    continue;
+                case ll_warning: lhs << "warning"; continue;
 
-                case ll_success:
-                    lhs << "success";
-                    continue;
+                case ll_success: lhs << "success"; continue;
 
-                case ll_completed:
-                    lhs << "completed";
-                    continue;
+                case ll_completed: lhs << "completed"; continue;
 
-                case ll_inprogress:
-                    lhs << "inprogress";
-                    continue;
+                case ll_inprogress: lhs << "inprogress"; continue;
 
-                case ll_informational:
-                    lhs << "informational";
-                    continue;
+                case ll_informational: lhs << "informational"; continue;
 
-                case ll_debug:
-                    lhs << "debug";
-                    continue;
+                case ll_debug: lhs << "debug"; continue;
 
-                case ll_last:
-                    break;
+                case ll_last: break;
             }
 
             throw InternalError("LogLevel::operator<<: Bad value for log_level");
@@ -148,85 +130,74 @@ namespace eos
 
     template <> struct Implementation<Log>
     {
-        Mutex mutex;
+            Mutex mutex;
 
-        LogLevel log_level;
+            LogLevel log_level;
 
-        std::ostream * stream;
+            std::ostream * stream;
 
-        std::string program_name;
+            std::string program_name;
 
-        std::vector<std::function<void (const std::string &, const LogLevel &, const std::string &)>> callbacks;
+            std::vector<std::function<void(const std::string &, const LogLevel &, const std::string &)>> callbacks;
 
-        std::set<std::string> one_time_messages;
+            std::set<std::string> one_time_messages;
 
-        Implementation() :
-            log_level(ll_error),
-            stream(nullptr)
-        {
-        }
-
-        void message(const std::string & id, const LogLevel & l, const std::string & m)
-        {
-            if (l > log_level)
-                return;
-
-            // forward message to all callbacks
-            for (auto & c : callbacks)
+            Implementation() :
+                log_level(ll_error),
+                stream(nullptr)
             {
-                c(id, l, m);
             }
 
-            if (! stream)
-                return;
-
-            *stream << program_name << '@' << ::time(0) << ": ";
-
-            do
+            void
+            message(const std::string & id, const LogLevel & l, const std::string & m)
             {
-                switch (l)
+                if (l > log_level)
                 {
-                    case ll_error:
-                        *stream << "[ERROR " << id << "] ";
-                        continue;
-
-                    case ll_warning:
-                        *stream << "[WARNING " << id << "] ";
-                        continue;
-
-                    case ll_informational:
-                        *stream << "[INFO " << id << "] ";
-                        continue;
-
-                    case ll_success:
-                        *stream << "[SUCCESS " << id << "] ";
-                        continue;
-
-                    case ll_completed:
-                        *stream << "[COMPLETED " << id << "] ";
-                        continue;
-
-                    case ll_inprogress:
-                        *stream << "[INPROGRESS " << id << "] ";
-                        continue;
-
-                    case ll_debug:
-                        *stream << "[DEBUG " << id << "] ";
-                        continue;
-
-                    case ll_silent:
-                        throw InternalError("Implementation<Log>::message: ll_silent used for a message");
-
-                    case ll_last:
-                        break;
+                    return;
                 }
 
-                throw InternalError("Implementation<Log>::message: Bad value for log_level");
-            }
-            while (false);
+                // forward message to all callbacks
+                for (auto & c : callbacks)
+                {
+                    c(id, l, m);
+                }
 
-            *stream << m << std::endl;
-        }
+                if (! stream)
+                {
+                    return;
+                }
+
+                *stream << program_name << '@' << ::time(0) << ": ";
+
+                do
+                {
+                    switch (l)
+                    {
+                        case ll_error: *stream << "[ERROR " << id << "] "; continue;
+
+                        case ll_warning: *stream << "[WARNING " << id << "] "; continue;
+
+                        case ll_informational: *stream << "[INFO " << id << "] "; continue;
+
+                        case ll_success: *stream << "[SUCCESS " << id << "] "; continue;
+
+                        case ll_completed: *stream << "[COMPLETED " << id << "] "; continue;
+
+                        case ll_inprogress: *stream << "[INPROGRESS " << id << "] "; continue;
+
+                        case ll_debug: *stream << "[DEBUG " << id << "] "; continue;
+
+                        case ll_silent: throw InternalError("Implementation<Log>::message: ll_silent used for a message");
+
+                        case ll_last: break;
+                    }
+
+                    throw InternalError("Implementation<Log>::message: Bad value for log_level");
+                }
+                while (false);
+
+                *stream << m << std::endl;
+            }
     };
 
     template class InstantiationPolicy<Log, Singleton>;
@@ -236,9 +207,7 @@ namespace eos
     {
     }
 
-    Log::~Log()
-    {
-    }
+    Log::~Log() {}
 
     const LogLevel &
     Log::get_log_level() const
@@ -273,7 +242,7 @@ namespace eos
     }
 
     void
-    Log::register_callback(const std::function<void (const std::string &, const LogLevel &, const std::string&)> & callback)
+    Log::register_callback(const std::function<void(const std::string &, const LogLevel &, const std::string &)> & callback)
     {
         Lock l(_imp->mutex);
 
@@ -327,4 +296,4 @@ namespace eos
     {
         _message.append(s);
     }
-}
+} // namespace eos

--- a/eos/utils/log.hh
+++ b/eos/utils/log.hh
@@ -37,14 +37,14 @@ namespace eos
      */
     enum LogLevel
     {
-        ll_silent,             ///< do not print any error message
-        ll_error,              ///< only print error messages
-        ll_warning,            ///< also print warning messages
-        ll_success,            ///< also print success messages
-        ll_completed,          ///< also print completion messages
-        ll_inprogress,         ///< also print in-progress messages
-        ll_informational,      ///< also print informational messages
-        ll_debug,              ///< also print debug messages
+        ll_silent,        ///< do not print any error message
+        ll_error,         ///< only print error messages
+        ll_warning,       ///< also print warning messages
+        ll_success,       ///< also print success messages
+        ll_completed,     ///< also print completion messages
+        ll_inprogress,    ///< also print in-progress messages
+        ll_informational, ///< also print informational messages
+        ll_debug,         ///< also print debug messages
         ll_last
     };
 
@@ -63,9 +63,7 @@ namespace eos
      * Facility to emit messages to the user, with a filter according to interest and urgency
      * of the messages at hand.
      */
-    class Log :
-        public InstantiationPolicy<Log, Singleton>,
-        public PrivateImplementationPattern<Log>
+    class Log : public InstantiationPolicy<Log, Singleton>, public PrivateImplementationPattern<Log>
     {
         private:
             ///@name Basic Functions
@@ -110,7 +108,7 @@ namespace eos
             /*!
              * Register a callback hook with the Log class.
              */
-            void register_callback(const std::function<void (const std::string &, const LogLevel &, const std::string &)> &);
+            void register_callback(const std::function<void(const std::string &, const LogLevel &, const std::string &)> &);
 
             /*!
              * Return a stream-like object to which message parts can be
@@ -140,8 +138,8 @@ namespace eos
     class LogMessageHandler
     {
         private:
-            Log * _log;
-            LogLevel _log_level;
+            Log *       _log;
+            LogLevel    _log_level;
             std::string _id;
             std::string _message;
 
@@ -166,18 +164,21 @@ namespace eos
             ///@{
             /// Destructor.
             ~LogMessageHandler();
+
             ///@}
 
             /*!
              * Append to our message.
              */
-            template <typename T_> LogMessageHandler & operator<< (const T_ & t)
+            template <typename T_>
+            LogMessageHandler &
+            operator<< (const T_ & t)
             {
                 _append(stringify(t));
 
                 return *this;
             }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/log_TEST.cc
+++ b/eos/utils/log_TEST.cc
@@ -17,15 +17,15 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/exception.hh>
 #include <eos/utils/log.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
 
-class LogLevelTest :
-    public TestCase
+class LogLevelTest : public TestCase
 {
     public:
         LogLevelTest() :
@@ -33,19 +33,20 @@ class LogLevelTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // stringification
             {
-                TEST_CHECK_EQUAL("silent",        stringify(ll_silent));
-                TEST_CHECK_EQUAL("error",         stringify(ll_error));
-                TEST_CHECK_EQUAL("warning",       stringify(ll_warning));
-                TEST_CHECK_EQUAL("success",       stringify(ll_success));
-                TEST_CHECK_EQUAL("completed",     stringify(ll_completed));
-                TEST_CHECK_EQUAL("inprogress",    stringify(ll_inprogress));
+                TEST_CHECK_EQUAL("silent", stringify(ll_silent));
+                TEST_CHECK_EQUAL("error", stringify(ll_error));
+                TEST_CHECK_EQUAL("warning", stringify(ll_warning));
+                TEST_CHECK_EQUAL("success", stringify(ll_success));
+                TEST_CHECK_EQUAL("completed", stringify(ll_completed));
+                TEST_CHECK_EQUAL("inprogress", stringify(ll_inprogress));
                 TEST_CHECK_EQUAL("informational", stringify(ll_informational));
-                TEST_CHECK_EQUAL("debug",         stringify(ll_debug));
-                TEST_CHECK_THROWS(InternalError,  stringify(ll_last));
+                TEST_CHECK_EQUAL("debug", stringify(ll_debug));
+                TEST_CHECK_THROWS(InternalError, stringify(ll_last));
             }
 
             // destringification
@@ -53,7 +54,7 @@ class LogLevelTest :
                 // silent
                 {
                     std::stringstream ss("silent");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     ss >> log_level;
 
@@ -63,7 +64,7 @@ class LogLevelTest :
                 // error
                 {
                     std::stringstream ss("error");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     ss >> log_level;
 
@@ -73,7 +74,7 @@ class LogLevelTest :
                 // warning
                 {
                     std::stringstream ss("warning");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     ss >> log_level;
 
@@ -83,7 +84,7 @@ class LogLevelTest :
                 // success
                 {
                     std::stringstream ss("success");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     ss >> log_level;
 
@@ -93,7 +94,7 @@ class LogLevelTest :
                 // completed
                 {
                     std::stringstream ss("completed");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     ss >> log_level;
 
@@ -103,7 +104,7 @@ class LogLevelTest :
                 // inprogress
                 {
                     std::stringstream ss("inprogress");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     ss >> log_level;
 
@@ -113,7 +114,7 @@ class LogLevelTest :
                 // informational
                 {
                     std::stringstream ss("informational");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     ss >> log_level;
 
@@ -123,7 +124,7 @@ class LogLevelTest :
                 // debug
                 {
                     std::stringstream ss("debug");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     ss >> log_level;
 
@@ -133,7 +134,7 @@ class LogLevelTest :
                 // last
                 {
                     std::stringstream ss("last");
-                    LogLevel log_level;
+                    LogLevel          log_level;
 
                     TEST_CHECK_THROWS(InternalError, ss >> log_level);
                 }
@@ -141,9 +142,7 @@ class LogLevelTest :
         }
 } log_level_test;
 
-
-class LogOneTimeMessageTest :
-    public TestCase
+class LogOneTimeMessageTest : public TestCase
 {
     public:
         LogOneTimeMessageTest() :
@@ -151,14 +150,14 @@ class LogOneTimeMessageTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             std::vector<std::tuple<std::string, LogLevel, std::string>> messages;
 
             // register callback
-            std::function<void(const std::string &, const LogLevel &, const std::string &)> callback = [&messages](const std::string & id, const LogLevel & level, const std::string & message) {
-                messages.push_back(std::make_tuple(id, level, message));
-            };
+            std::function<void(const std::string &, const LogLevel &, const std::string &)> callback =
+                    [&messages](const std::string & id, const LogLevel & level, const std::string & message) { messages.push_back(std::make_tuple(id, level, message)); };
             Log::instance()->register_callback(callback);
 
             // first message

--- a/eos/utils/memoise.cc
+++ b/eos/utils/memoise.cc
@@ -31,7 +31,7 @@ namespace eos
     }
 
     void
-    MemoisationControl::register_clear_function(const std::function<void ()> & clear_function)
+    MemoisationControl::register_clear_function(const std::function<void()> & clear_function)
     {
         Lock l(*_mutex);
 
@@ -48,4 +48,4 @@ namespace eos
             _clear_function();
         }
     }
-}
+} // namespace eos

--- a/eos/utils/memoise.hh
+++ b/eos/utils/memoise.hh
@@ -21,8 +21,8 @@
 #ifndef EOS_GUARD_EOS_UTILS_MEMOISE_HH
 #define EOS_GUARD_EOS_UTILS_MEMOISE_HH 1
 
-#include <eos/utils/instantiation_policy.hh>
 #include <eos/utils/instantiation_policy-impl.hh>
+#include <eos/utils/instantiation_policy.hh>
 #include <eos/utils/lock.hh>
 #include <eos/utils/mutex.hh>
 
@@ -35,7 +35,9 @@
 /* We are using a custom std::hash for tuple<FunctionPtr, double, ..., double> */
 namespace std
 {
-    template <typename U_> static uint64_t __hash_one(const U_ & u)
+    template <typename U_>
+    static uint64_t
+    __hash_one(const U_ & u)
     {
         static_assert(sizeof(U_) == sizeof(uint32_t) || sizeof(U_) == sizeof(uint64_t), "Need to specialize __hash_one for non 32- and 64-bit data types");
 
@@ -49,33 +51,33 @@ namespace std
         }
     }
 
-    template <unsigned n_, typename ... T_>
-    struct __TupleHasher
+    template <unsigned n_, typename... T_> struct __TupleHasher
     {
-        static uint64_t hash(const std::tuple<T_ ...> & t)
-        {
-            return __TupleHasher<n_ - 1, T_ ...>::hash(t) ^ __hash_one<decltype(std::get<n_>(t))>(std::get<n_>(t));
-        }
+            static uint64_t
+            hash(const std::tuple<T_...> & t)
+            {
+                return __TupleHasher<n_ - 1, T_...>::hash(t) ^ __hash_one<decltype(std::get<n_>(t))>(std::get<n_>(t));
+            }
     };
 
-    template <typename ... T_>
-    struct __TupleHasher<0, T_ ...>
+    template <typename... T_> struct __TupleHasher<0, T_...>
     {
-        static uint64_t hash(const std::tuple<T_ ...> & t)
-        {
-            return __hash_one<decltype(std::get<0>(t))>(std::get<0>(t));
-        }
+            static uint64_t
+            hash(const std::tuple<T_...> & t)
+            {
+                return __hash_one<decltype(std::get<0>(t))>(std::get<0>(t));
+            }
     };
 
-    template <typename ... T_>
-    struct hash<std::tuple<T_ ...>>
+    template <typename... T_> struct hash<std::tuple<T_...>>
     {
-        size_t operator() (const std::tuple<T_ ...> & t) const
-        {
-            return __TupleHasher<sizeof...(T_) - 1, T_ ...>::hash(t);
-        }
+            size_t
+            operator() (const std::tuple<T_...> & t) const
+            {
+                return __TupleHasher<sizeof...(T_) - 1, T_...>::hash(t);
+            }
     };
-}
+} // namespace std
 
 namespace eos
 {
@@ -83,44 +85,39 @@ namespace eos
     {
         template <typename T_> struct ResultOf;
 
-        template <typename Result_, typename Class_, typename ... Args_>
-        struct ResultOf<Result_ (Class_::*) (Args_ ...)>
+        template <typename Result_, typename Class_, typename... Args_> struct ResultOf<Result_ (Class_::*)(Args_...)>
         {
-            using Type = Result_;
+                using Type = Result_;
         };
 
-        template <typename Result_, typename ... Args_>
-        struct ResultOf<Result_ (*) (Args_ ...)>
+        template <typename Result_, typename... Args_> struct ResultOf<Result_ (*)(Args_...)>
         {
-            using Type = Result_;
+                using Type = Result_;
         };
-    }
+    } // namespace implementation
 
-    class MemoisationControl :
-        public InstantiationPolicy<MemoisationControl, Singleton>
+    class MemoisationControl : public InstantiationPolicy<MemoisationControl, Singleton>
     {
         private:
             Mutex * const _mutex;
 
-            std::vector<std::function<void ()>> _clear_functions;
+            std::vector<std::function<void()>> _clear_functions;
 
         public:
             MemoisationControl();
 
             ~MemoisationControl();
 
-            void register_clear_function(const std::function<void ()> & clear_function);
+            void register_clear_function(const std::function<void()> & clear_function);
 
             void clear();
     };
 
-    template <typename Result_, typename ... Params_>
-    class Memoiser :
-        public InstantiationPolicy<Memoiser<Result_, Params_ ...>, Singleton>
+    template <typename Result_, typename... Params_> class Memoiser : public InstantiationPolicy<Memoiser<Result_, Params_...>, Singleton>
     {
         public:
-            using FunctionType = Result_(*)(const Params_ & ...);
-            using KeyType = std::tuple<FunctionType, Params_...>;
+            using FunctionType = Result_ (*)(const Params_ &...);
+            using KeyType      = std::tuple<FunctionType, Params_...>;
 
         private:
             Mutex * const _mutex;
@@ -131,25 +128,25 @@ namespace eos
             Memoiser() :
                 _mutex(new Mutex)
             {
-                MemoisationControl::instance()->register_clear_function(std::bind(&Memoiser<Result_, Params_ ...>::clear, this));
+                MemoisationControl::instance()->register_clear_function(std::bind(&Memoiser<Result_, Params_...>::clear, this));
             }
 
-            ~Memoiser()
-            {
-                delete _mutex;
-            }
+            ~Memoiser() { delete _mutex; }
 
-            Result_ operator() (const FunctionType & f, const Params_ & ... p)
+            Result_
+            operator() (const FunctionType & f, const Params_ &... p)
             {
                 Lock l(*_mutex);
 
-                KeyType key(f, p ...);
-                auto i = _memoisations.find(key);
+                KeyType key(f, p...);
+                auto    i = _memoisations.find(key);
 
                 if (_memoisations.end() != i)
+                {
                     return i->second;
+                }
 
-                Result_ result = f(p ...);
+                Result_ result = f(p...);
 
                 if (_memoisations.size() > 100000u)
                 {
@@ -161,14 +158,16 @@ namespace eos
                 return result;
             }
 
-            void clear()
+            void
+            clear()
             {
                 Lock l(*_mutex);
 
                 _memoisations.clear();
             }
 
-            unsigned number_of_memoisations() const
+            unsigned
+            number_of_memoisations() const
             {
                 Lock l(*_mutex);
 
@@ -176,17 +175,19 @@ namespace eos
             }
     };
 
-    template <typename FunctionType_, typename ... Params>
-    typename implementation::ResultOf<FunctionType_>::Type memoise(FunctionType_ f, const Params & ... p)
+    template <typename FunctionType_, typename... Params>
+    typename implementation::ResultOf<FunctionType_>::Type
+    memoise(FunctionType_ f, const Params &... p)
     {
-        return (*Memoiser<typename implementation::ResultOf<FunctionType_>::Type, Params ...>::instance())(f, p ...);
+        return (*Memoiser<typename implementation::ResultOf<FunctionType_>::Type, Params...>::instance())(f, p...);
     }
 
-    template <typename FunctionType_, typename ... Params>
-    unsigned number_of_memoisations(FunctionType_, const Params & ...)
+    template <typename FunctionType_, typename... Params>
+    unsigned
+    number_of_memoisations(FunctionType_, const Params &...)
     {
-        return Memoiser<typename implementation::ResultOf<FunctionType_>::Type, Params ...>::instance()->number_of_memoisations();
+        return Memoiser<typename implementation::ResultOf<FunctionType_>::Type, Params...>::instance()->number_of_memoisations();
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/memoise_TEST.cc
+++ b/eos/utils/memoise_TEST.cc
@@ -17,16 +17,16 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/memoise.hh>
+
+#include <test/test.hh>
 
 #include <complex>
 
 using namespace test;
 using namespace eos;
 
-class MemoiseTest :
-    public TestCase
+class MemoiseTest : public TestCase
 {
     public:
         MemoiseTest() :
@@ -34,17 +34,20 @@ class MemoiseTest :
         {
         }
 
-        static double f1(const double & x, const double & y)
+        static double
+        f1(const double & x, const double & y)
         {
             return x / y;
         }
 
-        static std::complex<double> f2(const double & x, const double & y)
+        static std::complex<double>
+        f2(const double & x, const double & y)
         {
             return std::complex<double>(x, y);
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             /* f1 */
             {

--- a/eos/utils/mutable-fwd.hh
+++ b/eos/utils/mutable-fwd.hh
@@ -29,6 +29,6 @@ namespace eos
     class Mutable;
 
     using MutablePtr = std::shared_ptr<Mutable>;
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/mutable.cc
+++ b/eos/utils/mutable.cc
@@ -23,7 +23,5 @@
 
 namespace eos
 {
-    Mutable::~Mutable()
-    {
-    }
-}
+    Mutable::~Mutable() {}
+} // namespace eos

--- a/eos/utils/mutable.hh
+++ b/eos/utils/mutable.hh
@@ -50,7 +50,7 @@ namespace eos
             virtual double operator() () const = 0;
 
             /// Retrieve a Mutable's numeric value.
-            //TODO: evaluate -> get
+            // TODO: evaluate -> get
             virtual double evaluate() const = 0;
 
             /// Set a Mutable's numeric value.
@@ -66,6 +66,6 @@ namespace eos
             virtual const std::string & name() const = 0;
             ///@}
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/mutable_TEST.cc
+++ b/eos/utils/mutable_TEST.cc
@@ -17,15 +17,15 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/mutable.hh>
 #include <eos/utils/parameters.hh>
+
+#include <test/test.hh>
 
 using namespace eos;
 using namespace test;
 
-class MutableAccessTest :
-    public TestCase
+class MutableAccessTest : public TestCase
 {
     public:
         MutableAccessTest() :
@@ -33,35 +33,36 @@ class MutableAccessTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // Test Parameter
             {
                 Parameters parameters = Parameters::Defaults();
-                Parameter p = parameters["mass::b(MSbar)"];
+                Parameter  p          = parameters["mass::b(MSbar)"];
 
                 Mutable & m = p;
 
                 TEST_CHECK_EQUAL(static_cast<double>(m), static_cast<double>(p));
-                TEST_CHECK_EQUAL(m(),                    p());
-                TEST_CHECK_EQUAL(m.name(),               p.name());
+                TEST_CHECK_EQUAL(m(), p());
+                TEST_CHECK_EQUAL(m.name(), p.name());
             }
 
             // Test Parameter Clone
             {
                 Parameters parameters = Parameters::Defaults();
-                Parameter p = parameters["mass::b(MSbar)"];
+                Parameter  p          = parameters["mass::b(MSbar)"];
 
                 MutablePtr m1(new Parameter(p));
                 MutablePtr m2(m1->clone());
 
                 TEST_CHECK_EQUAL(static_cast<double>(*m1), static_cast<double>(p));
-                TEST_CHECK_EQUAL((*m1)(),                  p());
-                TEST_CHECK_EQUAL(m1->name(),               p.name());
+                TEST_CHECK_EQUAL((*m1)(), p());
+                TEST_CHECK_EQUAL(m1->name(), p.name());
 
                 TEST_CHECK_EQUAL(static_cast<double>(*m2), static_cast<double>(p));
-                TEST_CHECK_EQUAL((*m2)(),                  p());
-                TEST_CHECK_EQUAL(m2->name(),               p.name());
+                TEST_CHECK_EQUAL((*m2)(), p());
+                TEST_CHECK_EQUAL(m2->name(), p.name());
             }
         }
 } mutable_access_test;

--- a/eos/utils/mutex.hh
+++ b/eos/utils/mutex.hh
@@ -29,8 +29,7 @@
 
 namespace eos
 {
-    class Mutex :
-        public InstantiationPolicy<Mutex, NonCopyable>
+    class Mutex : public InstantiationPolicy<Mutex, NonCopyable>
     {
         private:
             /// Our attributes.
@@ -47,11 +46,12 @@ namespace eos
             ~Mutex();
 
             /// Returns a pointer to our underlying posix mutex.
-            pthread_mutex_t * mutex()
+            pthread_mutex_t *
+            mutex()
             {
                 return _mutex;
             }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/named-value-fwd.hh
+++ b/eos/utils/named-value-fwd.hh
@@ -26,11 +26,9 @@
 
 namespace eos
 {
-    template <typename K_, typename V_>
-    class NamedValue;
+    template <typename K_, typename V_> class NamedValue;
 
-    template <typename T_>
-    class Name;
-}
+    template <typename T_> class Name;
+} // namespace eos
 
 #endif

--- a/eos/utils/named-value.hh
+++ b/eos/utils/named-value.hh
@@ -25,9 +25,9 @@
 
 #include <eos/utils/named-value-fwd.hh>
 
-#include <utility>
-#include <type_traits>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 namespace eos
 {
@@ -47,16 +47,15 @@ namespace eos
      * In all cases, NamedValue members are listed in name-sorted order, and
      * the same name is used for K_ and the member name.
      */
-    template <typename K_, typename V_>
-    class NamedValue
+    template <typename K_, typename V_> class NamedValue
     {
-        static_assert(! std::is_reference<V_>::value, "Tried to make a NamedValue hold a reference");
+            static_assert(! std::is_reference<V_>::value, "Tried to make a NamedValue hold a reference");
 
         private:
             V_ _value;
 
         public:
-            using KeyType = K_;
+            using KeyType   = K_;
             using ValueType = V_;
 
             template <typename T_>
@@ -91,18 +90,21 @@ namespace eos
             {
             }
 
-            NamedValue & operator=(const NamedValue & v)
+            NamedValue &
+            operator= (const NamedValue & v)
             {
                 _value = v._value;
                 return *this;
             }
 
-            V_ & operator() ()
+            V_ &
+            operator() ()
             {
                 return _value;
             }
 
-            const V_ & operator() () const
+            const V_ &
+            operator() () const
             {
                 return _value;
             }
@@ -111,23 +113,25 @@ namespace eos
     /**
      * A Name is used to make the assignment for NamedValue keys work.
      */
-    template <typename T_>
-    class Name
+    template <typename T_> class Name
     {
         public:
             template <typename V_>
-            NamedValue<Name<T_>, V_> operator= (const V_ & v) const
+            NamedValue<Name<T_>, V_>
+            operator= (const V_ & v) const
             {
                 return NamedValue<Name<T_>, V_>(v);
             }
 
             template <typename V_>
-            NamedValue<Name<T_>, typename std::remove_reference<V_>::type> operator= (V_ && v) const
+            NamedValue<Name<T_>, typename std::remove_reference<V_>::type>
+            operator= (V_ && v) const
             {
                 return NamedValue<Name<T_>, typename std::remove_reference<V_>::type>(v);
             }
 
-            NamedValue<Name<T_>, std::string> operator= (const char * const v) const
+            NamedValue<Name<T_>, std::string>
+            operator= (const char * const v) const
             {
                 return NamedValue<Name<T_>, std::string>(std::string(v));
             }
@@ -139,11 +143,12 @@ namespace eos
      * 4.4 is buggy, so for now we can't use braces directly...
      */
     template <typename R_, typename... T_>
-    R_ make_named_values(T_ && ... a)
+    R_
+    make_named_values(T_ &&... a)
     {
         R_ result = { std::forward<T_>(a)... };
         return result;
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/observable_cache.cc
+++ b/eos/utils/observable_cache.cc
@@ -36,149 +36,157 @@
 
 namespace eos
 {
-    template <>
-    struct WrappedForwardIteratorTraits<ObservableCache::IteratorTag>
+    template <> struct WrappedForwardIteratorTraits<ObservableCache::IteratorTag>
     {
-        using UnderlyingIterator = std::vector<ObservablePtr>::iterator;
+            using UnderlyingIterator = std::vector<ObservablePtr>::iterator;
     };
     template class WrappedForwardIterator<ObservableCache::IteratorTag, ObservablePtr>;
 
-    template <> struct
-    Implementation<ObservableCache>
+    template <> struct Implementation<ObservableCache>
     {
-        // Parameters which are common to all observables in the cache.
-        Parameters parameters;
+            // Parameters which are common to all observables in the cache.
+            Parameters parameters;
 
-        // Contains each observable that needs to be calculated exactly once
-        std::vector<ObservablePtr> observables;
+            // Contains each observable that needs to be calculated exactly once
+            std::vector<ObservablePtr> observables;
 
-        // Contains each regular observable and its associated index
-        std::vector<std::tuple<ObservablePtr, ObservableCache::Id>> regular_observables;
+            // Contains each regular observable and its associated index
+            std::vector<std::tuple<ObservablePtr, ObservableCache::Id>> regular_observables;
 
-        // Contains each cacheable observable and its associated index
-        std::multimap<std::type_index, std::tuple<CacheableObservable *, ObservableCache::Id>> cacheable_observables;
+            // Contains each cacheable observable and its associated index
+            std::multimap<std::type_index, std::tuple<CacheableObservable *, ObservableCache::Id>> cacheable_observables;
 
-        // Contains each cached observable and its associated index
-        std::vector<std::tuple<ObservablePtr, ObservableCache::Id>> cached_observables;
+            // Contains each cached observable and its associated index
+            std::vector<std::tuple<ObservablePtr, ObservableCache::Id>> cached_observables;
 
-        // Contains each expression observable and its associated index
-        std::vector<std::tuple<ObservablePtr, ObservableCache::Id>> expression_observables;
+            // Contains each expression observable and its associated index
+            std::vector<std::tuple<ObservablePtr, ObservableCache::Id>> expression_observables;
 
-        // Contains values of all observables
-        std::vector<double> predictions;
+            // Contains values of all observables
+            std::vector<double> predictions;
 
-        Implementation(const Parameters & parameters) :
-            parameters(parameters)
-        {
-        }
-
-        ~Implementation()
-        {
-        }
-
-        static bool identical_observables(const ObservablePtr & lhs, const ObservablePtr & rhs)
-        {
-            // compare name
-            if (lhs->name() != rhs->name())
+            Implementation(const Parameters & parameters) :
+                parameters(parameters)
             {
-                return false;
             }
 
-            // compare kinematics
-            if( lhs->kinematics() != rhs->kinematics())
+            ~Implementation() {}
+
+            static bool
+            identical_observables(const ObservablePtr & lhs, const ObservablePtr & rhs)
             {
-                return false;
-            }
-
-            // compare options
-            if (lhs->options() != rhs->options())
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        ObservableCache::Id add(const ObservablePtr & observable, const ObservableCache & cache)
-        {
-            if (observable->parameters() != parameters)
-                throw InternalError("ObservableCache::add(): Mismatch of Parameters between different observables detected.");
-
-            // compare each observable for options, kinematics and name
-            unsigned index = 0;
-            for (auto i = observables.begin(), i_end = observables.end() ; i != i_end ; ++i, ++index)
-            {
-                if (identical_observables(*i, observable))
-                    return index;
-            }
-
-            CacheableObservable * cacheable_observable = dynamic_cast<CacheableObservable *>(observable.get());
-            ExpressionObservable * expression_observable = dynamic_cast<ExpressionObservable *>(observable.get());
-
-            if (nullptr != expression_observable) // is the new observable an expression?
-            {
-                ObservablePtr cached_expression_observable(new ExpressionObservable(expression_observable->name(),
-                        cache,
-                        expression_observable->kinematics(),
-                        expression_observable->options(),
-                        expression_observable->expression()));
-
-                // ensure that the new index is correct, since the ExpressionCacher is capable to modify our cache
-                index = observables.size();
-
-                observables.push_back(cached_expression_observable);
-                predictions.push_back(std::numeric_limits<double>::quiet_NaN());
-                expression_observables.push_back(std::make_tuple(cached_expression_observable, index));
-
-                return index;
-            }
-            else if (nullptr != cacheable_observable) // is the new observable cacheable?
-            {
-                std::type_index type_index(typeid(*cacheable_observable));
-
-                // have we encountered this type of cacheable observable before?
-                auto range = cacheable_observables.equal_range(type_index);
-                for (auto c = range.first, c_end = range.second ; c != c_end ; ++c)
+                // compare name
+                if (lhs->name() != rhs->name())
                 {
-                    // have we encountered this cacheable observable with the same properties before?
-                    if (std::get<0>(c->second)->kinematics() != cacheable_observable->kinematics())
-                        continue;
+                    return false;
+                }
 
-                    if (std::get<0>(c->second)->options() != cacheable_observable->options())
-                        continue;
+                // compare kinematics
+                if (lhs->kinematics() != rhs->kinematics())
+                {
+                    return false;
+                }
 
-                    // yes! cache it...
-                    ObservablePtr cached_observable = cacheable_observable->make_cached_observable(std::get<0>(c->second));
-                    if (! cached_observable)
-                        throw InternalError("make_cached_observable() failed");
+                // compare options
+                if (lhs->options() != rhs->options())
+                {
+                    return false;
+                }
 
-                    // add the newly created cached observable
-                    observables.push_back(cached_observable);
+                return true;
+            }
+
+            ObservableCache::Id
+            add(const ObservablePtr & observable, const ObservableCache & cache)
+            {
+                if (observable->parameters() != parameters)
+                {
+                    throw InternalError("ObservableCache::add(): Mismatch of Parameters between different observables detected.");
+                }
+
+                // compare each observable for options, kinematics and name
+                unsigned index = 0;
+                for (auto i = observables.begin(), i_end = observables.end(); i != i_end; ++i, ++index)
+                {
+                    if (identical_observables(*i, observable))
+                    {
+                        return index;
+                    }
+                }
+
+                CacheableObservable *  cacheable_observable  = dynamic_cast<CacheableObservable *>(observable.get());
+                ExpressionObservable * expression_observable = dynamic_cast<ExpressionObservable *>(observable.get());
+
+                if (nullptr != expression_observable) // is the new observable an expression?
+                {
+                    ObservablePtr cached_expression_observable(new ExpressionObservable(expression_observable->name(),
+                                                                                        cache,
+                                                                                        expression_observable->kinematics(),
+                                                                                        expression_observable->options(),
+                                                                                        expression_observable->expression()));
+
+                    // ensure that the new index is correct, since the ExpressionCacher is capable to modify our cache
+                    index = observables.size();
+
+                    observables.push_back(cached_expression_observable);
                     predictions.push_back(std::numeric_limits<double>::quiet_NaN());
-                    cached_observables.push_back(std::make_tuple(cached_observable, index));
+                    expression_observables.push_back(std::make_tuple(cached_expression_observable, index));
+
+                    return index;
+                }
+                else if (nullptr != cacheable_observable) // is the new observable cacheable?
+                {
+                    std::type_index type_index(typeid(*cacheable_observable));
+
+                    // have we encountered this type of cacheable observable before?
+                    auto range = cacheable_observables.equal_range(type_index);
+                    for (auto c = range.first, c_end = range.second; c != c_end; ++c)
+                    {
+                        // have we encountered this cacheable observable with the same properties before?
+                        if (std::get<0>(c->second)->kinematics() != cacheable_observable->kinematics())
+                        {
+                            continue;
+                        }
+
+                        if (std::get<0>(c->second)->options() != cacheable_observable->options())
+                        {
+                            continue;
+                        }
+
+                        // yes! cache it...
+                        ObservablePtr cached_observable = cacheable_observable->make_cached_observable(std::get<0>(c->second));
+                        if (! cached_observable)
+                        {
+                            throw InternalError("make_cached_observable() failed");
+                        }
+
+                        // add the newly created cached observable
+                        observables.push_back(cached_observable);
+                        predictions.push_back(std::numeric_limits<double>::quiet_NaN());
+                        cached_observables.push_back(std::make_tuple(cached_observable, index));
+
+                        return index;
+                    }
+
+                    // else add this new cacheable observable
+                    observables.push_back(observable);
+                    predictions.push_back(std::numeric_limits<double>::quiet_NaN());
+                    cacheable_observables.insert(std::make_pair(type_index, std::make_tuple(cacheable_observable, index)));
+
+                    return index;
+                }
+                else
+                {
+                    // add this new regular observable
+                    observables.push_back(observable);
+                    predictions.push_back(std::numeric_limits<double>::quiet_NaN());
+                    regular_observables.push_back(std::make_tuple(observable, index));
 
                     return index;
                 }
 
-                // else add this new cacheable observable
-                observables.push_back(observable);
-                predictions.push_back(std::numeric_limits<double>::quiet_NaN());
-                cacheable_observables.insert(std::make_pair(type_index, std::make_tuple(cacheable_observable, index)));
-
-                return index;
+                throw InternalError("should not be reached");
             }
-            else
-            {
-                // add this new regular observable
-                observables.push_back(observable);
-                predictions.push_back(std::numeric_limits<double>::quiet_NaN());
-                regular_observables.push_back(std::make_tuple(observable, index));
-
-                return index;
-            }
-
-            throw InternalError("should not be reached");
-        }
     };
 
     ObservableCache::ObservableCache(const Parameters & parameters) :
@@ -186,9 +194,7 @@ namespace eos
     {
     }
 
-    ObservableCache::~ObservableCache()
-    {
-    }
+    ObservableCache::~ObservableCache() {}
 
     ObservableCache::Id
     ObservableCache::add(const ObservablePtr & observable)
@@ -206,7 +212,8 @@ namespace eos
         // evaluate all cacheable observables in parallel
         for (auto co : _imp->cacheable_observables)
         {
-            auto f = [=, this]() {
+            auto f = [=, this]()
+            {
                 auto & o   = std::get<0>(co.second);
                 auto & idx = std::get<1>(co.second);
                 try
@@ -215,14 +222,12 @@ namespace eos
                 }
                 catch (eos::Exception & e)
                 {
-                    Log::instance()->message("ObservableCache::update", ll_error)
-                        << "Exception encountered when evaluating cacheable observable '" << o->name() << "[" << o->kinematics().as_string() << "];" << o->options().as_string() << "': "
-                        << e.what();
+                    Log::instance()->message("ObservableCache::update", ll_error) << "Exception encountered when evaluating cacheable observable '" << o->name() << "["
+                                                                                  << o->kinematics().as_string() << "];" << o->options().as_string() << "': " << e.what();
                     _imp->predictions[idx] = std::numeric_limits<double>::quiet_NaN();
-
                 }
             };
-            cacheable_tickets.push_back(ThreadPool::instance()->enqueue(std::function<void (void)>(f)));
+            cacheable_tickets.push_back(ThreadPool::instance()->enqueue(std::function<void(void)>(f)));
         }
 
         std::vector<Ticket> regular_tickets;
@@ -231,7 +236,8 @@ namespace eos
         // evaluate all regular observables in parallel
         for (auto ro : _imp->regular_observables)
         {
-            auto f = [=, this]() {
+            auto f = [=, this]()
+            {
                 auto & o   = std::get<0>(ro);
                 auto & idx = std::get<1>(ro);
                 try
@@ -240,14 +246,12 @@ namespace eos
                 }
                 catch (eos::Exception & e)
                 {
-                    Log::instance()->message("ObservableCache::update", ll_error)
-                        << "Exception encountered when evaluating regular observable '" << o->name() << "[" << o->kinematics().as_string() << "];" << o->options().as_string() << "': "
-                        << e.what();
+                    Log::instance()->message("ObservableCache::update", ll_error) << "Exception encountered when evaluating regular observable '" << o->name() << "["
+                                                                                  << o->kinematics().as_string() << "];" << o->options().as_string() << "': " << e.what();
                     _imp->predictions[idx] = std::numeric_limits<double>::quiet_NaN();
-
                 }
             };
-            regular_tickets.push_back(ThreadPool::instance()->enqueue(std::function<void (void)>(f)));
+            regular_tickets.push_back(ThreadPool::instance()->enqueue(std::function<void(void)>(f)));
         }
 
         // await completion of the cacheable observables
@@ -262,7 +266,8 @@ namespace eos
         // evaluate all cached observables in parallel
         for (auto co : _imp->cached_observables)
         {
-            auto f = [=, this]() {
+            auto f = [=, this]()
+            {
                 auto & o   = std::get<0>(co);
                 auto & idx = std::get<1>(co);
                 try
@@ -271,14 +276,12 @@ namespace eos
                 }
                 catch (eos::Exception & e)
                 {
-                    Log::instance()->message("ObservableCache::update", ll_error)
-                        << "Exception encountered when evaluating cached observable '" << o->name() << "[" << o->kinematics().as_string() << "];" << o->options().as_string() << "': "
-                        << e.what();
+                    Log::instance()->message("ObservableCache::update", ll_error) << "Exception encountered when evaluating cached observable '" << o->name() << "["
+                                                                                  << o->kinematics().as_string() << "];" << o->options().as_string() << "': " << e.what();
                     _imp->predictions[idx] = std::numeric_limits<double>::quiet_NaN();
-
                 }
             };
-            cached_tickets.push_back(ThreadPool::instance()->enqueue(std::function<void (void)>(f)));
+            cached_tickets.push_back(ThreadPool::instance()->enqueue(std::function<void(void)>(f)));
         }
 
         // await completion of the regular observables
@@ -311,9 +314,8 @@ namespace eos
             }
             catch (eos::Exception & e)
             {
-                Log::instance()->message("ObservableCache::update", ll_error)
-                    << "Exception encountered when evaluating expression observable '" << o->name() << "[" << o->kinematics().as_string() << "];" << o->options().as_string() << "': "
-                    << e.what();
+                Log::instance()->message("ObservableCache::update", ll_error) << "Exception encountered when evaluating expression observable '" << o->name() << "["
+                                                                              << o->kinematics().as_string() << "];" << o->options().as_string() << "': " << e.what();
                 _imp->predictions[idx] = std::numeric_limits<double>::quiet_NaN();
             }
         }
@@ -360,7 +362,7 @@ namespace eos
     {
         ObservableCache result(parameters);
 
-        for (auto o = _imp->observables.begin(), o_end = _imp->observables.end() ; o != o_end ; ++o)
+        for (auto o = _imp->observables.begin(), o_end = _imp->observables.end(); o != o_end; ++o)
         {
             // cloning cached observables creates independent *cacheable* observables
             // adding them back creates new and independent cached observables
@@ -371,4 +373,4 @@ namespace eos
 
         return result;
     }
-}
+} // namespace eos

--- a/eos/utils/observable_cache.hh
+++ b/eos/utils/observable_cache.hh
@@ -28,8 +28,7 @@
 
 namespace eos
 {
-    class ObservableCache :
-        public PrivateImplementationPattern<ObservableCache>
+    class ObservableCache : public PrivateImplementationPattern<ObservableCache>
     {
         public:
             ///@name Basic Functions
@@ -90,6 +89,6 @@ namespace eos
     };
 
     extern template class WrappedForwardIterator<ObservableCache::IteratorTag, ObservablePtr>;
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/observable_set.cc
+++ b/eos/utils/observable_set.cc
@@ -26,70 +26,71 @@
 
 namespace eos
 {
-    template <>
-    struct Implementation<ObservableSet>
+    template <> struct Implementation<ObservableSet>
     {
-        // The list of observables
-        std::vector<ObservablePtr> observables;
+            // The list of observables
+            std::vector<ObservablePtr> observables;
 
-        // <observable name, index>
-        std::map<QualifiedName, unsigned> observable_names;
+            // <observable name, index>
+            std::map<QualifiedName, unsigned> observable_names;
 
-        Implementation()
-        {
-        }
+            Implementation() {}
 
-        std::pair<unsigned, bool> add(const ObservablePtr & observable)
-        {
-            if (! observables.empty() && (observable->parameters() != observables.front()->parameters()))
-                throw InternalError("ObservableSet::add(): Mismatch of Parameters between different observables detected.");
-
-            // compare each observable for options, kinematics and name
-            unsigned index = 0;
-            for (auto i = observables.begin(), i_end = observables.end() ; i != i_end ; ++i, ++index)
+            std::pair<unsigned, bool>
+            add(const ObservablePtr & observable)
             {
-                if (identical_observables(*i, observable))
-                    return std::make_pair(index, false);
+                if (! observables.empty() && (observable->parameters() != observables.front()->parameters()))
+                {
+                    throw InternalError("ObservableSet::add(): Mismatch of Parameters between different observables detected.");
+                }
+
+                // compare each observable for options, kinematics and name
+                unsigned index = 0;
+                for (auto i = observables.begin(), i_end = observables.end(); i != i_end; ++i, ++index)
+                {
+                    if (identical_observables(*i, observable))
+                    {
+                        return std::make_pair(index, false);
+                    }
+                }
+
+                // new observable
+                observables.push_back(observable);
+
+                return std::make_pair(index, true);
             }
 
-            // new observable
-            observables.push_back(observable);
-
-            return std::make_pair(index, true);
-        }
-
-        static bool identical_observables(const ObservablePtr & lhs, const ObservablePtr & rhs)
-        {
-            // compare name
-            if (lhs->name() != rhs->name())
+            static bool
+            identical_observables(const ObservablePtr & lhs, const ObservablePtr & rhs)
             {
-                return false;
-            }
+                // compare name
+                if (lhs->name() != rhs->name())
+                {
+                    return false;
+                }
 
-            // compare kinematics
-            if( lhs->kinematics() != rhs->kinematics())
-            {
-                return false;
-            }
+                // compare kinematics
+                if (lhs->kinematics() != rhs->kinematics())
+                {
+                    return false;
+                }
 
-            // compare options
-            if (lhs->options() != rhs->options())
-            {
-                return false;
-            }
+                // compare options
+                if (lhs->options() != rhs->options())
+                {
+                    return false;
+                }
 
-            return true;
-        }
+                return true;
+            }
     };
 
     ObservableSet::ObservableSet() :
-    PrivateImplementationPattern<ObservableSet>(new Implementation<ObservableSet>())
+        PrivateImplementationPattern<ObservableSet>(new Implementation<ObservableSet>())
     {
     }
 
-    ObservableSet::~ObservableSet()
-    {
-    }
+    ObservableSet::~ObservableSet() {}
 
     std::pair<unsigned, bool>
     ObservableSet::add(const ObservablePtr & observable)
@@ -97,10 +98,9 @@ namespace eos
         return _imp->add(observable);
     }
 
-    template <>
-    struct WrappedForwardIteratorTraits<ObservableSet::IteratorTag>
+    template <> struct WrappedForwardIteratorTraits<ObservableSet::IteratorTag>
     {
-        using UnderlyingIterator = std::vector<ObservablePtr>::iterator;
+            using UnderlyingIterator = std::vector<ObservablePtr>::iterator;
     };
     template class WrappedForwardIterator<ObservableSet::IteratorTag, ObservablePtr>;
 
@@ -133,4 +133,4 @@ namespace eos
     {
         return _imp->observables.size();
     }
-}
+} // namespace eos

--- a/eos/utils/observable_set.hh
+++ b/eos/utils/observable_set.hh
@@ -31,8 +31,7 @@ namespace eos
      * i.e. they differ by at least one of the following:
      * name, kinematics, or options.
      */
-    class ObservableSet :
-        public PrivateImplementationPattern<ObservableSet>
+    class ObservableSet : public PrivateImplementationPattern<ObservableSet>
     {
         public:
             ///@name Basic Functions
@@ -83,6 +82,6 @@ namespace eos
     };
 
     extern template class WrappedForwardIterator<ObservableSet::IteratorTag, ObservablePtr>;
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/observable_set_TEST.cc
+++ b/eos/utils/observable_set_TEST.cc
@@ -17,17 +17,17 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/observable_set.hh>
 #include <eos/utils/observable_stub.hh>
+
+#include <test/test.hh>
 
 #include <vector>
 
 using namespace test;
 using namespace eos;
 
-class ObservableSetTest :
-    public TestCase
+class ObservableSetTest : public TestCase
 {
     public:
         ObservableSetTest() :
@@ -35,19 +35,20 @@ class ObservableSetTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // create simple observables vector
             {
                 ObservableSet o;
-                Parameters p = Parameters::Defaults();
+                Parameters    p = Parameters::Defaults();
                 o.add(ObservablePtr(new ObservableStub(p, "mass::b(MSbar)")));
                 o.add(ObservablePtr(new ObservableStub(p, "mass::c")));
                 o.add(ObservablePtr(new ObservableStub(p, "mass::s(2GeV)")));
 
                 p["mass::b(MSbar)"] = 4.5;
-                p["mass::c"] = 1.5;
-                p["mass::s(2GeV)"] = 0.1;
+                p["mass::c"]        = 1.5;
+                p["mass::s(2GeV)"]  = 0.1;
 
                 // evaluate the observables
                 std::vector<double> results;
@@ -62,8 +63,10 @@ class ObservableSetTest :
 
                 // check iterator
                 unsigned counter = 0;
-                for (auto i = o.begin(), i_end = o.end(); i != i_end ; ++i)
+                for (auto i = o.begin(), i_end = o.end(); i != i_end; ++i)
+                {
                     counter++;
+                }
                 TEST_CHECK_EQUAL(counter, 3);
 
                 // random access
@@ -73,7 +76,7 @@ class ObservableSetTest :
             // name, options and kinematics need to differ
             {
                 ObservableSet o;
-                Parameters p = Parameters::Defaults();
+                Parameters    p = Parameters::Defaults();
 
                 // adding to empty container should always work
                 TEST_CHECK(o.add(ObservablePtr(new ObservableStub(p, "mass::b(MSbar)"))).second);

--- a/eos/utils/observable_stub.cc
+++ b/eos/utils/observable_stub.cc
@@ -22,27 +22,26 @@
 
 namespace eos
 {
-    template <>
-    struct Implementation<ObservableStub>
+    template <> struct Implementation<ObservableStub>
     {
-        Parameters parameters;
+            Parameters parameters;
 
-        Kinematics kinematics;
+            Kinematics kinematics;
 
-        Options options;
+            Options options;
 
-        QualifiedName name;
+            QualifiedName name;
 
-        UsedParameter parameter;
+            UsedParameter parameter;
 
-        Implementation(const Parameters & p, const QualifiedName & n, const Kinematics & k, ParameterUser & u) :
-            parameters(p),
-            kinematics(k),
-            options(n.options()),
-            name(n),
-            parameter(p[n.str()], u)
-        {
-        }
+            Implementation(const Parameters & p, const QualifiedName & n, const Kinematics & k, ParameterUser & u) :
+                parameters(p),
+                kinematics(k),
+                options(n.options()),
+                name(n),
+                parameter(p[n.str()], u)
+            {
+            }
     };
 
     ObservableStub::ObservableStub(const Parameters & parameters, const QualifiedName & name, const Kinematics & kinematics) :
@@ -50,9 +49,7 @@ namespace eos
     {
     }
 
-    ObservableStub::~ObservableStub()
-    {
-    }
+    ObservableStub::~ObservableStub() {}
 
     const QualifiedName &
     ObservableStub::name() const
@@ -95,4 +92,4 @@ namespace eos
     {
         return ObservablePtr(new ObservableStub(parameters, _imp->name, _imp->kinematics));
     }
-}
+} // namespace eos

--- a/eos/utils/observable_stub.hh
+++ b/eos/utils/observable_stub.hh
@@ -26,9 +26,7 @@
 
 namespace eos
 {
-    class ObservableStub :
-        public Observable,
-        public PrivateImplementationPattern<ObservableStub>
+    class ObservableStub : public Observable, public PrivateImplementationPattern<ObservableStub>
     {
         public:
             ObservableStub(const Parameters & parameters, const QualifiedName & name, const Kinematics & kinematics = Kinematics());
@@ -49,6 +47,6 @@ namespace eos
 
             virtual ObservablePtr clone(const Parameters & parameters) const;
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/observable_stub_TEST.cc
+++ b/eos/utils/observable_stub_TEST.cc
@@ -17,14 +17,14 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/observable_stub.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
 
-class ObservableStubTest :
-    public TestCase
+class ObservableStubTest : public TestCase
 {
     public:
         ObservableStubTest() :
@@ -32,13 +32,14 @@ class ObservableStubTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // Setting and retrieval
             {
-                Parameters parameters = Parameters::Defaults();
-                Parameter p = parameters["mass::c"];
-                ObservablePtr o = ObservablePtr(new ObservableStub(parameters, "mass::c"));
+                Parameters    parameters = Parameters::Defaults();
+                Parameter     p          = parameters["mass::c"];
+                ObservablePtr o          = ObservablePtr(new ObservableStub(parameters, "mass::c"));
 
                 TEST_CHECK_EQUAL(p(), o->evaluate());
 
@@ -51,10 +52,10 @@ class ObservableStubTest :
 
             // Cloning w/ anonymous parameters
             {
-                Parameters parameters = Parameters::Defaults();
-                Parameter p = parameters["mass::c"];
-                ObservablePtr o1 = ObservablePtr(new ObservableStub(parameters, "mass::c"));
-                ObservablePtr o2 = o1->clone();
+                Parameters    parameters = Parameters::Defaults();
+                Parameter     p          = parameters["mass::c"];
+                ObservablePtr o1         = ObservablePtr(new ObservableStub(parameters, "mass::c"));
+                ObservablePtr o2         = o1->clone();
 
                 TEST_CHECK_EQUAL(o1->evaluate(), o2->evaluate());
 
@@ -67,13 +68,13 @@ class ObservableStubTest :
 
             // Check name, kinematics, options after cloning
             {
-                Parameters parameters = Parameters::Defaults();
-                ObservablePtr o1 = ObservablePtr(new ObservableStub(parameters, "mass::c"));
-                ObservablePtr o2 = o1->clone();
+                Parameters    parameters = Parameters::Defaults();
+                ObservablePtr o1         = ObservablePtr(new ObservableStub(parameters, "mass::c"));
+                ObservablePtr o2         = o1->clone();
 
                 TEST_CHECK_EQUAL(o1->name().full(), o2->name().full());
-                TEST_CHECK_EQUAL(o1->kinematics(),  o2->kinematics());
-                TEST_CHECK_EQUAL(o1->options(),     o2->options());
+                TEST_CHECK_EQUAL(o1->kinematics(), o2->kinematics());
+                TEST_CHECK_EQUAL(o1->options(), o2->options());
             }
         }
 } observable_stub_test;

--- a/eos/utils/one-of.hh
+++ b/eos/utils/one-of.hh
@@ -33,156 +33,133 @@ namespace eos
     /* Helpers */
     struct UnknownTypeForOneOf;
 
-    template <typename Want_, typename ... Types_>
-    struct SelectOneOfType;
+    template <typename Want_, typename... Types_> struct SelectOneOfType;
 
-    template <typename Want_>
-    struct SelectOneOfType<Want_>
+    template <typename Want_> struct SelectOneOfType<Want_>
     {
-        using Type = UnknownTypeForOneOf;
+            using Type = UnknownTypeForOneOf;
     };
 
-    template <typename Want_, typename Try_, typename ... Rest_>
-    struct SelectOneOfType<Want_, Try_, Rest_ ...>
+    template <typename Want_, typename Try_, typename... Rest_> struct SelectOneOfType<Want_, Try_, Rest_...>
     {
-        using Type = typename std::conditional<
-            std::is_same<Want_, Try_>::value,
-            Try_,
-            typename SelectOneOfType<Want_, Rest_ ...>::Type
-                >::type;
+            using Type = typename std::conditional<std::is_same<Want_, Try_>::value, Try_, typename SelectOneOfType<Want_, Rest_...>::Type>::type;
     };
 
     /* OneOfVisitor */
-    template <typename Type_>
-    struct OneOfVisitorVisit
+    template <typename Type_> struct OneOfVisitorVisit
     {
-        virtual void visit(Type_ &) = 0;
+            virtual void visit(Type_ &) = 0;
     };
 
-    template <typename ... Types_>
-    struct OneOfVisitor :
-        OneOfVisitorVisit<Types_> ...
-    {
-    };
+    template <typename... Types_> struct OneOfVisitor : OneOfVisitorVisit<Types_>...
+    {};
 
     /* OneOfVisitorWrapper */
-    template <typename Visitor_, typename Underlying_, typename Result_, typename ... Types_>
-    struct OneOfVisitorWrapperVisit;
+    template <typename Visitor_, typename Underlying_, typename Result_, typename... Types_> struct OneOfVisitorWrapperVisit;
 
-    template <typename Visitor_, typename Underlying_, typename Result_>
-    struct OneOfVisitorWrapperVisit<Visitor_, Underlying_, Result_> :
-        Visitor_
+    template <typename Visitor_, typename Underlying_, typename Result_> struct OneOfVisitorWrapperVisit<Visitor_, Underlying_, Result_> : Visitor_
     {
-        Underlying_ & underlying;
+            Underlying_ & underlying;
 
-        Result_ result;
+            Result_ result;
 
-        OneOfVisitorWrapperVisit(Underlying_ & u) :
-            underlying(u)
-        {
-        }
+            OneOfVisitorWrapperVisit(Underlying_ & u) :
+                underlying(u)
+            {
+            }
     };
 
-    template <typename Visitor_, typename Underlying_>
-    struct OneOfVisitorWrapperVisit<Visitor_, Underlying_, void> :
-        Visitor_
+    template <typename Visitor_, typename Underlying_> struct OneOfVisitorWrapperVisit<Visitor_, Underlying_, void> : Visitor_
     {
-        Underlying_ & underlying;
+            Underlying_ & underlying;
 
-        OneOfVisitorWrapperVisit(Underlying_ & u) :
-            underlying(u)
-        {
-        }
+            OneOfVisitorWrapperVisit(Underlying_ & u) :
+                underlying(u)
+            {
+            }
     };
 
-    template <typename Visitor_, typename Underlying_, typename Type_, typename ... Rest_>
-    struct OneOfVisitorWrapperVisit<Visitor_, Underlying_, void, Type_, Rest_ ...> :
-        OneOfVisitorWrapperVisit<Visitor_, Underlying_, void, Rest_ ...>
+    template <typename Visitor_, typename Underlying_, typename Type_, typename... Rest_>
+    struct OneOfVisitorWrapperVisit<Visitor_, Underlying_, void, Type_, Rest_...> : OneOfVisitorWrapperVisit<Visitor_, Underlying_, void, Rest_...>
     {
-        OneOfVisitorWrapperVisit(Underlying_ & u) :
-            OneOfVisitorWrapperVisit<Visitor_, Underlying_, void, Rest_ ...>(u)
-        {
-        }
+            OneOfVisitorWrapperVisit(Underlying_ & u) :
+                OneOfVisitorWrapperVisit<Visitor_, Underlying_, void, Rest_...>(u)
+            {
+            }
 
-        virtual void visit(Type_ & t)
-        {
-            this->underlying.visit(t);
-        }
+            virtual void
+            visit(Type_ & t)
+            {
+                this->underlying.visit(t);
+            }
     };
 
-    template <typename Visitor_, typename Underlying_, typename Result_, typename Type_, typename ... Rest_>
-    struct OneOfVisitorWrapperVisit<Visitor_, Underlying_, Result_, Type_, Rest_ ...> :
-        OneOfVisitorWrapperVisit<Visitor_, Underlying_, Result_, Rest_ ...>
+    template <typename Visitor_, typename Underlying_, typename Result_, typename Type_, typename... Rest_>
+    struct OneOfVisitorWrapperVisit<Visitor_, Underlying_, Result_, Type_, Rest_...> : OneOfVisitorWrapperVisit<Visitor_, Underlying_, Result_, Rest_...>
     {
-        OneOfVisitorWrapperVisit(Underlying_ & u) :
-            OneOfVisitorWrapperVisit<Visitor_, Underlying_, Result_, Rest_ ...>(u)
-        {
-        }
+            OneOfVisitorWrapperVisit(Underlying_ & u) :
+                OneOfVisitorWrapperVisit<Visitor_, Underlying_, Result_, Rest_...>(u)
+            {
+            }
 
-        virtual void visit(Type_ & t)
-        {
-            this->result = this->underlying.visit(t);
-        }
+            virtual void
+            visit(Type_ & t)
+            {
+                this->result = this->underlying.visit(t);
+            }
     };
 
-    template <typename Underlying_, typename Result_, typename ... Types_>
-    struct OneOfVisitorWrapper :
-        OneOfVisitorWrapperVisit<OneOfVisitor<Types_ ...>, Underlying_, Result_, Types_...>
+    template <typename Underlying_, typename Result_, typename... Types_>
+    struct OneOfVisitorWrapper : OneOfVisitorWrapperVisit<OneOfVisitor<Types_...>, Underlying_, Result_, Types_...>
     {
-        OneOfVisitorWrapper(Underlying_ & u) :
-            OneOfVisitorWrapperVisit<OneOfVisitor<Types_ ...>, Underlying_, Result_, Types_...>(u)
-        {
-        }
+            OneOfVisitorWrapper(Underlying_ & u) :
+                OneOfVisitorWrapperVisit<OneOfVisitor<Types_...>, Underlying_, Result_, Types_...>(u)
+            {
+            }
     };
 
     /* OneOf */
-    template <typename ... Types_>
-    struct OneOfValueBase
+    template <typename... Types_> struct OneOfValueBase
     {
-        virtual ~OneOfValueBase() = 0;
+            virtual ~OneOfValueBase() = 0;
 
-        virtual void accept(OneOfVisitor<Types_ ...> &) = 0;
+            virtual void accept(OneOfVisitor<Types_...> &) = 0;
     };
 
-    template <typename ... Types_>
-    OneOfValueBase<Types_ ...>::~OneOfValueBase() = default;
+    template <typename... Types_> OneOfValueBase<Types_...>::~OneOfValueBase() = default;
 
-    template <typename Type_, typename ... Types_>
-    struct OneOfValue :
-        OneOfValueBase<Types_ ...>
+    template <typename Type_, typename... Types_> struct OneOfValue : OneOfValueBase<Types_...>
     {
-        Type_ value;
+            Type_ value;
 
-        OneOfValue(const Type_ & type) :
-            value(type)
-        {
-        }
+            OneOfValue(const Type_ & type) :
+                value(type)
+            {
+            }
 
-        virtual void accept(OneOfVisitor<Types_ ...> & visitor)
-        {
-            static_cast<OneOfVisitorVisit<Type_> &>(visitor).visit(value);
-        }
+            virtual void
+            accept(OneOfVisitor<Types_...> & visitor)
+            {
+                static_cast<OneOfVisitorVisit<Type_> &>(visitor).visit(value);
+            }
     };
 
-    template <typename ... Types_>
-    class OneOf
+    template <typename... Types_> class OneOf
     {
         private:
-            std::shared_ptr<OneOfValueBase<Types_ ...>> _value;
+            std::shared_ptr<OneOfValueBase<Types_...>> _value;
 
-            OneOf(OneOfValueBase<Types_ ...> * ptr) :
+            OneOf(OneOfValueBase<Types_...> * ptr) :
                 _value(ptr)
             {
             }
 
         public:
-            OneOf()
-            {
-            }
+            OneOf() {}
 
             template <typename Type_>
             OneOf(const Type_ & value) :
-                _value(new OneOfValue<typename SelectOneOfType<Type_, Types_ ...>::Type, Types_ ...>{value})
+                _value(new OneOfValue<typename SelectOneOfType<Type_, Types_...>::Type, Types_...>{ value })
             {
             }
 
@@ -191,19 +168,22 @@ namespace eos
             {
             }
 
-            bool empty() const
+            bool
+            empty() const
             {
-                return !_value;
+                return ! _value;
             }
 
             template <typename Type_>
-            OneOf & operator= (const Type_ & value)
+            OneOf &
+            operator= (const Type_ & value)
             {
-                _value.reset(new OneOfValue<typename SelectOneOfType<Type_, Types_ ...>::Type, Types_ ...>{value});
+                _value.reset(new OneOfValue<typename SelectOneOfType<Type_, Types_...>::Type, Types_...>{ value });
                 return *this;
             }
 
-            OneOf & operator= (const OneOf & other)
+            OneOf &
+            operator= (const OneOf & other)
             {
                 _value = other._value;
 
@@ -211,23 +191,25 @@ namespace eos
             }
 
             template <typename Visitor_>
-            void accept(Visitor_ & visitor) const
+            void
+            accept(Visitor_ & visitor) const
             {
-                OneOfVisitorWrapper<Visitor_, void, Types_ ...> visitor_wrapper(visitor);
+                OneOfVisitorWrapper<Visitor_, void, Types_...> visitor_wrapper(visitor);
 
                 _value->accept(visitor_wrapper);
             }
 
             template <typename Result_, typename Visitor_>
-            Result_ accept_returning(Visitor_ & visitor) const
+            Result_
+            accept_returning(Visitor_ & visitor) const
             {
-                OneOfVisitorWrapper<Visitor_, Result_, Types_ ...> visitor_wrapper(visitor);
+                OneOfVisitorWrapper<Visitor_, Result_, Types_...> visitor_wrapper(visitor);
 
                 _value->accept(visitor_wrapper);
 
                 return visitor_wrapper.result;
             }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/one-of_TEST.cc
+++ b/eos/utils/one-of_TEST.cc
@@ -17,16 +17,16 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/one-of.hh>
+
+#include <test/test.hh>
 
 #include <array>
 
 using namespace test;
 using namespace eos;
 
-class OneOfTest :
-    public TestCase
+class OneOfTest : public TestCase
 {
     public:
         OneOfTest() :
@@ -34,7 +34,8 @@ class OneOfTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             using Type = OneOf<int, std::string>;
 
@@ -44,33 +45,40 @@ class OneOfTest :
         }
 } one_of_test;
 
-struct Foo {};
-struct Bar {};
-struct Baz {};
+struct Foo
+{};
+
+struct Bar
+{};
+
+struct Baz
+{};
 
 class TestVisitorReturningVoid
 {
     public:
         std::string result;
 
-        void visit(const Foo &)
+        void
+        visit(const Foo &)
         {
             result += "Foo";
         }
 
-        void visit(Bar &)
+        void
+        visit(Bar &)
         {
             result += "Bar";
         }
 
-        void visit(Baz)
+        void
+        visit(Baz)
         {
             result += "Baz";
         }
 };
 
-class OneOfVisitorReturningVoidTest :
-    public TestCase
+class OneOfVisitorReturningVoidTest : public TestCase
 {
     public:
         OneOfVisitorReturningVoidTest() :
@@ -78,17 +86,13 @@ class OneOfVisitorReturningVoidTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             using Type = OneOf<Foo, Bar, Baz>;
-            std::array<Type, 5> items
-            {{
-                Type{Foo()},
-                Type{Bar()},
-                Type{Bar()},
-                Type{Foo()},
-                Type{Baz()}
-            }};
+            std::array<Type, 5> items{
+                { Type{ Foo() }, Type{ Bar() }, Type{ Bar() }, Type{ Foo() }, Type{ Baz() } }
+            };
 
             TestVisitorReturningVoid visitor;
             for (const auto & item : items)
@@ -103,24 +107,26 @@ class OneOfVisitorReturningVoidTest :
 class TestVisitorReturningString
 {
     public:
-        std::string visit(const Foo &)
+        std::string
+        visit(const Foo &)
         {
             return "Foo";
         }
 
-        std::string visit(Bar &)
+        std::string
+        visit(Bar &)
         {
             return "Bar";
         }
 
-        std::string visit(Baz)
+        std::string
+        visit(Baz)
         {
             return "Baz";
         }
 };
 
-class OneOfVisitorReturningStringTest :
-    public TestCase
+class OneOfVisitorReturningStringTest : public TestCase
 {
     public:
         OneOfVisitorReturningStringTest() :
@@ -128,20 +134,16 @@ class OneOfVisitorReturningStringTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             using Type = OneOf<Foo, Bar, Baz>;
-            std::array<Type, 5> items
-            {{
-                Type{Foo()},
-                Type{Bar()},
-                Type{Bar()},
-                Type{Foo()},
-                Type{Baz()}
-            }};
+            std::array<Type, 5> items{
+                { Type{ Foo() }, Type{ Bar() }, Type{ Bar() }, Type{ Foo() }, Type{ Baz() } }
+            };
 
             TestVisitorReturningString visitor;
-            std::string result;
+            std::string                result;
             for (const auto & item : items)
             {
                 result += item.accept_returning<std::string>(visitor);

--- a/eos/utils/options-impl.hh
+++ b/eos/utils/options-impl.hh
@@ -40,7 +40,9 @@ namespace eos
                 _value(nullptr)
             {
                 if (! options.has(key))
+                {
                     throw UnspecifiedOptionError(key);
+                }
 
                 std::string raw_value(options[key]);
                 try
@@ -70,7 +72,11 @@ namespace eos
                 }
             }
 
-            const qnp::Name & value() const { return *_value; };
+            const qnp::Name &
+            value() const
+            {
+                return *_value;
+            }
     };
 
     class SwitchOption
@@ -79,8 +85,7 @@ namespace eos
             std::string _value;
 
         public:
-            SwitchOption(const Options & options, const qnp::OptionKey & key,
-                    const std::initializer_list<std::string> & allowed_values)
+            SwitchOption(const Options & options, const qnp::OptionKey & key, const std::initializer_list<std::string> & allowed_values)
             {
                 if (allowed_values.begin() == allowed_values.end())
                 {
@@ -100,9 +105,7 @@ namespace eos
                 }
             }
 
-            SwitchOption(const Options & options, const qnp::OptionKey & key,
-                    const std::initializer_list<std::string> & allowed_values,
-                    const std::string & default_value) :
+            SwitchOption(const Options & options, const qnp::OptionKey & key, const std::initializer_list<std::string> & allowed_values, const std::string & default_value) :
                 _value(options.get(key, default_value))
             {
                 if (allowed_values.begin() == allowed_values.end())
@@ -112,7 +115,8 @@ namespace eos
 
                 if (std::find(allowed_values.begin(), allowed_values.end(), default_value) == allowed_values.end())
                 {
-                    throw InternalError("SwitchOption: The default value '" + default_value + "'is not in the list of allowed values: '" + join(allowed_values.begin(), allowed_values.end()) + "'");
+                    throw InternalError("SwitchOption: The default value '" + default_value + "'is not in the list of allowed values: '"
+                                        + join(allowed_values.begin(), allowed_values.end()) + "'");
                 }
 
                 if (std::find(allowed_values.begin(), allowed_values.end(), _value) == allowed_values.end())
@@ -123,8 +127,12 @@ namespace eos
 
             ~SwitchOption() = default;
 
-            const std::string & value() const { return _value; };
+            const std::string &
+            value() const
+            {
+                return _value;
+            }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/options.cc
+++ b/eos/utils/options.cc
@@ -24,34 +24,30 @@
 #include <eos/utils/private_implementation_pattern-impl.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
-#include <map>
 #include <algorithm>
+#include <map>
 
 namespace eos
 {
-    template <>
-    struct WrappedForwardIteratorTraits<Options::OptionIteratorTag>
+    template <> struct WrappedForwardIteratorTraits<Options::OptionIteratorTag>
     {
-        using UnderlyingIterator = std::map<qnp::OptionKey, std::string>::const_iterator;
+            using UnderlyingIterator = std::map<qnp::OptionKey, std::string>::const_iterator;
     };
     template class WrappedForwardIterator<Options::OptionIteratorTag, const std::pair<const qnp::OptionKey, std::string>>;
 
-    template <>
-    struct Implementation<Options>
+    template <> struct Implementation<Options>
     {
-        std::map<qnp::OptionKey, std::string> options;
+            std::map<qnp::OptionKey, std::string> options;
 
-        Implementation()
-        {
-        }
+            Implementation() {}
 
-        Implementation(const std::initializer_list<std::pair<qnp::OptionKey, std::string>> & _options)
-        {
-            for (const auto & _option : _options)
+            Implementation(const std::initializer_list<std::pair<qnp::OptionKey, std::string>> & _options)
             {
-                options.insert(_option);
+                for (const auto & _option : _options)
+                {
+                    options.insert(_option);
+                }
             }
-        }
     };
 
     Options::Options() :
@@ -64,20 +60,22 @@ namespace eos
     {
     }
 
-    Options::~Options()
-    {
-    }
+    Options::~Options() {}
 
     bool
     Options::operator== (const Options & rhs) const
     {
         if (_imp->options.size() != rhs._imp->options.size())
+        {
             return false;
+        }
 
-        for (auto l = _imp->options.cbegin(), l_end = _imp->options.cend(), r = rhs._imp->options.cbegin() ; l != l_end ; ++l, ++r)
+        for (auto l = _imp->options.cbegin(), l_end = _imp->options.cend(), r = rhs._imp->options.cbegin(); l != l_end; ++l, ++r)
         {
             if (*l != *r)
+            {
                 return false;
+            }
         }
 
         return true;
@@ -94,7 +92,9 @@ namespace eos
     {
         auto i(_imp->options.find(key));
         if (_imp->options.end() == i)
+        {
             throw UnknownOptionError(key);
+        }
 
         return i->second;
     }
@@ -125,7 +125,9 @@ namespace eos
         auto i(_imp->options.find(key));
 
         if (_imp->options.end() == i)
+        {
             return default_value;
+        }
 
         return i->second;
     }
@@ -143,7 +145,7 @@ namespace eos
             ++i;
         }
 
-        for ( ; i != i_end ; ++i)
+        for (; i != i_end; ++i)
         {
             result += ',' + i->first.str() + '=' + i->second;
         }
@@ -169,17 +171,17 @@ namespace eos
         return _imp->options.empty();
     }
 
-    UnknownOptionError::UnknownOptionError(const qnp::OptionKey & key) throw () :
+    UnknownOptionError::UnknownOptionError(const qnp::OptionKey & key) throw() :
         Exception("Unknown option: '" + key.str() + "'")
     {
     }
 
-    InvalidOptionValueError::InvalidOptionValueError(const qnp::OptionKey & key, const std::string & value, const std::string & allowed) throw () :
+    InvalidOptionValueError::InvalidOptionValueError(const qnp::OptionKey & key, const std::string & value, const std::string & allowed) throw() :
         Exception("Invalid value '" + value + "' for option: '" + key.str() + "'" + (allowed.empty() ? "" : ". Allowed values: '" + allowed + "'"))
     {
     }
 
-    UnspecifiedOptionError::UnspecifiedOptionError(const qnp::OptionKey & key, const std::string & allowed) throw () :
+    UnspecifiedOptionError::UnspecifiedOptionError(const qnp::OptionKey & key, const std::string & allowed) throw() :
         Exception("Mandatory option '" + key.str() + "' not specified'" + (allowed.empty() ? "" : ". Allowed values: '" + allowed + "'"))
     {
     }
@@ -231,7 +233,9 @@ namespace eos
         if (! options.has(specification.key))
         {
             if ("" == specification.default_value)
+            {
                 throw UnspecifiedOptionError(specification.key, join(specification.allowed_values.cbegin(), specification.allowed_values.cend()));
+            }
 
             _value = specification.default_value;
         }
@@ -244,20 +248,19 @@ namespace eos
     SpecifiedOption::SpecifiedOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key) :
         _specification("dummy"_ok, {}, "")
     {
-        const auto s = std::find_if(specifications.cbegin(), specifications.cend(), [&] (const auto & e) -> bool {
-            return e.key == key;
-        });
+        const auto s = std::find_if(specifications.cbegin(), specifications.cend(), [&](const auto & e) -> bool { return e.key == key; });
 
         if (specifications.cend() == s)
+        {
             throw UnspecifiedOptionError("Options key '" + key.str() + "' is not specified in the options specifications");
+        }
 
         *this = SpecifiedOption(options, *s);
     }
 
     SpecifiedOption::~SpecifiedOption() = default;
 
-    SpecifiedOption &
-    SpecifiedOption::operator= (const SpecifiedOption & other) = default;
+    SpecifiedOption & SpecifiedOption::operator= (const SpecifiedOption & other) = default;
 
     const std::string &
     SpecifiedOption::value() const
@@ -346,16 +349,17 @@ namespace eos
     LeptonFlavor
     LeptonFlavorOption::value() const
     {
-        static const std::map<std::string, LeptonFlavor> map
-        {
-            { "e",   LeptonFlavor::electron },
-            { "mu",  LeptonFlavor::muon     },
-            { "tau", LeptonFlavor::tauon    }
+        static const std::map<std::string, LeptonFlavor> map{
+            {   "e", LeptonFlavor::electron },
+            {  "mu",     LeptonFlavor::muon },
+            { "tau",    LeptonFlavor::tauon }
         };
 
         const auto i = map.find(_value);
         if (map.cend() == i)
+        {
             throw InternalError("Invalid lepton flavor '" + _value + "' encountered in LeptonFlavorOption::value()");
+        }
 
         return i->second;
     }
@@ -376,19 +380,20 @@ namespace eos
     QuarkFlavor
     QuarkFlavorOption::value() const
     {
-        static const std::map<std::string, QuarkFlavor> map
-        {
-            { "u", QuarkFlavor::up      },
-            { "d", QuarkFlavor::down    },
+        static const std::map<std::string, QuarkFlavor> map{
+            { "u",      QuarkFlavor::up },
+            { "d",    QuarkFlavor::down },
             { "s", QuarkFlavor::strange },
-            { "c", QuarkFlavor::charm   },
-            { "b", QuarkFlavor::bottom  },
-            { "t", QuarkFlavor::top     }
+            { "c",   QuarkFlavor::charm },
+            { "b",  QuarkFlavor::bottom },
+            { "t",     QuarkFlavor::top }
         };
 
         const auto i = map.find(_value);
         if (map.cend() == i)
+        {
             throw InternalError("Invalid quark flavor '" + _value + "' encountered in QuarkFlavorOption::value()");
+        }
 
         return i->second;
     }
@@ -409,23 +414,24 @@ namespace eos
     LightMeson
     LightMesonOption::value() const
     {
-        static const std::map<std::string, LightMeson> map
-        {
-            { "pi^0",      LightMeson::pi0     },
-            { "pi^+",      LightMeson::piplus  },
-            { "pi^-",      LightMeson::piminus },
-            { "K_d",       LightMeson::K0      },
-            { "Kbar_d",    LightMeson::K0bar   },
-            { "K_S",       LightMeson::KS      },
-            { "K_u",       LightMeson::Kplus   },
-            { "Kbar_u",    LightMeson::Kminus  },
-            { "eta",       LightMeson::eta     },
-            { "eta_prime", LightMeson::etap    }
+        static const std::map<std::string, LightMeson> map{
+            {      "pi^0",     LightMeson::pi0 },
+            {      "pi^+",  LightMeson::piplus },
+            {      "pi^-", LightMeson::piminus },
+            {       "K_d",      LightMeson::K0 },
+            {    "Kbar_d",   LightMeson::K0bar },
+            {       "K_S",      LightMeson::KS },
+            {       "K_u",   LightMeson::Kplus },
+            {    "Kbar_u",  LightMeson::Kminus },
+            {       "eta",     LightMeson::eta },
+            { "eta_prime",    LightMeson::etap }
         };
 
         const auto i = map.find(_value);
         if (map.cend() == i)
+        {
             throw InternalError("Invalid light meson '" + _value + "' encountered in LightMesonOption::value()");
+        }
 
         return i->second;
     }
@@ -441,7 +447,9 @@ namespace eos
         _isospin_value(destringify<Isospin>(_value))
     {
         if (((_isospin_value ^ destringify<Isospin>(this->_specification.allowed_values.front())) & _isospin_value) != Isospin::none)
+        {
             throw InvalidOptionValueError(_specification.key, _value, join(_specification.allowed_values.cbegin(), _specification.allowed_values.cend()));
+        }
     }
 
     IsospinOption::~IsospinOption() = default;
@@ -463,7 +471,9 @@ namespace eos
         _partial_wave_value(destringify<PartialWave>(_value))
     {
         if (((_partial_wave_value ^ destringify<PartialWave>(this->_specification.allowed_values.front())) & _partial_wave_value) != PartialWave::none)
+        {
             throw InvalidOptionValueError(_specification.key, _value, join(_specification.allowed_values.cbegin(), _specification.allowed_values.cend()));
+        }
     }
 
     PartialWaveOption::~PartialWaveOption() = default;
@@ -479,4 +489,4 @@ namespace eos
     {
         return _value;
     }
-}
+} // namespace eos

--- a/eos/utils/options.hh
+++ b/eos/utils/options.hh
@@ -35,35 +35,31 @@ namespace eos
     /*!
      * UnknownOptionError is thrown when an Options object does not contain a value for a given option key.
      */
-    struct UnknownOptionError :
-        public Exception
+    struct UnknownOptionError : public Exception
     {
-        UnknownOptionError(const qnp::OptionKey & key) throw ();
+            UnknownOptionError(const qnp::OptionKey & key) throw();
     };
 
     /*!
      * InvalidOptionValueError is thrown when the value passed to a known option is invalid.
      */
-    struct InvalidOptionValueError :
-        public Exception
+    struct InvalidOptionValueError : public Exception
     {
-        InvalidOptionValueError(const qnp::OptionKey & key, const std::string & value, const std::string & allowed = "") throw ();
+            InvalidOptionValueError(const qnp::OptionKey & key, const std::string & value, const std::string & allowed = "") throw();
     };
 
     /*!
      * UnspecifiedOptionError is thrown by an observable provider or similar when a mandatory option is not specified.
      */
-    struct UnspecifiedOptionError :
-        public Exception
+    struct UnspecifiedOptionError : public Exception
     {
-        UnspecifiedOptionError(const qnp::OptionKey & key, const std::string & allowed = "") throw ();
+            UnspecifiedOptionError(const qnp::OptionKey & key, const std::string & allowed = "") throw();
     };
 
     /*!
      * Options keeps the set of all string options for any Observable.
      */
-    class Options :
-        public PrivateImplementationPattern<Options>
+    class Options : public PrivateImplementationPattern<Options>
     {
         public:
             friend Options operator+ (const Options &, const Options &);
@@ -129,13 +125,13 @@ namespace eos
      */
     struct OptionSpecification
     {
-        OptionSpecification(const OptionSpecification &);
-        OptionSpecification(const qnp::OptionKey & key_in, const std::vector<std::string> & allowed_values_in);
-        OptionSpecification(const qnp::OptionKey & key_in, const std::vector<std::string> & allowed_values_in, const std::string & default_value_in);
+            OptionSpecification(const OptionSpecification &);
+            OptionSpecification(const qnp::OptionKey & key_in, const std::vector<std::string> & allowed_values_in);
+            OptionSpecification(const qnp::OptionKey & key_in, const std::vector<std::string> & allowed_values_in, const std::string & default_value_in);
 
-        qnp::OptionKey key;
-        std::vector<std::string> allowed_values;
-        std::string default_value;
+            qnp::OptionKey           key;
+            std::vector<std::string> allowed_values;
+            std::string              default_value;
     };
 
     class SpecifiedOption
@@ -145,7 +141,7 @@ namespace eos
 
         protected:
             OptionSpecification _specification;
-            std::string _value;
+            std::string         _value;
 
         public:
             SpecifiedOption(const SpecifiedOption &);
@@ -156,16 +152,14 @@ namespace eos
             const std::string & value() const;
     };
 
-    class RestrictedOption :
-        public SpecifiedOption
+    class RestrictedOption : public SpecifiedOption
     {
         public:
             RestrictedOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key);
             ~RestrictedOption();
     };
 
-    class BooleanOption :
-        public SpecifiedOption
+    class BooleanOption : public SpecifiedOption
     {
         private:
             bool boolean_value;
@@ -174,12 +168,11 @@ namespace eos
             BooleanOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "true"_ok);
             ~BooleanOption();
 
-            bool value() const;
+            bool                value() const;
             const std::string & str() const;
     };
 
-    class IntegerOption :
-        public SpecifiedOption
+    class IntegerOption : public SpecifiedOption
     {
         private:
             double _int_value;
@@ -188,12 +181,11 @@ namespace eos
             IntegerOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key);
             ~IntegerOption();
 
-            double value() const;
+            double              value() const;
             const std::string & str() const;
     };
 
-    class FloatOption :
-        public SpecifiedOption
+    class FloatOption : public SpecifiedOption
     {
         private:
             double _float_value;
@@ -202,45 +194,41 @@ namespace eos
             FloatOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key);
             ~FloatOption();
 
-            double value() const;
+            double              value() const;
             const std::string & str() const;
     };
 
-    class LeptonFlavorOption :
-        public RestrictedOption
+    class LeptonFlavorOption : public RestrictedOption
     {
         public:
             LeptonFlavorOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "l"_ok);
             ~LeptonFlavorOption();
 
-            LeptonFlavor value() const;
+            LeptonFlavor        value() const;
             const std::string & str() const;
     };
 
-    class QuarkFlavorOption :
-        public RestrictedOption
+    class QuarkFlavorOption : public RestrictedOption
     {
         public:
             QuarkFlavorOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "q"_ok);
             ~QuarkFlavorOption();
 
-            QuarkFlavor value() const;
+            QuarkFlavor         value() const;
             const std::string & str() const;
     };
 
-    class LightMesonOption :
-        public RestrictedOption
+    class LightMesonOption : public RestrictedOption
     {
         public:
             LightMesonOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key);
             ~LightMesonOption();
 
-            LightMeson value() const;
+            LightMeson          value() const;
             const std::string & str() const;
     };
 
-    class IsospinOption :
-        public SpecifiedOption
+    class IsospinOption : public SpecifiedOption
     {
         private:
             Isospin _isospin_value;
@@ -249,12 +237,11 @@ namespace eos
             IsospinOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "I"_ok);
             ~IsospinOption();
 
-            Isospin value() const;
+            Isospin             value() const;
             const std::string & str() const;
     };
 
-    class PartialWaveOption :
-        public SpecifiedOption
+    class PartialWaveOption : public SpecifiedOption
     {
         private:
             PartialWave _partial_wave_value;
@@ -263,9 +250,9 @@ namespace eos
             PartialWaveOption(const Options & options, const std::vector<OptionSpecification> & specifications, const qnp::OptionKey & key = "L"_ok);
             ~PartialWaveOption();
 
-            PartialWave value() const;
+            PartialWave         value() const;
             const std::string & str() const;
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/options_TEST.cc
+++ b/eos/utils/options_TEST.cc
@@ -17,17 +17,17 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
-#include <eos/utils/options.hh>
 #include <eos/utils/options-impl.hh>
+#include <eos/utils/options.hh>
+
+#include <test/test.hh>
 
 #include <cmath>
 
 using namespace test;
 using namespace eos;
 
-class OptionsTest :
-    public TestCase
+class OptionsTest : public TestCase
 {
     public:
         OptionsTest() :
@@ -35,17 +35,17 @@ class OptionsTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // Creation from initializer list
             {
-                Options options
-                {
-                    { "q"_ok, "d"  },
+                Options options{
+                    { "q"_ok,  "d" },
                     { "l"_ok, "mu" },
                 };
 
-                TEST_CHECK_EQUAL("d",  options.get("q"_ok, "s"));
+                TEST_CHECK_EQUAL("d", options.get("q"_ok, "s"));
                 TEST_CHECK_EQUAL("mu", options.get("l"_ok, "tau"));
             }
 
@@ -61,38 +61,34 @@ class OptionsTest :
 
             // Merging w/o duplicates
             {
-                Options o1
-                {
+                Options o1{
                     { "q"_ok, "d" }
                 };
 
-                Options o2
-                {
+                Options o2{
                     { "l"_ok, "mu" }
                 };
 
                 Options o3 = o1 + o2;
 
-                TEST_CHECK_EQUAL("d"_ok,  o3.get("q"_ok, "s"));
+                TEST_CHECK_EQUAL("d"_ok, o3.get("q"_ok, "s"));
                 TEST_CHECK_EQUAL("mu"_ok, o3.get("l"_ok, "tau"));
             }
 
             // Merging w/ duplicates
             {
-                Options o1
-                {
+                Options o1{
                     { "q"_ok, "d" }
                 };
 
-                Options o2
-                {
-                    { "q"_ok, "s" },
+                Options o2{
+                    { "q"_ok,  "s" },
                     { "l"_ok, "mu" }
                 };
 
                 Options o3 = o1 + o2;
 
-                TEST_CHECK_EQUAL("s"_ok,  o3.get("q"_ok, "foo"));
+                TEST_CHECK_EQUAL("s"_ok, o3.get("q"_ok, "foo"));
                 TEST_CHECK_EQUAL("mu"_ok, o3.get("l"_ok, "tau"));
             }
 
@@ -128,10 +124,9 @@ class OptionsTest :
 
             // Iteration (check for names, values, and lexicographical order)
             {
-                Options o
-                {
-                    { "l"_ok,     "tau"     },
-                    { "q"_ok,     "u"       },
+                Options o{
+                    {     "l"_ok, "tau" },
+                    {     "q"_ok,   "u" },
                     { "model"_ok, "CKM" },
                 };
 
@@ -153,8 +148,7 @@ class OptionsTest :
         }
 } options_test;
 
-class NameOptionTest :
-    public TestCase
+class NameOptionTest : public TestCase
 {
     public:
         NameOptionTest() :
@@ -162,12 +156,12 @@ class NameOptionTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // Creation with valid default value, value = default value
             {
-                NameOption no
-                {
+                NameOption no{
                     Options{ { "key"_ok, "value1" }, { "unused"_ok, "foo" } },
                     "key"_ok,
                     qnp::Name("value1")
@@ -177,19 +171,13 @@ class NameOptionTest :
 
             // Creation with unspecified value
             {
-                NameOption no
-                {
-                    Options{ { "unused"_ok, "foo" } },
-                    "key"_ok,
-                    qnp::Name("value1")
-                };
+                NameOption no{ Options{ { "unused"_ok, "foo" } }, "key"_ok, qnp::Name("value1") };
                 TEST_CHECK_EQUAL(no.value(), qnp::Name("value1"));
             }
 
             // Creation without default value
             {
-                NameOption no
-                {
+                NameOption no{
                     Options{ { "key"_ok, "value4" }, { "unused"_ok, "foo" } },
                     "key"_ok,
                 };
@@ -198,24 +186,16 @@ class NameOptionTest :
 
             // Creation with unspecified value, non-empty list, no default value
             {
-                auto test = [] ()
-                {
-                    NameOption no
-                    {
-                        Options{ { "unused"_ok, "foo" } },
-                        "key"_ok
-                    };
-                };
+                auto test = []() { NameOption no{ Options{ { "unused"_ok, "foo" } }, "key"_ok }; };
                 TEST_CHECK_THROWS(UnspecifiedOptionError, test());
             }
 
             // Creation with invalid value
             {
-                auto test = [] ()
+                auto test = []()
                 {
-                    NameOption so
-                    {
-                        Options{ { "key"_ok, "invalid@value"}, { "unused"_ok, "foo" } },
+                    NameOption so{
+                        Options{ { "key"_ok, "invalid@value" }, { "unused"_ok, "foo" } },
                         "key"_ok,
                         qnp::Name("value1")
                     };
@@ -225,8 +205,7 @@ class NameOptionTest :
         }
 } name_option_test;
 
-class SwitchOptionTest :
-    public TestCase
+class SwitchOptionTest : public TestCase
 {
     public:
         SwitchOptionTest() :
@@ -234,12 +213,12 @@ class SwitchOptionTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // Creation with valid default value, value = default value, non-empty list
             {
-                SwitchOption so
-                {
+                SwitchOption so{
                     Options{ { "key"_ok, "value1" }, { "unused"_ok, "foo" } },
                     "key"_ok,
                     { "value1", "value2", "value4" },
@@ -250,8 +229,7 @@ class SwitchOptionTest :
 
             // Creation with unspecified value, non-empty list
             {
-                SwitchOption so
-                {
+                SwitchOption so{
                     Options{ { "unused"_ok, "foo" } },
                     "key"_ok,
                     { "value1", "value2", "value4" },
@@ -262,8 +240,7 @@ class SwitchOptionTest :
 
             // Creation with non-empty list, no default value
             {
-                SwitchOption so
-                {
+                SwitchOption so{
                     Options{ { "key"_ok, "value4" }, { "unused"_ok, "foo" } },
                     "key"_ok,
                     { "value1", "value2", "value4" }
@@ -273,10 +250,9 @@ class SwitchOptionTest :
 
             // Creation with unspecified value, non-empty list, no default value
             {
-                auto test = [] ()
+                auto test = []()
                 {
-                    SwitchOption so
-                    {
+                    SwitchOption so{
                         Options{ { "unused"_ok, "foo" } },
                         "key"_ok,
                         { "value1", "value2", "value4" }
@@ -287,11 +263,10 @@ class SwitchOptionTest :
 
             // Creation with value not in list of allowed values
             {
-                auto test = [] ()
+                auto test = []()
                 {
-                    SwitchOption so
-                    {
-                        Options{ { "key"_ok, "value3"}, { "unused"_ok, "foo" } },
+                    SwitchOption so{
+                        Options{ { "key"_ok, "value3" }, { "unused"_ok, "foo" } },
                         "key"_ok,
                         { "value1", "value2", "value4" },
                         "value1"
@@ -302,13 +277,12 @@ class SwitchOptionTest :
 
             // Creating with empty list
             {
-                auto test = [] ()
+                auto test = []()
                 {
-                    SwitchOption so
-                    {
+                    SwitchOption so{
                         Options{ { "key"_ok, "value1" }, { "unused"_ok, "foo" } },
                         "key"_ok,
-                        { },
+                        {},
                         "value1"
                     };
                 };
@@ -317,8 +291,7 @@ class SwitchOptionTest :
         }
 } switch_option_test;
 
-class SpecifiedOptionTest :
-    public TestCase
+class SpecifiedOptionTest : public TestCase
 {
     public:
         SpecifiedOptionTest() :
@@ -326,22 +299,19 @@ class SpecifiedOptionTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // specify permitted options
-            std::vector<OptionSpecification> specifications
-            {
-                { "key-with-full-specification"_ok,   { "value1", "value2", "value4" }, "value1" },
-                { "key-without-default"_ok,           { "value1", "value2", "value4" }           }
+            std::vector<OptionSpecification> specifications{
+                { "key-with-full-specification"_ok, { "value1", "value2", "value4" }, "value1" },
+                { "key-without-default"_ok, { "value1", "value2", "value4" } }
             };
 
             // Creation of fully specified option, with value
             {
-                SpecifiedOption so
-                {
-                    Options{
-                        { "key-with-full-specification"_ok, "value1" }, { "unused"_ok, "foo" }
-                    },
+                SpecifiedOption so{
+                    Options{ { "key-with-full-specification"_ok, "value1" }, { "unused"_ok, "foo" } },
                     specifications,
                     "key-with-full-specification"_ok
                 };
@@ -350,24 +320,14 @@ class SpecifiedOptionTest :
 
             // Creation of fully specified option, without value
             {
-                SpecifiedOption so
-                {
-                    Options{
-                        { "unused"_ok, "foo" }
-                    },
-                    specifications,
-                    "key-with-full-specification"_ok
-                };
+                SpecifiedOption so{ Options{ { "unused"_ok, "foo" } }, specifications, "key-with-full-specification"_ok };
                 TEST_CHECK_EQUAL(so.value(), "value1");
             }
 
             // Creation of specified option without default value, with value
             {
-                SpecifiedOption so
-                {
-                    Options{
-                        { "key-without-default"_ok, "value4" }, { "unused"_ok, "foo" }
-                    },
+                SpecifiedOption so{
+                    Options{ { "key-without-default"_ok, "value4" }, { "unused"_ok, "foo" } },
                     specifications,
                     "key-without-default"_ok
                 };
@@ -375,24 +335,13 @@ class SpecifiedOptionTest :
             }
             // Creation of specified option without default value, without value
             {
-                auto test = [specifications] ()
-                {
-                    SpecifiedOption so
-                    {
-                        Options{
-                            { "unused"_ok, "foo" }
-                        },
-                        specifications,
-                        "key-without-default"_ok
-                    };
-                };
+                auto test = [specifications]() { SpecifiedOption so{ Options{ { "unused"_ok, "foo" } }, specifications, "key-without-default"_ok }; };
                 TEST_CHECK_THROWS(UnspecifiedOptionError, test());
             }
         }
 } specified_option_test;
 
-class RestrictedOptionTest :
-    public TestCase
+class RestrictedOptionTest : public TestCase
 {
     public:
         RestrictedOptionTest() :
@@ -400,26 +349,23 @@ class RestrictedOptionTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // specify permitted options
-            std::vector<OptionSpecification> specifications
-            {
-                { "key-with-default"_ok,              { "value1", "value2", "value4" }, "value1" },
-                { "key-without-value"_ok,             { "foo", "bar" },                 "foo"    },
-                { "key-without-default"_ok,           { "value1", "value2", "value4" }           },
-                { "key-without-value-and-default"_ok, { "foo", "bar" }                           },
-                { "key-with-invalid-default"_ok,      { "value1", "value2", "value4" }, "value3" },
-                { "key-with-invalid-value"_ok,        { "value1", "value2", "value4" }, "value1" },
+            std::vector<OptionSpecification> specifications{
+                { "key-with-default"_ok, { "value1", "value2", "value4" }, "value1" },
+                { "key-without-value"_ok, { "foo", "bar" }, "foo" },
+                { "key-without-default"_ok, { "value1", "value2", "value4" } },
+                { "key-without-value-and-default"_ok, { "foo", "bar" } },
+                { "key-with-invalid-default"_ok, { "value1", "value2", "value4" }, "value3" },
+                { "key-with-invalid-value"_ok, { "value1", "value2", "value4" }, "value1" },
             };
 
             // Creation of option with valid default value, with value = default value
             {
-                RestrictedOption so
-                {
-                    Options{
-                        { "key-with-default"_ok, "value1" }, { "unused"_ok, "foo" }
-                    },
+                RestrictedOption so{
+                    Options{ { "key-with-default"_ok, "value1" }, { "unused"_ok, "foo" } },
                     specifications,
                     "key-with-default"_ok
                 };
@@ -428,24 +374,14 @@ class RestrictedOptionTest :
 
             // Creation of option with valid default value, with unspecified value
             {
-                RestrictedOption so
-                {
-                    Options{
-                        { "unused"_ok, "foo" }
-                    },
-                    specifications,
-                    "key-without-value"_ok
-                };
+                RestrictedOption so{ Options{ { "unused"_ok, "foo" } }, specifications, "key-without-value"_ok };
                 TEST_CHECK_EQUAL(so.value(), "foo");
             }
 
             // Creation of option without default valuee, with valid value
             {
-                RestrictedOption so
-                {
-                    Options{
-                        { "key-without-default"_ok, "value4" }, { "unused"_ok, "foo" }
-                    },
+                RestrictedOption so{
+                    Options{ { "key-without-default"_ok, "value4" }, { "unused"_ok, "foo" } },
                     specifications,
                     "key-without-default"_ok
                 };
@@ -454,45 +390,22 @@ class RestrictedOptionTest :
 
             // Creation of option without default value, with unspecified valu
             {
-                auto test = [specifications] ()
-                {
-                    RestrictedOption so
-                    {
-                        Options{
-                            { "unused"_ok, "foo" }
-                        },
-                        specifications,
-                        "key-without-value-and-default"_ok
-                    };
-                };
+                auto test = [specifications]() { RestrictedOption so{ Options{ { "unused"_ok, "foo" } }, specifications, "key-without-value-and-default"_ok }; };
                 TEST_CHECK_THROWS(UnspecifiedOptionError, test());
             }
 
             // Creation with invalid value
             {
-                auto test = [specifications] ()
-                {
-                    RestrictedOption so
-                    {
-                        Options{
-                            { "unused"_ok, "foo" }
-                        },
-                        specifications,
-                        "key-with-invalid-default"_ok
-                    };
-                };
+                auto test = [specifications]() { RestrictedOption so{ Options{ { "unused"_ok, "foo" } }, specifications, "key-with-invalid-default"_ok }; };
                 TEST_CHECK_THROWS(InvalidOptionValueError, test());
             }
 
             // Creation with invalid value
             {
-                auto test = [specifications] ()
+                auto test = [specifications]()
                 {
-                    RestrictedOption so
-                    {
-                        Options{
-                            { "key-with-invalid-value"_ok, "value3"}, { "unused"_ok, "foo" }
-                        },
+                    RestrictedOption so{
+                        Options{ { "key-with-invalid-value"_ok, "value3" }, { "unused"_ok, "foo" } },
                         specifications,
                         "key-with-invalid-value"_ok
                     };
@@ -502,8 +415,7 @@ class RestrictedOptionTest :
         }
 } restricted_option_test;
 
-class IsospinOptionTest :
-    public TestCase
+class IsospinOptionTest : public TestCase
 {
     public:
         IsospinOptionTest() :
@@ -511,89 +423,47 @@ class IsospinOptionTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // specify permitted options
-            std::vector<OptionSpecification> specifications
-            {
-                { "I"_ok,              { "0|2" }, "0" },
+            std::vector<OptionSpecification> specifications{
+                { "I"_ok, { "0|2" }, "0" },
             };
 
             // Creation of option with valid default value, with value = default value
             {
-                IsospinOption so
-                {
-                    Options{
-                        { "I"_ok, "0" }
-                    },
-                    specifications,
-                    "I"_ok
-                };
+                IsospinOption so{ Options{ { "I"_ok, "0" } }, specifications, "I"_ok };
                 TEST_CHECK_EQUAL(so.value(), Isospin::zero);
             }
 
             // Creation of option with valid default value, with value != default value
             {
-                IsospinOption so
-                {
-                    Options{
-                        { "I"_ok, "2" }
-                    },
-                    specifications,
-                    "I"_ok
-                };
+                IsospinOption so{ Options{ { "I"_ok, "2" } }, specifications, "I"_ok };
                 TEST_CHECK_EQUAL(so.value(), Isospin::two);
             }
 
             // Creation of option with valid default value, with value != default value but containing default value
             {
-                IsospinOption so
-                {
-                    Options{
-                        { "I"_ok, "0|2" }
-                    },
-                    specifications,
-                    "I"_ok
-                };
+                IsospinOption so{ Options{ { "I"_ok, "0|2" } }, specifications, "I"_ok };
                 TEST_CHECK_EQUAL(so.value(), Isospin::zero | Isospin::two);
             }
 
             // Creation with invalid value
             {
-                auto test = [specifications] ()
-                {
-                    IsospinOption so
-                    {
-                        Options{
-                            { "I"_ok, "1"}
-                        },
-                        specifications,
-                        "I"_ok
-                    };
-                };
+                auto test = [specifications]() { IsospinOption so{ Options{ { "I"_ok, "1" } }, specifications, "I"_ok }; };
                 TEST_CHECK_THROWS(InvalidOptionValueError, test());
             }
 
             // Creation with invalid value but containing a valid value
             {
-                auto test = [specifications] ()
-                {
-                    IsospinOption so
-                    {
-                        Options{
-                            { "I"_ok, "0|1"}
-                        },
-                        specifications,
-                        "I"_ok
-                    };
-                };
+                auto test = [specifications]() { IsospinOption so{ Options{ { "I"_ok, "0|1" } }, specifications, "I"_ok }; };
                 TEST_CHECK_THROWS(InvalidOptionValueError, test());
             }
         }
 } isospin_option_test;
 
-class PartialWaveOptionTest :
-    public TestCase
+class PartialWaveOptionTest : public TestCase
 {
     public:
         PartialWaveOptionTest() :
@@ -601,82 +471,41 @@ class PartialWaveOptionTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // specify permitted options
-            std::vector<OptionSpecification> specifications
-            {
-                { "L"_ok,              { "S|P|D" }, "S|P" },
+            std::vector<OptionSpecification> specifications{
+                { "L"_ok, { "S|P|D" }, "S|P" },
             };
 
             // Creation of option with valid default value, with value = default value
             {
-                PartialWaveOption so
-                {
-                    Options{
-                        { "L"_ok, "S|P" }
-                    },
-                    specifications,
-                    "L"_ok
-                };
+                PartialWaveOption so{ Options{ { "L"_ok, "S|P" } }, specifications, "L"_ok };
                 TEST_CHECK_EQUAL(so.value(), PartialWave::S | PartialWave::P);
             }
 
             // Creation of option with valid default value, with value != default value but part of default value
             {
-                PartialWaveOption so
-                {
-                    Options{
-                        { "L"_ok, "P" }
-                    },
-                    specifications,
-                    "L"_ok
-                };
+                PartialWaveOption so{ Options{ { "L"_ok, "P" } }, specifications, "L"_ok };
                 TEST_CHECK_EQUAL(so.value(), PartialWave::P);
             }
 
             // Creation of option with valid default value, with value != default value but containing default value
             {
-                PartialWaveOption so
-                {
-                    Options{
-                        { "L"_ok, "S|P|D" }
-                    },
-                    specifications,
-                    "L"_ok
-                };
+                PartialWaveOption so{ Options{ { "L"_ok, "S|P|D" } }, specifications, "L"_ok };
                 TEST_CHECK_EQUAL(so.value(), PartialWave::S | PartialWave::P | PartialWave::D);
             }
 
             // Creation with invalid value
             {
-                auto test = [specifications] ()
-                {
-                    PartialWaveOption so
-                    {
-                        Options{
-                            { "L"_ok, "F"}
-                        },
-                        specifications,
-                        "L"_ok
-                    };
-                };
+                auto test = [specifications]() { PartialWaveOption so{ Options{ { "L"_ok, "F" } }, specifications, "L"_ok }; };
                 TEST_CHECK_THROWS(InvalidOptionValueError, test());
             }
 
             // Creation with invalid value but containing a valid value
             {
-                auto test = [specifications] ()
-                {
-                    PartialWaveOption so
-                    {
-                        Options{
-                            { "L"_ok, "P|F"}
-                        },
-                        specifications,
-                        "L"_ok
-                    };
-                };
+                auto test = [specifications]() { PartialWaveOption so{ Options{ { "L"_ok, "P|F" } }, specifications, "L"_ok }; };
                 TEST_CHECK_THROWS(InvalidOptionValueError, test());
             }
         }

--- a/eos/utils/parameters-fwd.hh
+++ b/eos/utils/parameters-fwd.hh
@@ -26,6 +26,6 @@ namespace eos
     class Parameter;
     class ParameterGroup;
     class ParameterSection;
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -19,8 +19,6 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <config.h>
-
 #include <eos/utils/cartesian-product.hh>
 #include <eos/utils/instantiation_policy-impl.hh>
 #include <eos/utils/log.hh>
@@ -30,19 +28,19 @@
 #include <eos/utils/stringify.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
+#include <boost/filesystem/directory.hpp>
+#include <boost/filesystem/file_status.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/format.hpp>
+
 #include <cmath>
+#include <config.h>
+#include <iostream>
 #include <map>
 #include <random>
 #include <vector>
-
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/directory.hpp>
-#include <boost/filesystem/file_status.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/format.hpp>
 #include <yaml-cpp/yaml.h>
-
-#include <iostream>
 
 namespace fs = boost::filesystem;
 
@@ -51,41 +49,47 @@ namespace eos
     bool
     operator== (const ParameterDescription & lhs, const ParameterDescription & rhs)
     {
-    	if (lhs.min != rhs.min)
-    		return false;
-    	if (lhs.max != rhs.max)
-    		return false;
-    	if (lhs.nuisance!= rhs.nuisance)
-    		return false;
-    	if (lhs.parameter->name() != rhs.parameter->name())
-    		return false;
+        if (lhs.min != rhs.min)
+        {
+            return false;
+        }
+        if (lhs.max != rhs.max)
+        {
+            return false;
+        }
+        if (lhs.nuisance != rhs.nuisance)
+        {
+            return false;
+        }
+        if (lhs.parameter->name() != rhs.parameter->name())
+        {
+            return false;
+        }
 
-    	return true;
+        return true;
     }
 
     /* ParameterGroup */
 
-    template <>
-    struct Implementation<ParameterGroup>
+    template <> struct Implementation<ParameterGroup>
     {
-        std::string name;
+            std::string name;
 
-        std::string description;
+            std::string description;
 
-        std::vector<Parameter> entries;
+            std::vector<Parameter> entries;
 
-        Implementation(const std::string & name, const std::string & description, std::vector<Parameter> && entries) :
-            name(name),
-            description(description),
-            entries(entries)
-        {
-        }
+            Implementation(const std::string & name, const std::string & description, std::vector<Parameter> && entries) :
+                name(name),
+                description(description),
+                entries(entries)
+            {
+            }
     };
 
-    template <>
-    struct WrappedForwardIteratorTraits<ParameterGroup::ParameterIteratorTag>
+    template <> struct WrappedForwardIteratorTraits<ParameterGroup::ParameterIteratorTag>
     {
-        using UnderlyingIterator = std::vector<Parameter>::const_iterator;
+            using UnderlyingIterator = std::vector<Parameter>::const_iterator;
     };
     template class WrappedForwardIterator<ParameterGroup::ParameterIteratorTag, const Parameter>;
 
@@ -122,27 +126,25 @@ namespace eos
 
     /* ParameterSection */
 
-    template <>
-    struct Implementation<ParameterSection>
+    template <> struct Implementation<ParameterSection>
     {
-        std::string name;
+            std::string name;
 
-        std::string description;
+            std::string description;
 
-        std::vector<ParameterGroup> groups;
+            std::vector<ParameterGroup> groups;
 
-        Implementation(const std::string & name, const std::string & description, const std::vector<ParameterGroup> & groups) :
-            name(name),
-            description(description),
-            groups(groups)
-        {
-        }
+            Implementation(const std::string & name, const std::string & description, const std::vector<ParameterGroup> & groups) :
+                name(name),
+                description(description),
+                groups(groups)
+            {
+            }
     };
 
-    template <>
-    struct WrappedForwardIteratorTraits<ParameterSection::GroupIteratorTag>
+    template <> struct WrappedForwardIteratorTraits<ParameterSection::GroupIteratorTag>
     {
-        using UnderlyingIterator = std::vector<ParameterGroup>::const_iterator;
+            using UnderlyingIterator = std::vector<ParameterGroup>::const_iterator;
     };
     template class WrappedForwardIterator<ParameterSection::GroupIteratorTag, const ParameterGroup &>;
 
@@ -179,52 +181,48 @@ namespace eos
 
     struct Parameter::Template
     {
-        QualifiedName name;
+            QualifiedName name;
 
-        double min, central, max;
+            double min, central, max;
 
-        std::string latex;
+            std::string latex;
 
-        Unit unit;
+            Unit unit;
     };
 
-    struct Parameter::Data :
-        Parameter::Template
+    struct Parameter::Data : Parameter::Template
     {
-        double value, generator_value;
+            double value, generator_value;
 
-        Parameter::Id id;
+            Parameter::Id id;
 
-        Data(const Parameter::Template & t, const Parameter::Id & i) :
-            Parameter::Template(t),
-            value(t.central),
-            generator_value(0.0),
-            id(i)
-        {
-        }
+            Data(const Parameter::Template & t, const Parameter::Id & i) :
+                Parameter::Template(t),
+                value(t.central),
+                generator_value(0.0),
+                id(i)
+            {
+            }
     };
 
     struct Parameters::Data
     {
-        std::vector<Parameter::Data> data;
+            std::vector<Parameter::Data> data;
     };
 
-    template <>
-    struct WrappedForwardIteratorTraits<Parameters::IteratorTag>
+    template <> struct WrappedForwardIteratorTraits<Parameters::IteratorTag>
     {
-        using UnderlyingIterator = std::vector<Parameter>::iterator;
+            using UnderlyingIterator = std::vector<Parameter>::iterator;
     };
     template class WrappedForwardIterator<Parameters::IteratorTag, Parameter>;
 
-    template <>
-    struct WrappedForwardIteratorTraits<Parameters::SectionIteratorTag>
+    template <> struct WrappedForwardIteratorTraits<Parameters::SectionIteratorTag>
     {
-        using UnderlyingIterator = std::vector<ParameterSection>::const_iterator;
+            using UnderlyingIterator = std::vector<ParameterSection>::const_iterator;
     };
     template class WrappedForwardIterator<Parameters::SectionIteratorTag, const ParameterSection &>;
 
-    class ParameterDefaults :
-        public InstantiationPolicy<ParameterDefaults, Singleton>
+    class ParameterDefaults : public InstantiationPolicy<ParameterDefaults, Singleton>
     {
         private:
             std::shared_ptr<Parameters::Data> _data;
@@ -250,12 +248,12 @@ namespace eos
                 if (std::getenv("EOS_TESTS_PARAMETERS"))
                 {
                     std::string envvar = std::string(std::getenv("EOS_TESTS_PARAMETERS"));
-                    base = fs::system_complete(envvar);
+                    base               = fs::system_complete(envvar);
                 }
                 else if (std::getenv("EOS_HOME"))
                 {
                     std::string envvar = std::string(std::getenv("EOS_HOME"));
-                    base = fs::system_complete(envvar) / "parameters";
+                    base               = fs::system_complete(envvar) / "parameters";
                 }
                 else
                 {
@@ -273,47 +271,63 @@ namespace eos
                 }
 
                 unsigned idx = _data->data.size();
-                for (fs::directory_iterator f(base), f_end ; f != f_end ; ++f)
+                for (fs::directory_iterator f(base), f_end; f != f_end; ++f)
                 {
                     auto file_path = f->path();
 
                     if (! fs::is_regular_file(status(file_path)))
+                    {
                         continue;
+                    }
 
                     if (".yaml" != file_path.extension().string())
+                    {
                         continue;
+                    }
 
                     std::string file = file_path.string();
-                    Context ctx("When parsing parameter file '" + file + "'");
+                    Context     ctx("When parsing parameter file '" + file + "'");
 
                     try
                     {
-                        YAML::Node root_node = YAML::LoadFile(file);
+                        YAML::Node                  root_node = YAML::LoadFile(file);
                         std::vector<ParameterGroup> section_groups;
 
                         // parse the section metadata
                         auto section_title_node = root_node["title"];
                         if (! section_title_node)
+                        {
                             throw ParameterInputFileNodeError(file, "/", "has no entry named 'title'");
+                        }
 
                         if (YAML::NodeType::Scalar != section_title_node.Type())
+                        {
                             throw ParameterInputFileNodeError(file, "title", "is not a scalar");
+                        }
                         std::string section_title = section_title_node.as<std::string>();
 
                         Context ctx("When parsing metadata for section '" + section_title + "'");
 
                         auto section_desc_node = root_node["description"];
                         if (! section_desc_node)
+                        {
                             throw ParameterInputFileNodeError(file, "/", "has no entry named 'description'");
+                        }
                         if (YAML::NodeType::Scalar != section_desc_node.Type())
+                        {
                             throw ParameterInputFileNodeError(file, "description", "is not a scalar");
+                        }
                         std::string section_desc = section_desc_node.as<std::string>();
 
                         auto section_groups_node = root_node["groups"];
                         if (! section_groups_node)
+                        {
                             throw ParameterInputFileNodeError(file, "/", "has no entry named 'group'");
+                        }
                         if (YAML::NodeType::Sequence != section_groups_node.Type())
+                        {
                             throw ParameterInputFileNodeError(file, "groups", "is not a sequence");
+                        }
 
                         // parse the section's groups
                         for (auto && group_node : section_groups_node)
@@ -322,31 +336,43 @@ namespace eos
 
                             auto group_title_node = group_node["title"];
                             if (! group_title_node)
+                            {
                                 throw ParameterInputFileNodeError(file, "", "has no entry named 'title'");
+                            }
                             if (YAML::NodeType::Scalar != group_title_node.Type())
+                            {
                                 throw ParameterInputFileNodeError(file, "title", "is not a scalar");
+                            }
                             std::string group_title = group_title_node.as<std::string>();
 
                             Context ctx("When parsing metadata for group '" + group_title + "'");
 
                             auto group_desc_node = group_node["description"];
                             if (! group_desc_node)
+                            {
                                 throw ParameterInputFileNodeError(file, group_title, "has no entry named 'description'");
+                            }
                             if (YAML::NodeType::Scalar != group_desc_node.Type())
+                            {
                                 throw ParameterInputFileNodeError(file, "'" + group_title + "'.description", "is not a scalar");
+                            }
                             std::string group_desc = group_desc_node.as<std::string>();
 
                             auto group_parameters_node = group_node["parameters"];
                             if (! group_parameters_node)
+                            {
                                 throw ParameterInputFileNodeError(file, group_title, "has no entry named 'parameters'");
+                            }
                             if (YAML::NodeType::Map != group_parameters_node.Type())
+                            {
                                 throw ParameterInputFileNodeError(file, "'" + group_title + "'.parameters", "is not a map");
+                            }
 
                             // parse the group's parameters
                             for (auto && p : group_parameters_node)
                             {
                                 std::string name = p.first.Scalar();
-                                Context ctx("When parsing metadata for parameter '" + name + "'");
+                                Context     ctx("When parsing metadata for parameter '" + name + "'");
 
                                 double central, min, max;
 
@@ -354,39 +380,53 @@ namespace eos
 
                                 auto central_node = p.second["central"];
                                 if (! central_node)
+                                {
                                     throw ParameterInputFileNodeError(file, name, "has no entry named 'central'");
+                                }
                                 if (YAML::NodeType::Scalar != central_node.Type())
+                                {
                                     throw ParameterInputFileNodeError(file, name + ".central", "is not a scalar");
+                                }
                                 central = central_node.as<double>();
 
                                 auto min_node = p.second["min"];
                                 if (! min_node)
+                                {
                                     throw ParameterInputFileNodeError(file, name, "has no entry named 'min'");
+                                }
                                 if (YAML::NodeType::Scalar != min_node.Type())
+                                {
                                     throw ParameterInputFileNodeError(file, name + ".min", "is not a scalar");
+                                }
                                 min = min_node.as<double>();
 
                                 auto max_node = p.second["max"];
                                 if (! max_node)
+                                {
                                     throw ParameterInputFileNodeError(file, name, "has no entry named 'max'");
+                                }
                                 if (YAML::NodeType::Scalar != max_node.Type())
+                                {
                                     throw ParameterInputFileNodeError(file, name + ".max", "is not a scalar");
+                                }
                                 max = max_node.as<double>();
 
                                 auto latex_node = p.second["latex"];
 
-                                Unit unit = Unit::Undefined();
+                                Unit unit      = Unit::Undefined();
                                 auto unit_node = p.second["unit"];
                                 if (unit_node)
                                 {
                                     if (YAML::NodeType::Scalar != unit_node.Type())
+                                    {
                                         throw ParameterInputFileNodeError(file, name + ".unit", "is not a scalar");
+                                    }
 
                                     unit = Unit(unit_node.as<std::string>());
                                 }
 
                                 std::list<std::string> alias_of_list;
-                                auto alias_of_node = p.second["alias_of"];
+                                auto                   alias_of_node = p.second["alias_of"];
                                 if (alias_of_node)
                                 {
                                     if (YAML::NodeType::Scalar == alias_of_node.Type())
@@ -398,7 +438,9 @@ namespace eos
                                         for (auto && alias_of_item_node : alias_of_node)
                                         {
                                             if (YAML::NodeType::Scalar != alias_of_item_node.Type())
+                                            {
                                                 throw ParameterInputFileNodeError(file, name + ".alias_of", "is not a sequence of scalars");
+                                            }
 
                                             alias_of_list.push_back(alias_of_item_node.as<std::string>());
                                         }
@@ -419,12 +461,14 @@ namespace eos
                                     if (latex_node)
                                     {
                                         if (YAML::NodeType::Scalar != latex_node.Type())
+                                        {
                                             throw ParameterInputFileNodeError(file, name + ".latex", "is not a scalar");
+                                        }
 
                                         latex = latex_node.as<std::string>();
                                     }
 
-                                    _data->data.push_back(Parameter::Data(Parameter::Template { QualifiedName(name), min, central, max, latex, unit }, idx));
+                                    _data->data.push_back(Parameter::Data(Parameter::Template{ QualifiedName(name), min, central, max, latex, unit }, idx));
                                     _map[name] = idx;
                                     for (auto && alias_of_item : alias_of_list)
                                     {
@@ -454,18 +498,22 @@ namespace eos
                                             }
                                             else if (YAML::NodeType::Sequence == matrix_node.Type())
                                             {
-                                                    if (YAML::NodeType::Map != latex_node.Type())
-                                                        throw ParameterInputFileNodeError(file, name + ".latex", "is not a map");
+                                                if (YAML::NodeType::Map != latex_node.Type())
+                                                {
+                                                    throw ParameterInputFileNodeError(file, name + ".latex", "is not a map");
+                                                }
 
-                                                    if ((! latex_node["template"]) || (! latex_node["map"]))
-                                                    {
-                                                        throw ParameterInputFileNodeError(file, name + ".latex", "is incomplete, needs 'template' and 'map' subkeys");
-                                                    }
-                                                    latex = latex_node["template"].as<std::string>();
-                                                    latex_map = latex_node["map"].as<std::map<std::string, std::string>>();
+                                                if ((! latex_node["template"]) || (! latex_node["map"]))
+                                                {
+                                                    throw ParameterInputFileNodeError(file, name + ".latex", "is incomplete, needs 'template' and 'map' subkeys");
+                                                }
+                                                latex     = latex_node["template"].as<std::string>();
+                                                latex_map = latex_node["map"].as<std::map<std::string, std::string>>();
                                             }
                                             else
+                                            {
                                                 throw ParameterInputFileNodeError(file, name + ".matrix", "is not a scalar nor a sequence");
+                                            }
                                         }
 
                                         CartesianProduct<std::vector<std::string>> cp;
@@ -483,17 +531,17 @@ namespace eos
                                             cp.over(instances);
                                         }
 
-                                        for (auto cp_it = cp.begin() ; cp.end() != cp_it ; ++cp_it)
+                                        for (auto cp_it = cp.begin(); cp.end() != cp_it; ++cp_it)
                                         {
                                             boost::format templated_name(name);
                                             boost::format templated_latex(latex);
 
                                             for (auto && i : *cp_it)
                                             {
-                                                templated_name  = templated_name  % i;
+                                                templated_name = templated_name % i;
 
                                                 std::string mapped_i;
-                                                auto latex_map_it = latex_map.find(i);
+                                                auto        latex_map_it = latex_map.find(i);
                                                 if (latex_map.end() != latex_map_it)
                                                 {
                                                     mapped_i = latex_map_it->second;
@@ -512,7 +560,7 @@ namespace eos
                                                 throw ParameterInputDuplicateError(file, qn.str());
                                             }
 
-                                            _data->data.push_back(Parameter::Data(Parameter::Template { qn, min, central, max, templated_latex.str(), unit }, idx));
+                                            _data->data.push_back(Parameter::Data(Parameter::Template{ qn, min, central, max, templated_latex.str(), unit }, idx));
                                             _map[templated_name.str()] = idx;
                                             group_parameters.push_back(Parameter(_data, idx));
 
@@ -536,22 +584,26 @@ namespace eos
         public:
             friend class InstantiationPolicy<ParameterDefaults, Singleton>;
 
-            const Parameters::Data & data() const
+            const Parameters::Data &
+            data() const
             {
                 return *_data;
             }
 
-            const std::map<QualifiedName, unsigned> & map() const
+            const std::map<QualifiedName, unsigned> &
+            map() const
             {
                 return _map;
             }
 
-            const std::vector<ParameterSection> & sections() const
+            const std::vector<ParameterSection> &
+            sections() const
             {
                 return _sections;
             }
 
-            Parameter::Id declare(const QualifiedName & key, const Parameter::Template & value)
+            Parameter::Id
+            declare(const QualifiedName & key, const Parameter::Template & value)
             {
                 unsigned idx = _data->data.size();
                 _data->data.push_back(Parameter::Data{ value, idx });
@@ -560,173 +612,180 @@ namespace eos
                 return idx;
             }
 
-            void redirect(const QualifiedName & name, const Parameter::Id & id)
+            void
+            redirect(const QualifiedName & name, const Parameter::Id & id)
             {
                 auto i = _map.find(name);
                 if (_map.end() == i)
+                {
                     throw UnknownParameterError(name);
+                }
 
                 i->second = id;
             }
     };
 
-    template <>
-    struct Implementation<Parameters>
+    template <> struct Implementation<Parameters>
     {
-        std::shared_ptr<Parameters::Data> parameters_data;
+            std::shared_ptr<Parameters::Data> parameters_data;
 
-        std::map<QualifiedName, unsigned> parameters_map;
+            std::map<QualifiedName, unsigned> parameters_map;
 
-        std::vector<Parameter> parameters;
+            std::vector<Parameter> parameters;
 
-        Implementation() :
-            parameters_data(new Parameters::Data(ParameterDefaults::instance()->data())),
-            parameters_map(ParameterDefaults::instance()->map())
-        {
-            for (auto i = parameters_data->data.begin(), i_end = parameters_data->data.end() ; i != i_end ; ++i)
+            Implementation() :
+                parameters_data(new Parameters::Data(ParameterDefaults::instance()->data())),
+                parameters_map(ParameterDefaults::instance()->map())
             {
-                parameters.push_back(Parameter(parameters_data, i->id));
-            }
-        }
-
-        Implementation(const Implementation & other) :
-            parameters_data(new Parameters::Data(*other.parameters_data)),
-            parameters_map(other.parameters_map)
-        {
-            parameters.reserve(other.parameters.size());
-            for (unsigned i = 0 ; i != parameters.size() ; ++i)
-            {
-                parameters.push_back(Parameter(parameters_data, i));
-            }
-        }
-
-        void
-        override_from_file(const std::string & file)
-        {
-            fs::path file_path(file);
-
-            if (! fs::is_regular_file(fs::status(file_path)))
-            {
-                throw ParameterInputFileParseError(file, "expect the parameter file to be a regular file");
-            }
-
-            try
-            {
-                YAML::Node node = YAML::LoadFile(file);
-
-                for (auto && p : node)
+                for (auto i = parameters_data->data.begin(), i_end = parameters_data->data.end(); i != i_end; ++i)
                 {
-                    std::string name = p.first.Scalar();
-
-                    if ("@metadata@" == name)
-                        continue;
-
-                    double central, min = -std::numeric_limits<double>::max(), max = +std::numeric_limits<double>::max();
-
-                    std::string latex;
-
-                    Unit unit = Unit::Undefined();
-
-                    bool has_min = false, has_max = false, has_latex = false, has_unit = false;
-
-                    if (! p.second["central"])
-                    {
-                        throw ParameterInputFileNodeError(file, name, "has no entry named 'central'");
-                    }
-                    else if (YAML::NodeType::Scalar != p.second["central"].Type())
-                    {
-                        throw ParameterInputFileNodeError(file, name + ".central", "is not a scalar");
-                    }
-                    central = p.second["central"].as<double>();
-
-                    if (p.second["min"])
-                    {
-                        if (YAML::NodeType::Scalar != p.second["min"].Type())
-                        {
-                            throw ParameterInputFileNodeError(file, name + ".min", "is not a scalar");
-                        }
-                        min = p.second["min"].as<double>();
-                        has_min = true;
-                    }
-
-                    if (p.second["max"])
-                    {
-                        if (YAML::NodeType::Scalar != p.second["max"].Type())
-                        {
-                            throw ParameterInputFileNodeError(file, name + ".max", "is not a scalar");
-                        }
-                        max = p.second["max"].as<double>();
-                        has_max = true;
-                    }
-
-                    if (p.second["latex"])
-                    {
-                        if (YAML::NodeType::Scalar != p.second["latex"].Type())
-                            throw ParameterInputFileNodeError(file, name + ".latex", "is not a scalar");
-
-                        latex = p.second["latex"].as<std::string>();
-                        has_latex = true;
-                    }
-
-                    auto unit_node = p.second["unit"];
-                    if (unit_node)
-                    {
-                        if (YAML::NodeType::Scalar != unit_node.Type())
-                            throw ParameterInputFileNodeError(file, name + ".unit", "is not a scalar");
-
-                        unit = Unit(unit_node.as<std::string>());
-                    }
-
-                    auto i = parameters_map.find(name);
-                    if (parameters_map.end() != i)
-                    {
-                        Log::instance()->message("[parameters.override]", ll_informational)
-                            << "Overriding existing parameter '" << name << "' with central value '" << central << "'";
-
-                        parameters_data->data[i->second].value = central;
-                        if (has_min)
-                        {
-                            parameters_data->data[i->second].min = min;
-                        }
-                        if (has_max)
-                        {
-                            parameters_data->data[i->second].max = max;
-                        }
-                        if (has_latex)
-                        {
-                            parameters_data->data[i->second].latex = latex;
-                        }
-                        if (has_unit)
-                        {
-                            parameters_data->data[i->second].unit = unit;
-                        }
-                    }
-                    else
-                    {
-                        Log::instance()->message("[parameters.override]", ll_informational)
-                            << "Adding new parameter '" << name << "' with central value '" << central << "'";
-
-                        if (! has_min)
-                        {
-                            min = central;
-                        }
-                        if (! has_max)
-                        {
-                            max = central;
-                        }
-
-                        auto idx = parameters_data->data.size();
-                        parameters_data->data.push_back(Parameter::Data(Parameter::Template { QualifiedName(name), min, central, max, latex, unit }, idx));
-                        parameters_map[name] = idx;
-                        parameters.push_back(Parameter(parameters_data, idx));
-                    }
+                    parameters.push_back(Parameter(parameters_data, i->id));
                 }
             }
-            catch (std::exception & e)
+
+            Implementation(const Implementation & other) :
+                parameters_data(new Parameters::Data(*other.parameters_data)),
+                parameters_map(other.parameters_map)
             {
-                throw ParameterInputFileParseError(file, e.what());
+                parameters.reserve(other.parameters.size());
+                for (unsigned i = 0; i != parameters.size(); ++i)
+                {
+                    parameters.push_back(Parameter(parameters_data, i));
+                }
             }
-        }
+
+            void
+            override_from_file(const std::string & file)
+            {
+                fs::path file_path(file);
+
+                if (! fs::is_regular_file(fs::status(file_path)))
+                {
+                    throw ParameterInputFileParseError(file, "expect the parameter file to be a regular file");
+                }
+
+                try
+                {
+                    YAML::Node node = YAML::LoadFile(file);
+
+                    for (auto && p : node)
+                    {
+                        std::string name = p.first.Scalar();
+
+                        if ("@metadata@" == name)
+                        {
+                            continue;
+                        }
+
+                        double central, min = -std::numeric_limits<double>::max(), max = +std::numeric_limits<double>::max();
+
+                        std::string latex;
+
+                        Unit unit = Unit::Undefined();
+
+                        bool has_min = false, has_max = false, has_latex = false, has_unit = false;
+
+                        if (! p.second["central"])
+                        {
+                            throw ParameterInputFileNodeError(file, name, "has no entry named 'central'");
+                        }
+                        else if (YAML::NodeType::Scalar != p.second["central"].Type())
+                        {
+                            throw ParameterInputFileNodeError(file, name + ".central", "is not a scalar");
+                        }
+                        central = p.second["central"].as<double>();
+
+                        if (p.second["min"])
+                        {
+                            if (YAML::NodeType::Scalar != p.second["min"].Type())
+                            {
+                                throw ParameterInputFileNodeError(file, name + ".min", "is not a scalar");
+                            }
+                            min     = p.second["min"].as<double>();
+                            has_min = true;
+                        }
+
+                        if (p.second["max"])
+                        {
+                            if (YAML::NodeType::Scalar != p.second["max"].Type())
+                            {
+                                throw ParameterInputFileNodeError(file, name + ".max", "is not a scalar");
+                            }
+                            max     = p.second["max"].as<double>();
+                            has_max = true;
+                        }
+
+                        if (p.second["latex"])
+                        {
+                            if (YAML::NodeType::Scalar != p.second["latex"].Type())
+                            {
+                                throw ParameterInputFileNodeError(file, name + ".latex", "is not a scalar");
+                            }
+
+                            latex     = p.second["latex"].as<std::string>();
+                            has_latex = true;
+                        }
+
+                        auto unit_node = p.second["unit"];
+                        if (unit_node)
+                        {
+                            if (YAML::NodeType::Scalar != unit_node.Type())
+                            {
+                                throw ParameterInputFileNodeError(file, name + ".unit", "is not a scalar");
+                            }
+
+                            unit = Unit(unit_node.as<std::string>());
+                        }
+
+                        auto i = parameters_map.find(name);
+                        if (parameters_map.end() != i)
+                        {
+                            Log::instance()->message("[parameters.override]", ll_informational)
+                                    << "Overriding existing parameter '" << name << "' with central value '" << central << "'";
+
+                            parameters_data->data[i->second].value = central;
+                            if (has_min)
+                            {
+                                parameters_data->data[i->second].min = min;
+                            }
+                            if (has_max)
+                            {
+                                parameters_data->data[i->second].max = max;
+                            }
+                            if (has_latex)
+                            {
+                                parameters_data->data[i->second].latex = latex;
+                            }
+                            if (has_unit)
+                            {
+                                parameters_data->data[i->second].unit = unit;
+                            }
+                        }
+                        else
+                        {
+                            Log::instance()->message("[parameters.override]", ll_informational) << "Adding new parameter '" << name << "' with central value '" << central << "'";
+
+                            if (! has_min)
+                            {
+                                min = central;
+                            }
+                            if (! has_max)
+                            {
+                                max = central;
+                            }
+
+                            auto idx = parameters_data->data.size();
+                            parameters_data->data.push_back(Parameter::Data(Parameter::Template{ QualifiedName(name), min, central, max, latex, unit }, idx));
+                            parameters_map[name] = idx;
+                            parameters.push_back(Parameter(parameters_data, idx));
+                        }
+                    }
+                }
+                catch (std::exception & e)
+                {
+                    throw ParameterInputFileParseError(file, e.what());
+                }
+            }
     };
 
     Parameters::Parameters(Implementation<Parameters> * imp) :
@@ -734,9 +793,7 @@ namespace eos
     {
     }
 
-    Parameters::~Parameters()
-    {
-    }
+    Parameters::~Parameters() {}
 
     Parameters
     Parameters::clone() const
@@ -750,7 +807,9 @@ namespace eos
         auto i(_imp->parameters_map.find(name));
 
         if (_imp->parameters_map.end() == i)
+        {
             throw UnknownParameterError(name);
+        }
 
         return Parameter(_imp->parameters_data, i->second);
     }
@@ -759,7 +818,9 @@ namespace eos
     Parameters::operator[] (const Parameter::Id & id) const
     {
         if (id >= _imp->parameters.size())
+        {
             throw InternalError("Parameters::operator[] (Parameter::Id): invalid id '" + stringify(id) + "'");
+        }
 
         return _imp->parameters[id];
     }
@@ -767,7 +828,7 @@ namespace eos
     Parameter::Id
     Parameters::declare(const QualifiedName & name, const std::string & latex, Unit unit, const double & value, const double & min, const double & max)
     {
-        return ParameterDefaults::instance()->declare(name, Parameter::Template { name, min, value, max, latex, unit });
+        return ParameterDefaults::instance()->declare(name, Parameter::Template{ name, min, value, max, latex, unit });
     }
 
     Parameter
@@ -778,17 +839,17 @@ namespace eos
         if (_imp->parameters_map.end() != i)
         {
             Log::instance()->message("[parameters.declare_and_insert]", ll_error)
-                << "Parameter '" << name << "' is already declared, returning existing instance; check your code for conflicting duplicate declarations";
+                    << "Parameter '" << name << "' is already declared, returning existing instance; check your code for conflicting duplicate declarations";
 
             return Parameter(_imp->parameters_data, i->second);
         }
 
         // declare the new parameter ...
-        ParameterDefaults::instance()->declare(name, Parameter::Template { name, min, value, max, latex, unit });
+        ParameterDefaults::instance()->declare(name, Parameter::Template{ name, min, value, max, latex, unit });
 
         // ... and insert it into this parameter set ...
         unsigned idx = _imp->parameters.size();
-        _imp->parameters_data->data.push_back(Parameter::Data(Parameter::Template { name, min, value, max, latex, unit }, idx));
+        _imp->parameters_data->data.push_back(Parameter::Data(Parameter::Template{ name, min, value, max, latex, unit }, idx));
         _imp->parameters_map[name] = idx;
         _imp->parameters.push_back(Parameter(_imp->parameters_data, idx));
 
@@ -811,7 +872,9 @@ namespace eos
         // ... and apply the change to this parameter set ...
         auto i = _imp->parameters_map.find(name);
         if (_imp->parameters_map.end() == i)
+        {
             throw UnknownParameterError(name);
+        }
 
         i->second = id;
     }
@@ -822,7 +885,9 @@ namespace eos
         auto i(_imp->parameters_map.find(name));
 
         if (_imp->parameters_map.end() == i)
+        {
             throw UnknownParameterError(name);
+        }
 
         _imp->parameters_data->data[i->second].value = value;
     }
@@ -833,8 +898,13 @@ namespace eos
         auto i(_imp->parameters_map.find(name));
 
         if (_imp->parameters_map.end() == i)
+        {
             return false;
-        else return true;
+        }
+        else
+        {
+            return true;
+        }
     }
 
     Parameters::Iterator
@@ -893,9 +963,7 @@ namespace eos
     {
     }
 
-    Parameter::~Parameter()
-    {
-    }
+    Parameter::~Parameter() {}
 
     MutablePtr
     Parameter::clone() const
@@ -1002,10 +1070,9 @@ namespace eos
 
     /* ParameterUser */
 
-    template <>
-    struct WrappedForwardIteratorTraits<ParameterUser::ConstIteratorTag>
+    template <> struct WrappedForwardIteratorTraits<ParameterUser::ConstIteratorTag>
     {
-        using UnderlyingIterator = std::set<Parameter::Id>::const_iterator;
+            using UnderlyingIterator = std::set<Parameter::Id>::const_iterator;
     };
     template class WrappedForwardIterator<ParameterUser::ConstIteratorTag, const Parameter::Id>;
 
@@ -1045,23 +1112,23 @@ namespace eos
         user.uses(parameter.id());
     }
 
-    UnknownParameterError::UnknownParameterError(const QualifiedName & name) throw () :
+    UnknownParameterError::UnknownParameterError(const QualifiedName & name) throw() :
         Exception("Unknown parameter: '" + name.full() + "'")
     {
     }
 
-    ParameterInputFileParseError::ParameterInputFileParseError(const std::string & file, const std::string & msg) throw () :
+    ParameterInputFileParseError::ParameterInputFileParseError(const std::string & file, const std::string & msg) throw() :
         Exception("Malformed parameter input file '" + file + "': " + msg)
     {
     }
 
-    ParameterInputFileNodeError::ParameterInputFileNodeError(const std::string & file, const std::string & node, const std::string & msg) throw () :
+    ParameterInputFileNodeError::ParameterInputFileNodeError(const std::string & file, const std::string & node, const std::string & msg) throw() :
         Exception("Malformed parameter input file '" + file + "': Node '" + node + "' " + msg)
     {
     }
 
-    ParameterInputDuplicateError::ParameterInputDuplicateError(const std::string & file, const std::string & node) throw () :
+    ParameterInputDuplicateError::ParameterInputDuplicateError(const std::string & file, const std::string & node) throw() :
         Exception("Malformed parameter input file '" + file + "': Duplicate entry for parameter '" + node + "'")
     {
     }
-}
+} // namespace eos

--- a/eos/utils/parameters.hh
+++ b/eos/utils/parameters.hh
@@ -29,8 +29,8 @@
 #include <eos/utils/units.hh>
 #include <eos/utils/wrapped_forward_iterator.hh>
 
-#include <set>
 #include <limits>
+#include <set>
 
 namespace eos
 {
@@ -41,40 +41,36 @@ namespace eos
      * UnknownParameterError is thrown when no parameter of a given
      * name could be found.
      */
-    struct UnknownParameterError :
-        public Exception
+    struct UnknownParameterError : public Exception
     {
-        UnknownParameterError(const QualifiedName & variable) throw ();
+            UnknownParameterError(const QualifiedName & variable) throw();
     };
 
     /*!
      * ParameterInputFileParseError is thrown when a malformed parameter input
      * file cannot be parsed by libyaml-cpp.
      */
-    struct ParameterInputFileParseError :
-        public Exception
+    struct ParameterInputFileParseError : public Exception
     {
-        ParameterInputFileParseError(const std::string & file, const std::string & msg) throw ();
+            ParameterInputFileParseError(const std::string & file, const std::string & msg) throw();
     };
 
     /*!
      * ParameterInputFileNodeError is thrown when a malformed node is encountered
      * within a parameter input file.
      */
-    struct ParameterInputFileNodeError :
-        public Exception
+    struct ParameterInputFileNodeError : public Exception
     {
-        ParameterInputFileNodeError(const std::string & file, const std::string & node, const std::string & msg) throw ();
+            ParameterInputFileNodeError(const std::string & file, const std::string & node, const std::string & msg) throw();
     };
 
     /*!
      * ParameterInputDuplicateError is thrown when a duplicate parameter entry is encountered when parsing
      * several input files.
      */
-    struct ParameterInputDuplicateError :
-        public Exception
+    struct ParameterInputDuplicateError : public Exception
     {
-        ParameterInputDuplicateError(const std::string & file, const std::string & msg) throw ();
+            ParameterInputDuplicateError(const std::string & file, const std::string & msg) throw();
     };
 
     /*!
@@ -84,8 +80,7 @@ namespace eos
      * a Parameter object will propagate to every other object with the same
      * parent Parameters and which handle the same parameter by name.
      */
-    class Parameters :
-        public PrivateImplementationPattern<Parameters>
+    class Parameters : public PrivateImplementationPattern<Parameters>
     {
         private:
             ///@name Internal Data
@@ -158,10 +153,8 @@ namespace eos
              * @param min   (Optional) minimal value for the new parameter.
              * @param max   (Optional) maximal value for the new parameter.
              */
-            static unsigned declare(const QualifiedName & name, const std::string & latex, Unit unit,
-                const double & value = 0.0,
-                const double & min = -std::numeric_limits<double>::max(),
-                const double & max = +std::numeric_limits<double>::max());
+            static unsigned declare(const QualifiedName & name, const std::string & latex, Unit unit, const double & value = 0.0,
+                                    const double & min = -std::numeric_limits<double>::max(), const double & max = +std::numeric_limits<double>::max());
 
             /*!
              * Redirect a parameter name to a different parameter id in the default set of parameters.
@@ -189,10 +182,8 @@ namespace eos
              * @param min   (Optional) minimal value for the new parameter.
              * @param max   (Optional) maximal value for the new parameter.
              */
-            Parameter declare_and_insert(const QualifiedName & name, const std::string & latex, Unit unit,
-                const double & value = 0.0,
-                const double & min = -std::numeric_limits<double>::max(),
-                const double & max = +std::numeric_limits<double>::max());
+            Parameter declare_and_insert(const QualifiedName & name, const std::string & latex, Unit unit, const double & value = 0.0,
+                                         const double & min = -std::numeric_limits<double>::max(), const double & max = +std::numeric_limits<double>::max());
 
             /*!
              * Redirect a parameter name to a different parameter id in the default set of parameters
@@ -258,8 +249,7 @@ namespace eos
     /*!
      * Parameter is the class that holds all information of one of Parameters' parameters.
      */
-    class Parameter :
-        public Mutable
+    class Parameter : public Mutable
     {
         private:
             struct Data;
@@ -359,8 +349,7 @@ namespace eos
      * them together under a common name. Examples of observable sections include SM & EFT parameters,
      * and form factor parameters.
      */
-    class ParameterSection :
-        public PrivateImplementationPattern<ParameterSection>
+    class ParameterSection : public PrivateImplementationPattern<ParameterSection>
     {
         public:
             ParameterSection(Implementation<ParameterSection> *);
@@ -389,8 +378,7 @@ namespace eos
      * them together under a common name and description. Examples of Parameter Groups
      * include fermion mass parameters and B->D form factors parameters.
      */
-    class ParameterGroup :
-        public PrivateImplementationPattern<ParameterGroup>
+    class ParameterGroup : public PrivateImplementationPattern<ParameterGroup>
     {
         public:
             ParameterGroup(Implementation<ParameterGroup> *);
@@ -460,8 +448,7 @@ namespace eos
     /*!
      * Wrapper class to automate usage tracking of Parameter objects.
      */
-    class UsedParameter :
-        public Parameter
+    class UsedParameter : public Parameter
     {
         public:
             /*!
@@ -479,16 +466,16 @@ namespace eos
 
     struct ParameterDescription
     {
-        MutablePtr parameter;
+            MutablePtr parameter;
 
-        double min;
+            double min;
 
-        double max;
+            double max;
 
-        bool nuisance;
+            bool nuisance;
     };
 
     bool operator== (const ParameterDescription & lhs, const ParameterDescription & rhs);
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/parameters_TEST.cc
+++ b/eos/utils/parameters_TEST.cc
@@ -18,14 +18,14 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/parameters.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
 
-class ParametersTest :
-    public TestCase
+class ParametersTest : public TestCase
 {
     public:
         ParametersTest() :
@@ -33,12 +33,13 @@ class ParametersTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // Setting and retrieval
             {
                 Parameters original = Parameters::Defaults();
-                Parameter m_c = original["mass::c"];
+                Parameter  m_c      = original["mass::c"];
 
                 TEST_CHECK_EQUAL(m_c(), m_c.central());
 
@@ -52,24 +53,24 @@ class ParametersTest :
             // Declaring a new parameter
             {
                 Parameters::declare("mass::boeing747", R"(\text{Boeing 747})", Unit::Undefined(), 100000.0, 90000.0, 110000.0);
-                Parameters parameters = Parameters::Defaults();
-                Parameter new_parameter = parameters["mass::boeing747"];
+                Parameters parameters    = Parameters::Defaults();
+                Parameter  new_parameter = parameters["mass::boeing747"];
 
-                TEST_CHECK_EQUAL(new_parameter.name(),      "mass::boeing747");
-                TEST_CHECK_EQUAL(new_parameter.latex(),     R"(\text{Boeing 747})");
-                TEST_CHECK_EQUAL(new_parameter.unit(),      Unit::Undefined());
-                TEST_CHECK_EQUAL(new_parameter.evaluate(),  100000.0);
-                TEST_CHECK_EQUAL(new_parameter.min(),        90000.0);
-                TEST_CHECK_EQUAL(new_parameter.max(),       110000.0);
+                TEST_CHECK_EQUAL(new_parameter.name(), "mass::boeing747");
+                TEST_CHECK_EQUAL(new_parameter.latex(), R"(\text{Boeing 747})");
+                TEST_CHECK_EQUAL(new_parameter.unit(), Unit::Undefined());
+                TEST_CHECK_EQUAL(new_parameter.evaluate(), 100000.0);
+                TEST_CHECK_EQUAL(new_parameter.min(), 90000.0);
+                TEST_CHECK_EQUAL(new_parameter.max(), 110000.0);
             }
 
             // Cloning
             {
                 Parameters original = Parameters::Defaults();
-                Parameters clone = original.clone();
+                Parameters clone    = original.clone();
 
                 Parameter m_c_original = original["mass::c"];
-                Parameter m_c_clone = clone["mass::c"];
+                Parameter m_c_clone    = clone["mass::c"];
 
                 TEST_CHECK_EQUAL(m_c_original(), m_c_original.central());
                 TEST_CHECK_EQUAL(m_c_clone(), m_c_clone.central());
@@ -110,13 +111,13 @@ class ParametersTest :
             {
                 Parameters p = Parameters::Defaults();
 
-                Parameter p_tau = p["ubtaunutau::Re{cVL}"];
+                Parameter     p_tau  = p["ubtaunutau::Re{cVL}"];
                 Parameter::Id id_tau = p_tau.id();
                 p_tau.set(-9.87);
 
                 TEST_CHECK_NEARLY_EQUAL(p_tau.evaluate(), -9.87, 1e-12);
 
-                Parameter p_ell = p.declare_and_insert("ublnul::Re{cVL}", R"(\text{Re} C_{V_L}^{ub\ell\nu_\ell})", Unit::None(), 1.23, -1.0, 1.0);
+                Parameter     p_ell  = p.declare_and_insert("ublnul::Re{cVL}", R"(\text{Re} C_{V_L}^{ub\ell\nu_\ell})", Unit::None(), 1.23, -1.0, 1.0);
                 Parameter::Id id_ell = p_ell.id();
 
                 TEST_CHECK_NEARLY_EQUAL(p_ell.evaluate(), +1.23, 1e-12);
@@ -136,8 +137,8 @@ class ParametersTest :
 
                 // check a new Parameters object
                 {
-                    Parameters p2 = Parameters::Defaults();
-                    Parameter p2_tau = p2["ubtaunutau::Re{cVL}"];
+                    Parameters p2     = Parameters::Defaults();
+                    Parameter  p2_tau = p2["ubtaunutau::Re{cVL}"];
                     TEST_CHECK_NEARLY_EQUAL(p2_tau.evaluate(), +1.23, 1e-12);
                 }
 
@@ -153,11 +154,10 @@ class ParametersTest :
 
                 // check a new Parameters object
                 {
-                    Parameters p2 = Parameters::Defaults();
-                    Parameter p2_tau = p2["ubtaunutau::Re{cVL}"];
+                    Parameters p2     = Parameters::Defaults();
+                    Parameter  p2_tau = p2["ubtaunutau::Re{cVL}"];
                     TEST_CHECK_NEARLY_EQUAL(p2_tau.evaluate(), +1.00, 1e-12); // default value
                 }
-
             }
         }
 } parameters_test;

--- a/eos/utils/private_implementation_pattern-impl.hh
+++ b/eos/utils/private_implementation_pattern-impl.hh
@@ -30,10 +30,7 @@ namespace eos
     {
     }
 
-    template <typename T_>
-    PrivateImplementationPattern<T_>::~PrivateImplementationPattern()
-    {
-    }
-}
+    template <typename T_> PrivateImplementationPattern<T_>::~PrivateImplementationPattern() {}
+} // namespace eos
 
 #endif

--- a/eos/utils/private_implementation_pattern.hh
+++ b/eos/utils/private_implementation_pattern.hh
@@ -29,13 +29,13 @@ namespace eos
     template <typename T_> class PrivateImplementationPattern
     {
         protected:
-            std::shared_ptr<Implementation<T_> > _imp;
+            std::shared_ptr<Implementation<T_>> _imp;
 
         public:
             explicit PrivateImplementationPattern(Implementation<T_> * imp);
 
             ~PrivateImplementationPattern();
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/qcd.cc
+++ b/eos/utils/qcd.cc
@@ -17,12 +17,12 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <eos/utils/stringify.hh>
-#include <eos/utils/qcd.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/utils/qcd.hh>
+#include <eos/utils/stringify.hh>
 
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 
 namespace eos
 {
@@ -31,73 +31,66 @@ namespace eos
     /* 6 flavor QCD constants */
 
     // cf. [CKS2000], Eq. (2), p. 2 with n_f = 6
-    const QCD::BetaFunction QCD::beta_function_nf_6
-    {{
-        21.0 / 3.0,
-        78.0 / 3.0,
-        -65.0 / 2.0,
-        2472.2837425797160,
-    }};
+    const QCD::BetaFunction QCD::beta_function_nf_6{
+        {
+         21.0 / 3.0,
+         78.0 / 3.0,
+         -65.0 / 2.0,
+         2472.2837425797160, }
+    };
 
     /* 5 flavor QCD constants */
 
     // cf. [CKS2000], Eq. (2), p. 2 with n_f = 5
-    const QCD::BetaFunction QCD::beta_function_nf_5
-    {{
-        23.0 / 3.0,
-        116.0 / 3.0,
-        9769.0 / 54.0,
-        4826.1563287908967,
-    }};
+    const QCD::BetaFunction QCD::beta_function_nf_5{
+        {
+         23.0 / 3.0,
+         116.0 / 3.0,
+         9769.0 / 54.0,
+         4826.1563287908967, }
+    };
 
     // cf. [CKS2000], Eq. (7), p. 5 with n_f = 5
-    const QCD::AnomalousMassDimension QCD::gamma_m_nf_5
-    {{
-        1.0,
-        506.0 / 9.0,
-        474.87124557719461,
-        2824.7862379694232,
-    }};
+    const QCD::AnomalousMassDimension QCD::gamma_m_nf_5{
+        {
+         1.0, 506.0 / 9.0,
+         474.87124557719461, 2824.7862379694232,
+         }
+    };
 
     /* 4 flavor QCD constants */
 
     // cf. [CKS2000], Eq. (2), p. 2 with n_f = 4
-    const QCD::BetaFunction QCD::beta_function_nf_4
-    {{
-        25.0 / 3.0,
-        154.0 / 3.0,
-        21943.0 / 54.0,
-        8035.1864197901160,
-    }};
+    const QCD::BetaFunction QCD::beta_function_nf_4{
+        {
+         25.0 / 3.0,
+         154.0 / 3.0,
+         21943.0 / 54.0,
+         8035.1864197901160, }
+    };
 
     // cf. [CKS2000], Eq. (7), p. 5 with n_f = 4
-    const QCD::AnomalousMassDimension QCD::gamma_m_nf_4
-    {{
-        1.0,
-        526.0 / 9.0,
-        636.61057670866927,
-        6989.5510103599477,
-    }};
+    const QCD::AnomalousMassDimension QCD::gamma_m_nf_4{
+        {
+         1.0, 526.0 / 9.0,
+         636.61057670866927, 6989.5510103599477,
+         }
+    };
 
     /* 3 flavor QCD constants */
 
     // cf. [CKS2000], Eq. (2), p. 2 with n_f = 3
-    const QCD::BetaFunction QCD::beta_function_nf_3
-    {{
-        9.0,
-        64.0,
-        3863.0 / 6.0,
-        12090.378130803711,
-    }};
+    const QCD::BetaFunction QCD::beta_function_nf_3{
+        {
+         9.0, 64.0,
+         3863.0 / 6.0,
+         12090.378130803711, }
+    };
 
     // cf. [CKS2000], Eq. (7), p. 5 with n_f = 3
-    const QCD::AnomalousMassDimension QCD::gamma_m_nf_3
-    {{
-        1.0,
-        182.0 / 3.0,
-        794.89311771668714,
-        11331.304567227756
-    }};
+    const QCD::AnomalousMassDimension QCD::gamma_m_nf_3{
+        { 1.0, 182.0 / 3.0, 794.89311771668714, 11331.304567227756 }
+    };
 
     double
     QCD::alpha_s(const double & mu, const double & alpha_s_0, const double & mu_0, const BetaFunction & beta, unsigned int loop_order)
@@ -111,39 +104,38 @@ namespace eos
             throw InternalError("QCD::alpha_s: loop order " + stringify(loop_order) + " not yet implemented");
         }
 
-        double a = alpha_s_0 / M_PI;
+        double                a = alpha_s_0 / M_PI;
         std::array<double, 4> switches;
-        std::generate(switches.begin(), switches.end(), [i = 0u, l = loop_order] () mutable { return (i++ < l) ? 1.0 : 0.0;});
+        std::generate(switches.begin(), switches.end(), [i = 0u, l = loop_order]() mutable { return (i++ < l) ? 1.0 : 0.0; });
 
         // Adjust for a different convention on beta function coefficients
         double beta0 = beta[0] / 4.0;
         double beta1 = switches[1] * beta[1] / 16.0;
         double beta2 = switches[2] * beta[2] / 64.0;
         double beta3 = switches[3] * beta[3] / 256.0;
-        double b1 = beta1 / beta0;
-        double b2 = beta2 / beta0;
-        double b3 = beta3 / beta0;
+        double b1    = beta1 / beta0;
+        double b2    = beta2 / beta0;
+        double b3    = beta3 / beta0;
 
         // cf. [CKS2000], Eq. (4), p. 3
         double ln_lambda2 = 2.0 * log(mu_0)
-            - (1.0 / a + b1 * log(a) + (b2 - b1 * b1) * a + (b3 / 2.0 - b1 * b2 + b1 * b1 * b1 / 2.0) * a * a) / beta0
-            // Use C for MSbar definition
-            - b1 / beta0 * log(beta0);
+                            - (1.0 / a + b1 * log(a) + (b2 - b1 * b1) * a + (b3 / 2.0 - b1 * b2 + b1 * b1 * b1 / 2.0) * a * a) / beta0
+                            // Use C for MSbar definition
+                            - b1 / beta0 * log(beta0);
 
         double L = 2.0 * log(mu) - ln_lambda2, lnL = log(L);
         double denom = beta0 * L, denom2 = denom * denom, denom3 = denom2 * denom, denom4 = denom2 * denom2;
 
         // cf. [CKS2000], Eq. (5), p. 3
-        double result = 1.0 / denom
-            - b1 * lnL / denom2
-            + (b1 * b1 * (lnL * lnL - lnL - 1.0) + b2) / denom3
-            + (b1 * b1 * b1 * (-1.0 * lnL * lnL * lnL + 5.0 / 2.0 * lnL * lnL + 2.0 * lnL - 0.5) - 3.0 * b1 * b2 * lnL + b3 / 2.0) / denom4;
+        double result = 1.0 / denom - b1 * lnL / denom2 + (b1 * b1 * (lnL * lnL - lnL - 1.0) + b2) / denom3
+                        + (b1 * b1 * b1 * (-1.0 * lnL * lnL * lnL + 5.0 / 2.0 * lnL * lnL + 2.0 * lnL - 0.5) - 3.0 * b1 * b2 * lnL + b3 / 2.0) / denom4;
 
         return M_PI * result;
     }
 
     double
-    QCD::m_q_msbar(const double & m_q_0, const double & alpha_s_0, const double & alpha_s_mu, const BetaFunction & beta, const AnomalousMassDimension & gamma_m, unsigned int loop_order)
+    QCD::m_q_msbar(const double & m_q_0, const double & alpha_s_0, const double & alpha_s_mu, const BetaFunction & beta, const AnomalousMassDimension & gamma_m,
+                   unsigned int loop_order)
     {
         if (loop_order == 0)
         {
@@ -154,45 +146,43 @@ namespace eos
             throw InternalError("QCD::alpha_s: loop order " + stringify(loop_order) + " not yet implemented");
         }
 
-        double a_mu0 = alpha_s_0 / M_PI;
-        double a_mu = alpha_s_mu / M_PI;
+        double                a_mu0 = alpha_s_0 / M_PI;
+        double                a_mu  = alpha_s_mu / M_PI;
         std::array<double, 4> switches;
-        std::generate(switches.begin(), switches.end(), [i = 0u, l = loop_order] () mutable { return (i++ < l) ? 1.0 : 0.0;});
+        std::generate(switches.begin(), switches.end(), [i = 0u, l = loop_order]() mutable { return (i++ < l) ? 1.0 : 0.0; });
 
         // Adjust for a different convention on beta function coefficients
         double beta0 = beta[0] / 4.0;
         double beta1 = switches[1] * beta[1] / 16.0;
         double beta2 = switches[2] * beta[2] / 64.0;
         double beta3 = switches[3] * beta[3] / 256.0;
-        double b1 = beta1 / beta0;
-        double b2 = beta2 / beta0;
-        double b3 = beta3 / beta0;
+        double b1    = beta1 / beta0;
+        double b2    = beta2 / beta0;
+        double b3    = beta3 / beta0;
 
         // Adjust for a different convention on gamma function coefficients
         double gamma0_m = gamma_m[0];
         double gamma1_m = switches[1] * gamma_m[1] / 16.0;
         double gamma2_m = switches[2] * gamma_m[2] / 64.0;
         double gamma3_m = switches[3] * gamma_m[3] / 256.0;
-        double c0 = gamma0_m / beta0;
-        double c1 = gamma1_m / beta0;
-        double c2 = gamma2_m / beta0;
-        double c3 = gamma3_m / beta0;
+        double c0       = gamma0_m / beta0;
+        double c1       = gamma1_m / beta0;
+        double c2       = gamma2_m / beta0;
+        double c3       = gamma3_m / beta0;
 
         // cf. [CKS2000], Eq. (10), p. 6
-        double c_mu0 = pow(a_mu0, c0) * (
-                1.0
-                + a_mu0 * (c1 - b1 * c0)
-                + a_mu0 * a_mu0 * 0.5 * (pow(c1 - b1 * c0, 2) + c2 - b1 * c1 + b1 * b1 * c0 - b2 * c0)
-                + a_mu0 * a_mu0 * a_mu0 * (pow(c1 - b1 * c0, 3) / 6.0 + (c1 - b1 * c0) / 2.0 * (c2 - b1 * c1 + b1 * b1 * c0 - b2 * c0)
-                    + (c3 - b1 * c2 + b1 * b1 * c1 - b2 * c1 - b1 * b1 * b1 * c0 + 2.0 * b1 * b2 * c0 - b3 * c0) / 3.0));
+        double c_mu0 = pow(a_mu0, c0)
+                       * (1.0 + a_mu0 * (c1 - b1 * c0) + a_mu0 * a_mu0 * 0.5 * (pow(c1 - b1 * c0, 2) + c2 - b1 * c1 + b1 * b1 * c0 - b2 * c0)
+                          + a_mu0 * a_mu0 * a_mu0
+                                    * (pow(c1 - b1 * c0, 3) / 6.0 + (c1 - b1 * c0) / 2.0 * (c2 - b1 * c1 + b1 * b1 * c0 - b2 * c0)
+                                       + (c3 - b1 * c2 + b1 * b1 * c1 - b2 * c1 - b1 * b1 * b1 * c0 + 2.0 * b1 * b2 * c0 - b3 * c0) / 3.0));
 
         // cf. [CKS2000], Eq. (10), p. 6
-        double c_mu = pow(a_mu, c0) * (
-                1.0
-                + a_mu * (c1 - b1 * c0)
-                + a_mu * a_mu * 0.5 * (pow(c1 - b1 * c0, 2) + c2 - b1 * c1 + b1 * b1 * c0 - b2 * c0)
-                + a_mu * a_mu * a_mu * (pow(c1 - b1 * c0, 3) / 6.0 + (c1 - b1 * c0) / 2.0 * (c2 - b1 * c1 + b1 * b1 * c0 - b2 * c0)
-                    + (c3 - b1 * c2 + b1 * b1 * c1 - b2 * c1 - b1 * b1 * b1 * c0 + 2.0 * b1 * b2 * c0 - b3 * c0) / 3.0));
+        double c_mu = pow(a_mu, c0)
+                      * (1.0 + a_mu * (c1 - b1 * c0) + a_mu * a_mu * 0.5 * (pow(c1 - b1 * c0, 2) + c2 - b1 * c1 + b1 * b1 * c0 - b2 * c0)
+                         + a_mu * a_mu * a_mu
+                                   * (pow(c1 - b1 * c0, 3) / 6.0 + (c1 - b1 * c0) / 2.0 * (c2 - b1 * c1 + b1 * b1 * c0 - b2 * c0)
+                                      + (c3 - b1 * c2 + b1 * b1 * c1 - b2 * c1 - b1 * b1 * b1 * c0 + 2.0 * b1 * b2 * c0 - b3 * c0) / 3.0));
 
         // cf. [CKS2000], Eq. (9), p. 6
         return m_q_0 * c_mu / c_mu0;
@@ -205,8 +195,7 @@ namespace eos
 
         // cf. [MvR1999], Eq. (12), pp. 4-5 for alpha_s = alpha_s(m_q_pole)
         // thus we return m_b(mu)
-        return m_q_pole * (1.0 + a_s * (-4.0 / 3.0 + a_s * (1.04 * nf - 14.3323 + a_s *
-                        (-0.65269 * nf * nf + 26.9239 * nf - 198.8068))));
+        return m_q_pole * (1.0 + a_s * (-4.0 / 3.0 + a_s * (1.04 * nf - 14.3323 + a_s * (-0.65269 * nf * nf + 26.9239 * nf - 198.8068))));
     }
 
     double
@@ -228,11 +217,8 @@ namespace eos
             case 1:
                 result = 4.0 / 3.0 + a_s * result;
                 // fall through
-            case 0:
-                result = 1.0 + a_s * result;
-                break;
-            default:
-                throw InternalError("QCD::m_q_pole: loop order " + stringify(loop_order) + " not yet implemented");
+            case 0:  result = 1.0 + a_s * result; break;
+            default: throw InternalError("QCD::m_q_pole: loop order " + stringify(loop_order) + " not yet implemented");
         }
         return m_q_MSbar * result;
     }
@@ -241,34 +227,39 @@ namespace eos
     QCD::m_q_ps(const double & m_q_MSbar, const double & alpha_s_mb, const double & mu_f, const double & nf, const QCD::BetaFunction & beta)
     {
         double a_s = alpha_s_mb / M_PI;
-        double K = 13.44 - 1.04 * nf;
+        double K   = 13.44 - 1.04 * nf;
         double a_1 = 10.33 - 1.11 * nf;
         double b_0 = beta[0];
-        double L = log(mu_f / m_q_MSbar);
+        double L   = log(mu_f / m_q_MSbar);
 
         // cf. [B1998], Eq. (25), p. 12
-        return m_q_MSbar * (1.0 + a_s * (4.0/3.0 * (1.0 - mu_f / m_q_MSbar) + a_s * (K - (mu_f / 3.0 / m_q_MSbar) * (a_1 - 2.0 * b_0 * (L - 1.0)))));
+        return m_q_MSbar * (1.0 + a_s * (4.0 / 3.0 * (1.0 - mu_f / m_q_MSbar) + a_s * (K - (mu_f / 3.0 / m_q_MSbar) * (a_1 - 2.0 * b_0 * (L - 1.0)))));
     }
 
     double
     QCD::m_q_kin(const double & m_q_MSbar, const double & alpha_s_mq, const double & mu, const BetaFunction & beta)
     {
         static const double zeta3 = 1.20206;
-        static const double ln2 = log(2.0);
+        static const double ln2   = log(2.0);
         static const double pi = M_PI, pi2 = pi * pi;
 
         double a_s = alpha_s_mq / M_PI, r = mu / m_q_MSbar;
         double b_0 = beta[0]; // We do not need to adjust for a factor of 4 when using [BBMU2003], Eq. (A.8).
-        double L = log(m_q_MSbar / (2.0 * mu));
+        double L   = log(m_q_MSbar / (2.0 * mu));
 
         // cf. [BBMU2003], Eq. (A.8) and the underlying work [MvR2000]. Note that
         // the latter does use 4 beta_0 = beta_0|here.
-        return m_q_MSbar * (1.0 + a_s * (4.0 / 3.0 * (1.0 - 4.0 / 3.0 * r - r * r / 2.0)
-                    + a_s * (b_0 / 2.0 * (pi2 / 6.0 + 71.0 / 48.0) + 665.0 / 144.0 + pi2 / 18.0 * (2.0 * ln2 - 19.0 / 2.0)
-                        - zeta3 / 6.0 - 8.0 / 3.0 - r * (8.0 * b_0 / 9.0 * (L + 8.0 / 3.0) - 8.0 * pi2 / 9.0 + 52.0 / 9.0)
-                        - r * r * (b_0 / 3.0 * (L + 13.0 / 6.0) - pi2 / 3.0 + 23.0 / 18.0)
-                        + a_s * b_0 * b_0 / 4.0 * (2353.0 / 2592.0 + 13.0 / 36.0 * pi2 + 7.0 / 6.0 * zeta3
-                            - r * 16.0 / 9.0 * (power_of<2>(L + 8.0 / 3.0) + 67.0 / 36.0 - pi2 / 6.0)
-                            - r * r * 2.0 / 3.0 * (power_of<2>(L + 13.0 / 6.0) + 10.0 / 9.0 - pi2 / 6.0)))));
+        return m_q_MSbar
+               * (1.0
+                  + a_s
+                            * (4.0 / 3.0 * (1.0 - 4.0 / 3.0 * r - r * r / 2.0)
+                               + a_s
+                                         * (b_0 / 2.0 * (pi2 / 6.0 + 71.0 / 48.0) + 665.0 / 144.0 + pi2 / 18.0 * (2.0 * ln2 - 19.0 / 2.0) - zeta3 / 6.0 - 8.0 / 3.0
+                                            - r * (8.0 * b_0 / 9.0 * (L + 8.0 / 3.0) - 8.0 * pi2 / 9.0 + 52.0 / 9.0)
+                                            - r * r * (b_0 / 3.0 * (L + 13.0 / 6.0) - pi2 / 3.0 + 23.0 / 18.0)
+                                            + a_s * b_0 * b_0 / 4.0
+                                                      * (2353.0 / 2592.0 + 13.0 / 36.0 * pi2 + 7.0 / 6.0 * zeta3
+                                                         - r * 16.0 / 9.0 * (power_of<2>(L + 8.0 / 3.0) + 67.0 / 36.0 - pi2 / 6.0)
+                                                         - r * r * 2.0 / 3.0 * (power_of<2>(L + 13.0 / 6.0) + 10.0 / 9.0 - pi2 / 6.0)))));
     }
-}
+} // namespace eos

--- a/eos/utils/qcd.hh
+++ b/eos/utils/qcd.hh
@@ -56,7 +56,8 @@ namespace eos
              * @param beta        parameters of QCD beta function that control the running
              * @param gamma_m     parameters of QCD anomalous mass dimension that control the running
              */
-            static double m_q_msbar(const double & m_q, const double & alpha_s_0, const double & alpha_s_mu, const BetaFunction & beta, const AnomalousMassDimension & gamma_m, unsigned int loop_order = 4);
+            static double m_q_msbar(const double & m_q, const double & alpha_s_0, const double & alpha_s_mu, const BetaFunction & beta, const AnomalousMassDimension & gamma_m,
+                                    unsigned int loop_order = 4);
 
             /*!
              * Calculate the shift from pole mass scheme to MSbar.
@@ -126,7 +127,7 @@ namespace eos
              * The 5-flavor-QCD constants.
              */
             ///@{
-            static const BetaFunction beta_function_nf_5;
+            static const BetaFunction           beta_function_nf_5;
             static const AnomalousMassDimension gamma_m_nf_5;
             ///@}
 
@@ -134,7 +135,7 @@ namespace eos
              * The 4-flavor-QCD constants.
              */
             ///@{
-            static const BetaFunction beta_function_nf_4;
+            static const BetaFunction           beta_function_nf_4;
             static const AnomalousMassDimension gamma_m_nf_4;
             ///@}
 
@@ -142,10 +143,10 @@ namespace eos
              * The 3-flavor QCD constants.
              */
             ///@{
-            static const BetaFunction beta_function_nf_3;
+            static const BetaFunction           beta_function_nf_3;
             static const AnomalousMassDimension gamma_m_nf_3;
             ///@}
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/qcd_TEST.cc
+++ b/eos/utils/qcd_TEST.cc
@@ -17,18 +17,18 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/qcd.hh>
 
-#include <cmath>
+#include <test/test.hh>
+
 #include <array>
+#include <cmath>
 #include <vector>
 
 using namespace test;
 using namespace eos;
 
-class QCDMassesTest :
-    public TestCase
+class QCDMassesTest : public TestCase
 {
     public:
         QCDMassesTest() :
@@ -36,7 +36,8 @@ class QCDMassesTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // alpha_s running from m_Z to m_b
             {
@@ -53,23 +54,19 @@ class QCDMassesTest :
                 static const double eps = 1e-10;
 
                 TEST_CHECK_NEARLY_EQUAL(QCD::m_q_msbar(4.18, 0.2187319006947108, 0.12, QCD::beta_function_nf_5, QCD::gamma_m_nf_5, 1), 3.055925614959463, eps);
-                TEST_CHECK_NEARLY_EQUAL(QCD::m_q_msbar(4.18,  0.231689606286231, 0.12, QCD::beta_function_nf_5, QCD::gamma_m_nf_5, 2), 2.851980190583699, eps);
-                TEST_CHECK_NEARLY_EQUAL(QCD::m_q_msbar(4.18,  0.232060563128784, 0.12, QCD::beta_function_nf_5, QCD::gamma_m_nf_5, 3), 2.833395418373546, eps);
+                TEST_CHECK_NEARLY_EQUAL(QCD::m_q_msbar(4.18, 0.231689606286231, 0.12, QCD::beta_function_nf_5, QCD::gamma_m_nf_5, 2), 2.851980190583699, eps);
+                TEST_CHECK_NEARLY_EQUAL(QCD::m_q_msbar(4.18, 0.232060563128784, 0.12, QCD::beta_function_nf_5, QCD::gamma_m_nf_5, 3), 2.833395418373546, eps);
                 TEST_CHECK_NEARLY_EQUAL(QCD::m_q_msbar(4.18, 0.2329548830209454, 0.12, QCD::beta_function_nf_5, QCD::gamma_m_nf_5, 4), 2.826500455559605, eps);
             }
 
             // m_q_msbar(m_q_pole) at 3-loop
             {
-                static const double eps = 1e-7;
-                static const std::vector<std::array<double, 5>> tests
-                {
-                                        // pole,  nf, alpha_s,   MSbar-ref
-                    std::array<double, 5>{{ 172.0, 5.0,    0.10,  162.6620051 }},
-                    std::array<double, 5>{{ 170.0, 5.0,    0.10,  160.7705865 }},
-                    std::array<double, 5>{{ 168.0, 5.0,    0.10,  158.8791678 }},
-                    std::array<double, 5>{{   4.9, 4.0,    0.22,    4.0271606 }},
-                    std::array<double, 5>{{   4.8, 4.0,    0.22,    3.9449736 }},
-                    std::array<double, 5>{{   4.7, 4.0,    0.22,    3.8627867 }},
+                static const double                             eps = 1e-7;
+                static const std::vector<std::array<double, 5>> tests{
+                    // pole,  nf, alpha_s,   MSbar-ref
+                    std::array<double, 5>{ { 172.0, 5.0, 0.10, 162.6620051 } }, std::array<double, 5>{ { 170.0, 5.0, 0.10, 160.7705865 } },
+                    std::array<double, 5>{ { 168.0, 5.0, 0.10, 158.8791678 } }, std::array<double, 5>{ { 4.9, 4.0, 0.22, 4.0271606 } },
+                    std::array<double, 5>{ { 4.8, 4.0, 0.22, 3.9449736 } },     std::array<double, 5>{ { 4.7, 4.0, 0.22, 3.8627867 } },
                 };
 
                 for (const auto & test : tests)
@@ -84,7 +81,7 @@ class QCDMassesTest :
             // m_q_pole(m_q_msbar) at orders 1 to 3
             {
                 static const double eps = 1e-15; // exact to float precision
-                TEST_CHECK_NEARLY_EQUAL(QCD::m_q_pole(4.0, 0.22, 5.0, 0), 4.0,               eps);
+                TEST_CHECK_NEARLY_EQUAL(QCD::m_q_pole(4.0, 0.22, 5.0, 0), 4.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(QCD::m_q_pole(4.0, 0.22, 5.0, 1), 4.373483599788981, eps);
                 TEST_CHECK_NEARLY_EQUAL(QCD::m_q_pole(4.0, 0.22, 5.0, 2), 4.535117636490992, eps);
                 TEST_CHECK_NEARLY_EQUAL(QCD::m_q_pole(4.0, 0.22, 5.0, 3), 4.636150134920265, eps);
@@ -92,8 +89,8 @@ class QCDMassesTest :
 
             // Safety check: higher-than-implemented loop order throws error
             {
-                const constexpr unsigned int zero_loop_order = 0;
-                const constexpr unsigned int higher_loop_order = 4;
+                const constexpr unsigned int zero_loop_order        = 0;
+                const constexpr unsigned int higher_loop_order      = 4;
                 const constexpr unsigned int even_higher_loop_order = 5;
 
                 TEST_CHECK_THROWS(InternalError, QCD::m_q_pole(4.0, 0.22, 5.0, higher_loop_order));

--- a/eos/utils/qualified-name-parts.hh
+++ b/eos/utils/qualified-name-parts.hh
@@ -37,10 +37,23 @@ namespace eos
             public:
                 Prefix(const std::string &);
 
-                const std::string & str() const { return _prefix; };
+                const std::string &
+                str() const
+                {
+                    return _prefix;
+                }
 
-                inline bool operator<  (const Prefix & rhs) const { return this->_prefix <  rhs._prefix; };
-                inline bool operator== (const Prefix & rhs) const { return this->_prefix == rhs._prefix; };
+                inline bool
+                operator< (const Prefix & rhs) const
+                {
+                    return this->_prefix < rhs._prefix;
+                }
+
+                inline bool
+                operator== (const Prefix & rhs) const
+                {
+                    return this->_prefix == rhs._prefix;
+                }
         };
 
         class Name
@@ -51,10 +64,23 @@ namespace eos
             public:
                 Name(const std::string &);
 
-                const std::string & str() const { return _name; };
+                const std::string &
+                str() const
+                {
+                    return _name;
+                }
 
-                inline bool operator<  (const Name & rhs) const { return this->_name <  rhs._name; };
-                inline bool operator== (const Name & rhs) const { return this->_name == rhs._name; };
+                inline bool
+                operator< (const Name & rhs) const
+                {
+                    return this->_name < rhs._name;
+                }
+
+                inline bool
+                operator== (const Name & rhs) const
+                {
+                    return this->_name == rhs._name;
+                }
         };
 
         class Suffix
@@ -66,10 +92,23 @@ namespace eos
                 Suffix();
                 Suffix(const std::string &);
 
-                const std::string & str() const { return _suffix; };
-                bool empty() const { return _suffix.empty(); };
+                const std::string &
+                str() const
+                {
+                    return _suffix;
+                }
 
-                inline bool operator<  (const Suffix & rhs) const { return this->_suffix <  rhs._suffix; };
+                bool
+                empty() const
+                {
+                    return _suffix.empty();
+                }
+
+                inline bool
+                operator< (const Suffix & rhs) const
+                {
+                    return this->_suffix < rhs._suffix;
+                }
         };
 
         class OptionKey
@@ -80,11 +119,15 @@ namespace eos
             public:
                 OptionKey(const std::string &);
 
-                const std::string & str() const { return _key; };
+                const std::string &
+                str() const
+                {
+                    return _key;
+                }
 
                 inline auto operator<=> (const OptionKey & rhs) const = default;
-                inline bool operator== (const OptionKey & rhs) const = default;
-                inline bool operator< (const OptionKey & rhs) const = default;
+                inline bool operator== (const OptionKey & rhs) const  = default;
+                inline bool operator< (const OptionKey & rhs) const   = default;
         };
 
         class OptionValue
@@ -95,67 +138,73 @@ namespace eos
             public:
                 OptionValue(const std::string &);
 
-                const std::string & str() const { return _value; };
+                const std::string &
+                str() const
+                {
+                    return _value;
+                }
         };
-    }
+    } // namespace qnp
 
-    inline qnp::OptionKey operator ""_ok(const char * str, size_t len)
+    inline qnp::OptionKey
+    operator""_ok (const char * str, size_t len)
     {
         return qnp::OptionKey(std::string(str, len));
     }
 
-    inline qnp::OptionValue operator ""_ov(const char * str, size_t len)
+    inline qnp::OptionValue
+    operator""_ov (const char * str, size_t len)
     {
         return qnp::OptionValue(std::string(str, len));
     }
 
     namespace implementation
     {
-        template <>
-        struct DoStringify<qnp::Prefix>
+        template <> struct DoStringify<qnp::Prefix>
         {
-            static std::string stringify(const qnp::Prefix & x, unsigned)
-            {
-                return x.str();
-            }
+                static std::string
+                stringify(const qnp::Prefix & x, unsigned)
+                {
+                    return x.str();
+                }
         };
 
-        template <>
-        struct DoStringify<qnp::Name>
+        template <> struct DoStringify<qnp::Name>
         {
-            static std::string stringify(const qnp::Name & x, unsigned)
-            {
-                return x.str();
-            }
+                static std::string
+                stringify(const qnp::Name & x, unsigned)
+                {
+                    return x.str();
+                }
         };
 
-        template <>
-        struct DoStringify<qnp::Suffix>
+        template <> struct DoStringify<qnp::Suffix>
         {
-            static std::string stringify(const qnp::Suffix & x, unsigned)
-            {
-                return x.str();
-            }
+                static std::string
+                stringify(const qnp::Suffix & x, unsigned)
+                {
+                    return x.str();
+                }
         };
 
-        template <>
-        struct DoStringify<qnp::OptionKey>
+        template <> struct DoStringify<qnp::OptionKey>
         {
-            static std::string stringify(const qnp::OptionKey & x, unsigned)
-            {
-                return x.str();
-            }
+                static std::string
+                stringify(const qnp::OptionKey & x, unsigned)
+                {
+                    return x.str();
+                }
         };
 
-        template <>
-        struct DoStringify<qnp::OptionValue>
+        template <> struct DoStringify<qnp::OptionValue>
         {
-            static std::string stringify(const qnp::OptionValue & x, unsigned)
-            {
-                return x.str();
-            }
+                static std::string
+                stringify(const qnp::OptionValue & x, unsigned)
+                {
+                    return x.str();
+                }
         };
-    }
-}
+    } // namespace implementation
+} // namespace eos
 
 #endif

--- a/eos/utils/qualified-name.cc
+++ b/eos/utils/qualified-name.cc
@@ -33,11 +33,10 @@ namespace eos
             }
 
             // PREFIX := ['a'-'z', 'A'-'Z', '0'-'9', '<', '>', '^', '_', '*', '+', '-', '(', ')']
-            static const char * valid_prefix_characters =
-                    "abcdefghijklmnopqrstuvwxyz"
-                    "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
-                    "0123456789"
-                    "<>^_*+-()";
+            static const char * valid_prefix_characters = "abcdefghijklmnopqrstuvwxyz"
+                                                          "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
+                                                          "0123456789"
+                                                          "<>^_*+-()";
 
             auto pos = prefix.find_first_not_of(valid_prefix_characters);
 
@@ -65,11 +64,10 @@ namespace eos
 
             // NAME := ['a'-'z', 'A'-'Z', '0'-'9', '(', ')', '[', ']', '{', '}', '|'
             //          '\'', ',', '.', '/', '^', '_', '*', '+', '-', '=']
-            static const char * valid_name_characters =
-                    "abcdefghijklmnopqrstuvwxyz"
-                    "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
-                    "0123456789"
-                    "()[]{}|',./^_*+-=";
+            static const char * valid_name_characters = "abcdefghijklmnopqrstuvwxyz"
+                                                        "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
+                                                        "0123456789"
+                                                        "()[]{}|',./^_*+-=";
 
             auto pos = name.find_first_not_of(valid_name_characters);
 
@@ -96,11 +94,10 @@ namespace eos
             _suffix(suffix)
         {
             // SUFFIX := ['a'-'z', 'A'-'Z', '0'-'9', '.', ':', '-', '(', ')']
-            static const char * valid_suffix_characters =
-                    "abcdefghijklmnopqrstuvwxyz"
-                    "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
-                    "0123456789"
-                    ".:-+()";
+            static const char * valid_suffix_characters = "abcdefghijklmnopqrstuvwxyz"
+                                                          "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
+                                                          "0123456789"
+                                                          ".:-+()";
 
             auto pos = suffix.find_first_not_of(valid_suffix_characters);
 
@@ -119,11 +116,10 @@ namespace eos
             }
 
             // KEY := ['a'-'z', 'A'-'Z', '0'-'9', '-']
-            static const char * valid_option_key_characters =
-                    "abcdefghijklmnopqrstuvwxyz"
-                    "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
-                    "0123456789"
-                    "-";
+            static const char * valid_option_key_characters = "abcdefghijklmnopqrstuvwxyz"
+                                                              "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
+                                                              "0123456789"
+                                                              "-";
 
             auto pos = key.find_first_not_of(valid_option_key_characters);
 
@@ -142,11 +138,10 @@ namespace eos
             }
 
             // VALUE := ['a'-'z', 'A'-'Z', '0'-'9', '+', '-', '/', '.', '^', '_']
-            static const char * valid_option_value_characters =
-                    "abcdefghijklmnopqrstuvwxyz"
-                    "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
-                    "0123456789"
-                    "+-/.^_";
+            static const char * valid_option_value_characters = "abcdefghijklmnopqrstuvwxyz"
+                                                                "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
+                                                                "0123456789"
+                                                                "+-/.^_";
 
             auto pos = value.find_first_not_of(valid_option_value_characters);
 
@@ -155,7 +150,7 @@ namespace eos
                 throw QualifiedNameSyntaxError("'" + value + "' is not a valid option value part: Character '" + value[pos] + "' may not be used");
             }
         }
-    }
+    } // namespace qnp
 
     QualifiedName::QualifiedName(const std::string & input) :
         _full(input),
@@ -226,7 +221,7 @@ namespace eos
 
             auto pos_next_comma = input.find(',', pos_equal + 1);
 
-            qnp::OptionKey key(input.substr(pos_option_start + 1, pos_equal - pos_option_start - 1));
+            qnp::OptionKey   key(input.substr(pos_option_start + 1, pos_equal - pos_option_start - 1));
             qnp::OptionValue value(input.substr(pos_equal + 1, pos_next_comma - pos_equal - 1));
 
             _options.declare(key.str(), value.str());
@@ -260,12 +255,10 @@ namespace eos
     {
     }
 
-    QualifiedName::~QualifiedName()
-    {
-    }
+    QualifiedName::~QualifiedName() {}
 
     QualifiedNameSyntaxError::QualifiedNameSyntaxError(const std::string & msg) :
         Exception(msg)
     {
     }
-}
+} // namespace eos

--- a/eos/utils/qualified-name.hh
+++ b/eos/utils/qualified-name.hh
@@ -54,15 +54,15 @@ namespace eos
      */
     class QualifiedName
     {
-        friend std::ostream & operator<< (std::ostream &, const QualifiedName &);
+            friend std::ostream & operator<< (std::ostream &, const QualifiedName &);
 
         private:
-            std::string  _str;     // short hand name, excluding possible options
-            std::string  _full;    // full name, including all given options
-            qnp::Prefix  _prefix;
-            qnp::Name    _name;
-            qnp::Suffix  _suffix;
-            Options      _options;
+            std::string _str;  // short hand name, excluding possible options
+            std::string _full; // full name, including all given options
+            qnp::Prefix _prefix;
+            qnp::Name   _name;
+            qnp::Suffix _suffix;
+            Options     _options;
 
         public:
             QualifiedName(const std::string & name);
@@ -71,36 +71,79 @@ namespace eos
             QualifiedName(const qnp::Prefix & prefix, const qnp::Name & name, const qnp::Suffix & suffix = qnp::Suffix());
             ~QualifiedName();
 
-            inline const std::string & str() const { return _str; };
-            inline const std::string & full() const { return _full; };
-            inline const qnp::Prefix & prefix_part() const { return _prefix; };
-            inline const qnp::Name & name_part() const { return _name; };
-            inline const qnp::Suffix & suffix_part() const { return _suffix; };
-            inline const Options & options() const { return _options; };
+            inline const std::string &
+            str() const
+            {
+                return _str;
+            }
+
+            inline const std::string &
+            full() const
+            {
+                return _full;
+            }
+
+            inline const qnp::Prefix &
+            prefix_part() const
+            {
+                return _prefix;
+            }
+
+            inline const qnp::Name &
+            name_part() const
+            {
+                return _name;
+            }
+
+            inline const qnp::Suffix &
+            suffix_part() const
+            {
+                return _suffix;
+            }
+
+            inline const Options &
+            options() const
+            {
+                return _options;
+            }
 
             /*
              * Two qualified names are compared based on their short names only.
              * As a consequence, two qualified names can be identical, even if their
              * full names aren't.
              */
-            inline bool operator<  (const QualifiedName & rhs) const { return this->_str <  rhs._str; };
-            inline bool operator== (const QualifiedName & rhs) const { return this->_str == rhs._str; };
-            inline bool operator!= (const QualifiedName & rhs) const { return this->_str != rhs._str; };
+            inline bool
+            operator< (const QualifiedName & rhs) const
+            {
+                return this->_str < rhs._str;
+            }
+
+            inline bool
+            operator== (const QualifiedName & rhs) const
+            {
+                return this->_str == rhs._str;
+            }
+
+            inline bool
+            operator!= (const QualifiedName & rhs) const
+            {
+                return this->_str != rhs._str;
+            }
     };
 
-    class QualifiedNameSyntaxError :
-        public Exception
+    class QualifiedNameSyntaxError : public Exception
     {
         public:
             QualifiedNameSyntaxError(const std::string & msg);
     };
 
-    inline std::ostream & operator<< (std::ostream & lhs, const QualifiedName & rhs)
+    inline std::ostream &
+    operator<< (std::ostream & lhs, const QualifiedName & rhs)
     {
         lhs << rhs._str;
 
         return lhs;
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/qualified-name_TEST.cc
+++ b/eos/utils/qualified-name_TEST.cc
@@ -18,8 +18,9 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/qualified-name.hh>
+
+#include <test/test.hh>
 
 #include <cmath>
 #include <iostream>
@@ -27,8 +28,7 @@
 using namespace test;
 using namespace eos;
 
-class PrefixTest :
-    public TestCase
+class PrefixTest : public TestCase
 {
     public:
         PrefixTest() :
@@ -36,7 +36,8 @@ class PrefixTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto p = qnp::Prefix("B->K^*ll"));
             TEST_CHECK_NO_THROW(auto p = qnp::Prefix("B->B"));
@@ -47,8 +48,7 @@ class PrefixTest :
         }
 } prefix_test;
 
-class NameTest :
-    public TestCase
+class NameTest : public TestCase
 {
     public:
         NameTest() :
@@ -56,7 +56,8 @@ class NameTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto n = qnp::Name("A_FB(s)"));
             TEST_CHECK_NO_THROW(auto n = qnp::Name("dBR/ds"));
@@ -68,8 +69,7 @@ class NameTest :
         }
 } name_test;
 
-class SuffixTest :
-    public TestCase
+class SuffixTest : public TestCase
 {
     public:
         SuffixTest() :
@@ -77,7 +77,8 @@ class SuffixTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto p = qnp::Suffix("LargeRecoil"));
             TEST_CHECK_NO_THROW(auto p = qnp::Suffix("LHCb:2014A"));
@@ -90,8 +91,7 @@ class SuffixTest :
         }
 } suffix_test;
 
-class OptionKeyTest :
-    public TestCase
+class OptionKeyTest : public TestCase
 {
     public:
         OptionKeyTest() :
@@ -99,7 +99,8 @@ class OptionKeyTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto k = qnp::OptionKey("form-factors"));
             TEST_CHECK_NO_THROW(auto k = qnp::OptionKey("correlator"));
@@ -111,8 +112,7 @@ class OptionKeyTest :
         }
 } option_key_test;
 
-class OptionValueTest :
-    public TestCase
+class OptionValueTest : public TestCase
 {
     public:
         OptionValueTest() :
@@ -120,7 +120,8 @@ class OptionValueTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto p = qnp::OptionValue("KMPW2010"));
             TEST_CHECK_NO_THROW(auto p = qnp::OptionValue("BCvD2016-model1"));
@@ -133,8 +134,7 @@ class OptionValueTest :
         }
 } option_value_test;
 
-class QualifiedNameTest :
-    public TestCase
+class QualifiedNameTest : public TestCase
 {
     public:
         QualifiedNameTest() :
@@ -142,7 +142,8 @@ class QualifiedNameTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto qn = QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010"));
             TEST_CHECK_NO_THROW(auto qn = QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=BSZ2015"));
@@ -151,33 +152,16 @@ class QualifiedNameTest :
             TEST_CHECK_NO_THROW(auto qn = QualifiedName("D->K::f_++f_0@ETM:2017B;form-factors=BFW2010,rescale-factor=6.346"));
             TEST_CHECK_NO_THROW(auto qn = QualifiedName(qnp::Prefix("mass"), qnp::Name("b(MSbar)"), qnp::Suffix("non-empty")));
 
-            TEST_CHECK_EQUAL_STR(
-                    "B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010",
-                    QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010").full()
-                    );
-            TEST_CHECK_EQUAL_STR(
-                    "B->K^*ll::A_FB(s)@LargeRecoil",
-                    QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010").str()
-                    );
+            TEST_CHECK_EQUAL_STR("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010", QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010").full());
+            TEST_CHECK_EQUAL_STR("B->K^*ll::A_FB(s)@LargeRecoil", QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010").str());
 
-            TEST_CHECK_EQUAL_STR(
-                    "B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010,model=WET",
-                    QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010,model=WET").full()
-                    );
-            TEST_CHECK_EQUAL_STR(
-                    "B->K^*ll::A_FB(s)@LargeRecoil",
-                    QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010,model=WET").str()
-                    );
+            TEST_CHECK_EQUAL_STR("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010,model=WET",
+                                 QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010,model=WET").full());
+            TEST_CHECK_EQUAL_STR("B->K^*ll::A_FB(s)@LargeRecoil", QualifiedName("B->K^*ll::A_FB(s)@LargeRecoil;form-factors=KMPW2010,model=WET").str());
 
-            TEST_CHECK_EQUAL_STR(
-                    "mass::b(MSbar)@non-empty",
-                    QualifiedName(qnp::Prefix("mass"), qnp::Name("b(MSbar)"), qnp::Suffix("non-empty")).str()
-                    );
+            TEST_CHECK_EQUAL_STR("mass::b(MSbar)@non-empty", QualifiedName(qnp::Prefix("mass"), qnp::Name("b(MSbar)"), qnp::Suffix("non-empty")).str());
 
-            TEST_CHECK_EQUAL_STR(
-                    "mass::b(MSbar)",
-                    QualifiedName(qnp::Prefix("mass"), qnp::Name("b(MSbar)")).str()
-                    );
+            TEST_CHECK_EQUAL_STR("mass::b(MSbar)", QualifiedName(qnp::Prefix("mass"), qnp::Name("b(MSbar)")).str());
 
             TEST_CHECK_THROWS(QualifiedNameSyntaxError, auto qn = QualifiedName(""));
         }

--- a/eos/utils/quantum-numbers.cc
+++ b/eos/utils/quantum-numbers.cc
@@ -28,10 +28,7 @@ namespace eos
     std::ostream &
     operator<< (std::ostream & os, LeptonFlavor lf)
     {
-        static const std::array<std::string, 3u> names
-        {
-            "e", "mu", "tau"
-        };
+        static const std::array<std::string, 3u> names{ "e", "mu", "tau" };
 
         os << names[static_cast<unsigned>(lf)];
 
@@ -41,10 +38,7 @@ namespace eos
     std::ostream &
     operator<< (std::ostream & os, QuarkFlavor qf)
     {
-        static const std::array<std::string, 6u> names
-        {
-            "u", "d", "s", "c", "b", "t"
-        };
+        static const std::array<std::string, 6u> names{ "u", "d", "s", "c", "b", "t" };
 
         os << names[static_cast<unsigned>(qf)];
 
@@ -54,16 +48,15 @@ namespace eos
     std::ostream &
     operator<< (std::ostream & os, Isospin i)
     {
-        static const std::array<std::string, 5u> names
-        {
-            "0", "1/2", "1", "3/2", "2"
-        };
+        static const std::array<std::string, 5u> names{ "0", "1/2", "1", "3/2", "2" };
 
         std::vector<std::string> tmp;
-        for (unsigned shift = 0 ; shift < 5 ; ++shift)
+        for (unsigned shift = 0; shift < 5; ++shift)
         {
             if (i && static_cast<Isospin>(1 << shift))
+            {
                 tmp.push_back(names[shift]);
+            }
         }
 
         os << join(tmp.begin(), tmp.end(), "|");
@@ -74,10 +67,7 @@ namespace eos
     std::ostream &
     operator<< (std::ostream & os, IsospinRepresentation ir)
     {
-        static const std::array<std::string, 5u> names
-        {
-            "0", "1", "2", "1/2", "3/2"
-        };
+        static const std::array<std::string, 5u> names{ "0", "1", "2", "1/2", "3/2" };
 
         os << names[static_cast<unsigned>(ir)];
 
@@ -87,10 +77,7 @@ namespace eos
     std::ostream &
     operator<< (std::ostream & os, LightMeson qf)
     {
-        static const std::array<std::string, 10u> names
-        {
-            "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime"
-        };
+        static const std::array<std::string, 10u> names{ "pi^0", "pi^+", "pi^-", "K_d", "Kbar_d", "K_S", "K_u", "Kbar_u", "eta", "eta_prime" };
 
         os << names[static_cast<unsigned>(qf)];
 
@@ -100,16 +87,15 @@ namespace eos
     std::ostream &
     operator<< (std::ostream & os, PartialWave pw)
     {
-        static const std::array<std::string, 4u> names
-        {
-            "S", "P", "D", "F"
-        };
+        static const std::array<std::string, 4u> names{ "S", "P", "D", "F" };
 
         std::vector<std::string> tmp;
-        for (unsigned shift = 0 ; shift < 4 ; ++shift)
+        for (unsigned shift = 0; shift < 4; ++shift)
         {
             if (pw && static_cast<PartialWave>(1 << shift))
+            {
                 tmp.push_back(names[shift]);
+            }
         }
 
         os << join(tmp.begin(), tmp.end(), "|");
@@ -117,4 +103,4 @@ namespace eos
         return os;
     }
 
-}
+} // namespace eos

--- a/eos/utils/quantum-numbers.hh
+++ b/eos/utils/quantum-numbers.hh
@@ -36,7 +36,7 @@ namespace eos
         tauon    = 2
     };
 
-    std::ostream& operator<< (std::ostream & os, LeptonFlavor lf);
+    std::ostream & operator<< (std::ostream & os, LeptonFlavor lf);
 
     enum class QuarkFlavor : uint8_t
     {
@@ -47,7 +47,7 @@ namespace eos
         bottom  = 4,
         top     = 5
     };
-    std::ostream& operator<< (std::ostream & os, QuarkFlavor qf);
+    std::ostream & operator<< (std::ostream & os, QuarkFlavor qf);
 
     enum class Isospin : uint16_t
     {
@@ -59,43 +59,50 @@ namespace eos
         two         = 1 << 4
     };
 
-    inline Isospin operator | (Isospin lhs, Isospin rhs)
+    inline Isospin
+    operator| (Isospin lhs, Isospin rhs)
     {
         using T = std::underlying_type_t<Isospin>;
         return static_cast<Isospin>(static_cast<T>(lhs) | static_cast<T>(rhs));
     }
 
-    inline Isospin & operator |= (Isospin & lhs, Isospin rhs)
+    inline Isospin &
+    operator|= (Isospin & lhs, Isospin rhs)
     {
         lhs = lhs | rhs;
         return lhs;
     }
 
-    inline Isospin operator & (Isospin lhs, Isospin rhs)
+    inline Isospin
+    operator& (Isospin lhs, Isospin rhs)
     {
         using T = std::underlying_type_t<Isospin>;
         return static_cast<Isospin>(static_cast<T>(lhs) & static_cast<T>(rhs));
     }
 
-    inline Isospin & operator &= (Isospin & lhs, Isospin rhs)
+    inline Isospin &
+    operator&= (Isospin & lhs, Isospin rhs)
     {
         lhs = lhs & rhs;
         return lhs;
     }
 
-    inline Isospin operator ^ (Isospin lhs, Isospin rhs)
+    inline Isospin
+    operator^ (Isospin lhs, Isospin rhs)
     {
         using T = std::underlying_type_t<Isospin>;
         return static_cast<Isospin>(static_cast<T>(lhs) ^ static_cast<T>(rhs));
     }
 
-    inline Isospin & operator ^= (Isospin & lhs, Isospin rhs)
+    inline Isospin &
+    operator^= (Isospin & lhs, Isospin rhs)
     {
         lhs = lhs ^ rhs;
         return lhs;
     }
 
-    inline bool operator && (Isospin lhs, Isospin rhs)
+    inline bool
+    operator&& (Isospin lhs, Isospin rhs)
     {
         return (lhs & rhs) != Isospin::none;
     }
@@ -111,23 +118,23 @@ namespace eos
         threehalves = 4
     };
 
-    std::ostream& operator<< (std::ostream & os, IsospinRepresentation ir);
+    std::ostream & operator<< (std::ostream & os, IsospinRepresentation ir);
 
     enum class LightMeson : uint8_t
     {
-        pi0      = 0,
-        piplus   = 1,
-        piminus  = 2,
-        K0       = 3,
-        K0bar    = 4,
-        KS       = 5,
-        Kplus    = 6,
-        Kminus   = 7,
-        eta      = 8,
-        etap     = 9,
+        pi0     = 0,
+        piplus  = 1,
+        piminus = 2,
+        K0      = 3,
+        K0bar   = 4,
+        KS      = 5,
+        Kplus   = 6,
+        Kminus  = 7,
+        eta     = 8,
+        etap    = 9,
     };
 
-    std::ostream& operator<< (std::ostream & os, LightMeson qf);
+    std::ostream & operator<< (std::ostream & os, LightMeson qf);
 
     enum class PartialWave : uint8_t
     {
@@ -138,49 +145,56 @@ namespace eos
         F    = 1 << 3
     };
 
-    inline PartialWave operator | (PartialWave lhs, PartialWave rhs)
+    inline PartialWave
+    operator| (PartialWave lhs, PartialWave rhs)
     {
         using T = std::underlying_type_t<PartialWave>;
         return static_cast<PartialWave>(static_cast<T>(lhs) | static_cast<T>(rhs));
     }
 
-    inline PartialWave & operator |= (PartialWave & lhs, PartialWave rhs)
+    inline PartialWave &
+    operator|= (PartialWave & lhs, PartialWave rhs)
     {
         lhs = lhs | rhs;
         return lhs;
     }
 
-    inline PartialWave operator & (PartialWave lhs, PartialWave rhs)
+    inline PartialWave
+    operator& (PartialWave lhs, PartialWave rhs)
     {
         using T = std::underlying_type_t<PartialWave>;
         return static_cast<PartialWave>(static_cast<T>(lhs) & static_cast<T>(rhs));
     }
 
-    inline PartialWave & operator &= (PartialWave & lhs, PartialWave rhs)
+    inline PartialWave &
+    operator&= (PartialWave & lhs, PartialWave rhs)
     {
         lhs = lhs & rhs;
         return lhs;
     }
 
-    inline PartialWave operator ^ (PartialWave lhs, PartialWave rhs)
+    inline PartialWave
+    operator^ (PartialWave lhs, PartialWave rhs)
     {
         using T = std::underlying_type_t<PartialWave>;
         return static_cast<PartialWave>(static_cast<T>(lhs) ^ static_cast<T>(rhs));
     }
 
-    inline PartialWave & operator ^= (PartialWave & lhs, PartialWave rhs)
+    inline PartialWave &
+    operator^= (PartialWave & lhs, PartialWave rhs)
     {
         lhs = lhs ^ rhs;
         return lhs;
     }
 
-    inline bool operator && (PartialWave lhs, PartialWave rhs)
+    inline bool
+    operator&& (PartialWave lhs, PartialWave rhs)
     {
         return (lhs & rhs) != PartialWave::none;
     }
 
     std::ostream & operator<< (std::ostream & os, PartialWave i);
 
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/quantum-numbers_TEST.cc
+++ b/eos/utils/quantum-numbers_TEST.cc
@@ -18,16 +18,16 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/destringify.hh>
 #include <eos/utils/quantum-numbers.hh>
 #include <eos/utils/stringify.hh>
 
+#include <test/test.hh>
+
 using namespace test;
 using namespace eos;
 
-class LeptonFlavorTest :
-    public TestCase
+class LeptonFlavorTest : public TestCase
 {
     public:
         LeptonFlavorTest() :
@@ -35,16 +35,16 @@ class LeptonFlavorTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-            TEST_CHECK_EQUAL_STR("e",   stringify(LeptonFlavor::electron));
-            TEST_CHECK_EQUAL_STR("mu",  stringify(LeptonFlavor::muon));
+            TEST_CHECK_EQUAL_STR("e", stringify(LeptonFlavor::electron));
+            TEST_CHECK_EQUAL_STR("mu", stringify(LeptonFlavor::muon));
             TEST_CHECK_EQUAL_STR("tau", stringify(LeptonFlavor::tauon));
         }
 } lepton_flavor_test;
 
-class QuarkFlavorTest :
-    public TestCase
+class QuarkFlavorTest : public TestCase
 {
     public:
         QuarkFlavorTest() :
@@ -52,7 +52,8 @@ class QuarkFlavorTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_EQUAL_STR("u", stringify(QuarkFlavor::up));
             TEST_CHECK_EQUAL_STR("d", stringify(QuarkFlavor::down));
@@ -63,8 +64,7 @@ class QuarkFlavorTest :
         }
 } quark_flavor_test;
 
-class IsospinTest :
-    public TestCase
+class IsospinTest : public TestCase
 {
     public:
         IsospinTest() :
@@ -72,28 +72,28 @@ class IsospinTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-            TEST_CHECK_EQUAL_STR("",      stringify(Isospin::none));
-            TEST_CHECK_EQUAL_STR("0",     stringify(Isospin::zero));
-            TEST_CHECK_EQUAL_STR("1",     stringify(Isospin::one));
-            TEST_CHECK_EQUAL_STR("1/2",   stringify(Isospin::onehalf));
-            TEST_CHECK_EQUAL_STR("2",     stringify(Isospin::two));
-            TEST_CHECK_EQUAL_STR("3/2",   stringify(Isospin::threehalves));
+            TEST_CHECK_EQUAL_STR("", stringify(Isospin::none));
+            TEST_CHECK_EQUAL_STR("0", stringify(Isospin::zero));
+            TEST_CHECK_EQUAL_STR("1", stringify(Isospin::one));
+            TEST_CHECK_EQUAL_STR("1/2", stringify(Isospin::onehalf));
+            TEST_CHECK_EQUAL_STR("2", stringify(Isospin::two));
+            TEST_CHECK_EQUAL_STR("3/2", stringify(Isospin::threehalves));
 
-            TEST_CHECK_EQUAL_STR("0|1",   stringify(Isospin::zero | Isospin::one));
+            TEST_CHECK_EQUAL_STR("0|1", stringify(Isospin::zero | Isospin::one));
             TEST_CHECK_EQUAL_STR("0|3/2", stringify(Isospin::zero | Isospin::threehalves));
-            TEST_CHECK_EQUAL_STR("1|2",   stringify(Isospin::one | Isospin::two));
+            TEST_CHECK_EQUAL_STR("1|2", stringify(Isospin::one | Isospin::two));
 
-            TEST_CHECK_EQUAL(destringify<Isospin>("0|1"),   Isospin::zero | Isospin::one);
+            TEST_CHECK_EQUAL(destringify<Isospin>("0|1"), Isospin::zero | Isospin::one);
             TEST_CHECK_EQUAL(destringify<Isospin>("0|3/2"), Isospin::zero | Isospin::threehalves);
-            TEST_CHECK_EQUAL(destringify<Isospin>("1|2"),   Isospin::one | Isospin::two);
+            TEST_CHECK_EQUAL(destringify<Isospin>("1|2"), Isospin::one | Isospin::two);
             TEST_CHECK_EQUAL(destringify<Isospin>("0|1|2"), Isospin::zero | Isospin::one | Isospin::two);
         }
 } isospin_test;
 
-class IsospinRepresentationTest :
-    public TestCase
+class IsospinRepresentationTest : public TestCase
 {
     public:
         IsospinRepresentationTest() :
@@ -101,18 +101,18 @@ class IsospinRepresentationTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-            TEST_CHECK_EQUAL_STR("0",   stringify(IsospinRepresentation::zero));
-            TEST_CHECK_EQUAL_STR("1",   stringify(IsospinRepresentation::one));
-            TEST_CHECK_EQUAL_STR("2",   stringify(IsospinRepresentation::two));
+            TEST_CHECK_EQUAL_STR("0", stringify(IsospinRepresentation::zero));
+            TEST_CHECK_EQUAL_STR("1", stringify(IsospinRepresentation::one));
+            TEST_CHECK_EQUAL_STR("2", stringify(IsospinRepresentation::two));
             TEST_CHECK_EQUAL_STR("1/2", stringify(IsospinRepresentation::onehalf));
             TEST_CHECK_EQUAL_STR("3/2", stringify(IsospinRepresentation::threehalves));
         }
 } isospin_representation_test;
 
-class LightMesonTest :
-    public TestCase
+class LightMesonTest : public TestCase
 {
     public:
         LightMesonTest() :
@@ -120,24 +120,23 @@ class LightMesonTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-            TEST_CHECK_EQUAL_STR("pi^0",        stringify(LightMeson::pi0));
-            TEST_CHECK_EQUAL_STR("pi^+",        stringify(LightMeson::piplus));
-            TEST_CHECK_EQUAL_STR("pi^-",        stringify(LightMeson::piminus));
-            TEST_CHECK_EQUAL_STR("K_d",         stringify(LightMeson::K0));
-            TEST_CHECK_EQUAL_STR("Kbar_d",      stringify(LightMeson::K0bar));
-            TEST_CHECK_EQUAL_STR("K_S",         stringify(LightMeson::KS));
-            TEST_CHECK_EQUAL_STR("K_u",         stringify(LightMeson::Kplus));
-            TEST_CHECK_EQUAL_STR("Kbar_u",      stringify(LightMeson::Kminus));
-            TEST_CHECK_EQUAL_STR("eta",         stringify(LightMeson::eta));
-            TEST_CHECK_EQUAL_STR("eta_prime",   stringify(LightMeson::etap));
-
+            TEST_CHECK_EQUAL_STR("pi^0", stringify(LightMeson::pi0));
+            TEST_CHECK_EQUAL_STR("pi^+", stringify(LightMeson::piplus));
+            TEST_CHECK_EQUAL_STR("pi^-", stringify(LightMeson::piminus));
+            TEST_CHECK_EQUAL_STR("K_d", stringify(LightMeson::K0));
+            TEST_CHECK_EQUAL_STR("Kbar_d", stringify(LightMeson::K0bar));
+            TEST_CHECK_EQUAL_STR("K_S", stringify(LightMeson::KS));
+            TEST_CHECK_EQUAL_STR("K_u", stringify(LightMeson::Kplus));
+            TEST_CHECK_EQUAL_STR("Kbar_u", stringify(LightMeson::Kminus));
+            TEST_CHECK_EQUAL_STR("eta", stringify(LightMeson::eta));
+            TEST_CHECK_EQUAL_STR("eta_prime", stringify(LightMeson::etap));
         }
 } light_meson_test;
 
-class PartialWaveTest :
-    public TestCase
+class PartialWaveTest : public TestCase
 {
     public:
         PartialWaveTest() :
@@ -145,22 +144,23 @@ class PartialWaveTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
-            TEST_CHECK_EQUAL_STR("",     stringify(PartialWave::none));
-            TEST_CHECK_EQUAL_STR("S",    stringify(PartialWave::S));
-            TEST_CHECK_EQUAL_STR("P",    stringify(PartialWave::P));
-            TEST_CHECK_EQUAL_STR("D",    stringify(PartialWave::D));
-            TEST_CHECK_EQUAL_STR("F",    stringify(PartialWave::F));
+            TEST_CHECK_EQUAL_STR("", stringify(PartialWave::none));
+            TEST_CHECK_EQUAL_STR("S", stringify(PartialWave::S));
+            TEST_CHECK_EQUAL_STR("P", stringify(PartialWave::P));
+            TEST_CHECK_EQUAL_STR("D", stringify(PartialWave::D));
+            TEST_CHECK_EQUAL_STR("F", stringify(PartialWave::F));
 
-            TEST_CHECK_EQUAL_STR("S|D",    stringify(PartialWave::S | PartialWave::D));
-            TEST_CHECK_EQUAL_STR("S|P",    stringify(PartialWave::S | PartialWave::P));
-            TEST_CHECK_EQUAL_STR("P|F",    stringify(PartialWave::P | PartialWave::F));
-            TEST_CHECK_EQUAL_STR("S|P|D",  stringify(PartialWave::S | PartialWave::P | PartialWave::D));
+            TEST_CHECK_EQUAL_STR("S|D", stringify(PartialWave::S | PartialWave::D));
+            TEST_CHECK_EQUAL_STR("S|P", stringify(PartialWave::S | PartialWave::P));
+            TEST_CHECK_EQUAL_STR("P|F", stringify(PartialWave::P | PartialWave::F));
+            TEST_CHECK_EQUAL_STR("S|P|D", stringify(PartialWave::S | PartialWave::P | PartialWave::D));
 
-            TEST_CHECK_EQUAL(destringify<PartialWave>("S|D"),     PartialWave::S | PartialWave::D);
-            TEST_CHECK_EQUAL(destringify<PartialWave>("S|P"),     PartialWave::S | PartialWave::P);
-            TEST_CHECK_EQUAL(destringify<PartialWave>("P|F"),     PartialWave::P | PartialWave::F);
+            TEST_CHECK_EQUAL(destringify<PartialWave>("S|D"), PartialWave::S | PartialWave::D);
+            TEST_CHECK_EQUAL(destringify<PartialWave>("S|P"), PartialWave::S | PartialWave::P);
+            TEST_CHECK_EQUAL(destringify<PartialWave>("P|F"), PartialWave::P | PartialWave::F);
             TEST_CHECK_EQUAL(destringify<PartialWave>("S|P|D|F"), PartialWave::S | PartialWave::P | PartialWave::D | PartialWave::F);
         }
 } partial_wave_test;

--- a/eos/utils/reference-name.cc
+++ b/eos/utils/reference-name.cc
@@ -32,15 +32,13 @@ namespace eos
                 throw ReferenceNameSyntaxError("A reference name's name part must not be empty");
             }
 
-            static const std::string valid_characters_begin =
-                    "abcdefghijklmnopqrstuvwxyz"
-                    "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
-                    "0123456789";
+            static const std::string valid_characters_begin = "abcdefghijklmnopqrstuvwxyz"
+                                                              "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
+                                                              "0123456789";
 
-            static const std::string valid_characters_all =
-                    "abcdefghijklmnopqrstuvwxyz"
-                    "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
-                    "0123456789-+";
+            static const std::string valid_characters_all = "abcdefghijklmnopqrstuvwxyz"
+                                                            "ABCDEFGHIJKLMNOPQRTSUVWXYZ"
+                                                            "0123456789-+";
 
             auto pos = valid_characters_begin.find_first_of(name[0]);
             if (std::string::npos == pos)
@@ -69,8 +67,7 @@ namespace eos
             }
 
             // YEAR          := ['0'-'9'] ['0'-'9'] ['0'-'9'] ['0'-'9']
-            static const char * valid_digits =
-                    "0123456789";
+            static const char * valid_digits = "0123456789";
 
             auto pos = year.find_first_not_of(valid_digits);
             if (std::string::npos != pos)
@@ -82,8 +79,7 @@ namespace eos
         Index::Index(const std::string & index) :
             _index(index)
         {
-            static const char * valid_index_characters =
-                    "ABCDEFGHIJKLMNOPQRTSUVWXYZ";
+            static const char * valid_index_characters = "ABCDEFGHIJKLMNOPQRTSUVWXYZ";
 
             auto pos = index.find_first_not_of(valid_index_characters);
 
@@ -97,7 +93,7 @@ namespace eos
                 throw ReferenceNameSyntaxError("'" + index + "' is not a valid index part: character '" + index[pos] + "' may not be used");
             }
         }
-    }
+    } // namespace rnp
 
     ReferenceName::ReferenceName(const std::string & input) :
         _str(input),
@@ -126,8 +122,8 @@ namespace eos
             throw ReferenceNameSyntaxError("A reference name must contain exactly one ':'");
         }
 
-        static const char * valid_digits = "0123456789";
-        const auto pos_non_digit = input.find_first_not_of(valid_digits, pos_colon + 1);
+        static const char * valid_digits  = "0123456789";
+        const auto          pos_non_digit = input.find_first_not_of(valid_digits, pos_colon + 1);
         if (std::string::npos == pos_non_digit)
         {
             throw ReferenceNameSyntaxError("A reference name must contain an index part");
@@ -151,12 +147,10 @@ namespace eos
     {
     }
 
-    ReferenceName::~ReferenceName()
-    {
-    }
+    ReferenceName::~ReferenceName() {}
 
     ReferenceNameSyntaxError::ReferenceNameSyntaxError(const std::string & msg) :
         Exception(msg)
     {
     }
-}
+} // namespace eos

--- a/eos/utils/reference-name.hh
+++ b/eos/utils/reference-name.hh
@@ -36,9 +36,17 @@ namespace eos
             public:
                 Name(const std::string &);
 
-                const std::string & str() const { return _name; };
+                const std::string &
+                str() const
+                {
+                    return _name;
+                }
 
-                inline bool operator<  (const Name & rhs) const { return this->_name <  rhs._name; };
+                inline bool
+                operator< (const Name & rhs) const
+                {
+                    return this->_name < rhs._name;
+                }
         };
 
         class Year
@@ -49,9 +57,17 @@ namespace eos
             public:
                 Year(const std::string &);
 
-                const std::string & str() const { return _year; };
+                const std::string &
+                str() const
+                {
+                    return _year;
+                }
 
-                inline bool operator<  (const Year & rhs) const { return this->_year <  rhs._year; };
+                inline bool
+                operator< (const Year & rhs) const
+                {
+                    return this->_year < rhs._year;
+                }
         };
 
         class Index
@@ -62,12 +78,25 @@ namespace eos
             public:
                 Index(const std::string &);
 
-                const std::string & str() const { return _index; };
-                bool empty() const { return _index.empty(); };
+                const std::string &
+                str() const
+                {
+                    return _index;
+                }
 
-                inline bool operator<  (const Index & rhs) const { return this->_index <  rhs._index; };
+                bool
+                empty() const
+                {
+                    return _index.empty();
+                }
+
+                inline bool
+                operator< (const Index & rhs) const
+                {
+                    return this->_index < rhs._index;
+                }
         };
-    }
+    } // namespace rnp
 
     /*
      * Holds a syntactically-correct reference name.
@@ -84,7 +113,7 @@ namespace eos
      */
     class ReferenceName
     {
-        friend std::ostream & operator<< (std::ostream &, const ReferenceName &);
+            friend std::ostream & operator<< (std::ostream &, const ReferenceName &);
 
         private:
             std::string _str;
@@ -98,31 +127,68 @@ namespace eos
             ReferenceName(const ReferenceName & other);
             ~ReferenceName();
 
-            inline const std::string & str() const { return _str; };
-            inline const rnp::Name & name_part() const { return _name; };
-            inline const rnp::Year & year_part() const { return _year; };
-            inline const rnp::Index & index_part() const { return _index; };
+            inline const std::string &
+            str() const
+            {
+                return _str;
+            }
 
-            inline bool operator<  (const ReferenceName & rhs) const { return this->_str <  rhs._str; };
-            inline bool operator== (const ReferenceName & rhs) const { return this->_str == rhs._str; };
-            inline bool operator!= (const ReferenceName & rhs) const { return this->_str != rhs._str; };
+            inline const rnp::Name &
+            name_part() const
+            {
+                return _name;
+            }
+
+            inline const rnp::Year &
+            year_part() const
+            {
+                return _year;
+            }
+
+            inline const rnp::Index &
+            index_part() const
+            {
+                return _index;
+            }
+
+            inline bool
+            operator< (const ReferenceName & rhs) const
+            {
+                return this->_str < rhs._str;
+            }
+
+            inline bool
+            operator== (const ReferenceName & rhs) const
+            {
+                return this->_str == rhs._str;
+            }
+
+            inline bool
+            operator!= (const ReferenceName & rhs) const
+            {
+                return this->_str != rhs._str;
+            }
     };
 
-    inline ReferenceName operator ""_rn(const char * c, size_t) { return ReferenceName(c); }
+    inline ReferenceName
+    operator""_rn (const char * c, size_t)
+    {
+        return ReferenceName(c);
+    }
 
-    class ReferenceNameSyntaxError :
-        public Exception
+    class ReferenceNameSyntaxError : public Exception
     {
         public:
             ReferenceNameSyntaxError(const std::string & msg);
     };
 
-    inline std::ostream & operator<< (std::ostream & lhs, const ReferenceName & rhs)
+    inline std::ostream &
+    operator<< (std::ostream & lhs, const ReferenceName & rhs)
     {
         lhs << rhs._str;
 
         return lhs;
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/reference-name_TEST.cc
+++ b/eos/utils/reference-name_TEST.cc
@@ -17,8 +17,9 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/reference-name.hh>
+
+#include <test/test.hh>
 
 #include <cmath>
 #include <iostream>
@@ -26,8 +27,7 @@
 using namespace test;
 using namespace eos;
 
-class NameTest :
-    public TestCase
+class NameTest : public TestCase
 {
     public:
         NameTest() :
@@ -35,7 +35,8 @@ class NameTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto p = rnp::Name("IKMvD"));
             TEST_CHECK_NO_THROW(auto p = rnp::Name("KMPW"));
@@ -51,8 +52,7 @@ class NameTest :
         }
 } name_test;
 
-class YearTest :
-    public TestCase
+class YearTest : public TestCase
 {
     public:
         YearTest() :
@@ -60,7 +60,8 @@ class YearTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto n = rnp::Year("0000"));
             TEST_CHECK_NO_THROW(auto n = rnp::Year("1905"));
@@ -75,8 +76,7 @@ class YearTest :
         }
 } year_test;
 
-class IndexTest :
-    public TestCase
+class IndexTest : public TestCase
 {
     public:
         IndexTest() :
@@ -84,7 +84,8 @@ class IndexTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto p = rnp::Index("A"));
             TEST_CHECK_NO_THROW(auto p = rnp::Index("Z"));
@@ -96,8 +97,7 @@ class IndexTest :
         }
 } index_test;
 
-class ReferenceNameTest :
-    public TestCase
+class ReferenceNameTest : public TestCase
 {
     public:
         ReferenceNameTest() :
@@ -105,7 +105,8 @@ class ReferenceNameTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK_NO_THROW(auto qn = ReferenceName("A:2010A"));
             TEST_CHECK_NO_THROW(auto qn = ReferenceName("IKMvD:2014A"));

--- a/eos/utils/rge-impl.hh
+++ b/eos/utils/rge-impl.hh
@@ -29,17 +29,15 @@ namespace eos
 {
     template <unsigned nf_> struct QCDBetaFunction;
 
-    template <>
-    struct QCDBetaFunction<5u>
+    template <> struct QCDBetaFunction<5u>
     {
-        static constexpr double beta_0 =  23.0 / 3.0;
-        static constexpr double beta_1 = 116.0 / 3.0;
+            static constexpr double beta_0 = 23.0 / 3.0;
+            static constexpr double beta_1 = 116.0 / 3.0;
     };
 
     template <unsigned nf_, unsigned dim_>
-    MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>::MultiplicativeRenormalizationGroupEvolution(
-            const std::array<double, dim_> & gamma_0_ev,
-            const std::array<std::array<double, dim_>, dim_> & V):
+    MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>::MultiplicativeRenormalizationGroupEvolution(const std::array<double, dim_> &                   gamma_0_ev,
+                                                                                                                      const std::array<std::array<double, dim_>, dim_> & V) :
         _gamma_0_ev(gamma_0_ev),
         _V(make_gsl_matrix(dim_, dim_)),
         _Vinv(make_gsl_matrix(dim_, dim_)),
@@ -60,7 +58,7 @@ namespace eos
         gsl_matrix_memcpy(_tmp_matrix.get(), _V.get());
 
         gsl_permutation * p = gsl_permutation_alloc(dim_);
-        int signum;
+        int               signum;
         // tmp_matrix stores L, U from LU decomposition: P * V = L * U
         gsl_linalg_LU_decomp(_tmp_matrix.get(), p, &signum);
         // Vinv <- V^-1
@@ -71,8 +69,7 @@ namespace eos
 
     template <unsigned nf_, unsigned dim_>
     std::array<double, dim_>
-    MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>::evolve(const double & alpha_s_mu, const double & alpha_s_0,
-            const std::array<double, dim_> & c_0_0) const
+    MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>::evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0) const
     {
         // LL evolution:
         //   c(mu) = U_0 . c(mu_0),
@@ -111,10 +108,9 @@ namespace eos
     }
 
     template <unsigned nf_, unsigned dim_>
-    MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>::MultiplicativeRenormalizationGroupEvolution(
-            const std::array<double, dim_> & gamma_0_ev,
-            const std::array<std::array<double, dim_>, dim_> & V,
-            const std::array<std::array<double, dim_>, dim_> & gamma_1) :
+    MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>::MultiplicativeRenormalizationGroupEvolution(const std::array<double, dim_> & gamma_0_ev,
+                                                                                                                       const std::array<std::array<double, dim_>, dim_> & V,
+                                                                                                                       const std::array<std::array<double, dim_>, dim_> & gamma_1) :
         _gamma_0_ev(gamma_0_ev),
         _V(make_gsl_matrix(dim_, dim_)),
         _Vinv(make_gsl_matrix(dim_, dim_)),
@@ -143,7 +139,7 @@ namespace eos
         gsl_matrix_memcpy(_tmp_matrix.get(), _V.get());
 
         gsl_permutation * p = gsl_permutation_alloc(dim_);
-        int signum;
+        int               signum;
         // tmp_matrix stores L, U from LU decomposition: P . V = L . U
         gsl_linalg_LU_decomp(_tmp_matrix.get(), p, &signum);
         // Vinv <- V^-1
@@ -163,7 +159,7 @@ namespace eos
         const double beta_0 = QCDBetaFunction<nf_>::beta_0;
         const double beta_1 = QCDBetaFunction<nf_>::beta_1;
 
-        for (unsigned i = 0 ; i < dim_; ++i)
+        for (unsigned i = 0; i < dim_; ++i)
         {
             for (unsigned j = 0; j < dim_; ++j)
             {
@@ -179,13 +175,12 @@ namespace eos
         gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _J.get(), _Vinv.get(), 0.0, _tmp_matrix.get());
         // J <- V . tmp
         gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _tmp_matrix.get(), 0.0, _J.get());
-
     }
 
     template <unsigned nf_, unsigned dim_>
     std::array<double, dim_>
-    MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>::evolve(const double & alpha_s_mu, const double & alpha_s_0,
-            const std::array<double, dim_> & c_0_0, const std::array<double, dim_> & c_0_1) const
+    MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>::evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0,
+                                                                                  const std::array<double, dim_> & c_0_1) const
     {
         // NLL evolution:
         //   U = (1 + a_s_mu J) . U_0 . (1 - a_s_0 J)
@@ -247,6 +242,6 @@ namespace eos
 
         return result;
     }
-}
+} // namespace eos
 
 #endif /* EOS_GUARD_EOS_UTILS_RGE_IMPL_HH */

--- a/eos/utils/rge.hh
+++ b/eos/utils/rge.hh
@@ -25,22 +25,20 @@
 namespace eos
 {
 
-    template <typename Accuracy_, unsigned nf_, unsigned dim_>
-    class MultiplicativeRenormalizationGroupEvolution;
+    template <typename Accuracy_, unsigned nf_, unsigned dim_> class MultiplicativeRenormalizationGroupEvolution;
 
     namespace accuracy
     {
         struct LL;
         struct NLL;
-    }
+    } // namespace accuracy
 
-    template <unsigned nf_, unsigned dim_>
-    class MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>
+    template <unsigned nf_, unsigned dim_> class MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>
     {
         private:
             // gamma_0 = V^-1,T . diag(gamma_0_ev) . V^T, see [BBL:1995A], p. 34, eq. (III.95)
             std::array<double, dim_> _gamma_0_ev;
-            GSLMatrixPtr _V, _Vinv;
+            GSLMatrixPtr             _V, _Vinv;
 
             // evolution matrix
             GSLMatrixPtr _U_0;
@@ -85,13 +83,12 @@ namespace eos
     };
 
     // Next-to-leading logarithmic accuracy, see [BBL:1995A], p. 34, eq. (III.93)
-    template <unsigned nf_, unsigned dim_>
-    class MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>
+    template <unsigned nf_, unsigned dim_> class MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>
     {
         private:
             // gamma_0 = V^-1,T . diag(gamma_0_ev) . V^T, see [BBL:1995A], p. 34, eq. (III.95)
             std::array<double, dim_> _gamma_0_ev;
-            GSLMatrixPtr _V, _Vinv;
+            GSLMatrixPtr             _V, _Vinv;
 
             // gamma_1 = V^-1,T . G . V^T, see [BBL:1995A], p. 34, eq. (III.96)
             GSLMatrixPtr _G;
@@ -126,7 +123,7 @@ namespace eos
              * @param gamma_1 The NLO term for the anomalous dimension matrix.
              */
             MultiplicativeRenormalizationGroupEvolution(const std::array<double, dim_> & gamma_0_ev, const std::array<std::array<double, dim_>, dim_> & V,
-                    const std::array<std::array<double, dim_>, dim_> & gamma_1);
+                                                        const std::array<std::array<double, dim_>, dim_> & gamma_1);
 
             /*!
              * Evolve the Wilson coefficients from the scale mu_0 to the scale mu at next-to-leading logarithmic accuracy.
@@ -142,8 +139,8 @@ namespace eos
              *              reduced by r^T . c_0_0, cf. [BBL:1995A], p. 34, eqs. (III.84) & (III.99).
              */
             std::array<double, dim_> evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0,
-                    const std::array<double, dim_> & c_0_1) const;
+                                            const std::array<double, dim_> & c_0_1) const;
     };
-}
+} // namespace eos
 
 #endif /* EOS_GUARD_EOS_UTILS_RGE_HH */

--- a/eos/utils/rge_TEST.cc
+++ b/eos/utils/rge_TEST.cc
@@ -18,16 +18,16 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/rge-impl.hh>
+
+#include <test/test.hh>
 
 #include <array>
 
 using namespace test;
 using namespace eos;
 
-class MultiplicativeRGELLTest :
-    public TestCase
+class MultiplicativeRGELLTest : public TestCase
 {
     public:
         MultiplicativeRGELLTest() :
@@ -35,30 +35,30 @@ class MultiplicativeRGELLTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // trivial test case (nf = 5, dim = 10)
             {
-                const std::array<double, 10u> gamma_0_ev{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-                const std::array<std::array<double, 10u>, 10u> V
-                {{
-                    { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 }
-                }};
+                const std::array<double, 10u>                  gamma_0_ev{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+                const std::array<std::array<double, 10u>, 10u> V{
+                    { { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 } }
+                };
                 const MultiplicativeRenormalizationGroupEvolution<accuracy::LL, 5u, 10u> rge(gamma_0_ev, V);
-                const std::array<double, 10u> c_0_0{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+                const std::array<double, 10u>                                            c_0_0{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
 
-                const double alpha_s_mu = 0.218017;
-                const double alpha_s_0  = 0.121864;
-                std::array<double, 10u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
+                const double            alpha_s_mu = 0.218017;
+                const double            alpha_s_0  = 0.121864;
+                std::array<double, 10u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
 
                 static const double eps = 1.0e-15;
                 TEST_CHECK_NEARLY_EQUAL(result[0], 0.1, eps);
@@ -75,19 +75,20 @@ class MultiplicativeRGELLTest :
 
             // current-current test case (nf = 5, dim = 2), checked by S. Meiser 2023/07/10
             {
-                const double sq2 = std::sqrt(2.0);
-                const std::array<double, 2u> gamma_0_ev{ -8.0, +4.0 };
-                const std::array<std::array<double, 2u>, 2u> V
-                {{
-                    { -1.0 / sq2, +1.0 / sq2 },
-                    { +1.0 / sq2, +1.0 / sq2 },
-                }};
+                const double                                 sq2 = std::sqrt(2.0);
+                const std::array<double, 2u>                 gamma_0_ev{ -8.0, +4.0 };
+                const std::array<std::array<double, 2u>, 2u> V{
+                    {
+                     { -1.0 / sq2, +1.0 / sq2 },
+                     { +1.0 / sq2, +1.0 / sq2 },
+                     }
+                };
                 const MultiplicativeRenormalizationGroupEvolution<accuracy::LL, 5u, 2u> rge(gamma_0_ev, V);
-                const std::array<double, 2u> c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u>                                            c_0_0{ 0.0, 1.0 };
 
-                const double alpha_s_mu = 0.218017;
-                const double alpha_s_0  = 0.121864;
-                std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
+                const double           alpha_s_mu = 0.218017;
+                const double           alpha_s_0  = 0.121864;
+                std::array<double, 2u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
 
                 static const double eps = 1.0e-6;
                 TEST_CHECK_NEARLY_EQUAL(result[0], -0.247675, eps);
@@ -96,18 +97,19 @@ class MultiplicativeRGELLTest :
 
             // non-symmetric test case (nf = 5, dim = 2), checked by S. Meiser 2023/07/10
             {
-                const std::array<double, 2u> gamma_0_ev{ -16.0, +2.0 };
-                const std::array<std::array<double, 2u>, 2u> V
-                {{
-                    {  1.0 / 6.0, -4.0 / 3.0 },
-                    {  1.0,        1.0       },
-                }};
+                const std::array<double, 2u>                 gamma_0_ev{ -16.0, +2.0 };
+                const std::array<std::array<double, 2u>, 2u> V{
+                    {
+                     { 1.0 / 6.0, -4.0 / 3.0 },
+                     { 1.0, 1.0 },
+                     }
+                };
                 const MultiplicativeRenormalizationGroupEvolution<accuracy::LL, 5u, 2u> rge(gamma_0_ev, V);
-                const std::array<double, 2u> c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u>                                            c_0_0{ 0.0, 1.0 };
 
-                const double alpha_s_mu = 0.218017;
-                const double alpha_s_0  = 0.121864;
-                std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
+                const double           alpha_s_mu = 0.218017;
+                const double           alpha_s_0  = 0.121864;
+                std::array<double, 2u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0);
 
                 static const double eps = 1.0e-6;
                 TEST_CHECK_NEARLY_EQUAL(result[0], +0.134504, eps);
@@ -116,8 +118,7 @@ class MultiplicativeRGELLTest :
         }
 } multiplicative_rge_ll_test;
 
-class MultiplicativeRGENLLTest :
-    public TestCase
+class MultiplicativeRGENLLTest : public TestCase
 {
     public:
         MultiplicativeRGENLLTest() :
@@ -125,44 +126,43 @@ class MultiplicativeRGENLLTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // trivial test case (nf = 5, dim = 10)
             {
-                const std::array<double, 10u> gamma_0_ev{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-                const std::array<std::array<double, 10u>, 10u> V
-                {{
-                    { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 }
-                }};
-                const std::array<std::array<double, 10u>, 10u> gamma_1
-                {{
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
-                    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }
-                }};
+                const std::array<double, 10u>                  gamma_0_ev{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+                const std::array<std::array<double, 10u>, 10u> V{
+                    { { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 } }
+                };
+                const std::array<std::array<double, 10u>, 10u> gamma_1{
+                    { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } }
+                };
                 const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 10u> rge(gamma_0_ev, V, gamma_1);
-                const std::array<double, 10u> c_0_0{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
-                const std::array<double, 10u> c_0_1{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+                const std::array<double, 10u>                                             c_0_0{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+                const std::array<double, 10u>                                             c_0_1{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
 
-                const double alpha_s_mu = 0.3 * 4.0 * M_PI;
-                const double alpha_s_0  = 0.1 * 4.0 * M_PI;
-                std::array<double, 10u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
+                const double            alpha_s_mu = 0.3 * 4.0 * M_PI;
+                const double            alpha_s_0  = 0.1 * 4.0 * M_PI;
+                std::array<double, 10u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
 
                 static const double eps = 1.0e-15;
                 TEST_CHECK_NEARLY_EQUAL(result[0], 0.11, eps);
@@ -179,25 +179,24 @@ class MultiplicativeRGENLLTest :
 
             // current-current test case (nf = 5, dim = 2)
             {
-                const double sq2 = std::sqrt(2.0);
-                const std::array<double, 2u> gamma_0_ev{ -8.0, +4.0 };
-                const std::array<std::array<double, 2u>, 2u> V
-                {{
-                    { -1.0 / sq2, +1.0 / sq2 },
-                    { +1.0 / sq2, +1.0 / sq2 },
-                }};
-                const std::array<std::array<double, 2u>, 2u> gamma_1
-                {{
-                    { -209.0 / 18.0, +41.0 / 6.0   },
-                    { +41.0 / 6.0,   -209.0 / 18.0 }
-                }};
+                const double                                 sq2 = std::sqrt(2.0);
+                const std::array<double, 2u>                 gamma_0_ev{ -8.0, +4.0 };
+                const std::array<std::array<double, 2u>, 2u> V{
+                    {
+                     { -1.0 / sq2, +1.0 / sq2 },
+                     { +1.0 / sq2, +1.0 / sq2 },
+                     }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_1{
+                    { { -209.0 / 18.0, +41.0 / 6.0 }, { +41.0 / 6.0, -209.0 / 18.0 } }
+                };
                 const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 2u> rge(gamma_0_ev, V, gamma_1);
-                const std::array<double, 2u> c_0_0{ 0.0, 1.0 };
-                const std::array<double, 2u> c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
+                const std::array<double, 2u>                                             c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u>                                             c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
 
-                const double alpha_s_mu = 0.218017;
-                const double alpha_s_0  = 0.121864;
-                std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
+                const double           alpha_s_mu = 0.218017;
+                const double           alpha_s_0  = 0.121864;
+                std::array<double, 2u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
 
                 static const double eps = 1.0e-6;
                 TEST_CHECK_NEARLY_EQUAL(result[0], -0.172203, eps);
@@ -206,24 +205,26 @@ class MultiplicativeRGENLLTest :
 
             // non-symmetric test case (nf = 5, dim = 2)
             {
-                const std::array<double, 2u> gamma_0_ev{ -16.0, +2.0 };
-                const std::array<std::array<double, 2u>, 2u> V
-                {{
-                    {  1.0 / 6.0, -4.0 / 3.0 },
-                    {  1.0,        1.0       },
-                }};
-                const std::array<std::array<double, 2u>, 2u> gamma_1
-                {{
-                    { -28.0 / 3.0,    -374.0 / 3.0   },
-                    { -2044.0 / 27.0, -2975.0 / 18.0 },
-                }};
+                const std::array<double, 2u>                 gamma_0_ev{ -16.0, +2.0 };
+                const std::array<std::array<double, 2u>, 2u> V{
+                    {
+                     { 1.0 / 6.0, -4.0 / 3.0 },
+                     { 1.0, 1.0 },
+                     }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_1{
+                    {
+                     { -28.0 / 3.0, -374.0 / 3.0 },
+                     { -2044.0 / 27.0, -2975.0 / 18.0 },
+                     }
+                };
                 const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 2u> rge(gamma_0_ev, V, gamma_1);
-                const std::array<double, 2u> c_0_0{ 0.0, 1.0 };
-                const std::array<double, 2u> c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
+                const std::array<double, 2u>                                             c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u>                                             c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
 
-                const double alpha_s_mu = 0.218017;
-                const double alpha_s_0  = 0.121864;
-                std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
+                const double           alpha_s_mu = 0.218017;
+                const double           alpha_s_0  = 0.121864;
+                std::array<double, 2u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
 
                 static const double eps = 1.0e-6;
                 TEST_CHECK_NEARLY_EQUAL(result[0], +0.229589, eps);

--- a/eos/utils/stringify.hh
+++ b/eos/utils/stringify.hh
@@ -20,35 +20,35 @@
 #ifndef EOS_GUARD_EOS_UTILS_STRINGIFY_HH
 #define EOS_GUARD_EOS_UTILS_STRINGIFY_HH 1
 
-#include <string>
 #include <sstream>
+#include <string>
 
 namespace eos
 {
     namespace implementation
     {
-        template <typename T_>
-        struct DoStringify
+        template <typename T_> struct DoStringify
         {
-            static std::string stringify(const T_ & x, unsigned precision)
-            {
-                std::stringstream ss;
-                ss.precision(precision);
-                ss << x;
+                static std::string
+                stringify(const T_ & x, unsigned precision)
+                {
+                    std::stringstream ss;
+                    ss.precision(precision);
+                    ss << x;
 
-                return ss.str();
-            }
+                    return ss.str();
+                }
         };
 
-        template <>
-        struct DoStringify<std::string>
+        template <> struct DoStringify<std::string>
         {
-            static std::string stringify(const std::string & x, unsigned)
-            {
-                return x;
-            }
+                static std::string
+                stringify(const std::string & x, unsigned)
+                {
+                    return x;
+                }
         };
-    }
+    } // namespace implementation
 
     /*!
      * Stringify an arbritrary (scalar) data type.
@@ -57,7 +57,8 @@ namespace eos
      * @param precision (Optional) floating point precision for the stringification.
      */
     template <typename T_>
-    std::string stringify(const T_ & x, const unsigned & precision = 10)
+    std::string
+    stringify(const T_ & x, const unsigned & precision = 10)
     {
         return implementation::DoStringify<T_>::stringify(x, precision);
     }
@@ -70,13 +71,14 @@ namespace eos
      * @param precision (Optional) floating point precision for the stringification.
      */
     template <typename Iterator_>
-    std::string stringify(const Iterator_ & begin, const Iterator_ & end, const unsigned & precision  = 10)
+    std::string
+    stringify(const Iterator_ & begin, const Iterator_ & end, const unsigned & precision = 10)
     {
         std::stringstream ss;
         ss.precision(precision);
         ss << '(';
 
-        for (Iterator_ i = begin ; i != end ; ++i)
+        for (Iterator_ i = begin; i != end; ++i)
         {
             ss << ' ' << *i;
         }
@@ -94,17 +96,18 @@ namespace eos
      * @param precision (Optional) floating point precision for the stringification.
      */
     template <typename T_>
-    std::string stringify(const T_ * m, const unsigned & dim, const unsigned & precision = 10)
+    std::string
+    stringify(const T_ * m, const unsigned & dim, const unsigned & precision = 10)
     {
         std::stringstream ss;
         ss.precision(precision);
         ss << "\n(";
 
-        for (unsigned i = 0 ; i < dim ; ++i)
+        for (unsigned i = 0; i < dim; ++i)
         {
             ss << '(';
 
-            for (unsigned j = 0 ; j < dim ; ++j)
+            for (unsigned j = 0; j < dim; ++j)
             {
                 ss << m[i * dim + j];
 
@@ -123,10 +126,11 @@ namespace eos
     }
 
     template <typename Container_>
-    std::string stringify_container(const Container_ & container, unsigned precision = 10)
+    std::string
+    stringify_container(const Container_ & container, unsigned precision = 10)
     {
         return stringify(container.begin(), container.end(), precision);
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/stringify_TEST.cc
+++ b/eos/utils/stringify_TEST.cc
@@ -17,14 +17,14 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/stringify.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
 
-class StringifyTest :
-    public TestCase
+class StringifyTest : public TestCase
 {
     public:
         StringifyTest() :
@@ -32,7 +32,8 @@ class StringifyTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             TEST_CHECK("foo" == stringify("foo"));
             TEST_CHECK("foobar" == stringify(std::string("foobar")));

--- a/eos/utils/test-observable.cc
+++ b/eos/utils/test-observable.cc
@@ -24,24 +24,21 @@
 
 namespace eos
 {
-    TestObservable::TestObservable(const Parameters & p, const Kinematics & k, const Options & o,
-            const QualifiedName & observable_name,
-            const std::vector<std::string> & kinematic_variable_names,
-            const std::function<double (const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function) :
+    TestObservable::TestObservable(const Parameters & p, const Kinematics & k, const Options & o, const QualifiedName & observable_name,
+                                   const std::vector<std::string> &                                                                           kinematic_variable_names,
+                                   const std::function<double(const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function) :
         p(p),
         o(o),
         observable_name(observable_name),
         function(function)
     {
-        for (auto kvn: kinematic_variable_names)
+        for (auto kvn : kinematic_variable_names)
         {
             kv.emplace_back(std::move(k[kvn]));
         }
     }
 
-    TestObservable::~TestObservable()
-    {
-    }
+    TestObservable::~TestObservable() {}
 
     double
     TestObservable::evaluate() const
@@ -79,16 +76,15 @@ namespace eos
         return o;
     }
 
-    const
-    QualifiedName &
+    const QualifiedName &
     TestObservable::name() const
     {
         return observable_name;
     }
 
     TestObservableEntry::TestObservableEntry(const QualifiedName & name, const std::string & latex, const Unit & unit,
-                const std::function<double (const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function,
-                const std::vector<std::string> & kinematics_names) :
+                                             const std::function<double(const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function,
+                                             const std::vector<std::string> &                                                                           kinematics_names) :
         _name(name),
         _latex(latex),
         _unit(unit),
@@ -97,9 +93,7 @@ namespace eos
     {
     }
 
-    TestObservableEntry::~TestObservableEntry()
-    {
-    }
+    TestObservableEntry::~TestObservableEntry() {}
 
     const QualifiedName &
     TestObservableEntry::name() const
@@ -158,4 +152,4 @@ namespace eos
 
         return os;
     }
-}
+} // namespace eos

--- a/eos/utils/test-observable.hh
+++ b/eos/utils/test-observable.hh
@@ -24,8 +24,7 @@
 
 namespace eos
 {
-    struct TestObservable :
-        public Observable
+    struct TestObservable : public Observable
     {
             Parameters p;
 
@@ -37,12 +36,11 @@ namespace eos
 
             const QualifiedName & observable_name;
 
-            const std::function<double (const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function;
+            const std::function<double(const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function;
 
-            TestObservable(const Parameters & p, const Kinematics & k, const Options & o,
-            const QualifiedName & observable_name,
-            const std::vector<std::string> & kinematic_variable_names,
-            const std::function<double (const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function);
+            TestObservable(const Parameters & p, const Kinematics & k, const Options & o, const QualifiedName & observable_name,
+                           const std::vector<std::string> &                                                                           kinematic_variable_names,
+                           const std::function<double(const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function);
 
             virtual ~TestObservable();
 
@@ -61,8 +59,7 @@ namespace eos
             const QualifiedName & name() const;
     };
 
-    class TestObservableEntry :
-        public ObservableEntry
+    class TestObservableEntry : public ObservableEntry
     {
         private:
             QualifiedName _name;
@@ -71,7 +68,7 @@ namespace eos
 
             Unit _unit;
 
-            std::function<double (const Parameters &, const std::vector<KinematicVariable> &, const Options &)> _function;
+            std::function<double(const Parameters &, const std::vector<KinematicVariable> &, const Options &)> _function;
 
             std::vector<std::string> _kinematics_names;
 
@@ -79,8 +76,8 @@ namespace eos
 
         public:
             TestObservableEntry(const QualifiedName & name, const std::string & latex, const Unit & unit,
-                const std::function<double (const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function,
-                const std::vector<std::string> & kinematics_names);
+                                const std::function<double(const Parameters &, const std::vector<KinematicVariable> &, const Options &)> & function,
+                                const std::vector<std::string> &                                                                           kinematics_names);
 
             virtual ~TestObservableEntry();
 
@@ -102,4 +99,4 @@ namespace eos
 
             virtual std::ostream & insert(std::ostream & os) const;
     };
-}
+} // namespace eos

--- a/eos/utils/thread.hh
+++ b/eos/utils/thread.hh
@@ -37,13 +37,11 @@ namespace eos
      * Thread uses POSIX threads internally and allows minimal synchronisation.
      * Thread guarantees that its function is finalised after destruction.
      */
-    class Thread :
-        public InstantiationPolicy<Thread, NonCopyable>,
-        public PrivateImplementationPattern<Thread>
+    class Thread : public InstantiationPolicy<Thread, NonCopyable>, public PrivateImplementationPattern<Thread>
     {
         public:
             /// Our function type.
-            using Function = std::function<void ()>;
+            using Function = std::function<void()>;
 
             /// \name Constructor and destructor
             /// \{
@@ -63,6 +61,6 @@ namespace eos
             /// Return wether we have yet completed executing our function.
             bool completed() const;
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/thread_pool.hh
+++ b/eos/utils/thread_pool.hh
@@ -28,16 +28,14 @@
 
 namespace eos
 {
-    class ThreadPool :
-        public InstantiationPolicy<ThreadPool, Singleton>,
-        public PrivateImplementationPattern<ThreadPool>
+    class ThreadPool : public InstantiationPolicy<ThreadPool, Singleton>, public PrivateImplementationPattern<ThreadPool>
     {
         public:
             ThreadPool();
 
             ~ThreadPool();
 
-            Ticket enqueue(const std::function<void (void)> & work);
+            Ticket enqueue(const std::function<void(void)> & work);
 
             static ThreadPool * instance();
 
@@ -45,6 +43,6 @@ namespace eos
 
             unsigned number_of_threads() const;
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/ticket.cc
+++ b/eos/utils/ticket.cc
@@ -31,16 +31,16 @@ namespace eos
 {
     template <> struct Implementation<Ticket>
     {
-        Mutex mutex;
+            Mutex mutex;
 
-        ConditionVariable completion;
+            ConditionVariable completion;
 
-        bool completed;
+            bool completed;
 
-        Implementation() :
-            completed(false)
-        {
-        }
+            Implementation() :
+                completed(false)
+            {
+            }
     };
 
     Ticket::Ticket() :
@@ -48,9 +48,7 @@ namespace eos
     {
     }
 
-    Ticket::~Ticket()
-    {
-    }
+    Ticket::~Ticket() {}
 
     void
     Ticket::mark()
@@ -74,7 +72,7 @@ namespace eos
 
     template <> struct Implementation<TicketList>
     {
-        std::list<std::shared_ptr<Implementation<Ticket> > > tickets;
+            std::list<std::shared_ptr<Implementation<Ticket>>> tickets;
     };
 
     TicketList::TicketList() :
@@ -82,9 +80,7 @@ namespace eos
     {
     }
 
-    TicketList::~TicketList()
-    {
-    }
+    TicketList::~TicketList() {}
 
     void
     TicketList::push_back(const Ticket & ticket)
@@ -97,7 +93,7 @@ namespace eos
     {
         while (! _imp->tickets.empty())
         {
-            std::shared_ptr<Implementation<Ticket> > ticket(_imp->tickets.front());
+            std::shared_ptr<Implementation<Ticket>> ticket(_imp->tickets.front());
 
             {
                 Lock l(ticket->mutex);
@@ -111,4 +107,4 @@ namespace eos
             _imp->tickets.pop_front();
         }
     }
-}
+} // namespace eos

--- a/eos/utils/ticket.hh
+++ b/eos/utils/ticket.hh
@@ -31,8 +31,7 @@ namespace eos
      * Ticket is used by all asynchronous function calls to relay/query
      * information on a function's completion status.
      */
-    class Ticket :
-        public PrivateImplementationPattern<Ticket>
+    class Ticket : public PrivateImplementationPattern<Ticket>
     {
         public:
             /// \name Friends of Ticket
@@ -63,9 +62,7 @@ namespace eos
     /**
      * TicketList is used when multiple tickets are needed.
      */
-    class TicketList :
-        public InstantiationPolicy<TicketList, NonCopyable>,
-        public PrivateImplementationPattern<TicketList>
+    class TicketList : public InstantiationPolicy<TicketList, NonCopyable>, public PrivateImplementationPattern<TicketList>
     {
         public:
             /// \name Basic Operations
@@ -85,6 +82,6 @@ namespace eos
             /// Wait for ticket completion.
             void wait() const;
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/transitions.hh
+++ b/eos/utils/transitions.hh
@@ -24,25 +24,46 @@ namespace eos
 {
     /* Mesonic Tags */
 
-    struct PToV { };
-    struct PToGamma { };
-    struct PToGammaOffShell { };
-    struct PToP { };
-    struct PToPP { };
-    struct VToP { };
-    struct VToV { };
-    struct VacuumToPP { };
+    struct PToV
+    {};
+
+    struct PToGamma
+    {};
+
+    struct PToGammaOffShell
+    {};
+
+    struct PToP
+    {};
+
+    struct PToPP
+    {};
+
+    struct VToP
+    {};
+
+    struct VToV
+    {};
+
+    struct VacuumToPP
+    {};
 
     /* Baryonic Tags */
 
     // J=1/2^+ -> J=1/2^+ transitions
-    struct OneHalfPlusToOneHalfPlus { };
+    struct OneHalfPlusToOneHalfPlus
+    {};
+
     // J=1/2^+ -> J=1/2^- transitions
-    struct OneHalfPlusToOneHalfMinus { };
+    struct OneHalfPlusToOneHalfMinus
+    {};
+
     // J=1/2^+ -> J=3/2^- transitions
-    struct OneHalfPlusToThreeHalfMinus { };
+    struct OneHalfPlusToThreeHalfMinus
+    {};
 
     /* Scattering Tags */
-    struct PPToPP {};
-}
+    struct PPToPP
+    {};
+} // namespace eos
 #endif

--- a/eos/utils/tuple-maker.hh
+++ b/eos/utils/tuple-maker.hh
@@ -30,57 +30,63 @@ namespace eos
 {
     namespace impl
     {
-        template <typename T_, typename U_> struct ConvertTo { using Type = U_; };
+        template <typename T_, typename U_> struct ConvertTo
+        {
+                using Type = U_;
+        };
 
         template <unsigned n_> struct TupleMaker
         {
-            template <typename Decay_, typename ... TupleElements_, typename ... ResultElements_>
-            static auto make(const Kinematics & k, const std::tuple<TupleElements_ ...> & t, const Decay_ * d, ResultElements_ ... r)
-                -> std::tuple<const Decay_ *, typename ConvertTo<TupleElements_, KinematicVariable>::Type ...>
-            {
-                return TupleMaker<n_ - 1>::make(k, t, d, k[static_cast<const char *>(std::get<n_ - 1>(t))], r ...);
-            }
+                template <typename Decay_, typename... TupleElements_, typename... ResultElements_>
+                static auto
+                make(const Kinematics & k, const std::tuple<TupleElements_...> & t, const Decay_ * d, ResultElements_... r)
+                        -> std::tuple<const Decay_ *, typename ConvertTo<TupleElements_, KinematicVariable>::Type...>
+                {
+                    return TupleMaker<n_ - 1>::make(k, t, d, k[static_cast<const char *>(std::get<n_ - 1>(t))], r...);
+                }
         };
 
         template <> struct TupleMaker<0>
         {
-            template <typename Decay_, typename ... TupleElements_, typename ... ResultElements_>
-            static auto make(const Kinematics &, const std::tuple<TupleElements_ ...> &, const Decay_ * d, ResultElements_ ... r)
-                -> std::tuple<const Decay_ *, typename ConvertTo<TupleElements_, KinematicVariable>::Type ...>
-            {
-                return std::make_tuple(d, r ...);
-            }
+                template <typename Decay_, typename... TupleElements_, typename... ResultElements_>
+                static auto
+                make(const Kinematics &, const std::tuple<TupleElements_...> &, const Decay_ * d, ResultElements_... r)
+                        -> std::tuple<const Decay_ *, typename ConvertTo<TupleElements_, KinematicVariable>::Type...>
+                {
+                    return std::make_tuple(d, r...);
+                }
         };
 
         template <typename T_> struct TupleSize;
 
-        template <typename ... TupleElements_> struct TupleSize<std::tuple<TupleElements_ ...>>
+        template <typename... TupleElements_> struct TupleSize<std::tuple<TupleElements_...>>
         {
-            static const unsigned long size = sizeof...(TupleElements_);
+                static const unsigned long size = sizeof...(TupleElements_);
         };
 
-        template <typename T_, typename Tuple_, std::size_t ... Indices_>
-        auto make_array(const Tuple_ & tuple, std::index_sequence<Indices_ ...>)
-        -> std::array<T_, std::tuple_size<Tuple_>::value>
+        template <typename T_, typename Tuple_, std::size_t... Indices_>
+        auto
+        make_array(const Tuple_ & tuple, std::index_sequence<Indices_...>) -> std::array<T_, std::tuple_size<Tuple_>::value>
         {
-            return {{ std::get<Indices_>(tuple) ... }};
+            return { { std::get<Indices_>(tuple)... } };
         }
 
         template <typename T_, typename Tuple_>
-        auto make_array(const Tuple_ & tuple)
-        -> std::array<T_, std::tuple_size<Tuple_>::value>
+        auto
+        make_array(const Tuple_ & tuple) -> std::array<T_, std::tuple_size<Tuple_>::value>
         {
             using Indices_ = std::make_index_sequence<std::tuple_size<Tuple_>::value>;
 
-            return make_array<T_>(tuple, Indices_{ });
+            return make_array<T_>(tuple, Indices_{});
         }
 
         template <typename T_>
-        std::array<T_, 0> make_array(const std::tuple<> &)
+        std::array<T_, 0>
+        make_array(const std::tuple<> &)
         {
             return {};
         }
-    }
-}
+    } // namespace impl
+} // namespace eos
 
 #endif

--- a/eos/utils/type-list-fwd.hh
+++ b/eos/utils/type-list-fwd.hh
@@ -27,25 +27,18 @@ namespace eos
 {
     struct TypeListTail;
 
-    template <typename Item_, typename Tail_>
-    struct TypeListEntry;
+    template <typename Item_, typename Tail_> struct TypeListEntry;
 
-    template <typename...>
-    struct MakeTypeList;
+    template <typename...> struct MakeTypeList;
 
-    template <>
-    struct MakeTypeList<>;
+    template <> struct MakeTypeList<>;
 
-    template <typename H_, typename... T_>
-    struct MakeTypeList<H_, T_...>;
+    template <typename H_, typename... T_> struct MakeTypeList<H_, T_...>;
 
-    template <typename TypeList_>
-    struct MakeTypeListConst;
+    template <typename TypeList_> struct MakeTypeListConst;
 
-    template <typename Item_>
-    struct MakeTypeListConstEntry;
+    template <typename Item_> struct MakeTypeListConstEntry;
 
-    template <typename TypeList_, typename Item_>
-    struct TypeListContains;
-}
+    template <typename TypeList_, typename Item_> struct TypeListContains;
+} // namespace eos
 #endif

--- a/eos/utils/type-list.hh
+++ b/eos/utils/type-list.hh
@@ -28,63 +28,62 @@
 namespace eos
 {
     struct TypeListTail
+    {};
+
+    template <typename Item_, typename Tail_> struct TypeListEntry
     {
+            using Item = Item_;
+            using Tail = Tail_;
     };
 
-    template <typename Item_, typename Tail_>
-    struct TypeListEntry
+    template <> struct MakeTypeList<>
     {
-        using Item = Item_;
-        using Tail = Tail_;
+            using Type = TypeListTail;
     };
 
-    template <>
-    struct MakeTypeList<>
+    template <typename H_, typename... T_> struct MakeTypeList<H_, T_...>
     {
-        using Type = TypeListTail;
+            using Type = TypeListEntry<H_, typename MakeTypeList<T_...>::Type>;
     };
 
-    template <typename H_, typename... T_>
-    struct MakeTypeList<H_, T_...>
+    template <> struct MakeTypeListConstEntry<TypeListTail>
     {
-        using Type = TypeListEntry<H_, typename MakeTypeList<T_...>::Type>;
+            using Type = TypeListTail;
     };
 
-    template <>
-    struct MakeTypeListConstEntry<TypeListTail>
+    template <typename Item_, typename Tail_> struct MakeTypeListConstEntry<TypeListEntry<Item_, Tail_>>
     {
-        using Type = TypeListTail;
+            using Type = TypeListEntry<const Item_, typename MakeTypeListConstEntry<Tail_>::Type>;
     };
 
-    template <typename Item_, typename Tail_>
-    struct MakeTypeListConstEntry<TypeListEntry<Item_, Tail_> >
+    template <typename TypeList_> struct MakeTypeListConst
     {
-        using Type = TypeListEntry<const Item_, typename MakeTypeListConstEntry<Tail_>::Type>;
+            using Type = typename MakeTypeListConstEntry<TypeList_>::Type;
     };
 
-    template <typename TypeList_>
-    struct MakeTypeListConst
+    template <typename Item_> struct TypeListContains<TypeListTail, Item_>
     {
-        using Type = typename MakeTypeListConstEntry<TypeList_>::Type;
+            enum
+            {
+                value = 0
+            };
     };
 
-    template <typename Item_>
-    struct TypeListContains<TypeListTail, Item_>
+    template <typename Item_, typename Tail_> struct TypeListContains<TypeListEntry<Item_, Tail_>, Item_>
     {
-        enum { value = 0 };
+            enum
+            {
+                value = 1
+            };
     };
 
-    template <typename Item_, typename Tail_>
-    struct TypeListContains<TypeListEntry<Item_, Tail_>, Item_>
+    template <typename NotItem_, typename Item_, typename Tail_> struct TypeListContains<TypeListEntry<NotItem_, Tail_>, Item_>
     {
-        enum { value = 1 };
+            enum
+            {
+                value = TypeListContains<Tail_, Item_>::value
+            };
     };
-
-    template <typename NotItem_, typename Item_, typename Tail_>
-    struct TypeListContains<TypeListEntry<NotItem_, Tail_>, Item_>
-    {
-        enum { value = TypeListContains<Tail_, Item_>::value };
-    };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/units.cc
+++ b/eos/utils/units.cc
@@ -31,20 +31,13 @@ namespace eos
     const std::string &
     Unit::latex() const
     {
-        static const std::vector<std::string> representations
-        {
-            R"(\textrm{undefined})",
-            "1",
-            R"(\textrm{GeV})",
-            R"(\textrm{GeV}^2)",
-            R"(\textrm{GeV}^3)",
-            R"(\textrm{GeV}^{-1})",
-            R"(\textrm{GeV}^{-2})",
-            R"(\textrm{GeV}^{-4})",
-            R"(\textrm{s})",
-            R"(\textrm{s}^{-1})",
-            R"(\textrm{ps}^{-1})",
-            R"(\textrm{GeV}\,\textrm{s})",
+        static const std::vector<std::string> representations{
+            R"(\textrm{undefined})", "1",
+            R"(\textrm{GeV})",       R"(\textrm{GeV}^2)",
+            R"(\textrm{GeV}^3)",     R"(\textrm{GeV}^{-1})",
+            R"(\textrm{GeV}^{-2})",  R"(\textrm{GeV}^{-4})",
+            R"(\textrm{s})",         R"(\textrm{s}^{-1})",
+            R"(\textrm{ps}^{-1})",   R"(\textrm{GeV}\,\textrm{s})",
             R"(\textrm{fm}^2)",
         };
 
@@ -54,27 +47,25 @@ namespace eos
     Unit::Unit(const std::string & s) :
         Unit(Id::undefined)
     {
-        static const std::map<std::string, Id> map
-        {
-            { "1",       Id::none         },
-            { "GeV",     Id::gev          },
-            { "GeV^2",   Id::gev2         },
-            { "GeV^3",   Id::gev3         },
-            { "GeV^-2",  Id::inverse_gev2 },
-            { "GeV^-1",  Id::inverse_gev  },
-            { "GeV^-4",  Id::inverse_gev4 },
-            { "s",       Id::s            },
-            { "s^-1",    Id::inverse_s    },
-            { "ps^-1",   Id::inverse_ps   },
-            { "GeV s",   Id::gev_s        },
-            { "fm^2",    Id::fm2          },
+        static const std::map<std::string, Id> map{
+            {      "1",         Id::none },
+            {    "GeV",          Id::gev },
+            {  "GeV^2",         Id::gev2 },
+            {  "GeV^3",         Id::gev3 },
+            { "GeV^-2", Id::inverse_gev2 },
+            { "GeV^-1",  Id::inverse_gev },
+            { "GeV^-4", Id::inverse_gev4 },
+            {      "s",            Id::s },
+            {   "s^-1",    Id::inverse_s },
+            {  "ps^-1",   Id::inverse_ps },
+            {  "GeV s",        Id::gev_s },
+            {   "fm^2",          Id::fm2 },
         };
 
         const auto i = map.find(s);
         if (map.cend() == i)
         {
-            Log::instance()->message("Unit", ll_error)
-                << "Unrecognized unit '" << s << "' encountered";
+            Log::instance()->message("Unit", ll_error) << "Unrecognized unit '" << s << "' encountered";
         }
         else
         {
@@ -165,4 +156,4 @@ namespace eos
     {
         return this->_id == rhs._id;
     }
-}
+} // namespace eos

--- a/eos/utils/units.hh
+++ b/eos/utils/units.hh
@@ -34,11 +34,13 @@ namespace eos
         private:
             Id _id;
 
-            Unit(const Id & id) : _id(id) {}
+            Unit(const Id & id) :
+                _id(id)
+            {
+            }
 
         public:
-            enum class Id :
-                int
+            enum class Id : int
             {
                 undefined = 0,
                 none,
@@ -57,8 +59,8 @@ namespace eos
 
             Unit(const std::string &);
             Unit(const Unit &) = default;
-            Unit(Unit &&) = default;
-            ~Unit() = default;
+            Unit(Unit &&)      = default;
+            ~Unit()            = default;
 
             const std::string & latex() const;
 
@@ -76,9 +78,9 @@ namespace eos
             static Unit GeVSecond();
             static Unit Femtometer2();
 
-            bool operator== (const Unit &) const;
+            bool   operator== (const Unit &) const;
             Unit & operator= (const Unit &) = default;
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/verify.cc
+++ b/eos/utils/verify.cc
@@ -35,4 +35,4 @@ namespace eos
         VerifiedRangeError("'" + value + "' smaller than minimum of '" + maximum + "'")
     {
     }
-}
+} // namespace eos

--- a/eos/utils/verify.hh
+++ b/eos/utils/verify.hh
@@ -30,8 +30,7 @@ namespace eos
      * VerifiedRangeError is thrown whenever a VerifiedRange is assigned a value
      * that exceeds its allowed range.
      */
-    class VerifiedRangeError :
-        public Exception
+    class VerifiedRangeError : public Exception
     {
         protected:
             VerifiedRangeError(const std::string & message);
@@ -41,20 +40,18 @@ namespace eos
      * VerifiedRangeOverflow is thrown whenever a VerifiedRange is assigned a value
      * that is larger than its allowed maximum.
      */
-    struct VerifiedRangeOverflow :
-        public VerifiedRangeError
+    struct VerifiedRangeOverflow : public VerifiedRangeError
     {
-        VerifiedRangeOverflow(const std::string & value, const std::string & maximum);
+            VerifiedRangeOverflow(const std::string & value, const std::string & maximum);
     };
 
     /*!
      * VerifiedRangeUnderflow is thrown whenever a VerifiedRange is assigned a value
      * that is smaller than its allowed minimum.
      */
-    struct VerifiedRangeUnderflow :
-        public VerifiedRangeError
+    struct VerifiedRangeUnderflow : public VerifiedRangeError
     {
-        VerifiedRangeUnderflow(const std::string & value, const std::string & minimum);
+            VerifiedRangeUnderflow(const std::string & value, const std::string & minimum);
     };
 
     /*!
@@ -67,8 +64,7 @@ namespace eos
      * test_range = -10; // not allowed, throws a VerifiedRangeUnderflow
      * @endcode
      */
-    template <typename T_>
-    class VerifiedRange
+    template <typename T_> class VerifiedRange
     {
         private:
             T_ _min;
@@ -77,13 +73,18 @@ namespace eos
 
             T_ _value;
 
-            const T_ & _verify(const T_ & t)
+            const T_ &
+            _verify(const T_ & t)
             {
                 if (t < _min)
+                {
                     throw VerifiedRangeUnderflow(stringify(t), stringify(_min));
+                }
 
                 if (t > _max)
+                {
                     throw VerifiedRangeOverflow(stringify(t), stringify(_max));
+                }
 
                 return t;
             }
@@ -104,40 +105,42 @@ namespace eos
                 _value(_verify(value))
             {
             }
+
             ///@}
 
             ///@name Operations
             ///@{
             /// Conversion operator its native type T_
-            operator T_ () const
-            {
-                return _value;
-            }
+            operator T_ () const { return _value; }
 
             /*!
              * Assignment operator.
              *
              * @param rhs Right-hand-side of an assignment to this object.
              */
-            const T_ & operator= (const T_ & rhs)
+            const T_ &
+            operator= (const T_ & rhs)
             {
                 _value = _verify(rhs);
                 return _value;
             }
 
             /// Retrieve the minimal value that is allowed for this object.
-            T_ min() const
+            T_
+            min() const
             {
                 return _min;
             }
 
             /// Retrieve the maximal value that is allowed for this object.
-            T_ max() const
+            T_
+            max() const
             {
                 return _max;
             }
+
             ///@}
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/verify_TEST.cc
+++ b/eos/utils/verify_TEST.cc
@@ -18,14 +18,14 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/utils/verify.hh>
+
+#include <test/test.hh>
 
 using namespace test;
 using namespace eos;
 
-class VerifiedRangeTest :
-    public TestCase
+class VerifiedRangeTest : public TestCase
 {
     public:
         VerifiedRangeTest() :
@@ -33,7 +33,8 @@ class VerifiedRangeTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             // proper construction
             TEST_CHECK_NO_THROW(VerifiedRange<double> test_range(0.0, 1.0, 0.5));

--- a/eos/utils/visitor-fwd.hh
+++ b/eos/utils/visitor-fwd.hh
@@ -7,33 +7,24 @@
 
 namespace eos
 {
-    template <typename TypeList_>
-    class DeclareAbstractVisitMethods;
+    template <typename TypeList_> class DeclareAbstractVisitMethods;
 
-    template <>
-    class DeclareAbstractVisitMethods<TypeListTail>;
+    template <> class DeclareAbstractVisitMethods<TypeListTail>;
 
-    template <typename TypeList_>
-    class WrappedVisitorBase;
+    template <typename TypeList_> class WrappedVisitorBase;
 
-    template <typename RealClass_, typename TypeList_>
-    class ImplementVisitMethods;
+    template <typename RealClass_, typename TypeList_> class ImplementVisitMethods;
 
-    template <typename RealClass_>
-    class ImplementVisitMethods<RealClass_, TypeListTail>;
+    template <typename RealClass_> class ImplementVisitMethods<RealClass_, TypeListTail>;
 
-    template <typename TypeList_, typename UnwrappedVisitor_>
-    class WrappedVoidResultVisitor;
+    template <typename TypeList_, typename UnwrappedVisitor_> class WrappedVoidResultVisitor;
 
-    template <typename TypeList_, typename Result_, typename UnwrappedVisitor_>
-    class WrappedNonVoidResultVisitor;
+    template <typename TypeList_, typename Result_, typename UnwrappedVisitor_> class WrappedNonVoidResultVisitor;
 
-    template <typename BaseClass_, typename VisitableTypeList_>
-    class DeclareAbstractAcceptMethods;
+    template <typename BaseClass_, typename VisitableTypeList_> class DeclareAbstractAcceptMethods;
 
-    template <typename BaseClass_, typename RealClass_>
-    class ImplementAcceptMethods;
+    template <typename BaseClass_, typename RealClass_> class ImplementAcceptMethods;
 
     template <unsigned u_> class NoType;
-}
+} // namespace eos
 #endif

--- a/eos/utils/visitor.hh
+++ b/eos/utils/visitor.hh
@@ -29,8 +29,7 @@
 
 namespace eos
 {
-    template <typename Visitor_>
-    class AcceptVisitor
+    template <typename Visitor_> class AcceptVisitor
     {
         private:
             Visitor_ & _v;
@@ -46,15 +45,16 @@ namespace eos
             }
 
             template <typename T_>
-            void operator() (T_ & t) const
+            void
+            operator() (T_ & t) const
             {
                 t.accept(_v);
             }
+
             /// @}
     };
 
-    template <typename Visitor_, typename Returning_>
-    class AcceptVisitorReturning
+    template <typename Visitor_, typename Returning_> class AcceptVisitorReturning
     {
         private:
             Visitor_ & _v;
@@ -70,10 +70,12 @@ namespace eos
             }
 
             template <typename T_>
-            Returning_ operator() (T_ & t) const
+            Returning_
+            operator() (T_ & t) const
             {
                 return t.template accept_returning<Returning_>(_v);
             }
+
             /// @}
     };
 
@@ -81,145 +83,137 @@ namespace eos
      * Convenience function for using a visitor with a standard algorithm.
      */
     template <typename Visitor_>
-    AcceptVisitor<Visitor_> accept_visitor(Visitor_ & v)
+    AcceptVisitor<Visitor_>
+    accept_visitor(Visitor_ & v)
     {
         return AcceptVisitor<Visitor_>(v);
     }
 
     template <typename Returning_, typename Visitor_>
-    AcceptVisitorReturning<Visitor_, Returning_> accept_visitor_returning(Visitor_ & v)
+    AcceptVisitorReturning<Visitor_, Returning_>
+    accept_visitor_returning(Visitor_ & v)
     {
         return AcceptVisitorReturning<Visitor_, Returning_>(v);
     }
 
-    template <typename>
-    struct ExtractFirstArgumentType;
+    template <typename> struct ExtractFirstArgumentType;
 
-    template <typename T_, typename R_, typename A1_, typename... As_>
-    struct ExtractFirstArgumentType<R_ (T_::*) (A1_, As_...) const>
+    template <typename T_, typename R_, typename A1_, typename... As_> struct ExtractFirstArgumentType<R_ (T_::*)(A1_, As_...) const>
     {
-        using Type = A1_;
+            using Type = A1_;
     };
 
-    template <typename T_>
-    using FirstCallArgumentType = typename ExtractFirstArgumentType<decltype(&T_::operator())>::Type;
+    template <typename T_> using FirstCallArgumentType = typename ExtractFirstArgumentType<decltype(&T_::operator())>::Type;
 
-    template <typename>
-    struct ExtractResultType;
+    template <typename> struct ExtractResultType;
 
-    template <typename T_, typename R_, typename... As_>
-    struct ExtractResultType<R_ (T_::*) (As_...) const>
+    template <typename T_, typename R_, typename... As_> struct ExtractResultType<R_ (T_::*)(As_...) const>
     {
-        using Type = R_;
+            using Type = R_;
     };
 
-    template <typename T_>
-    using CallResultType = typename std::remove_const<typename ExtractResultType<decltype(&T_::operator())>::Type>::type;
+    template <typename T_> using CallResultType = typename std::remove_const<typename ExtractResultType<decltype(&T_::operator())>::Type>::type;
 
-    template <typename Revisitor_, typename Result_, typename... Cases_>
-    struct MadeVisitor;
+    template <typename Revisitor_, typename Result_, typename... Cases_> struct MadeVisitor;
 
-    template <typename Revisitor_, typename Result_>
-    struct MadeVisitor<Revisitor_, Result_>
+    template <typename Revisitor_, typename Result_> struct MadeVisitor<Revisitor_, Result_>
     {
-        Result_ visit(const NoType<0u> &) const;
+            Result_ visit(const NoType<0u> &) const;
     };
 
-    template <typename>
-    struct CallThisCaseNeedsTwoArgs;
+    template <typename> struct CallThisCaseNeedsTwoArgs;
 
-    template <typename T_, typename R_, typename A1_>
-    struct CallThisCaseNeedsTwoArgs<R_ (T_::*) (A1_) const>
+    template <typename T_, typename R_, typename A1_> struct CallThisCaseNeedsTwoArgs<R_ (T_::*)(A1_) const>
     {
-        enum { value = false };
+            enum
+            {
+                value = false
+            };
     };
 
-    template <typename T_, typename R_, typename A1_, typename A2_>
-    struct CallThisCaseNeedsTwoArgs<R_ (T_::*) (A1_, A2_) const>
+    template <typename T_, typename R_, typename A1_, typename A2_> struct CallThisCaseNeedsTwoArgs<R_ (T_::*)(A1_, A2_) const>
     {
-        enum { value = true };
+            enum
+            {
+                value = true
+            };
     };
 
-    template <typename Result_, typename Case_, typename V_, bool needs_two_args_>
-    struct CallThisCase;
+    template <typename Result_, typename Case_, typename V_, bool needs_two_args_> struct CallThisCase;
 
-    template <typename Result_, typename Case_, typename V_>
-    struct CallThisCase<Result_, Case_, V_, false>
+    template <typename Result_, typename Case_, typename V_> struct CallThisCase<Result_, Case_, V_, false>
     {
-        static Result_ call(const Case_ & thiscase, const FirstCallArgumentType<Case_> & v, const V_ &)
-        {
-            return thiscase(v);
-        }
+            static Result_
+            call(const Case_ & thiscase, const FirstCallArgumentType<Case_> & v, const V_ &)
+            {
+                return thiscase(v);
+            }
     };
 
-    template <typename Result_, typename Case_, typename V_>
-    struct CallThisCase<Result_, Case_, V_, true>
+    template <typename Result_, typename Case_, typename V_> struct CallThisCase<Result_, Case_, V_, true>
     {
-        static Result_ call(const Case_ & thiscase, const FirstCallArgumentType<Case_> & v, const V_ & revisitor)
-        {
-            return thiscase(v, accept_visitor_returning<Result_>(revisitor));
-        }
+            static Result_
+            call(const Case_ & thiscase, const FirstCallArgumentType<Case_> & v, const V_ & revisitor)
+            {
+                return thiscase(v, accept_visitor_returning<Result_>(revisitor));
+            }
     };
 
-    template <typename Case_, typename V_>
-    struct CallThisCase<void, Case_, V_, true>
+    template <typename Case_, typename V_> struct CallThisCase<void, Case_, V_, true>
     {
-        static void call(const Case_ & thiscase, const FirstCallArgumentType<Case_> & v, const V_ & revisitor)
-        {
-            thiscase(v, accept_visitor(revisitor));
-        }
+            static void
+            call(const Case_ & thiscase, const FirstCallArgumentType<Case_> & v, const V_ & revisitor)
+            {
+                thiscase(v, accept_visitor(revisitor));
+            }
     };
 
     template <typename Revisitor_, typename Result_, typename Case_, typename... Rest_>
-    struct MadeVisitor<Revisitor_, Result_, Case_, Rest_...> :
-        MadeVisitor<Revisitor_, Result_, Rest_...>
+    struct MadeVisitor<Revisitor_, Result_, Case_, Rest_...> : MadeVisitor<Revisitor_, Result_, Rest_...>
     {
-        const Case_ & thiscase;
+            const Case_ & thiscase;
 
-        MadeVisitor(const Case_ & c, const Rest_ & ... cases) :
-            MadeVisitor<Revisitor_, Result_, Rest_...>(cases...),
-            thiscase(c)
-        {
-        }
+            MadeVisitor(const Case_ & c, const Rest_ &... cases) :
+                MadeVisitor<Revisitor_, Result_, Rest_...>(cases...),
+                thiscase(c)
+            {
+            }
 
-        using MadeVisitor<Revisitor_, Result_, Rest_...>::visit;
+            using MadeVisitor<Revisitor_, Result_, Rest_...>::visit;
 
-        Result_ visit(const FirstCallArgumentType<Case_> & v) const
-        {
-            return CallThisCase<Result_, Case_, Revisitor_, CallThisCaseNeedsTwoArgs<decltype(&Case_::operator())>::value>::call(
-                    thiscase, v, *static_cast<const Revisitor_ *>(this));
-        }
+            Result_
+            visit(const FirstCallArgumentType<Case_> & v) const
+            {
+                return CallThisCase<Result_, Case_, Revisitor_, CallThisCaseNeedsTwoArgs<decltype(&Case_::operator())>::value>::call(thiscase,
+                                                                                                                                     v,
+                                                                                                                                     *static_cast<const Revisitor_ *>(this));
+            }
     };
 
-    template <typename Result_, typename... Cases_>
-    struct BaseMadeVisitor :
-        MadeVisitor<BaseMadeVisitor<Result_, Cases_...>, Result_, Cases_...>
+    template <typename Result_, typename... Cases_> struct BaseMadeVisitor : MadeVisitor<BaseMadeVisitor<Result_, Cases_...>, Result_, Cases_...>
     {
-        BaseMadeVisitor(const Cases_ & ... cases) :
-            MadeVisitor<BaseMadeVisitor<Result_, Cases_...>, Result_, Cases_...>(cases...)
-        {
-        }
+            BaseMadeVisitor(const Cases_ &... cases) :
+                MadeVisitor<BaseMadeVisitor<Result_, Cases_...>, Result_, Cases_...>(cases...)
+            {
+            }
     };
 
     template <typename Case_, typename... Cases_>
-    auto make_visitor(const Case_ & firstcase, const Cases_ & ... cases) -> BaseMadeVisitor<CallResultType<Case_>, Case_, Cases_...>
+    auto
+    make_visitor(const Case_ & firstcase, const Cases_ &... cases) -> BaseMadeVisitor<CallResultType<Case_>, Case_, Cases_...>
     {
         return BaseMadeVisitor<CallResultType<Case_>, Case_, Cases_...>{ firstcase, cases... };
     }
 
-    template <typename Result_, typename Base_>
-    using Revisit = std::function<Result_ (const Base_ &)>;
+    template <typename Result_, typename Base_> using Revisit = std::function<Result_(const Base_ &)>;
 
-    template <>
-    class DeclareAbstractVisitMethods<TypeListTail>
+    template <> class DeclareAbstractVisitMethods<TypeListTail>
     {
         public:
             void forward_visit(const NoType<0u> &);
     };
 
-    template <typename TypeList_>
-    class DeclareAbstractVisitMethods :
-        public virtual DeclareAbstractVisitMethods<typename TypeList_::Tail>
+    template <typename TypeList_> class DeclareAbstractVisitMethods : public virtual DeclareAbstractVisitMethods<typename TypeList_::Tail>
     {
         public:
             using DeclareAbstractVisitMethods<typename TypeList_::Tail>::forward_visit;
@@ -227,37 +221,30 @@ namespace eos
             virtual void forward_visit(typename TypeList_::Item &) = 0;
     };
 
-    template <typename TypeList_>
-    class WrappedVisitorBase :
-        public virtual DeclareAbstractVisitMethods<TypeList_>
-    {
-    };
+    template <typename TypeList_> class WrappedVisitorBase : public virtual DeclareAbstractVisitMethods<TypeList_>
+    {};
 
-    template <typename RealClass_>
-    class ImplementVisitMethods<RealClass_, TypeListTail>
+    template <typename RealClass_> class ImplementVisitMethods<RealClass_, TypeListTail>
     {
         public:
             void forward_visit(const NoType<1u> &);
     };
 
     template <typename RealClass_, typename TypeList_>
-    class ImplementVisitMethods :
-        public virtual DeclareAbstractVisitMethods<TypeList_>,
-        public ImplementVisitMethods<RealClass_, typename TypeList_::Tail>
+    class ImplementVisitMethods : public virtual DeclareAbstractVisitMethods<TypeList_>, public ImplementVisitMethods<RealClass_, typename TypeList_::Tail>
     {
         public:
             using ImplementVisitMethods<RealClass_, typename TypeList_::Tail>::forward_visit;
 
-            virtual void forward_visit(typename TypeList_::Item & n)
+            virtual void
+            forward_visit(typename TypeList_::Item & n)
             {
                 static_cast<RealClass_ *>(this)->perform_visit(n);
             }
     };
 
     template <typename TypeList_, typename UnwrappedVisitor_>
-    class WrappedVoidResultVisitor :
-        public WrappedVisitorBase<TypeList_>,
-        public ImplementVisitMethods<WrappedVoidResultVisitor<TypeList_, UnwrappedVisitor_>, TypeList_>
+    class WrappedVoidResultVisitor : public WrappedVisitorBase<TypeList_>, public ImplementVisitMethods<WrappedVoidResultVisitor<TypeList_, UnwrappedVisitor_>, TypeList_>
     {
         private:
             UnwrappedVisitor_ & _unwrapped_visitor;
@@ -269,7 +256,8 @@ namespace eos
             }
 
             template <typename C_>
-            void perform_visit(C_ & t)
+            void
+            perform_visit(C_ & t)
             {
                 _unwrapped_visitor.visit(t);
             }
@@ -277,9 +265,8 @@ namespace eos
 
     template <typename TypeList_, typename Result_, typename UnwrappedVisitor_>
     class WrappedNonVoidResultVisitor :
-            public WrappedVisitorBase<TypeList_>,
-            public ImplementVisitMethods<WrappedNonVoidResultVisitor<TypeList_, Result_, UnwrappedVisitor_>,
-                TypeList_>
+        public WrappedVisitorBase<TypeList_>,
+        public ImplementVisitMethods<WrappedNonVoidResultVisitor<TypeList_, Result_, UnwrappedVisitor_>, TypeList_>
     {
         private:
             UnwrappedVisitor_ & _unwrapped_visitor;
@@ -294,53 +281,58 @@ namespace eos
             }
 
             template <typename C_>
-            void perform_visit(C_ & t)
+            void
+            perform_visit(C_ & t)
             {
                 result = _unwrapped_visitor.visit(t);
             }
     };
 
-    template <typename BaseClass_, typename VisitableTypeList_>
-    class DeclareAbstractAcceptMethods
+    template <typename BaseClass_, typename VisitableTypeList_> class DeclareAbstractAcceptMethods
     {
         private:
-            virtual void _real_accept(WrappedVisitorBase<VisitableTypeList_> &) = 0;
+            virtual void _real_accept(WrappedVisitorBase<VisitableTypeList_> &)                                               = 0;
             virtual void _real_accept_const(WrappedVisitorBase<typename MakeTypeListConst<VisitableTypeList_>::Type> &) const = 0;
 
         public:
-            using VisitableTypeList = VisitableTypeList_;
+            using VisitableTypeList  = VisitableTypeList_;
             using VisitableBaseClass = BaseClass_;
 
             template <typename UnwrappedVisitor_>
-            void accept(UnwrappedVisitor_ & v)
+            void
+            accept(UnwrappedVisitor_ & v)
             {
                 WrappedVoidResultVisitor<VisitableTypeList_, UnwrappedVisitor_> vv(v);
                 _real_accept(vv);
             }
 
             template <typename UnwrappedVisitor_>
-            void accept(UnwrappedVisitor_ & v) const
+            void
+            accept(UnwrappedVisitor_ & v) const
             {
                 WrappedVoidResultVisitor<typename MakeTypeListConst<VisitableTypeList_>::Type, UnwrappedVisitor_> vv(v);
                 _real_accept_const(vv);
             }
 
             template <typename UnwrappedVisitor_>
-            void accept(const UnwrappedVisitor_ & v)
+            void
+            accept(const UnwrappedVisitor_ & v)
             {
                 WrappedVoidResultVisitor<VisitableTypeList_, const UnwrappedVisitor_> vv(v);
                 _real_accept(vv);
             }
 
             template <typename UnwrappedVisitor_>
-            void accept(const UnwrappedVisitor_ & v) const
+            void
+            accept(const UnwrappedVisitor_ & v) const
             {
                 WrappedVoidResultVisitor<typename MakeTypeListConst<VisitableTypeList_>::Type, const UnwrappedVisitor_> vv(v);
                 _real_accept_const(vv);
             }
 
             template <typename Result_, typename UnwrappedVisitor_>
-            Result_ accept_returning(UnwrappedVisitor_ & v, const Result_ & r = Result_())
+            Result_
+            accept_returning(UnwrappedVisitor_ & v, const Result_ & r = Result_())
             {
                 WrappedNonVoidResultVisitor<VisitableTypeList_, Result_, UnwrappedVisitor_> vv(v, r);
                 _real_accept(vv);
@@ -348,7 +340,8 @@ namespace eos
             }
 
             template <typename Result_, typename UnwrappedVisitor_>
-            Result_ accept_returning(const UnwrappedVisitor_ & v, const Result_ & r = Result_())
+            Result_
+            accept_returning(const UnwrappedVisitor_ & v, const Result_ & r = Result_())
             {
                 WrappedNonVoidResultVisitor<VisitableTypeList_, Result_, const UnwrappedVisitor_> vv(v, r);
                 _real_accept(vv);
@@ -356,7 +349,8 @@ namespace eos
             }
 
             template <typename Result_, typename UnwrappedVisitor_>
-            Result_ accept_returning(UnwrappedVisitor_ & v, const Result_ & r = Result_()) const
+            Result_
+            accept_returning(UnwrappedVisitor_ & v, const Result_ & r = Result_()) const
             {
                 WrappedNonVoidResultVisitor<typename MakeTypeListConst<VisitableTypeList_>::Type, Result_, UnwrappedVisitor_> vv(v, r);
                 _real_accept_const(vv);
@@ -364,7 +358,8 @@ namespace eos
             }
 
             template <typename Result_, typename UnwrappedVisitor_>
-            Result_ accept_returning(const UnwrappedVisitor_ & v, const Result_ & r = Result_()) const
+            Result_
+            accept_returning(const UnwrappedVisitor_ & v, const Result_ & r = Result_()) const
             {
                 WrappedNonVoidResultVisitor<typename MakeTypeListConst<VisitableTypeList_>::Type, Result_, const UnwrappedVisitor_> vv(v, r);
                 _real_accept_const(vv);
@@ -372,33 +367,36 @@ namespace eos
             }
 
             template <typename Case_, typename... Cases_>
-            auto make_accept_returning(const Case_ & firstcase, const Cases_ & ... cases) const -> CallResultType<Case_>
+            auto
+            make_accept_returning(const Case_ & firstcase, const Cases_ &... cases) const -> CallResultType<Case_>
             {
-                return this->accept_returning<CallResultType<Case_> >(make_visitor(firstcase, cases...));
+                return this->accept_returning<CallResultType<Case_>>(make_visitor(firstcase, cases...));
             }
 
             template <typename... Cases_>
-            void make_accept(const Cases_ & ... cases) const
+            void
+            make_accept(const Cases_ &... cases) const
             {
                 this->accept(make_visitor(cases...));
             }
     };
 
     template <typename BaseClass_, typename RealClass_>
-    class ImplementAcceptMethods :
-        public virtual DeclareAbstractAcceptMethods<BaseClass_, typename BaseClass_::VisitableTypeList>
+    class ImplementAcceptMethods : public virtual DeclareAbstractAcceptMethods<BaseClass_, typename BaseClass_::VisitableTypeList>
     {
         private:
-            void _real_accept(WrappedVisitorBase<typename BaseClass_::VisitableTypeList> & v)
+            void
+            _real_accept(WrappedVisitorBase<typename BaseClass_::VisitableTypeList> & v)
             {
                 v.forward_visit(*static_cast<RealClass_ *>(this));
-            };
+            }
 
-            void _real_accept_const(WrappedVisitorBase<typename MakeTypeListConst<typename BaseClass_::VisitableTypeList>::Type> & v) const
+            void
+            _real_accept_const(WrappedVisitorBase<typename MakeTypeListConst<typename BaseClass_::VisitableTypeList>::Type> & v) const
             {
                 v.forward_visit(*static_cast<const RealClass_ *>(this));
-            };
+            }
     };
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/wilson-polynomial.cc
+++ b/eos/utils/wilson-polynomial.cc
@@ -28,73 +28,73 @@ namespace eos
     /* WilsonPolynomial elements */
     struct Constant
     {
-        double value;
+            double value;
 
-        Constant(const double & value) :
-            value(value)
-        {
-        }
+            Constant(const double & value) :
+                value(value)
+            {
+            }
     };
 
     struct Sum
     {
-        std::list<WilsonPolynomial> summands;
+            std::list<WilsonPolynomial> summands;
 
-        Sum()
-        {
-        }
+            Sum() {}
 
-        Sum(const WilsonPolynomial & x, const WilsonPolynomial & y)
-        {
-            add(x);
-            add(y);
-        }
+            Sum(const WilsonPolynomial & x, const WilsonPolynomial & y)
+            {
+                add(x);
+                add(y);
+            }
 
-        void add(const WilsonPolynomial & summand)
-        {
-            summands.push_back(summand);
-        }
+            void
+            add(const WilsonPolynomial & summand)
+            {
+                summands.push_back(summand);
+            }
     };
 
     struct Product
     {
-        WilsonPolynomial x, y;
+            WilsonPolynomial x, y;
 
-        Product() :
-            x(Constant(0)),
-            y(Constant(0))
-        {
-        }
+            Product() :
+                x(Constant(0)),
+                y(Constant(0))
+            {
+            }
 
-        Product(const WilsonPolynomial & x, const WilsonPolynomial & y) :
-            x(x),
-            y(y)
-        {
-        };
+            Product(const WilsonPolynomial & x, const WilsonPolynomial & y) :
+                x(x),
+                y(y)
+            {
+            }
     };
 
     struct Sine
     {
-        WilsonPolynomial phi;
+            WilsonPolynomial phi;
 
-        Sine(const WilsonPolynomial & phi) :
-            phi(phi)
-        {
-        }
+            Sine(const WilsonPolynomial & phi) :
+                phi(phi)
+            {
+            }
     };
 
     struct Cosine
     {
-        WilsonPolynomial phi;
+            WilsonPolynomial phi;
 
-        Cosine(const WilsonPolynomial & phi) :
-            phi(phi)
-        {
-        }
+            Cosine(const WilsonPolynomial & phi) :
+                phi(phi)
+            {
+            }
     };
 
     /* Build a WilsonPolynomial from an observable */
-    WilsonPolynomial make_polynomial(const ObservablePtr & o, const std::list<std::string> & _coefficients)
+    WilsonPolynomial
+    make_polynomial(const ObservablePtr & o, const std::list<std::string> & _coefficients)
     {
         Sum result;
 
@@ -129,10 +129,10 @@ namespace eos
 
 
             // calculate observables
-            p_i = +1.0;
+            p_i               = +1.0;
             double o_plus_one = o->evaluate();
 
-            p_i = -1.0;
+            p_i                = -1.0;
             double o_minus_one = o->evaluate();
 
             double q_i = 0.5 * ((o_plus_one + o_minus_one) - 2.0 * n);
@@ -148,20 +148,22 @@ namespace eos
         }
 
         // Determine the bilinear terms 'b_{ij}'
-        for (auto i = coefficients.begin(), i_end = coefficients.end() ; i != i_end ; ++i)
+        for (auto i = coefficients.begin(), i_end = coefficients.end(); i != i_end; ++i)
         {
             Parameter p_i = std::get<0>(*i);
-            double q_i = std::get<1>(*i), l_i = std::get<2>(*i);
+            double    q_i = std::get<1>(*i), l_i = std::get<2>(*i);
             p_i = 1.0;
 
             auto j = i;
             if (j != i_end)
+            {
                 ++j;
+            }
 
-            for ( ; j != i_end; ++j)
+            for (; j != i_end; ++j)
             {
                 Parameter p_j = std::get<0>(*j);
-                double q_j = std::get<1>(*j), l_j = std::get<2>(*j);
+                double    q_j = std::get<1>(*j), l_j = std::get<2>(*j);
                 p_j = 1.0;
 
                 // extract bilinear term
@@ -186,8 +188,7 @@ namespace eos
         return result;
     }
 
-    class WilsonPolynomialRatio :
-        public Observable
+    class WilsonPolynomialRatio : public Observable
     {
         private:
             WilsonPolynomial _numerator, _denominator;
@@ -201,8 +202,7 @@ namespace eos
             QualifiedName _name;
 
         public:
-            WilsonPolynomialRatio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator,
-                    const Parameters & parameters):
+            WilsonPolynomialRatio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator, const Parameters & parameters) :
                 _numerator(numerator),
                 _denominator(denominator),
                 _parameters(parameters),
@@ -210,36 +210,57 @@ namespace eos
             {
             }
 
-            ~WilsonPolynomialRatio()
+            ~WilsonPolynomialRatio() {}
+
+            virtual const QualifiedName &
+            name() const
             {
+                return _name;
             }
 
-            virtual const QualifiedName & name() const { return _name; }
-            virtual Kinematics kinematics() { return _kinematics; }
-            virtual Parameters parameters() { return _parameters; }
-            virtual Options options() { return _options; }
-            virtual ObservablePtr clone() const { throw InternalError("Cloning WilsonPolynomialRatio without external parameters"); }
+            virtual Kinematics
+            kinematics()
+            {
+                return _kinematics;
+            }
 
-            virtual double evaluate() const
+            virtual Parameters
+            parameters()
+            {
+                return _parameters;
+            }
+
+            virtual Options
+            options()
+            {
+                return _options;
+            }
+
+            virtual ObservablePtr
+            clone() const
+            {
+                throw InternalError("Cloning WilsonPolynomialRatio without external parameters");
+            }
+
+            virtual double
+            evaluate() const
             {
                 WilsonPolynomialEvaluator evaluator;
 
-                return _numerator.accept_returning<double>(evaluator)
-                    / _denominator.accept_returning<double>(evaluator);
+                return _numerator.accept_returning<double>(evaluator) / _denominator.accept_returning<double>(evaluator);
             }
 
-            virtual ObservablePtr clone(const Parameters & parameters) const
+            virtual ObservablePtr
+            clone(const Parameters & parameters) const
             {
                 WilsonPolynomialCloner cloner(parameters);
 
-                return ObservablePtr(new WilsonPolynomialRatio(_numerator.accept_returning<WilsonPolynomial>(cloner),
-                            _denominator.accept_returning<WilsonPolynomial>(cloner),
-                            parameters));
+                return ObservablePtr(
+                        new WilsonPolynomialRatio(_numerator.accept_returning<WilsonPolynomial>(cloner), _denominator.accept_returning<WilsonPolynomial>(cloner), parameters));
             }
     };
 
-    class WilsonPolynomialHTLikeRatio :
-        public Observable
+    class WilsonPolynomialHTLikeRatio : public Observable
     {
         private:
             WilsonPolynomial _numerator, _denominator1, _denominator2;
@@ -253,8 +274,8 @@ namespace eos
             QualifiedName _name;
 
         public:
-            WilsonPolynomialHTLikeRatio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator1,
-                    const WilsonPolynomial & denominator2, const Parameters & parameters):
+            WilsonPolynomialHTLikeRatio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator1, const WilsonPolynomial & denominator2,
+                                        const Parameters & parameters) :
                 _numerator(numerator),
                 _denominator1(denominator1),
                 _denominator2(denominator2),
@@ -263,32 +284,56 @@ namespace eos
             {
             }
 
-            ~WilsonPolynomialHTLikeRatio()
+            ~WilsonPolynomialHTLikeRatio() {}
+
+            virtual const QualifiedName &
+            name() const
             {
+                return _name;
             }
 
-            virtual const QualifiedName & name() const { return _name; }
-            virtual Kinematics kinematics() { return _kinematics; }
-            virtual Parameters parameters() { return _parameters; }
-            virtual Options options() { return _options; }
-            virtual ObservablePtr clone() const { throw InternalError("Cloning WilsonPolynomialHTLikeRatio without external parameters"); }
+            virtual Kinematics
+            kinematics()
+            {
+                return _kinematics;
+            }
 
-            virtual double evaluate() const
+            virtual Parameters
+            parameters()
+            {
+                return _parameters;
+            }
+
+            virtual Options
+            options()
+            {
+                return _options;
+            }
+
+            virtual ObservablePtr
+            clone() const
+            {
+                throw InternalError("Cloning WilsonPolynomialHTLikeRatio without external parameters");
+            }
+
+            virtual double
+            evaluate() const
             {
                 WilsonPolynomialEvaluator evaluator;
 
                 return _numerator.accept_returning<double>(evaluator)
-                    / std::sqrt(_denominator1.accept_returning<double>(evaluator) * _denominator2.accept_returning<double>(evaluator));
+                       / std::sqrt(_denominator1.accept_returning<double>(evaluator) * _denominator2.accept_returning<double>(evaluator));
             }
 
-            virtual ObservablePtr clone(const Parameters & parameters) const
+            virtual ObservablePtr
+            clone(const Parameters & parameters) const
             {
                 WilsonPolynomialCloner cloner(parameters);
 
                 return ObservablePtr(new WilsonPolynomialHTLikeRatio(_numerator.accept_returning<WilsonPolynomial>(cloner),
-                            _denominator1.accept_returning<WilsonPolynomial>(cloner),
-                            _denominator2.accept_returning<WilsonPolynomial>(cloner),
-                            parameters));
+                                                                     _denominator1.accept_returning<WilsonPolynomial>(cloner),
+                                                                     _denominator2.accept_returning<WilsonPolynomial>(cloner),
+                                                                     parameters));
             }
     };
 
@@ -305,8 +350,7 @@ namespace eos
     }
 
     ObservablePtr
-    make_polynomial_ht_like_ratio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator1,
-            const WilsonPolynomial & denominator2, const Parameters & parameters)
+    make_polynomial_ht_like_ratio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator1, const WilsonPolynomial & denominator2, const Parameters & parameters)
     {
         return ObservablePtr(new WilsonPolynomialHTLikeRatio(numerator, denominator1, denominator2, parameters));
     }
@@ -339,8 +383,7 @@ namespace eos
     WilsonPolynomial
     WilsonPolynomialCloner::visit(const Product & p)
     {
-        return WilsonPolynomial(Product(p.x.accept_returning<WilsonPolynomial>(*this),
-                    p.y.accept_returning<WilsonPolynomial>(*this)));
+        return WilsonPolynomial(Product(p.x.accept_returning<WilsonPolynomial>(*this), p.y.accept_returning<WilsonPolynomial>(*this)));
     }
 
     WilsonPolynomial
@@ -379,7 +422,9 @@ namespace eos
         std::string result = "(";
 
         if (_pretty)
+        {
             result += "\n   ";
+        }
 
         auto i = s.summands.cbegin(), i_end = s.summands.cend();
 
@@ -389,13 +434,15 @@ namespace eos
             ++i;
         }
 
-        for ( ; i != i_end ; ++i)
+        for (; i != i_end; ++i)
         {
             result += std::string(_pretty ? "\n" : "") + " + " + (*i).accept_returning<std::string>(*this);
         }
 
         if (_pretty)
+        {
             result += "\n";
+        }
 
         result += ")";
 
@@ -432,9 +479,16 @@ namespace eos
 
     /* WilsonPolynomialEvaluator */
     double
-    WilsonPolynomialEvaluator::visit(const Constant & c) { return c.value; }
+    WilsonPolynomialEvaluator::visit(const Constant & c)
+    {
+        return c.value;
+    }
+
     double
-    WilsonPolynomialEvaluator::visit(const Parameter & p) { return p(); }
+    WilsonPolynomialEvaluator::visit(const Parameter & p)
+    {
+        return p();
+    }
 
     double
     WilsonPolynomialEvaluator::visit(const Sum & s)
@@ -466,4 +520,4 @@ namespace eos
     {
         return std::cos(c.phi.accept_returning<double>(*this));
     }
-}
+} // namespace eos

--- a/eos/utils/wilson-polynomial.hh
+++ b/eos/utils/wilson-polynomial.hh
@@ -48,8 +48,7 @@ namespace eos
      * @param polynomial  The polynomial that shall be wrapped.
      * @param parameters  The Parameters object of the polynomial.
      */
-    ObservablePtr make_polynomial_observable(const WilsonPolynomial & polynomial,
-            const Parameters & parameters);
+    ObservablePtr make_polynomial_observable(const WilsonPolynomial & polynomial, const Parameters & parameters);
 
     /*!
      * Return an Observable that is a ratio of two WilsonPolynomial objects.
@@ -58,8 +57,7 @@ namespace eos
      * @param denominator The denominator of the ratio.
      * @param parameters  The common Parameters object of both numerator and denominator.
      */
-    ObservablePtr make_polynomial_ratio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator,
-            const Parameters & parameters);
+    ObservablePtr make_polynomial_ratio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator, const Parameters & parameters);
 
     /*!
      * Return an Observable that is a ratio similar to H_T^(i) of three WilsonPolynomial objects N,D1,D2:
@@ -70,8 +68,8 @@ namespace eos
      * @param denominator2 The first denominator component of the ratio.
      * @param parameters   The common Parameters object of both numerator and denominator.
      */
-    ObservablePtr make_polynomial_ht_like_ratio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator,
-            const WilsonPolynomial & denominator2, const Parameters & parameters);
+    ObservablePtr make_polynomial_ht_like_ratio(const WilsonPolynomial & numerator, const WilsonPolynomial & denominator, const WilsonPolynomial & denominator2,
+                                                const Parameters & parameters);
 
     class WilsonPolynomialCloner
     {
@@ -115,7 +113,7 @@ namespace eos
             double visit(const Sine & s);
             double visit(const Cosine & c);
     };
-}
+} // namespace eos
 
 
 #endif

--- a/eos/utils/wilson-polynomial_TEST.cc
+++ b/eos/utils/wilson-polynomial_TEST.cc
@@ -17,76 +17,97 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#include <test/test.hh>
 #include <eos/maths/complex.hh>
 #include <eos/utils/wilson-polynomial.hh>
 
+#include <test/test.hh>
+
 #include <array>
 #include <cmath>
-#include <vector>
-
 #include <iostream>
+#include <vector>
 
 using namespace test;
 using namespace eos;
 
-struct WilsonPolynomialTestObservable :
-    public Observable
+struct WilsonPolynomialTestObservable : public Observable
 {
-    QualifiedName n;
-    Parameters p;
-    Kinematics k;
-    Parameter c1;
-    Parameter c2;
-    Parameter re_c7;
-    Parameter im_c7;
-    Parameter re_c9;
-    Parameter im_c9;
-    Parameter re_c10;
-    Parameter im_c10;
+        QualifiedName n;
+        Parameters    p;
+        Kinematics    k;
+        Parameter     c1;
+        Parameter     c2;
+        Parameter     re_c7;
+        Parameter     im_c7;
+        Parameter     re_c9;
+        Parameter     im_c9;
+        Parameter     re_c10;
+        Parameter     im_c10;
 
-    WilsonPolynomialTestObservable(const Parameters & p, const Kinematics & k, const Options &) :
-        n("WilsonPolynomial::TestObservable"),
-        p(p),
-        k(k),
-        c1(p["b->s::c1"]),
-        c2(p["b->s::c2"]),
-        re_c7(p["b->s::Re{c7}"]),
-        im_c7(p["b->s::Im{c7}"]),
-        re_c9(p["b->smumu::Re{c9}"]),
-        im_c9(p["b->smumu::Im{c9}"]),
-        re_c10(p["b->smumu::Re{c10}"]),
-        im_c10(p["b->smumu::Im{c10}"])
-    {
-    }
+        WilsonPolynomialTestObservable(const Parameters & p, const Kinematics & k, const Options &) :
+            n("WilsonPolynomial::TestObservable"),
+            p(p),
+            k(k),
+            c1(p["b->s::c1"]),
+            c2(p["b->s::c2"]),
+            re_c7(p["b->s::Re{c7}"]),
+            im_c7(p["b->s::Im{c7}"]),
+            re_c9(p["b->smumu::Re{c9}"]),
+            im_c9(p["b->smumu::Im{c9}"]),
+            re_c10(p["b->smumu::Re{c10}"]),
+            im_c10(p["b->smumu::Im{c10}"])
+        {
+        }
 
-    virtual const QualifiedName & name() const { return n; }
-    virtual Parameters parameters() { return p; }
-    virtual Kinematics kinematics() { return k; }
-    virtual Options options() { return Options(); }
-    virtual ObservablePtr clone() const { return ObservablePtr(new WilsonPolynomialTestObservable(p.clone(), k.clone(), Options())); }
-    virtual ObservablePtr clone(const Parameters & p) const { return ObservablePtr(new WilsonPolynomialTestObservable(p, k.clone(), Options())); }
+        virtual const QualifiedName &
+        name() const
+        {
+            return n;
+        }
 
-    virtual double evaluate() const
-    {
-        complex<double> c7(re_c7(), im_c7());
-        complex<double> c9(re_c9(), im_c9());
-        complex<double> c10(re_c10(), im_c10());
+        virtual Parameters
+        parameters()
+        {
+            return p;
+        }
 
-        return real(
-                    0.01234
-                    + c7 * complex<double>(0.321, 1.000)
-                    + c9 * complex<double>(0.731, 1.000)
-                    + conj(c7) * c7 * 0.6
-                    + conj(c7) * c9 * complex<double>(1.300, 0.123)
-                    + conj(c9) * c9 * 2.1
-                    + conj(c10) * c10 * 1.23
-                );
-    }
+        virtual Kinematics
+        kinematics()
+        {
+            return k;
+        }
+
+        virtual Options
+        options()
+        {
+            return Options();
+        }
+
+        virtual ObservablePtr
+        clone() const
+        {
+            return ObservablePtr(new WilsonPolynomialTestObservable(p.clone(), k.clone(), Options()));
+        }
+
+        virtual ObservablePtr
+        clone(const Parameters & p) const
+        {
+            return ObservablePtr(new WilsonPolynomialTestObservable(p, k.clone(), Options()));
+        }
+
+        virtual double
+        evaluate() const
+        {
+            complex<double> c7(re_c7(), im_c7());
+            complex<double> c9(re_c9(), im_c9());
+            complex<double> c10(re_c10(), im_c10());
+
+            return real(0.01234 + c7 * complex<double>(0.321, 1.000) + c9 * complex<double>(0.731, 1.000) + conj(c7) * c7 * 0.6 + conj(c7) * c9 * complex<double>(1.300, 0.123)
+                        + conj(c9) * c9 * 2.1 + conj(c10) * c10 * 1.23);
+        }
 };
 
-class WilsonPolynomialTest :
-    public TestCase
+class WilsonPolynomialTest : public TestCase
 {
     public:
         WilsonPolynomialTest() :
@@ -94,49 +115,51 @@ class WilsonPolynomialTest :
         {
         }
 
-        void run_one(const ObservablePtr & o, const WilsonPolynomial & p, const std::array<double, 6> & values) const
+        void
+        run_one(const ObservablePtr & o, const WilsonPolynomial & p, const std::array<double, 6> & values) const
         {
             Parameters parameters = o->parameters();
-            Parameter re_c7(parameters["b->s::Re{c7}"]);
-            Parameter im_c7(parameters["b->s::Im{c7}"]);
-            Parameter re_c9(parameters["b->smumu::Re{c9}"]);
-            Parameter im_c9(parameters["b->smumu::Im{c9}"]);
-            Parameter re_c10(parameters["b->smumu::Re{c10}"]);
-            Parameter im_c10(parameters["b->smumu::Im{c10}"]);
+            Parameter  re_c7(parameters["b->s::Re{c7}"]);
+            Parameter  im_c7(parameters["b->s::Im{c7}"]);
+            Parameter  re_c9(parameters["b->smumu::Re{c9}"]);
+            Parameter  im_c9(parameters["b->smumu::Im{c9}"]);
+            Parameter  re_c10(parameters["b->smumu::Re{c10}"]);
+            Parameter  im_c10(parameters["b->smumu::Im{c10}"]);
 
-            re_c7 = values[0];
-            im_c7 = values[1];
-            re_c9 = values[2];
-            im_c9 = values[3];
+            re_c7  = values[0];
+            im_c7  = values[1];
+            re_c9  = values[2];
+            im_c9  = values[3];
             re_c10 = values[4];
             im_c10 = values[5];
 
-            static const double eps = 1e-10;
+            static const double       eps = 1e-10;
             WilsonPolynomialEvaluator evaluator;
             TEST_CHECK_NEARLY_EQUAL(o->evaluate(), p.accept_returning<double>(evaluator), eps);
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             Parameters parameters = Parameters::Defaults();
             Kinematics kinematics;
 
-            ObservablePtr o = ObservablePtr(new WilsonPolynomialTestObservable(parameters, kinematics, Options()));
-            WilsonPolynomial p = make_polynomial(o, std::list<std::string>{ "b->s::Re{c7}", "b->s::Im{c7}", "b->smumu::Re{c9}", "b->smumu::Im{c9}", "b->smumu::Re{c10}", "b->smumu::Im{c10}" });
+            ObservablePtr    o = ObservablePtr(new WilsonPolynomialTestObservable(parameters, kinematics, Options()));
+            WilsonPolynomial p =
+                    make_polynomial(o, std::list<std::string>{ "b->s::Re{c7}", "b->s::Im{c7}", "b->smumu::Re{c9}", "b->smumu::Im{c9}", "b->smumu::Re{c10}", "b->smumu::Im{c10}" });
 
             WilsonPolynomialPrinter printer;
             std::cout << p.accept_returning<std::string>(printer) << std::endl;
 
-            static const std::vector<std::array<double, 6>> inputs
-            {
-                std::array<double, 6>{{0.0,       0.0,       0.0,       0.0,       0.0,       0.0      }},
-                std::array<double, 6>{{1.0,       0.0,       1.0,       0.0,       1.0,       0.0      }},
-                std::array<double, 6>{{0.7808414, 0.8487257, 0.7735165, 0.5383695, 0.6649164, 0.7235497}},
-                std::array<double, 6>{{0.5860642, 0.9830907, 0.7644369, 0.8330194, 0.4935018, 0.4492084}},
-                std::array<double, 6>{{0.2177456, 0.5062894, 0.6463376, 0.3624364, 0.6770480, 0.0718421}},
-                std::array<double, 6>{{0.0088306, 0.9441413, 0.8721501, 0.2984633, 0.2961408, 0.9145809}},
-                std::array<double, 6>{{0.7967655, 0.2427081, 0.8403112, 0.3351082, 0.6477823, 0.5569495}},
-                std::array<double, 6>{{0.7607454, 0.5025871, 0.5877762, 0.5516025, 0.2930899, 0.4882813}},
+            static const std::vector<std::array<double, 6>> inputs{
+                std::array<double, 6>{ { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } },
+                std::array<double, 6>{ { 1.0, 0.0, 1.0, 0.0, 1.0, 0.0 } },
+                std::array<double, 6>{ { 0.7808414, 0.8487257, 0.7735165, 0.5383695, 0.6649164, 0.7235497 } },
+                std::array<double, 6>{ { 0.5860642, 0.9830907, 0.7644369, 0.8330194, 0.4935018, 0.4492084 } },
+                std::array<double, 6>{ { 0.2177456, 0.5062894, 0.6463376, 0.3624364, 0.6770480, 0.0718421 } },
+                std::array<double, 6>{ { 0.0088306, 0.9441413, 0.8721501, 0.2984633, 0.2961408, 0.9145809 } },
+                std::array<double, 6>{ { 0.7967655, 0.2427081, 0.8403112, 0.3351082, 0.6477823, 0.5569495 } },
+                std::array<double, 6>{ { 0.7607454, 0.5025871, 0.5877762, 0.5516025, 0.2930899, 0.4882813 } },
             };
 
             for (const auto & input : inputs)
@@ -146,8 +169,7 @@ class WilsonPolynomialTest :
         }
 } wilson_polynomial_test;
 
-class WilsonPolynomialClonerTest :
-    public TestCase
+class WilsonPolynomialClonerTest : public TestCase
 {
     public:
         WilsonPolynomialClonerTest() :
@@ -155,17 +177,18 @@ class WilsonPolynomialClonerTest :
         {
         }
 
-        virtual void run() const
+        virtual void
+        run() const
         {
             Parameters parameters = Parameters::Defaults();
             Kinematics kinematics;
 
-            ObservablePtr o = ObservablePtr(new WilsonPolynomialTestObservable(parameters, kinematics, Options()));
+            ObservablePtr    o = ObservablePtr(new WilsonPolynomialTestObservable(parameters, kinematics, Options()));
             WilsonPolynomial p = make_polynomial(o, std::list<std::string>{ "b->s::Re{c7}", "b->smumu::Re{c9}", "b->smumu::Re{c10}" });
 
-            Parameters clone_parameters = Parameters::Defaults();
+            Parameters             clone_parameters = Parameters::Defaults();
             WilsonPolynomialCloner cloner(clone_parameters);
-            WilsonPolynomial c = p.accept_returning<WilsonPolynomial>(cloner);
+            WilsonPolynomial       c = p.accept_returning<WilsonPolynomial>(cloner);
 
             WilsonPolynomialPrinter printer;
             TEST_CHECK_EQUAL(p.accept_returning<std::string>(printer), c.accept_returning<std::string>(printer));

--- a/eos/utils/wrapped_forward_iterator-fwd.hh
+++ b/eos/utils/wrapped_forward_iterator-fwd.hh
@@ -25,13 +25,11 @@
 
 namespace eos
 {
-    template <typename Tag_, typename Value_>
-    class WrappedForwardIterator;
+    template <typename Tag_, typename Value_> class WrappedForwardIterator;
 
-    template <typename Tag_>
-    struct WrappedForwardIteratorTraits;
+    template <typename Tag_> struct WrappedForwardIteratorTraits;
 
     struct WrappedForwardIteratorUnderlyingIteratorHolder;
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/wrapped_forward_iterator-impl.hh
+++ b/eos/utils/wrapped_forward_iterator-impl.hh
@@ -28,9 +28,10 @@
 namespace eos
 {
     template <typename T_>
-    void checked_delete(T_ * const t)
+    void
+    checked_delete(T_ * const t)
     {
-        typedef char make_sure_type_is_defined[sizeof(T_) ? 1 : -1];
+        typedef char     make_sure_type_is_defined[sizeof(T_) ? 1 : -1];
         static const int make_sure_type_is_defined_again __attribute__((unused)) = sizeof(make_sure_type_is_defined);
         delete t;
     }
@@ -44,8 +45,7 @@ namespace eos
 
     template <typename WrappedIter_>
     WrappedForwardIteratorUnderlyingIteratorHolder *
-    wrapped_underlying_iterator_hide_real_type(const WrappedIter_ &,
-            typename WrappedForwardIteratorTraits<typename WrappedIter_::Tag>::UnderlyingIterator * const i)
+    wrapped_underlying_iterator_hide_real_type(const WrappedIter_ &, typename WrappedForwardIteratorTraits<typename WrappedIter_::Tag>::UnderlyingIterator * const i)
     {
         return reinterpret_cast<WrappedForwardIteratorUnderlyingIteratorHolder *>(i);
     }
@@ -56,49 +56,48 @@ namespace eos
     {
     }
 
-    template <typename Tag_, typename Value_>
-    WrappedForwardIterator<Tag_, Value_>::~WrappedForwardIterator()
+    template <typename Tag_, typename Value_> WrappedForwardIterator<Tag_, Value_>::~WrappedForwardIterator()
     {
         checked_delete(wrapped_underlying_iterator_real_type(*this, _iter));
     }
 
-    template <typename Tag_, typename Value_, typename Iter_>
-    struct WrappedForwardIteratorGetBase
+    template <typename Tag_, typename Value_, typename Iter_> struct WrappedForwardIteratorGetBase
     {
-        template <typename Traits_>
-        static typename Traits_::UnderlyingIterator real_get_iter(const typename Traits_::UnderlyingIterator & i)
-        {
-            return i;
-        }
+            template <typename Traits_>
+            static typename Traits_::UnderlyingIterator
+            real_get_iter(const typename Traits_::UnderlyingIterator & i)
+            {
+                return i;
+            }
 
-        template <typename Traits_>
-        static typename Traits_::UnderlyingIterator
-        real_get_iter(const typename Traits_::EquivalentNonConstIterator & i)
-        {
-            return typename Traits_::UnderlyingIterator(
-                    i.template underlying_iterator<typename WrappedForwardIteratorTraits<
-                    typename WrappedForwardIteratorTraits<Tag_>::EquivalentNonConstIterator::Tag
-                    >::UnderlyingIterator>()
-                    );
-        }
+            template <typename Traits_>
+            static typename Traits_::UnderlyingIterator
+            real_get_iter(const typename Traits_::EquivalentNonConstIterator & i)
+            {
+                return typename Traits_::UnderlyingIterator(
+                        i.template underlying_iterator<
+                                typename WrappedForwardIteratorTraits<typename WrappedForwardIteratorTraits<Tag_>::EquivalentNonConstIterator::Tag>::UnderlyingIterator>());
+            }
 
-        static typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator get_iter(const Iter_ & i)
-        {
-            return real_get_iter<WrappedForwardIteratorTraits<Tag_> >(i);
-        }
+            static typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator
+            get_iter(const Iter_ & i)
+            {
+                return real_get_iter<WrappedForwardIteratorTraits<Tag_>>(i);
+            }
     };
 
-    template <typename Tag_, typename Value_>
-    struct WrappedForwardIteratorGetBase<Tag_, Value_, WrappedForwardIterator<Tag_, Value_> >
+    template <typename Tag_, typename Value_> struct WrappedForwardIteratorGetBase<Tag_, Value_, WrappedForwardIterator<Tag_, Value_>>
     {
-        static WrappedForwardIterator<Tag_, Value_> get_iter(const WrappedForwardIterator<Tag_, Value_> & i)
-        {
-            return i.template underlying_iterator<typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator>();
-        }
+            static WrappedForwardIterator<Tag_, Value_>
+            get_iter(const WrappedForwardIterator<Tag_, Value_> & i)
+            {
+                return i.template underlying_iterator<typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator>();
+            }
     };
 
     template <typename LHS_, typename RHS_>
-    void set_wrapped_forward_iterator_iterator(LHS_ & lhs, RHS_ rhs)
+    void
+    set_wrapped_forward_iterator_iterator(LHS_ & lhs, RHS_ rhs)
     {
         lhs = rhs;
     }
@@ -108,15 +107,13 @@ namespace eos
     WrappedForwardIterator<Tag_, Value_>::WrappedForwardIterator(const T_ & iter) :
         _iter(wrapped_underlying_iterator_hide_real_type(*this, new typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator))
     {
-        set_wrapped_forward_iterator_iterator(
-                *wrapped_underlying_iterator_real_type(*this, _iter),
-                WrappedForwardIteratorGetBase<Tag_, Value_, T_>::get_iter(iter));
+        set_wrapped_forward_iterator_iterator(*wrapped_underlying_iterator_real_type(*this, _iter), WrappedForwardIteratorGetBase<Tag_, Value_, T_>::get_iter(iter));
     }
 
     template <typename Tag_, typename Value_>
     WrappedForwardIterator<Tag_, Value_>::WrappedForwardIterator(const WrappedForwardIterator & other) :
-        _iter(wrapped_underlying_iterator_hide_real_type(*this, new typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator(
-                        *wrapped_underlying_iterator_real_type(other, other._iter))))
+        _iter(wrapped_underlying_iterator_hide_real_type(
+                *this, new typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator(*wrapped_underlying_iterator_real_type(other, other._iter))))
     {
     }
 
@@ -151,26 +148,36 @@ namespace eos
 
         template <typename R_, typename T_> struct GetPointer<R_, T_, true>
         {
-            static R_ get_pointer(T_ * t) { return *t; }
+                static R_
+                get_pointer(T_ * t)
+                {
+                    return *t;
+                }
         };
 
         template <typename R_, typename T_> struct GetPointer<R_, T_, false>
         {
-            static R_ get_pointer(T_ * t) { return t->operator-> (); }
+                static R_
+                get_pointer(T_ * t)
+                {
+                    return t->operator->();
+                }
         };
 
-        template <typename R_, typename T_> R_ get_pointer(T_ * t)
+        template <typename R_, typename T_>
+        R_
+        get_pointer(T_ * t)
         {
             return GetPointer<R_, T_, std::is_pointer<T_>::value>::get_pointer(t);
         }
-    }
+    } // namespace impl
 
     template <typename Tag_, typename Value_>
     typename WrappedForwardIterator<Tag_, Value_>::pointer
-    WrappedForwardIterator<Tag_, Value_>::operator-> () const
+    WrappedForwardIterator<Tag_, Value_>::operator->() const
     {
-        return impl::get_pointer<WrappedForwardIterator<Tag_, Value_>::pointer, typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator>
-            (wrapped_underlying_iterator_real_type(*this, _iter));
+        return impl::get_pointer<WrappedForwardIterator<Tag_, Value_>::pointer, typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator>(
+                wrapped_underlying_iterator_real_type(*this, _iter));
     }
 
     namespace impl
@@ -179,26 +186,36 @@ namespace eos
 
         template <typename R_, typename T_> struct GetReference<R_, T_, true>
         {
-            static R_ get_reference(T_ * t) { return **t; }
+                static R_
+                get_reference(T_ * t)
+                {
+                    return **t;
+                }
         };
 
         template <typename R_, typename T_> struct GetReference<R_, T_, false>
         {
-            static R_ get_reference(T_ * t) { return t->operator* (); }
+                static R_
+                get_reference(T_ * t)
+                {
+                    return t->operator* ();
+                }
         };
 
-        template <typename R_, typename T_> R_ get_reference(T_ * t)
+        template <typename R_, typename T_>
+        R_
+        get_reference(T_ * t)
         {
             return GetReference<R_, T_, std::is_pointer<T_>::value>::get_reference(t);
         }
-    }
+    } // namespace impl
 
     template <typename Tag_, typename Value_>
     typename WrappedForwardIterator<Tag_, Value_>::reference
     WrappedForwardIterator<Tag_, Value_>::operator* () const
     {
-        return impl::get_reference<WrappedForwardIterator<Tag_, Value_>::reference, typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator>
-            (wrapped_underlying_iterator_real_type(*this, _iter));
+        return impl::get_reference<WrappedForwardIterator<Tag_, Value_>::reference, typename WrappedForwardIteratorTraits<Tag_>::UnderlyingIterator>(
+                wrapped_underlying_iterator_real_type(*this, _iter));
     }
 
     template <typename Tag_, typename Value_>
@@ -230,6 +247,6 @@ namespace eos
     {
         return *wrapped_underlying_iterator_real_type(*this, _iter);
     }
-}
+} // namespace eos
 
 #endif

--- a/eos/utils/wrapped_forward_iterator.hh
+++ b/eos/utils/wrapped_forward_iterator.hh
@@ -26,8 +26,8 @@
 #include <eos/utils/wrapped_forward_iterator-fwd.hh>
 
 #include <functional>
-#include <type_traits>
 #include <iterator>
+#include <type_traits>
 
 namespace eos
 {
@@ -35,11 +35,10 @@ namespace eos
      * A WrappedForwardIterator is a generic wrapper around a forward iterator,
      * hiding the underlying base iterator.
      */
-    template <typename Tag_, typename Value_>
-    class WrappedForwardIterator
+    template <typename Tag_, typename Value_> class WrappedForwardIterator
     {
         private:
-             WrappedForwardIteratorUnderlyingIteratorHolder * _iter;
+            WrappedForwardIteratorUnderlyingIteratorHolder * _iter;
 
         public:
             using Tag = Tag_;
@@ -51,8 +50,7 @@ namespace eos
             ~WrappedForwardIterator();
             WrappedForwardIterator(const WrappedForwardIterator &);
 
-            template <typename T_>
-            WrappedForwardIterator(const T_ &);
+            template <typename T_> WrappedForwardIterator(const T_ &);
 
             WrappedForwardIterator & operator= (const WrappedForwardIterator &);
 
@@ -61,10 +59,10 @@ namespace eos
             ///@name Standard library typedefs
             ///@{
 
-            using value_type = typename std::remove_reference<Value_>::type &;
-            using reference = typename std::remove_reference<Value_>::type &;
-            using pointer = typename std::remove_reference<Value_>::type *;
-            using difference_type = std::ptrdiff_t;
+            using value_type        = typename std::remove_reference<Value_>::type &;
+            using reference         = typename std::remove_reference<Value_>::type &;
+            using pointer           = typename std::remove_reference<Value_>::type *;
+            using difference_type   = std::ptrdiff_t;
             using iterator_category = std::forward_iterator_tag;
 
             ///@}
@@ -73,14 +71,14 @@ namespace eos
             ///@{
 
             WrappedForwardIterator & operator++ ();
-            WrappedForwardIterator operator++ (int);
+            WrappedForwardIterator   operator++ (int);
 
             ///@}
 
             ///@name Dereference
             ///@{
 
-            pointer operator-> () const;
+            pointer   operator->() const;
             reference operator* () const;
 
             ///@}
@@ -96,11 +94,11 @@ namespace eos
             ///@name Underlying iterator
             ///@{
 
-            template <typename T_> T_ & underlying_iterator();
+            template <typename T_> T_ &       underlying_iterator();
             template <typename T_> const T_ & underlying_iterator() const;
 
             ///@}
     };
-}
+} // namespace eos
 
 #endif


### PR DESCRIPTION
- a7e7440e5e61e1ad004f62fa24e75f76d1071334 Adapt the new coding style in ``eos/utils``. Prerequisite for the next commit.
- 98c1f5dbc60439fed377360a0627c71df564dc2d Enable running the ``clang-format`` hook on ``eos/utils``.

One further library adapted. Nine to go...