### PR TITLE
Changes applied after review of EOS-2024-04

### DIFF
--- a/eos/b-decays/bq-to-dq-psd.cc
+++ b/eos/b-decays/bq-to-dq-psd.cc
@@ -75,6 +75,8 @@ namespace eos
 
         UsedParameter mu;
 
+        UsedParameter DeltaP;
+
         RestrictedOption opt_accuracy;
         double switch_lo;
         double switch_nlo;
@@ -98,6 +100,7 @@ namespace eos
             f_P(p["decay-constant::" + stringify(opt_q.value() == QuarkFlavor::down ? "K_u" : "pi")], u),
             opt_cp_conjugate(o, options, "cp-conjugate"_ok),
             mu(p[stringify(opt_q.value() == QuarkFlavor::down ? "s" : "d") + "bcu::mu"], u),
+            DeltaP(p["B->DP::DeltaP"], u),
             opt_accuracy(o, options, "accuracy"_ok)
         {
             Context ctx("When constructing B_q->D_q P observable");
@@ -336,7 +339,7 @@ namespace eos
                     (4.0 * (wc.c10() - wc.c10p()) * (TVLL_nlp + (2.0 * f_3P * m_P * m_P * TTLL_nlp) / (f_P()* mb * mb * (mb - mc)))) / 9.0;
 
             // return sum of all contributions
-            return switch_lo * a_1_lo + switch_nlo * a_s_mu * a_1_nlo + switch_nlp * a_1_nlp;
+            return (switch_lo * a_1_lo + switch_nlo * a_s_mu * a_1_nlo + switch_nlp * a_1_nlp) * (1.0 + DeltaP);
         };
 
         double decay_width() const

--- a/eos/b-decays/bq-to-dstarq-psd.cc
+++ b/eos/b-decays/bq-to-dstarq-psd.cc
@@ -76,6 +76,8 @@ namespace eos
 
         UsedParameter mu;
 
+        UsedParameter DeltaV;
+
         RestrictedOption opt_accuracy;
         double switch_lo;
         double switch_nlo;
@@ -99,6 +101,7 @@ namespace eos
             f_P(p["decay-constant::" + stringify(opt_q.value() == QuarkFlavor::down ? "K_u" : "pi")], u),
             opt_cp_conjugate(o, options, "cp-conjugate"_ok),
             mu(p[stringify(opt_q.value() == QuarkFlavor::down ? "s" : "d") + "bcu::mu"], u),
+            DeltaV(p["B->DP::DeltaV"], u),
             opt_accuracy(o, options, "accuracy"_ok)
         {
             Context ctx("When constructing B_q->Dstar_q P observable");
@@ -367,7 +370,7 @@ namespace eos
                     (16.0 * (wc.c10() + wc.c10p()) * ((-2.0 * f_3P * m_P * m_P * TTLL_nlp) / (f_P * mb * mb * (mb + mc)) + TVLL_nlp)) / 9.0;
 
             // return sum of all contributions
-            return switch_lo * a_1_lo + switch_nlo * a_s_mu * a_1_nlo + switch_nlp * a_1_nlp;
+            return (switch_lo * a_1_lo + switch_nlo * a_s_mu * a_1_nlo + switch_nlp * a_1_nlp) * (1.0 + DeltaV);
         };
 
         double decay_width() const

--- a/eos/models/standard-model.cc
+++ b/eos/models/standard-model.cc
@@ -759,7 +759,7 @@ namespace eos
         // SM Wilson coefficients are real so cp conjugation has no effect
 
         // RGE
-        static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 10u> rge{
+        thread_local static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 10u> rge{
             // gamma_0: eigenvalues
             (2.0 / 3.0) * std::array<double, 10u>{ { -24.0, -12.0, 6.0, 3.0, (-17.0 - sqrt(241.0)), -24.0, (+1.0 + sqrt(241.0)), (+1.0 - sqrt(241.0)), 3.0, (-17 + sqrt(241.0)) } },
             // gamma_0: V
@@ -854,7 +854,7 @@ namespace eos
         // SM Wilson coefficients are real so cp conjugation has no effect
 
         // RGE
-        static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 10u> rge{
+        thread_local static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 10u> rge{
             // gamma_0: eigenvalues
             (2.0 / 3.0) * std::array<double, 10u>{ { -24.0, -12.0, 6.0, 3.0, (-17.0 - sqrt(241.0)), -24.0, (+1.0 + sqrt(241.0)), (+1.0 - sqrt(241.0)), 3.0, (-17 + sqrt(241.0)) } },
             // gamma_0: V

--- a/eos/parameters/hadronic-matrix-elements.yaml
+++ b/eos/parameters/hadronic-matrix-elements.yaml
@@ -5503,6 +5503,27 @@ groups:
           latex:   '$A_0^{B_s \to D_s^*}(q^2 = M_\pi^2)$'
   # }}}
 
+  #
+  # {{{
+  - title: 'Parameters parametrizing power corrections in non-leptonic class-I B decays'
+    description: ''
+    parameters:
+      # B->DP
+      'B->DP::DeltaP' :
+          central: 0
+          min:     0
+          max:     0
+          unit:    '1'
+          latex:   '$\Delta_P$'
+      # B->D^*P
+      'B->DP::DeltaV' :
+          central: 0
+          min:     0
+          max:     0
+          unit:    '1'
+          latex:   '$\Delta_V$'
+  # }}}
+
   # Miscellaneous Form Factor Parameters
   # {{{
   - title: 'Miscellaneous Form Factor Parameters'


### PR DESCRIPTION
- 6393d1979c5b7a04e3a18fb08f7004dc754b74b6 When evolving the Wilson coefficients from the high scale to the low scale in the ``StandardModel`` class, the RGE objects are declared as ``static``. However, this leaves us open to a race condition: when the coefficients are computed for the first time concurrently in two or more separate threads, the static initialization can occur simultaneously for the same object. This commit fixes the problem by declaring the RGE as ``thread_local static``.
- 2ca2ebbc0e5eead7ff2990c4a3ef20b473e846f2 Add two new parameters to represent unknown power corrections in class-I non-leptonic B decays.
- 3a732245927429a21fc8142feec915966f4477ae Use the two new parameters in B->DP and B->D^*P decay observables.