### PR TITLE
Allow the same variable to be fixed to several values in the same ExpressionObservable

### DIFF
--- a/eos/utils/expression-visitors.cc
+++ b/eos/utils/expression-visitors.cc
@@ -105,7 +105,7 @@ namespace eos::exp
     void
     ExpressionPrinter::operator() (ObservableExpression & e)
     {
-        _os << "ObservableExpression(" << e.observable->name() << ")";
+        _os << "ObservableExpression(" << e.observable->name();
         if (! e.kinematics_specification.aliases.empty())
         {
             auto a = e.kinematics_specification.aliases.cbegin();

--- a/eos/utils/expression-visitors.cc
+++ b/eos/utils/expression-visitors.cc
@@ -546,7 +546,6 @@ namespace eos::exp
             for (const auto & value : kinematics_values)
             {
                 kinematic_set.erase(value.first);
-                alias_set.insert(value.first);
             }
             for (const auto & alias : kinematics_aliases)
             {


### PR DESCRIPTION
@dvandyk, can you please check that my fix makes sense? I don't understand why a fixed kinematic value was added to the set of aliased kinematics.

Github: Fixes #1048