### PR TITLE
Add mappings for draw-figure task

### DIFF
--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -298,6 +298,9 @@ _task_argument_map = {
     # report
     ('report', 'TEMPLATE'): 'template',
     ('report', 'o'): 'output_file', ('report', 'output-file'): 'output_file', ('report', 'OUTPUT_FILE'): 'output_file',
+    # draw-figure
+    ('draw-figure', 'FIGURE'): 'figure_name', ('draw-figure', 'figure'): 'figure_name',
+    ('draw-figure', 'F'): 'format', ('draw-figure', 'FORMAT'): 'format',
 }
 
 @dataclass


### PR DESCRIPTION
As for other tasks, we map between what the argument is called on the command line and what the variable is called internally.
Right now you have to put
```yaml
steps:
  - title: 'Corner plot all posteriors'
    id: 'all.corner-plot'
    depends_on: [ 'all.sample' ]
    tasks:
      - task: 'draw-figure'
        arguments:
          figure_name: 'corner_1_1_4_4'
```
but you can only find `figure_name` in the code