### PR TITLE
Change expected directory hierarchy for tasks

### DIFF
--- a/examples/analysis-organisation.ipynb
+++ b/examples/analysis-organisation.ipynb
@@ -319,7 +319,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = os.path.join(BASE_DIRECTORY, 'CKM-all', 'nested')\n",
+    "path = os.path.join(BASE_DIRECTORY, 'data', 'CKM-all', 'nested')\n",
     "ns_results = eos.data.DynestyResults(path)\n",
     "\n",
     "# Obtain dynesty results object\n",
@@ -407,7 +407,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = os.path.join(BASE_DIRECTORY, 'WET-all', 'nested')\n",
+    "path = os.path.join(BASE_DIRECTORY, 'data', 'WET-all', 'nested')\n",
     "ns_results = eos.data.DynestyResults(path)\n",
     "\n",
     "# Obtain dynesty results object\n",
@@ -468,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = eos.data.Prediction('./CKM-all/pred-leptonic-BR-CKM')\n",
+    "predictions = eos.data.Prediction('./data/CKM-all/pred-leptonic-BR-CKM')\n",
     "lo, mi, up = eos.Plotter._weighted_quantiles(\n",
     "        predictions.samples[:, 0], # Here 0 gives access to the prediction with the option l = e\n",
     "        [0.15865, 0.5, 0.84135],\n",
@@ -506,7 +506,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = eos.data.Prediction('./WET-all/pred-leptonic-BR-WET')\n",
+    "predictions = eos.data.Prediction('./data/WET-all/pred-leptonic-BR-WET')\n",
     "lo, mi, up = eos.Plotter._weighted_quantiles(\n",
     "        predictions.samples[:, 0], # Here 0 gives access to the prediction with the option l = e\n",
     "        [0.15865, 0.5, 0.84135],\n",
@@ -544,7 +544,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictions = eos.data.Prediction('./CKM-all/pred-R_pi')\n",
+    "predictions = eos.data.Prediction('./data/CKM-all/pred-R_pi')\n",
     "lo, mi, up = eos.Plotter._weighted_quantiles(\n",
     "        predictions.samples[:, 0], # Here 0 gives access to the prediction with the option l = e\n",
     "        [0.15865, 0.5, 0.84135],\n",
@@ -640,7 +640,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.9"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/examples/cli/btopilnu.analysis
+++ b/examples/cli/btopilnu.analysis
@@ -101,14 +101,14 @@ figures:
         label: 'Posterior Density'
       items:
       - type: 'histogram1D'
-        datafile: 'th+exp/samples'
+        datafile: 'data/th+exp/samples'
         variable: 'CKM::abs(V_ub)'
       - type: 'kde1D'
-        datafile: 'th+exp/samples'
+        datafile: 'data/th+exp/samples'
         variable: 'CKM::abs(V_ub)'
   - name: CKM-Vub-v-FF
     type: 'corner'
     contents:
-      - path: 'th+exp/samples'
+      - path: 'data/th+exp/samples'
         label: 'th+exp'
     variables: ['CKM::abs(V_ub)', 'B->pi::f_+(0)@BCL2008']

--- a/examples/cli/btopilnu.plot
+++ b/examples/cli/btopilnu.plot
@@ -15,7 +15,7 @@ contents:
       type: 'uncertainty'
       color: 'C0'
       opacity: 0.5
-      data-file: '/tmp/btopilnu/th+exp/pred-differential'
+      data-file: '/tmp/btopilnu/data/th+exp/pred-differential'
 
     - name: 'B->pi mu nu (V_ub inclusive)'
       type: 'observable'

--- a/examples/inference.ipynb
+++ b/examples/inference.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "EOS_BASE_DIRECTORY='./inference-data'"
+    "EOS_BASE_DIRECTORY='./inference-base'"
    ]
   },
   {
@@ -180,8 +180,8 @@
     "  xaxis: { label: '$|V_{cb}|$', range: [38.e-3, 47.e-3] }\n",
     "  legend: { position: 'upper left' }\n",
     "  items:\n",
-    "    - { type: 'histogram1D', variable: 'CKM::abs(V_cb)', datafile: './inference-data/CKM/samples', color: 'C0' }\n",
-    "    - { type: 'kde1D',       variable: 'CKM::abs(V_cb)', datafile: './inference-data/CKM/samples', color: 'C0',\n",
+    "    - { type: 'histogram1D', variable: 'CKM::abs(V_cb)', datafile: './inference-base/data/CKM/samples', color: 'C0' }\n",
+    "    - { type: 'kde1D',       variable: 'CKM::abs(V_cb)', datafile: './inference-base/data/CKM/samples', color: 'C0',\n",
     "        label: 'posterior'\n",
     "      }\n",
     "\"\"\"\n",
@@ -202,7 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parameter_samples = eos.data.ImportanceSamples(EOS_BASE_DIRECTORY+'/CKM/samples')"
+    "parameter_samples = eos.data.ImportanceSamples(EOS_BASE_DIRECTORY + '/data/CKM/samples')"
    ]
   },
   {
@@ -250,13 +250,13 @@
     "      }\n",
     "    - { type: 'kde2D', label: 'posterior', color: 'C1',\n",
     "        levels: [68, 95], contours: ['lines', 'areas'], bandwidth: 3.0,\n",
-    "        datafile: './inference-data/CKM/samples',\n",
+    "        datafile: './inference-base/data/CKM/samples',\n",
     "        variables: ['CKM::abs(V_cb)', 'B->D::alpha^f+_0@BSZ2015'],\n",
     "        label: 'Belle 2015 from $\\\\mathcal{B}(\\\\bar{B}\\\\to D \\\\ell \\\\bar{\\\\nu})$'\n",
     "      }\n",
     "\"\"\"\n",
     "figure = eos.figure.FigureFactory.from_yaml(figure_args)\n",
-    "figure.draw(output='./inference-data/fig-Vcb-v-fp0.pdf')"
+    "figure.draw(output=f'{EOS_BASE_DIRECTORY}/fig-Vcb-v-fp0.pdf')"
    ]
   },
   {
@@ -332,7 +332,7 @@
     "  items:\n",
     "    - { type: 'uncertainty', label: '$\\\\ell=e$',\n",
     "        variable: 'q2', range: [3.0e-7, 11.63],\n",
-    "        datafile: './inference-data/CKM/pred-B-to-D-e-nu',\n",
+    "        datafile: './inference-base/data/CKM/pred-B-to-D-e-nu',\n",
     "      }\n",
     "    - { type: 'constraint', 'constraints': 'B^0->D^+e^-nu::BRs@Belle:2015A',  observable: 'B->Dlnu::BR', label: 'Belle 2015 $\\\\ell=e,\\\\, q=d$',\n",
     "        variable: 'q2', rescale_by_width: true\n",

--- a/examples/predictions.ipynb
+++ b/examples/predictions.ipynb
@@ -293,7 +293,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "EOS_BASE_DIRECTORY='./predictions-data'"
+    "EOS_BASE_DIRECTORY='./predictions-base'"
    ]
   },
   {
@@ -372,7 +372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!tree ./predictions-data"
+    "!tree ./predictions-base"
    ]
   },
   {
@@ -388,7 +388,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output = eos.data.ImportanceSamples(EOS_BASE_DIRECTORY + '/DecayConstant/samples')\n",
+    "output = eos.data.ImportanceSamples(EOS_BASE_DIRECTORY + '/data/DecayConstant/samples')\n",
     "display(output.samples.shape)"
    ]
   },
@@ -421,7 +421,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!tree ./predictions-data"
+    "!tree ./predictions-base"
    ]
   },
   {
@@ -438,7 +438,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "prediction = eos.data.Prediction(EOS_BASE_DIRECTORY + '/DecayConstant/pred-Bc-to-tau-nu')\n",
+    "prediction = eos.data.Prediction(EOS_BASE_DIRECTORY + '/data/DecayConstant/pred-Bc-to-tau-nu')\n",
     "avg = np.average(prediction.samples[:, 0], weights=prediction.weights, axis=0)\n",
     "std = np.sqrt(np.average((prediction.samples[:, 0] - avg)**2, weights=prediction.weights, axis=0))\n",
     "print(f'BR(B_c->tau nu) = {100 * avg:.2f} +/- {100 * std:.2f} %')"
@@ -563,7 +563,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!tree -L 2 ./predictions-data"
+    "!tree -L 2 ./predictions-base"
    ]
   },
   {
@@ -604,11 +604,11 @@
     "  items:\n",
     "    - { type: 'uncertainty', label: '$\\\\ell=\\\\mu$',\n",
     "        variable: 'q2', range: [0.02, 11.63],\n",
-    "        datafile: './predictions-data/FF-LQCD-SSE/pred-B-to-D-mu-nu'\n",
+    "        datafile: './predictions-base/data/FF-LQCD-SSE/pred-B-to-D-mu-nu'\n",
     "      }\n",
     "    - { type: 'uncertainty', label: '$\\\\ell=\\\\tau$',\n",
     "        variable: 'q2', range: [3.17, 11.63], resolution: 1000,\n",
-    "        datafile: './predictions-data/FF-LQCD-SSE/pred-B-to-D-tau-nu'\n",
+    "        datafile: './predictions-base/data/FF-LQCD-SSE/pred-B-to-D-tau-nu'\n",
     "      }\n",
     "\"\"\"\n",
     "figure = eos.figure.FigureFactory.from_yaml(figure_args)\n",
@@ -645,7 +645,7 @@
     "  items:\n",
     "    - { type: 'uncertainty-binned', label: '$\\\\ell=\\\\mu$',\n",
     "        variable: 'q2', range: [0.00, 11.63],\n",
-    "        datafile: './predictions-data/FF-LQCD-SSE/pred-B-to-D-mu-nu-binned'\n",
+    "        datafile: './predictions-base/data/FF-LQCD-SSE/pred-B-to-D-mu-nu-binned'\n",
     "      }\n",
     "\"\"\"\n",
     "figure = eos.figure.FigureFactory.from_yaml(figure_args)\n",
@@ -662,7 +662,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "master",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/examples/pyhf_example.ipynb
+++ b/examples/pyhf_example.ipynb
@@ -168,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parameter_samples = eos.data.ImportanceSamples('./EXP-pyhf/samples')\n",
+    "parameter_samples = eos.data.ImportanceSamples('./data/EXP-pyhf/samples')\n",
     "\n",
     "mean = np.average(parameter_samples.samples[:,0], weights = parameter_samples.weights)\n",
     "std = np.sqrt(np.average((parameter_samples.samples[:,0]-mean)**2, weights = parameter_samples.weights))\n",
@@ -200,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mode = eos.data.Mode('./EXP-pyhf/mode-default')\n",
+    "mode = eos.data.Mode('./data/EXP-pyhf/mode-default')\n",
     "print(f'EOS posterior mode: $C_{{V_L}} = {mode.mode[0]:.3f}')\n",
     "print(f'pyhf best fit: $C_{{V_L}} = {np.sqrt(best_fit[1]):.3f}')"
    ]
@@ -236,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parameter_samples = eos.data.ImportanceSamples('./WET-pyhf/samples')\n",
+    "parameter_samples = eos.data.ImportanceSamples('./data/WET-pyhf/samples')\n",
     "\n",
     "mean = np.average(parameter_samples.samples[:,0], weights = parameter_samples.weights)\n",
     "std = np.sqrt(np.average((parameter_samples.samples[:,0]-mean)**2, weights = parameter_samples.weights))\n",

--- a/src/scripts/eos-analysis_TEST.d/analysis.yaml
+++ b/src/scripts/eos-analysis_TEST.d/analysis.yaml
@@ -91,15 +91,15 @@ figures:
         label: 'Posterior Density'
       items:
       - type: 'histogram1D'
-        datafile: 'CKM+FF/samples'
+        datafile: 'data/CKM+FF/samples'
         variable: 'CKM::abs(V_ub)'
       - type: 'kde1D'
-        datafile: 'CKM+FF/samples'
+        datafile: 'data/CKM+FF/samples'
         variable: 'CKM::abs(V_ub)'
   - name: CKM-Vub-v-FF
     type: 'corner'
     contents:
-      - path: 'CKM+FF/samples'
+      - path: 'data/CKM+FF/samples'
         label: 'CKM+FF'
     variables: ['CKM::abs(V_ub)', 'B->pi::f_+(0)@BCL2008']
 


### PR DESCRIPTION
Prior to this commit, tasks expect samples and other data produced by tasks to reside within ``EOS_BASE_DIRECTORY/POSTERIOR``. As of this commit, they will reside within ``EOS_BASE_DIRECTORY/data/POSTERIOR``, to mirror what is done for other outputs, such as reports and figures.

@mreboud We had discussed this at one point. Thought I'd PR it.