### PR TITLE
WET Wilson coefficients for c->ull transitions

### DIFF
--- a/eos/models/ckm.cc
+++ b/eos/models/ckm.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2014-2025 Danny van Dyk
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -126,6 +127,8 @@ namespace eos
         SMComponent<components::WET::SBCU>(parameters, *this),
         // Hadronic sectors (Delta B = 2)
         SMComponent<components::WET::SBSB>(parameters, *this),
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        SMComponent<components::WET::UC>(parameters, *this),
         // Old-style WET sectors
         SMComponent<components::DeltaBS1>(parameters, *this)
     {

--- a/eos/models/ckm.hh
+++ b/eos/models/ckm.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2014-2025 Danny van Dyk
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -90,6 +91,8 @@ namespace eos
         public SMComponent<components::WET::SBCU>,
         // Hadronic sectors (Delta B = 2)
         public SMComponent<components::WET::SBSB>,
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        public SMComponent<components::WET::UC>,
         // Old-style WET sectors
         public SMComponent<components::DeltaBS1>
     {

--- a/eos/models/model.hh
+++ b/eos/models/model.hh
@@ -4,6 +4,7 @@
  * Copyright (c) 2010-2025 Danny van Dyk
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018 Christoph Bobeth
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -66,6 +67,9 @@ namespace eos
 
             // Hadronic sectors (Delta B = 2)
             struct SBSB;
+
+            // Neutral-current semileptonic sectors (Delta C = 1)
+            struct UC;
         } // namespace WET
 
         // Old-style WET sectors
@@ -202,6 +206,16 @@ namespace eos
             virtual WilsonCoefficients<wc::SBSB> wet_sbsb() const = 0;
     };
 
+    /*!
+     * Base class for the Delta C = 1 = -Delta U FCNC component of models.
+     */
+    template <> class ModelComponent<components::WET::UC>
+    {
+        public:
+            /* c->u Wilson coefficients */
+            virtual WilsonCoefficients<wc::UC> wilson_coefficients_uc(const LeptonFlavor & lepton_flavor, const bool & cp_conjugate = false) const = 0;
+    };
+
     /* Old-style WET sectors */
 
     /*!
@@ -236,6 +250,8 @@ namespace eos
         public virtual ModelComponent<components::WET::SBCU>,
         // Hadronic sectors (Delta B = 2)
         public virtual ModelComponent<components::WET::SBSB>,
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        public virtual ModelComponent<components::WET::UC>,
         // Old-style WET sectors
         public virtual ModelComponent<components::DeltaBS1>
     {

--- a/eos/models/standard-model.cc
+++ b/eos/models/standard-model.cc
@@ -1083,22 +1083,27 @@ namespace eos
         // RGE [dB:2017A] and [dBMS:2016A]
 
         // RGE mu_b < mu < mu_W
-        thread_local static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 2u> rgeW{ // gamma_0: eigenvalues
-                                                                                                           std::array<double, 2u>{ { -8., 4. } },
-                                                                                                           // gamma_0: V
-                                                                                                           { {
-                                                                                                               { { -3., 1.5 } },
-                                                                                                               { { 1., 1. } },
-                                                                                                           } },
-                                                                                                           // gamma_1
-                                                                                                           { {
-                                                                                                               { { -355.0 / 9.0, -502.0 / 27.0 } },
-                                                                                                               { { -35.0 / 3.0, -28.0 / 3.0 } },
-                                                                                                           } }
+        thread_local static const MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, 5u, 2u> rgeW{ // gamma_0: eigenvalues
+                                                                                                            std::array<double, 2u>{ { -8., 4. } },
+                                                                                                            // gamma_0: V
+                                                                                                            { {
+                                                                                                                { { -3., 1.5 } },
+                                                                                                                { { 1., 1. } },
+                                                                                                            } },
+                                                                                                            // gamma_1
+                                                                                                            { {
+                                                                                                                { { -355.0 / 9.0, -502.0 / 27.0 } },
+                                                                                                                { { -35.0 / 3.0, -28.0 / 3.0 } },
+                                                                                                            } },
+                                                                                                            // gamma_2
+                                                                                                            { {
+                                                                                                                { { -119.802, -489.936 } },
+                                                                                                                { { -1988.71, 36.7393 } },
+                                                                                                            } }
         };
 
         // RGE mu_c < mu < mu_b
-        thread_local static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 4u, 10u> rgeb{
+        thread_local static const MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, 4u, 10u> rgeb{
             // gamma_0: eigenvalues
             std::array<double, 10u>{ { -16.666666667, -16.6666666667, -14.0856421441, -8., -7.3333333333, -7.0020014176, -6., 5.7817459320, 4., 2.1947865186 } },
             // gamma_0: V
@@ -1126,6 +1131,19 @@ namespace eos
                 { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4832.0 / 81.0, 1352.0 / 27.0, 0.0, 0.0 } },
                 { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -308.0 / 3.0, 0.0 } },
                 { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, -308.0 / 3.0 } },
+            } },
+            // gamma_2
+            { {
+                { { -252.467, -447.27, -12.2288, -168.202, -2.55867, 4.05922, -1030.0 / 729.0, 9161.0 / 1944.0, 26.9223, 0.0 } },
+                { { -1856.71, 62.0726, 167.891, -77.6989, -15.8332, 15.9014, -10288.0 / 243.0, 2633.0 / 162.0, 174.497, 0.0 } },
+                { { 0.0, 0.0, -1718.26, -4501.33, 109.819, 289.682, -76000.0 / 243.0, 23143.0 / 81.0, 270.531, 0.0 } },
+                { { 0.0, 0.0, 731.265, -2724.14, -87.7522, 204.978, 37316.0 / 243.0, -25009.0 / 108.0, 312.357, 0.0 } },
+                { { 0.0, 0.0, -67977.3, -60351.6, 4812.95, 2121.09, -4064768.0 / 729.0, 2977916.0 / 243.0, 15098.6, 0.0 } },
+                { { 0.0, 0.0, 30427.5, -5196.21, -2671.1, -1654.85, 3675760.0 / 2187.0, -2941804.0 / 729.0, 727.757, 0.0 } },
+                { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 972.829, 0.0, 0.0, 0.0 } },
+                { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 212.741, -203.859, 0.0, 0.0 } },
+                { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -21943.0 / 27.0, 0.0 } },
+                { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -21943.0 / 27.0 } },
             } }
         };
 
@@ -1144,6 +1162,18 @@ namespace eos
         static const auto & beta4        = QCD::beta_function_nf_4;
         const double        alpha_s_mu_0 = QCD::alpha_s(_mu_0__uc, _alpha_s_Z__uc, _m_Z__uc, beta5);
 
+        // next-to-next-to-leading order in alpha_s
+        // calculate m_t at the matching scales in the MSbar scheme
+        const double alpha_s_m_t_pole   = QCD::alpha_s(_m_t_pole__uc, _alpha_s_Z__uc, _m_Z__uc, beta5);
+        const double m_t_msbar_m_t_pole = QCD::m_q_msbar(_m_t_pole__uc, alpha_s_m_t_pole, 5.0);
+        const double m_t_mu_0           = QCD::m_q_msbar(m_t_msbar_m_t_pole, alpha_s_m_t_pole, alpha_s_mu_0, beta5, QCD::gamma_m_nf_5);
+        const double x                  = m_t_mu_0 * m_t_mu_0 / (_m_W__uc * _m_W__uc);
+        const double T = -(16.0 * x + 8.0) * std::sqrt(4.0 * x - 1.0) * gsl_sf_clausen(2.0 * std::asin(1.0 / (2.0 * std::sqrt(x)))) + (16.0 * x + 20.0 / 3.0) * std::log(x)
+                         + 32.0 * x + 112.0 / 9.0;
+
+        const std::array<double, 2u> nnlo_unprimed = { -T + 7987.0 / 72.0 + 17.0 / 3.0 * M_PI * M_PI + 475.0 / 6.0 * L + 17.0 * L * L,
+                                                       127.0 / 18.0 + 4.0 / 3.0 * M_PI * M_PI + 46.0 / 3.0 * L + 4.0 * L * L };
+
         if (_mu__uc <= _mu_0b__uc)
         {
             const double alpha_s_mu_b  = QCD::alpha_s(_mu_0b__uc, _alpha_s_Z__uc, _m_Z__uc, beta5);
@@ -1153,15 +1183,18 @@ namespace eos
             const double as            = alpha_s_mu / (4.0 * M_PI);
 
             // evolve to mu_b
-            const auto _unprimed_interW = rgeW.evolve_intermediate(alpha_s_mu_b, alpha_s_mu_0, lo_unprimed, nlo_unprimed);
+            const auto _unprimed_interW = rgeW.evolve_intermediate(alpha_s_mu_b, alpha_s_mu_0, lo_unprimed, nlo_unprimed, nnlo_unprimed);
 
             // matching at mu_b
             std::array<double, 10u> lo_unprimed_b;
             std::array<double, 10u> nlo_unprimed_b;
+            std::array<double, 10u> nnlo_unprimed_b;
             lo_unprimed_b.fill(0.0);
             nlo_unprimed_b.fill(0.0);
+            nnlo_unprimed_b.fill(0.0);
             std::copy(std::get<0>(_unprimed_interW).begin(), std::get<0>(_unprimed_interW).end(), lo_unprimed_b.begin());
             std::copy(std::get<1>(_unprimed_interW).begin(), std::get<1>(_unprimed_interW).end(), nlo_unprimed_b.begin());
+            std::copy(std::get<2>(_unprimed_interW).begin(), std::get<2>(_unprimed_interW).end(), nnlo_unprimed_b.begin());
 
             double       m_b_MSbar         = _m_b_MSbar__uc;
             double       alpha_s_m_b_MSbar = QCD::alpha_s(_mu_0b__uc, _alpha_s_Z__uc, _m_Z__uc, beta5);
@@ -1171,13 +1204,18 @@ namespace eos
             nlo_unprimed_b[3] += (1.0 / 9.0) * (1 - LogB) * lo_unprimed_b[0] - (2.0 / 3.0) * (1 - LogB) * lo_unprimed_b[1];
             nlo_unprimed_b[8] += (-8.0 / 27.0) * (1 - LogB) * lo_unprimed_b[0] - (2.0 / 9.0) * (1 - LogB) * lo_unprimed_b[1];
 
+            nnlo_unprimed_b[0] += (2.0 / 3.0) * LogB * LogB * nlo_unprimed_b[0] + (59.0 / 54.0 + 148.0 / 81.0 * LogB + 2.0 / 3.0 * LogB * LogB) * lo_unprimed_b[0]
+                                  - (59.0 / 18.0 + 104.0 / 27.0 * LogB + 2.0 * LogB * LogB) * lo_unprimed_b[1];
+            nnlo_unprimed_b[1] += (2.0 / 3.0) * LogB * LogB * nlo_unprimed_b[1] + (-59.0 / 81.0 + 176.0 / 243.0 * LogB - 4.0 / 9.0 * LogB * LogB) * lo_unprimed_b[0]
+                                  - 220.0 / 81.0 * LogB * lo_unprimed_b[1];
+
             // evolve to mu
-            const auto _unprimed_inter = rgeb.evolve_intermediate(alpha_s_mu, alpha_s_mu_b4, lo_unprimed_b, nlo_unprimed_b);
+            const auto _unprimed_inter = rgeb.evolve_intermediate(alpha_s_mu, alpha_s_mu_b4, lo_unprimed_b, nlo_unprimed_b, nnlo_unprimed_b);
 
             std::array<double, 10u> _unprimed;
             for (unsigned i = 0; i < 10u; ++i)
             {
-                _unprimed[i] = std::get<0>(_unprimed_inter)[i] + as * std::get<1>(_unprimed_inter)[i];
+                _unprimed[i] = std::get<0>(_unprimed_inter)[i] + as * std::get<1>(_unprimed_inter)[i] + +as * as * std::get<2>(_unprimed_inter)[i];
             }
 
             std::copy(_unprimed.begin(), _unprimed.end(), wc._sm_like_coefficients.begin());
@@ -1190,12 +1228,12 @@ namespace eos
             wc._alpha_s             = alpha_s_mu;
             const double as         = alpha_s_mu / (4.0 * M_PI);
 
-            const auto _unprimed_inter = rgeW.evolve_intermediate(alpha_s_mu, alpha_s_mu_0, lo_unprimed, nlo_unprimed);
+            const auto _unprimed_inter = rgeW.evolve_intermediate(alpha_s_mu, alpha_s_mu_0, lo_unprimed, nlo_unprimed, nnlo_unprimed);
 
             std::array<double, 2u> _unprimed;
             for (unsigned i = 0; i < 2u; ++i)
             {
-                _unprimed[i] = std::get<0>(_unprimed_inter)[i] + as * std::get<1>(_unprimed_inter)[i];
+                _unprimed[i] = std::get<0>(_unprimed_inter)[i] + as * std::get<1>(_unprimed_inter)[i] + as * as * std::get<2>(_unprimed_inter)[i];
             }
 
             std::copy(_unprimed.begin(), _unprimed.end(), wc._sm_like_coefficients.begin());

--- a/eos/models/standard-model.cc
+++ b/eos/models/standard-model.cc
@@ -5,6 +5,7 @@
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018, 2021 Christoph Bobeth
  * Copyright (c) 2022 Philip Lüghausen
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -1058,6 +1059,26 @@ namespace eos
         return wc;
     }
 
+    SMComponent<components::WET::UC>::SMComponent(const Parameters & p, ParameterUser & u) :
+        _alpha_s_Z__uc(p["QCD::alpha_s(MZ)"], u),
+        _mu_t__uc(p["QCD::mu_t"], u),
+        _mu_b__uc(p["QCD::mu_b"], u),
+        _mu_c__uc(p["QCD::mu_c"], u),
+        _sw2__uc(p["GSW::sin^2(theta)"], u),
+        _m_t_pole__uc(p["mass::t(pole)"], u),
+        _m_W__uc(p["mass::W"], u),
+        _m_Z__uc(p["mass::Z"], u),
+        _mu_0__uc(p["uc::mu_0"], u),
+        _mu_0b__uc(p["uc::mu_b"], u),
+        _mu__uc(p["uc::mu"], u)
+    {
+    }
+
+    WilsonCoefficients<wc::UC>
+    SMComponent<components::WET::UC>::wilson_coefficients_uc(const LeptonFlavor & /*lepton_flavor*/, const bool & /*cp_conjugate*/) const
+    {
+    }
+
     /* Old-style WET sectors */
 
     SMComponent<components::DeltaBS1>::SMComponent(const Parameters & p, ParameterUser & u) :
@@ -1273,6 +1294,8 @@ namespace eos
         SMComponent<components::WET::SBCU>(p, *this),
         // Hadronic sectors (Delta B = 2)
         SMComponent<components::WET::SBSB>(p, *this),
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        SMComponent<components::WET::UC>(p, *this),
         // Old-style WET sectors
         SMComponent<components::DeltaBS1>(p, *this)
     {

--- a/eos/models/standard-model.cc
+++ b/eos/models/standard-model.cc
@@ -1068,6 +1068,7 @@ namespace eos
         _m_t_pole__uc(p["mass::t(pole)"], u),
         _m_W__uc(p["mass::W"], u),
         _m_Z__uc(p["mass::Z"], u),
+        _m_b_MSbar__uc(p["mass::b(MSbar)"], u),
         _mu_0__uc(p["uc::mu_0"], u),
         _mu_0b__uc(p["uc::mu_b"], u),
         _mu__uc(p["uc::mu"], u)
@@ -1077,6 +1078,130 @@ namespace eos
     WilsonCoefficients<wc::UC>
     SMComponent<components::WET::UC>::wilson_coefficients_uc(const LeptonFlavor & /*lepton_flavor*/, const bool & /*cp_conjugate*/) const
     {
+        // SM Wilson coefficients are real so cp conjugation has no effect
+
+        // RGE [dB:2017A] and [dBMS:2016A]
+
+        // RGE mu_b < mu < mu_W
+        thread_local static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 2u> rgeW{ // gamma_0: eigenvalues
+                                                                                                           std::array<double, 2u>{ { -8., 4. } },
+                                                                                                           // gamma_0: V
+                                                                                                           { {
+                                                                                                               { { -3., 1.5 } },
+                                                                                                               { { 1., 1. } },
+                                                                                                           } },
+                                                                                                           // gamma_1
+                                                                                                           { {
+                                                                                                               { { -355.0 / 9.0, -502.0 / 27.0 } },
+                                                                                                               { { -35.0 / 3.0, -28.0 / 3.0 } },
+                                                                                                           } }
+        };
+
+        // RGE mu_c < mu < mu_b
+        thread_local static const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 4u, 10u> rgeb{
+            // gamma_0: eigenvalues
+            std::array<double, 10u>{ { -16.666666667, -16.6666666667, -14.0856421441, -8., -7.3333333333, -7.0020014176, -6., 5.7817459320, 4., 2.1947865186 } },
+            // gamma_0: V
+            { {
+                { { 0., 0., 0., 24., 0., 0., 0., 0., 11.625, 0. } },
+                { { 0., 0., 0., -8., 0., 0., 0., 0., 7.75, 0. } },
+                { { 0., 0., -7.86200331176, 4. / 3., 0.0, -2.32053410133, 0., 1.86661383453, 0.43055555556, -6.14066447729 } },
+                { { 0., 0., -47.7743291687, -4., 0., 1.80863211686, 0., -0.355178772878, 0.64583333333, 5.56529680325 } },
+                { { 0., 0., 0.380512010965, -1. / 3., 0., 0.427158994274, 0., -0.276300647008, -0.1076388888889, 0.325556486776 } },
+                { { 0., 0., 3.57148781283, 1., 0., -0.853830985457, 0., -0.323919654625, -0.1614583333, -0.395761107980 } },
+                { { 0., 0., 0., 0., -5.33333333333, 0., 1., 0., 0., 0. } },
+                { { 0., 0., 0., 0., 1., 0., 0., 0., 0., 0. } },
+                { { 0., 1., 1., 0., 0., 1., 0., 1., 1., 1. } },
+                { { 1., 0., 0., 0., 0., 0., 0., 0., 0., 0. } },
+            } },
+            // gamma_1
+            { {
+                { { -371.0 / 9.0, -542.0 / 27.0, -1412.0 / 243.0, -1369.0 / 243.0, 134.0 / 243.0, -35.0 / 162.0, 140.0 / 243.0, 167.0 / 162.0, 872.0 / 729.0, 0.0 } },
+                { { -55.0 / 3.0, -28.0 / 3.0, -416.0 / 81.0, 1280.0 / 81.0, 56.0 / 81.0, 35.0 / 27.0, -280.0 / 81.0, 76.0 / 27.0, -448.0 / 243.0, 0.0 } },
+                { { 0.0, 0.0, -4468.0 / 81.0, -31001.0 / 81.0, 400.0 / 81.0, 3397.0 / 108.0, -128.0 / 81.0, 368.0 / 27.0, 3136.0 / 243.0, 0.0 } },
+                { { 0.0, 0.0, -9262.0 / 243.0, -63401.0 / 243.0, 317.0 / 486.0, 13019.0 / 648.0, 592.0 / 243.0, -649.0 / 81.0, 21856.0 / 729.0, 0.0 } },
+                { { 0.0, 0.0, -250240.0 / 81.0, -108848.0 / 81.0, 23692.0 / 81.0, 5662.0 / 27.0, 12928.0 / 81.0, 12080.0 / 27.0, 64384.0 / 243.0, 0.0 } },
+                { { 0.0, 0.0, 62432.0 / 243.0, -26840.0 / 243.0, -15524.0 / 243.0, -6283.0 / 162.0, 40288.0 / 243.0, -3400.0 / 81.0, 246976.0 / 729.0, 0.0 } },
+                { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2140.0 / 27.0, 0.0, 0.0, 0.0 } },
+                { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4832.0 / 81.0, 1352.0 / 27.0, 0.0, 0.0 } },
+                { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -308.0 / 3.0, 0.0 } },
+                { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, -308.0 / 3.0 } },
+            } }
+        };
+
+        WilsonCoefficients<wc::UC> wc(0.0);
+        wc._sm_like_coefficients.fill(complex<double>(0.0));
+        wc._primed_coefficients.fill(complex<double>(0.0));
+
+        // only unprimed WCs are non-zero in the SM
+        // leading order in alpha_s
+        const std::array<double, 2u> lo_unprimed  = { 0.0, 1.0 };
+        // next-to-leading order in alpha_s
+        const double                 L            = 2.0 * std::log(_mu_0__uc / _m_W__uc);
+        const std::array<double, 2u> nlo_unprimed = { +15.0 + 6.0 * L, 0.0 };
+
+        static const auto & beta5        = QCD::beta_function_nf_5;
+        static const auto & beta4        = QCD::beta_function_nf_4;
+        const double        alpha_s_mu_0 = QCD::alpha_s(_mu_0__uc, _alpha_s_Z__uc, _m_Z__uc, beta5);
+
+        if (_mu__uc <= _mu_0b__uc)
+        {
+            const double alpha_s_mu_b  = QCD::alpha_s(_mu_0b__uc, _alpha_s_Z__uc, _m_Z__uc, beta5);
+            const double alpha_s_mu_b4 = QCD::alpha_s(_mu_0b__uc, alpha_s_mu_b, _mu_0b__uc, beta4);
+            const double alpha_s_mu    = QCD::alpha_s(_mu__uc, alpha_s_mu_b, _mu_0b__uc, beta4);
+            wc._alpha_s                = alpha_s_mu;
+            const double as            = alpha_s_mu / (4.0 * M_PI);
+
+            // evolve to mu_b
+            const auto _unprimed_interW = rgeW.evolve_intermediate(alpha_s_mu_b, alpha_s_mu_0, lo_unprimed, nlo_unprimed);
+
+            // matching at mu_b
+            std::array<double, 10u> lo_unprimed_b;
+            std::array<double, 10u> nlo_unprimed_b;
+            lo_unprimed_b.fill(0.0);
+            nlo_unprimed_b.fill(0.0);
+            std::copy(std::get<0>(_unprimed_interW).begin(), std::get<0>(_unprimed_interW).end(), lo_unprimed_b.begin());
+            std::copy(std::get<1>(_unprimed_interW).begin(), std::get<1>(_unprimed_interW).end(), nlo_unprimed_b.begin());
+
+            double       m_b_MSbar         = _m_b_MSbar__uc;
+            double       alpha_s_m_b_MSbar = QCD::alpha_s(_mu_0b__uc, _alpha_s_Z__uc, _m_Z__uc, beta5);
+            const double mb                = QCD::m_q_msbar(m_b_MSbar, alpha_s_m_b_MSbar, alpha_s_mu_b, QCD::beta_function_nf_5, QCD::gamma_m_nf_5);
+            const double LogB              = 2.0 * std::log(_mu_0b__uc / mb);
+
+            nlo_unprimed_b[3] += (1.0 / 9.0) * (1 - LogB) * lo_unprimed_b[0] - (2.0 / 3.0) * (1 - LogB) * lo_unprimed_b[1];
+            nlo_unprimed_b[8] += (-8.0 / 27.0) * (1 - LogB) * lo_unprimed_b[0] - (2.0 / 9.0) * (1 - LogB) * lo_unprimed_b[1];
+
+            // evolve to mu
+            const auto _unprimed_inter = rgeb.evolve_intermediate(alpha_s_mu, alpha_s_mu_b4, lo_unprimed_b, nlo_unprimed_b);
+
+            std::array<double, 10u> _unprimed;
+            for (unsigned i = 0; i < 10u; ++i)
+            {
+                _unprimed[i] = std::get<0>(_unprimed_inter)[i] + as * std::get<1>(_unprimed_inter)[i];
+            }
+
+            std::copy(_unprimed.begin(), _unprimed.end(), wc._sm_like_coefficients.begin());
+
+            return wc;
+        }
+        else
+        {
+            const double alpha_s_mu = QCD::alpha_s(_mu__uc, _alpha_s_Z__uc, _m_Z__uc, beta5);
+            wc._alpha_s             = alpha_s_mu;
+            const double as         = alpha_s_mu / (4.0 * M_PI);
+
+            const auto _unprimed_inter = rgeW.evolve_intermediate(alpha_s_mu, alpha_s_mu_0, lo_unprimed, nlo_unprimed);
+
+            std::array<double, 2u> _unprimed;
+            for (unsigned i = 0; i < 2u; ++i)
+            {
+                _unprimed[i] = std::get<0>(_unprimed_inter)[i] + as * std::get<1>(_unprimed_inter)[i];
+            }
+
+            std::copy(_unprimed.begin(), _unprimed.end(), wc._sm_like_coefficients.begin());
+
+            return wc;
+        }
     }
 
     /* Old-style WET sectors */

--- a/eos/models/standard-model.hh
+++ b/eos/models/standard-model.hh
@@ -273,6 +273,7 @@ namespace eos
             UsedParameter _m_t_pole__uc;
             UsedParameter _m_W__uc;
             UsedParameter _m_Z__uc;
+            UsedParameter _m_b_MSbar__uc;
 
             /* Matching scales */
             UsedParameter _mu_0__uc;

--- a/eos/models/standard-model.hh
+++ b/eos/models/standard-model.hh
@@ -4,6 +4,7 @@
  * Copyright (c) 2010-2025 Danny van Dyk
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018 Christoph Bobeth
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -256,6 +257,35 @@ namespace eos
             virtual WilsonCoefficients<wc::SBSB> wet_sbsb() const;
     };
 
+    template <> class SMComponent<components::WET::UC> : public virtual ModelComponent<components::WET::UC>
+    {
+        private:
+            /* QCD parameters */
+            UsedParameter _alpha_s_Z__uc;
+            UsedParameter _mu_t__uc;
+            UsedParameter _mu_b__uc;
+            UsedParameter _mu_c__uc;
+
+            /* GSW parameters */
+            UsedParameter _sw2__uc;
+
+            /* Masses */
+            UsedParameter _m_t_pole__uc;
+            UsedParameter _m_W__uc;
+            UsedParameter _m_Z__uc;
+
+            /* Matching scales */
+            UsedParameter _mu_0__uc;
+            UsedParameter _mu_0b__uc;
+            UsedParameter _mu__uc;
+
+        public:
+            SMComponent(const Parameters &, ParameterUser &);
+
+            /* c->u Wilson coefficients */
+            virtual WilsonCoefficients<wc::UC> wilson_coefficients_uc(const LeptonFlavor & lepton_flavor, const bool & cp_conjugate) const;
+    };
+
     /* Old-style WET sectors */
 
     template <> class SMComponent<components::DeltaBS1> : public virtual ModelComponent<components::DeltaBS1>
@@ -305,6 +335,8 @@ namespace eos
         public SMComponent<components::WET::SBCU>,
         // Hadronic sectors (Delta B = 2)
         public SMComponent<components::WET::SBSB>,
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        public SMComponent<components::WET::UC>,
         // Old-style WET sectors
         public SMComponent<components::DeltaBS1>
     {

--- a/eos/models/standard-model_TEST.cc
+++ b/eos/models/standard-model_TEST.cc
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2010-2025 Danny van Dyk
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -447,6 +448,160 @@ class WilsonCoefficientsBToSTest : public TestCase
             }
         }
 } wilson_coefficients_b_to_s_test;
+
+class WilsonCoefficientsUCTest : public TestCase
+{
+    public:
+        WilsonCoefficientsUCTest() :
+            TestCase("wilson_coefficients_uc_test")
+        {
+        }
+
+        virtual void
+        run() const
+        {
+            /* Test for 5 active flavors, evolving from mu_0 = 80.398 to mu = 80.398 */
+            {
+                static const double eps = 1e-5;
+                static const double mu  = 80.398;
+
+                Parameters parameters  = reference_parameters();
+                parameters["uc::mu"]   = mu;
+                parameters["uc::mu_0"] = mu;
+                parameters["uc::mu_b"] = 0.0;
+                StandardModel model(parameters);
+
+                WilsonCoefficients<wc::UC> wc = model.wilson_coefficients_uc(LeptonFlavor::muon, false);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), +0.143143, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()), +0.0, eps);
+            }
+
+            /* Test for 5 active flavors, evolving from mu_0 = 80.398 to mu = 4.18 */
+            {
+                static const double eps = 1e-5;
+                static const double mu  = 4.18;
+
+                Parameters parameters  = reference_parameters();
+                parameters["uc::mu"]   = mu;
+                parameters["uc::mu_0"] = 80.398;
+                parameters["uc::mu_b"] = 0.0;
+                StandardModel model(parameters);
+
+                WilsonCoefficients<wc::UC> wc = model.wilson_coefficients_uc(LeptonFlavor::muon, false);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.322704, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.00931, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()), +0.0, eps);
+            }
+
+            /* Test matching from 5 active flavors to 4 active flavors, evolving from mu_0 = 80.398 to mu = 4.18 */
+            {
+                static const double eps = 1e-5;
+                static const double mu  = 4.18;
+
+                Parameters parameters  = reference_parameters();
+                parameters["uc::mu"]   = mu;
+                parameters["uc::mu_0"] = 80.398;
+                parameters["uc::mu_b"] = mu;
+                StandardModel model(parameters);
+
+                WilsonCoefficients<wc::UC> wc = model.wilson_coefficients_uc(LeptonFlavor::muon, false);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.322236, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.00927, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), -0.0134116, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()) * wc._alpha_s / (4.0 * M_PI), -0.00126266, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()), +0.0, eps);
+            }
+
+            /* Test for 4 active flavors, evolving from mu_0 = 80.398 to mu = 2 */
+            {
+                static const double eps = 1e-5;
+                static const double mu  = 1.275;
+
+                Parameters parameters  = reference_parameters();
+                parameters["uc::mu"]   = mu;
+                parameters["uc::mu_0"] = 80.398;
+                parameters["uc::mu_b"] = 4.18;
+                StandardModel model(parameters);
+
+                TEST_CHECK_NEARLY_EQUAL(model.alpha_s(mu), +0.3890153724544784, eps);
+
+                WilsonCoefficients<wc::UC> wc = model.wilson_coefficients_uc(LeptonFlavor::muon, false);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.731053, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.03993, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), -0.00686138, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), -0.0981417, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.000445031, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()), +0.000644389, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()) * wc._alpha_s / (4.0 * M_PI), +0.00379697, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()) * wc._alpha_s / (4.0 * M_PI), -0.0021484, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()) * wc._alpha_s / (4.0 * M_PI), -0.00984944, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()), +0.122692956, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()), -0.069421972, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()), -0.318268105, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c10()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c3()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c4()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c5()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c6()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c7()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c8()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c9()), +0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(imag(wc.c10()), +0.0, eps);
+            }
+        }
+} wilson_coefficients_c_to_u_test;
 
 class WilsonCoefficientsUSLNUTest : public TestCase
 {

--- a/eos/models/standard-model_TEST.cc
+++ b/eos/models/standard-model_TEST.cc
@@ -472,8 +472,8 @@ class WilsonCoefficientsUCTest : public TestCase
                 StandardModel model(parameters);
 
                 WilsonCoefficients<wc::UC> wc = model.wilson_coefficients_uc(LeptonFlavor::muon, false);
-                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), +0.143143, eps);
-                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.0, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), +0.1582722277, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.001840898, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.0, eps);
@@ -506,8 +506,8 @@ class WilsonCoefficientsUCTest : public TestCase
                 StandardModel model(parameters);
 
                 WilsonCoefficients<wc::UC> wc = model.wilson_coefficients_uc(LeptonFlavor::muon, false);
-                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.322704, eps);
-                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.00931, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.2887762145, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.010189030, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.0, eps);
@@ -540,15 +540,15 @@ class WilsonCoefficientsUCTest : public TestCase
                 StandardModel model(parameters);
 
                 WilsonCoefficients<wc::UC> wc = model.wilson_coefficients_uc(LeptonFlavor::muon, false);
-                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.322236, eps);
-                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.00927, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.2894013188, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.010285004, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), +0.0, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), -0.0134116, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), -0.01341164772, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c6()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c7()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c8()), +0.0, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()) * wc._alpha_s / (4.0 * M_PI), -0.00126266, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()) * wc._alpha_s / (4.0 * M_PI), -0.001262659765, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c10()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()), +0.0, eps);
@@ -576,18 +576,18 @@ class WilsonCoefficientsUCTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(model.alpha_s(mu), +0.3890153724544784, eps);
 
                 WilsonCoefficients<wc::UC> wc = model.wilson_coefficients_uc(LeptonFlavor::muon, false);
-                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.731053, eps);
-                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.03993, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), -0.00686138, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), -0.0981417, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.000445031, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()), +0.000644389, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()) * wc._alpha_s / (4.0 * M_PI), +0.00379697, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()) * wc._alpha_s / (4.0 * M_PI), -0.0021484, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()) * wc._alpha_s / (4.0 * M_PI), -0.00984944, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()), +0.122692956, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()), -0.069421972, eps);
-                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()), -0.318268105, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c1()), -0.6511905155, eps);
+                TEST_CHECK_RELATIVE_ERROR(real(wc.c2()), +1.035740588, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c3()), -0.008919680307, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c4()), -0.09917618128, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c5()), +0.0005431321897, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c6()), +0.001012196678, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()) * wc._alpha_s / (4.0 * M_PI), +0.003983767585, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()) * wc._alpha_s / (4.0 * M_PI), -0.002502911933, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()) * wc._alpha_s / (4.0 * M_PI), -0.01378272104, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c7()), +0.1287292333, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c8()), -0.08087769358, eps);
+                TEST_CHECK_NEARLY_EQUAL(real(wc.c9()), -0.4453671240, eps);
                 TEST_CHECK_NEARLY_EQUAL(real(wc.c10()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(imag(wc.c1()), +0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(imag(wc.c2()), +0.0, eps);

--- a/eos/models/wet.cc
+++ b/eos/models/wet.cc
@@ -5,6 +5,7 @@
  * Copyright (c) 2014 Frederik Beaujean
  * Copyright (c) 2014, 2018 Christoph Bobeth
  * Copyright (c) 2018 Ahmet Kokulu
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -768,6 +769,208 @@ namespace eos
         return result;
     }
 
+    /* c->u Wilson coefficients */
+    WilsonScanComponent<components::WET::UC>::WilsonScanComponent(const Parameters & p, const Options &, ParameterUser & u) :
+        _alpha_s_Z__uc(p["QCD::alpha_s(MZ)"], u),
+        _mu_b__uc(p["QCD::mu_b"], u),
+        _m_Z__uc(p["mass::Z"], u),
+        _mu__uc(p["uc::mu"], u),
+        /* c->u */
+        _re_c1(p["uc::Re{c1}"], u),
+        _im_c1(p["uc::Im{c1}"], u),
+        _re_c2(p["uc::Re{c2}"], u),
+        _im_c2(p["uc::Im{c2}"], u),
+        _re_c3(p["uc::Re{c3}"], u),
+        _im_c3(p["uc::Im{c3}"], u),
+        _re_c4(p["uc::Re{c4}"], u),
+        _im_c4(p["uc::Im{c4}"], u),
+        _re_c5(p["uc::Re{c5}"], u),
+        _im_c5(p["uc::Im{c5}"], u),
+        _re_c6(p["uc::Re{c6}"], u),
+        _im_c6(p["uc::Im{c6}"], u),
+        _re_c7(p["uc::Re{c7}"], u),
+        _im_c7(p["uc::Im{c7}"], u),
+        _re_c7prime(p["uc::Re{c7'}"], u),
+        _im_c7prime(p["uc::Im{c7'}"], u),
+        _re_c8(p["uc::Re{c8}"], u),
+        _im_c8(p["uc::Im{c8}"], u),
+        _re_c8prime(p["uc::Re{c8'}"], u),
+        _im_c8prime(p["uc::Im{c8'}"], u),
+        /* c->uee */
+        _e_re_c9(p["ucee::Re{c9}"], u),
+        _e_im_c9(p["ucee::Im{c9}"], u),
+        _e_re_c10(p["ucee::Re{c10}"], u),
+        _e_im_c10(p["ucee::Im{c10}"], u),
+        _e_re_c9prime(p["ucee::Re{c9'}"], u),
+        _e_im_c9prime(p["ucee::Im{c9'}"], u),
+        _e_re_c10prime(p["ucee::Re{c10'}"], u),
+        _e_im_c10prime(p["ucee::Im{c10'}"], u),
+        _e_re_cS(p["ucee::Re{cS}"], u),
+        _e_im_cS(p["ucee::Im{cS}"], u),
+        _e_re_cSprime(p["ucee::Re{cS'}"], u),
+        _e_im_cSprime(p["ucee::Im{cS'}"], u),
+        _e_re_cP(p["ucee::Re{cP}"], u),
+        _e_im_cP(p["ucee::Im{cP}"], u),
+        _e_re_cPprime(p["ucee::Re{cP'}"], u),
+        _e_im_cPprime(p["ucee::Im{cP'}"], u),
+        _e_re_cT(p["ucee::Re{cT}"], u),
+        _e_im_cT(p["ucee::Im{cT}"], u),
+        _e_re_cT5(p["ucee::Re{cT5}"], u),
+        _e_im_cT5(p["ucee::Im{cT5}"], u),
+        /* c->umumu */
+        _mu_re_c9(p["ucmumu::Re{c9}"], u),
+        _mu_im_c9(p["ucmumu::Im{c9}"], u),
+        _mu_re_c10(p["ucmumu::Re{c10}"], u),
+        _mu_im_c10(p["ucmumu::Im{c10}"], u),
+        _mu_re_c9prime(p["ucmumu::Re{c9'}"], u),
+        _mu_im_c9prime(p["ucmumu::Im{c9'}"], u),
+        _mu_re_c10prime(p["ucmumu::Re{c10'}"], u),
+        _mu_im_c10prime(p["ucmumu::Im{c10'}"], u),
+        _mu_re_cS(p["ucmumu::Re{cS}"], u),
+        _mu_im_cS(p["ucmumu::Im{cS}"], u),
+        _mu_re_cSprime(p["ucmumu::Re{cS'}"], u),
+        _mu_im_cSprime(p["ucmumu::Im{cS'}"], u),
+        _mu_re_cP(p["ucmumu::Re{cP}"], u),
+        _mu_im_cP(p["ucmumu::Im{cP}"], u),
+        _mu_re_cPprime(p["ucmumu::Re{cP'}"], u),
+        _mu_im_cPprime(p["ucmumu::Im{cP'}"], u),
+        _mu_re_cT(p["ucmumu::Re{cT}"], u),
+        _mu_im_cT(p["ucmumu::Im{cT}"], u),
+        _mu_re_cT5(p["ucmumu::Re{cT5}"], u),
+        _mu_im_cT5(p["ucmumu::Im{cT5}"], u),
+
+        /* functions for four-quark and gluon operators */
+        _c1(std::bind(&wcimplementation::cartesian, _re_c1, _im_c1)),
+        _c2(std::bind(&wcimplementation::cartesian, _re_c2, _im_c2)),
+        _c3(std::bind(&wcimplementation::cartesian, _re_c3, _im_c3)),
+        _c4(std::bind(&wcimplementation::cartesian, _re_c4, _im_c4)),
+        _c5(std::bind(&wcimplementation::cartesian, _re_c5, _im_c5)),
+        _c6(std::bind(&wcimplementation::cartesian, _re_c6, _im_c6)),
+        _c8(std::bind(&wcimplementation::cartesian, _re_c8, _im_c8)),
+        _c8prime(std::bind(&wcimplementation::cartesian, _re_c8prime, _im_c8prime)),
+
+        /* functions for c->ugamma */
+        _c7(std::bind(&wcimplementation::cartesian, _re_c7, _im_c7)),
+        _c7prime(std::bind(&wcimplementation::cartesian, _re_c7prime, _im_c7prime)),
+
+        /* functions for c->uee */
+        _e_c9(std::bind(&wcimplementation::cartesian, _e_re_c9, _e_im_c9)),
+        _e_c10(std::bind(&wcimplementation::cartesian, _e_re_c10, _e_im_c10)),
+        _e_c9prime(std::bind(&wcimplementation::cartesian, _e_re_c9prime, _e_im_c9prime)),
+        _e_c10prime(std::bind(&wcimplementation::cartesian, _e_re_c10prime, _e_im_c10prime)),
+        _e_cS(std::bind(&wcimplementation::cartesian, _e_re_cS, _e_im_cS)),
+        _e_cSprime(std::bind(&wcimplementation::cartesian, _e_re_cSprime, _e_im_cSprime)),
+        _e_cP(std::bind(&wcimplementation::cartesian, _e_re_cP, _e_im_cP)),
+        _e_cPprime(std::bind(&wcimplementation::cartesian, _e_re_cPprime, _e_im_cPprime)),
+        _e_cT(std::bind(&wcimplementation::cartesian, _e_re_cT, _e_im_cT)),
+        _e_cT5(std::bind(&wcimplementation::cartesian, _e_re_cT5, _e_im_cT5)),
+
+        /* functions for c->umumu */
+        _mu_c9(std::bind(&wcimplementation::cartesian, _mu_re_c9, _mu_im_c9)),
+        _mu_c10(std::bind(&wcimplementation::cartesian, _mu_re_c10, _mu_im_c10)),
+        _mu_c9prime(std::bind(&wcimplementation::cartesian, _mu_re_c9prime, _mu_im_c9prime)),
+        _mu_c10prime(std::bind(&wcimplementation::cartesian, _mu_re_c10prime, _mu_im_c10prime)),
+        _mu_cS(std::bind(&wcimplementation::cartesian, _mu_re_cS, _mu_im_cS)),
+        _mu_cSprime(std::bind(&wcimplementation::cartesian, _mu_re_cSprime, _mu_im_cSprime)),
+        _mu_cP(std::bind(&wcimplementation::cartesian, _mu_re_cP, _mu_im_cP)),
+        _mu_cPprime(std::bind(&wcimplementation::cartesian, _mu_re_cPprime, _mu_im_cPprime)),
+        _mu_cT(std::bind(&wcimplementation::cartesian, _mu_re_cT, _mu_im_cT)),
+        _mu_cT5(std::bind(&wcimplementation::cartesian, _mu_re_cT5, _mu_im_cT5))
+    {
+    }
+
+    WilsonCoefficients<wc::UC>
+    WilsonScanComponent<components::WET::UC>::wilson_coefficients_uc(const LeptonFlavor & lepton_flavor, const bool & cp_conjugate) const
+    {
+        std::function<complex<double>()> c9, c9prime;
+        std::function<complex<double>()> c10, c10prime;
+        std::function<complex<double>()> cS, cSprime;
+        std::function<complex<double>()> cP, cPprime;
+        std::function<complex<double>()> cT, cT5;
+
+        if (LeptonFlavor::electron == lepton_flavor)
+        {
+            c9       = _e_c9;
+            c9prime  = _e_c9prime;
+            c10      = _e_c10;
+            c10prime = _e_c10prime;
+            cS       = _e_cS;
+            cSprime  = _e_cSprime;
+            cP       = _e_cP;
+            cPprime  = _e_cPprime;
+            cT       = _e_cT;
+            cT5      = _e_cT5;
+        }
+        else if (LeptonFlavor::muon == lepton_flavor)
+        {
+            c9       = _mu_c9;
+            c9prime  = _mu_c9prime;
+            c10      = _mu_c10;
+            c10prime = _mu_c10prime;
+            cS       = _mu_cS;
+            cSprime  = _mu_cSprime;
+            cP       = _mu_cP;
+            cPprime  = _mu_cPprime;
+            cT       = _mu_cT;
+            cT5      = _mu_cT5;
+        }
+        else
+        {
+            throw InternalError("WilsonScan presently only implements 'e' and 'mu' lepton flavors");
+        }
+
+        double alpha_s = 0.0;
+        if (_mu__uc < _mu_b__uc)
+        {
+            alpha_s = QCD::alpha_s(_mu_b__uc, _alpha_s_Z__uc, _m_Z__uc, QCD::beta_function_nf_5);
+            alpha_s = QCD::alpha_s(_mu__uc, alpha_s, _mu_b__uc, QCD::beta_function_nf_4);
+        }
+        else
+        {
+            alpha_s = QCD::alpha_s(_mu__uc, _alpha_s_Z__uc, _m_Z__uc, QCD::beta_function_nf_5);
+        }
+
+        complex<double>            a_s = alpha_s / 4.0 / M_PI;
+        WilsonCoefficients<wc::UC> result(alpha_s);
+        result._sm_like_coefficients = std::array<std::complex<double>, 10>{
+            { _c1(), _c2(), _c3(), _c4(), _c5(), _c6(), a_s * _c7(), a_s * _c8(), a_s * c9(), a_s * c10() }
+        };
+        result._primed_coefficients = std::array<std::complex<double>, 10>{
+            { /* we only consider c7', c8', c9' and c10' */
+              0.0, 0.0,
+             0.0, 0.0,
+             0.0, 0.0,
+             a_s * _c7prime(),
+             a_s * _c8prime(),
+             a_s * c9prime(),
+             a_s * c10prime() }
+        };
+        result._scalar_tensor_coefficients = std::array<std::complex<double>, 6>{
+            { cS(), cSprime(), cP(), cPprime(), cT(), cT5() }
+        };
+        result._alpha_s = alpha_s;
+
+        if (cp_conjugate)
+        {
+            for (auto & c : result._sm_like_coefficients)
+            {
+                c = conj(c);
+            }
+
+            for (auto & c : result._primed_coefficients)
+            {
+                c = conj(c);
+            }
+
+            for (auto & c : result._scalar_tensor_coefficients)
+            {
+                c = conj(c);
+            }
+        }
+
+        return result;
+    }
+
     /* Old-style WET sectors */
 
     /* b->s Wilson coefficients */
@@ -1009,6 +1212,8 @@ namespace eos
         WilsonScanComponent<components::WET::SBCU>(parameters, options, *this),
         // Hadronic sectors (Delta B = 2)
         WilsonScanComponent<components::WET::SBSB>(parameters, options, *this),
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        WilsonScanComponent<components::WET::UC>(parameters, options, *this),
         // Old-style WET sectors
         WilsonScanComponent<components::DeltaBS1>(parameters, options, *this)
     {
@@ -1040,6 +1245,8 @@ namespace eos
         WilsonScanComponent<components::WET::SBCU>(parameters, options, *this),
         // Hadronic sectors (Delta B = 2)
         WilsonScanComponent<components::WET::SBSB>(parameters, options, *this),
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        WilsonScanComponent<components::WET::UC>(parameters, options, *this),
         // Old-style WET sectors
         ConstrainedWilsonScanComponent(parameters, options, *this)
     {

--- a/eos/models/wet.hh
+++ b/eos/models/wet.hh
@@ -5,6 +5,7 @@
  * Copyright (c) 2014 Frederik Beaujean
  * Copyright (c) 2014, 2018 Christoph Bobeth
  * Copyright (c) 2018 Ahmet Kokulu
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -373,6 +374,98 @@ namespace eos
             virtual WilsonCoefficients<wc::SBSB> wet_sbsb() const;
     };
 
+    template <> class WilsonScanComponent<components::WET::UC> : public virtual ModelComponent<components::WET::UC>
+    {
+        protected:
+            /* QCD parameters */
+            UsedParameter _alpha_s_Z__uc;
+            UsedParameter _mu_b__uc;
+
+            /* Masses */
+            UsedParameter _m_Z__uc;
+
+            /* Renormalization scale */
+            UsedParameter _mu__uc;
+
+            /* c->u Wilson coefficients */
+            UsedParameter _re_c1, _im_c1;
+            UsedParameter _re_c2, _im_c2;
+            UsedParameter _re_c3, _im_c3;
+            UsedParameter _re_c4, _im_c4;
+            UsedParameter _re_c5, _im_c5;
+            UsedParameter _re_c6, _im_c6;
+            UsedParameter _re_c7, _im_c7;
+            UsedParameter _re_c7prime, _im_c7prime;
+            UsedParameter _re_c8, _im_c8;
+            UsedParameter _re_c8prime, _im_c8prime;
+            /* c->uee Wilson coefficients */
+            UsedParameter _e_re_c9, _e_im_c9;
+            UsedParameter _e_re_c10, _e_im_c10;
+            UsedParameter _e_re_c9prime, _e_im_c9prime;
+            UsedParameter _e_re_c10prime, _e_im_c10prime;
+            UsedParameter _e_re_cS, _e_im_cS;
+            UsedParameter _e_re_cSprime, _e_im_cSprime;
+            UsedParameter _e_re_cP, _e_im_cP;
+            UsedParameter _e_re_cPprime, _e_im_cPprime;
+            UsedParameter _e_re_cT, _e_im_cT;
+            UsedParameter _e_re_cT5, _e_im_cT5;
+            /* c->umumu Wilson coefficients */
+            UsedParameter _mu_re_c9, _mu_im_c9;
+            UsedParameter _mu_re_c10, _mu_im_c10;
+            UsedParameter _mu_re_c9prime, _mu_im_c9prime;
+            UsedParameter _mu_re_c10prime, _mu_im_c10prime;
+            UsedParameter _mu_re_cS, _mu_im_cS;
+            UsedParameter _mu_re_cSprime, _mu_im_cSprime;
+            UsedParameter _mu_re_cP, _mu_im_cP;
+            UsedParameter _mu_re_cPprime, _mu_im_cPprime;
+            UsedParameter _mu_re_cT, _mu_im_cT;
+            UsedParameter _mu_re_cT5, _mu_im_cT5;
+
+            /* four-quark and gluon */
+            std::function<complex<double>()> _c1;
+            std::function<complex<double>()> _c2;
+            std::function<complex<double>()> _c3;
+            std::function<complex<double>()> _c4;
+            std::function<complex<double>()> _c5;
+            std::function<complex<double>()> _c6;
+            std::function<complex<double>()> _c8;
+            std::function<complex<double>()> _c8prime;
+
+            /* c->ugamma */
+            std::function<complex<double>()> _c7;
+            std::function<complex<double>()> _c7prime;
+
+            /* c->uee */
+            std::function<complex<double>()> _e_c9;
+            std::function<complex<double>()> _e_c10;
+            std::function<complex<double>()> _e_c9prime;
+            std::function<complex<double>()> _e_c10prime;
+            std::function<complex<double>()> _e_cS;
+            std::function<complex<double>()> _e_cSprime;
+            std::function<complex<double>()> _e_cP;
+            std::function<complex<double>()> _e_cPprime;
+            std::function<complex<double>()> _e_cT;
+            std::function<complex<double>()> _e_cT5;
+
+            /* c->umumu */
+            std::function<complex<double>()> _mu_c9;
+            std::function<complex<double>()> _mu_c10;
+            std::function<complex<double>()> _mu_c9prime;
+            std::function<complex<double>()> _mu_c10prime;
+            std::function<complex<double>()> _mu_cS;
+            std::function<complex<double>()> _mu_cSprime;
+            std::function<complex<double>()> _mu_cP;
+            std::function<complex<double>()> _mu_cPprime;
+            std::function<complex<double>()> _mu_cT;
+            std::function<complex<double>()> _mu_cT5;
+
+        public:
+            WilsonScanComponent(const Parameters &, const Options &, ParameterUser &);
+
+            /*! c->u Wilson coefficients */
+            virtual WilsonCoefficients<wc::UC> wilson_coefficients_uc(const LeptonFlavor & lepton_flavor, const bool & cp_conjugate) const;
+    };
+
     /* Old-style WET sectors */
 
     template <> class WilsonScanComponent<components::DeltaBS1> : public virtual ModelComponent<components::DeltaBS1>
@@ -480,6 +573,8 @@ namespace eos
         public WilsonScanComponent<components::WET::SBCU>,
         // Hadronic sectors (Delta B = 2)
         public WilsonScanComponent<components::WET::SBSB>,
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        public WilsonScanComponent<components::WET::UC>,
         // Old-style WET sectors
         public WilsonScanComponent<components::DeltaBS1>
     {
@@ -522,6 +617,8 @@ namespace eos
         public WilsonScanComponent<components::WET::SBCU>,
         // Hadronic sectors (Delta B = 2)
         public WilsonScanComponent<components::WET::SBSB>,
+        // Neutral-current semileptonic sectors (Delta C = 1)
+        public WilsonScanComponent<components::WET::UC>,
         // Old-style WET sectors
         public ConstrainedWilsonScanComponent
     {

--- a/eos/models/wilson-coefficients.cc
+++ b/eos/models/wilson-coefficients.cc
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2010, 2011 Danny van Dyk
  * Copyright (c) 2010 Christoph Bobeth
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -402,5 +403,13 @@ namespace eos
     WilsonCoefficients<wc::SBNuNu>::WilsonCoefficients()
     {
         _coefficients.fill(0.0);
+    }
+
+    WilsonCoefficients<wc::UC>::WilsonCoefficients(const double & alpha_s_mu) :
+        _alpha_s(alpha_s_mu)
+    {
+        _sm_like_coefficients.fill(0.0);
+        _primed_coefficients.fill(0.0);
+        _scalar_tensor_coefficients.fill(0.0);
     }
 } // namespace eos

--- a/eos/models/wilson-coefficients.hh
+++ b/eos/models/wilson-coefficients.hh
@@ -4,6 +4,7 @@
  * Copyright (c) 2010-2023 Danny van Dyk
  * Copyright (c) 2014 Frederik Beaujean
  * Copyright (c) 2014 Christoph Bobeth
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -421,6 +422,9 @@ namespace eos
 
         struct SBCU
         {};
+
+        struct UC
+        {};
     } // namespace wc
 
     /* Wilson coefficients for |Delta B| = |Delta S| = 2 operators */
@@ -588,6 +592,147 @@ namespace eos
              * Normalisation:
              * H^eff = 4 G_F / sqrt(2) V_cb V_ud^* \sum C_i O_i
              */
+    };
+
+    template <> struct WilsonCoefficients<wc::UC>
+    {
+            /*
+             * The operators are defined as in [dB:2017A], eq. (3.1) for c1..c6 and eq. (2.7) for others
+             */
+
+            /* Order: c1..c6, c7..c10 */
+            std::array<complex<double>, 10> _sm_like_coefficients;
+
+            /* Same order as above, with helicity flip */
+            std::array<complex<double>, 10> _primed_coefficients;
+
+            /* Scalar, pseudoscalar, and tensor coefficients */
+            std::array<complex<double>, 6> _scalar_tensor_coefficients;
+
+            double _alpha_s;
+
+            /*! Default ctor */
+            WilsonCoefficients(const double & alpha_s_mu);
+
+            inline complex<double>
+            c1() const
+            {
+                return _sm_like_coefficients[0];
+            }
+
+            inline complex<double>
+            c2() const
+            {
+                return _sm_like_coefficients[1];
+            }
+
+            inline complex<double>
+            c3() const
+            {
+                return _sm_like_coefficients[2];
+            }
+
+            inline complex<double>
+            c4() const
+            {
+                return _sm_like_coefficients[3];
+            }
+
+            inline complex<double>
+            c5() const
+            {
+                return _sm_like_coefficients[4];
+            }
+
+            inline complex<double>
+            c6() const
+            {
+                return _sm_like_coefficients[5];
+            }
+
+            inline complex<double>
+            c7() const
+            {
+                return 4.0 * M_PI / _alpha_s * _sm_like_coefficients[6];
+            }
+
+            inline complex<double>
+            c8() const
+            {
+                return 4.0 * M_PI / _alpha_s * _sm_like_coefficients[7];
+            }
+
+            inline complex<double>
+            c9() const
+            {
+                return 4.0 * M_PI / _alpha_s * _sm_like_coefficients[8];
+            }
+
+            inline complex<double>
+            c10() const
+            {
+                return 4.0 * M_PI / _alpha_s * _sm_like_coefficients[9];
+            }
+
+            inline complex<double>
+            c7prime() const
+            {
+                return 4.0 * M_PI / _alpha_s * _primed_coefficients[6];
+            }
+
+            inline complex<double>
+            c8prime() const
+            {
+                return 4.0 * M_PI / _alpha_s * _primed_coefficients[7];
+            }
+
+            inline complex<double>
+            c9prime() const
+            {
+                return 4.0 * M_PI / _alpha_s * _primed_coefficients[8];
+            }
+
+            inline complex<double>
+            c10prime() const
+            {
+                return 4.0 * M_PI / _alpha_s * _primed_coefficients[9];
+            }
+
+            inline complex<double>
+            cS() const
+            {
+                return _scalar_tensor_coefficients[0];
+            }
+
+            inline complex<double>
+            cSprime() const
+            {
+                return _scalar_tensor_coefficients[1];
+            }
+
+            inline complex<double>
+            cP() const
+            {
+                return _scalar_tensor_coefficients[2];
+            }
+
+            inline complex<double>
+            cPprime() const
+            {
+                return _scalar_tensor_coefficients[3];
+            }
+
+            inline complex<double>
+            cT() const
+            {
+                return _scalar_tensor_coefficients[4];
+            }
+
+            inline complex<double>
+            cT5() const
+            {
+                return _scalar_tensor_coefficients[5];
+            }
     };
 } // namespace eos
 

--- a/eos/parameters/sm-and-eft.yaml
+++ b/eos/parameters/sm-and-eft.yaml
@@ -67,6 +67,21 @@ groups:
           unit:     'GeV'
           latex:    '$\mu^{b \to s}_{0t}$'
           comments: ''
+      # c->u matching parameters
+      'uc::mu_b' :
+          central: +4.18
+          min:     +4.18
+          max:     +4.18
+          unit:     'GeV'
+          latex:    '$\mu^{uc}_{0b}$'
+          comments: ''
+      'uc::mu_0' :
+          central: +80.0
+          min:     +80.0
+          max:     +80.0
+          unit:     'GeV'
+          latex:    '$\mu^{uc}_{0}$'
+          comments: ''
       # QCD inputs
       'QCD::alpha_s(MZ)' :
           central: +0.1184
@@ -466,6 +481,451 @@ groups:
           min:     +0.0
           unit:     '1'
           latex:    '$\textrm{Im}\,C_{5}^{\bar{s}b\bar{s}b}$'
+  # }}}
+
+  # c -> u {qqbar, gamma, l^+l^-} WET Parameters
+  # {{{
+  - title: '$c\to u\left\lbrace \bar{q}q,\, \gamma,\, \ell^+\ell^-\right\rbrace$ WET Parameters'
+    description: >
+        The list of parameters describing the $c\to u \left\lbrace
+        q\bar{q},\gamma,\ell^+\ell^-\right\rbrace$ Wilson coefficients.
+    wcxf-relevant: true
+    parameters:
+      # Factorization scales
+      'uc::mu' :
+          central: +1.3
+          min:     +1.3
+          max:     +1.3
+          unit:     'GeV'
+          latex:    '$\mu^{uc}$'
+          comments: ''
+
+      # Wilson coefficients C1 - C6 at mu = 1.3 GeV to NLL accuracy as calculated in the SM by EOS's StandardModel class.
+      # For the calculations, cf. [dBMS:2016A].
+      "uc::Re{c1}" :
+          central: -0.721090
+          min:     -0.721090
+          max:     -0.721090
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_1$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "uc::Im{c1}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_1$
+          comment:  ''
+      "uc::Re{c2}" :
+          central: +1.039098
+          min:     +1.039098
+          max:     +1.039098
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_2$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "uc::Im{c2}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_2$
+          comment:  ''
+      "uc::Re{c3}" :
+          central: -0.006528
+          min:     -0.006528
+          max:     -0.006528
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_3$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "uc::Im{c3}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_3$
+          comment:  ''
+      "uc::Re{c4}" :
+          central: -0.095337
+          min:     -0.095337
+          max:     -0.095337
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_4$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "uc::Im{c4}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_4$
+          comment:  ''
+      "uc::Re{c5}" :
+          central: +0.000422
+          min:     +0.000422
+          max:     +0.000422
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_5$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "uc::Im{c5}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_5$
+          comment:  ''
+      "uc::Re{c6}" :
+          central: +0.000593
+          min:     +0.000593
+          max:     +0.000593
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_6$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "uc::Im{c6}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_6$
+          comment:  ''
+      "uc::Re{c7}" :
+          central: +0.122692956
+          min:     +0.122692956
+          max:     +0.122692956
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_7$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "uc::Im{c7}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_7$
+          comment:  ''
+      "uc::Re{c8}" :
+          central: -0.069421972
+          min:     -0.069421972
+          max:     -0.069421972
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_8$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "uc::Im{c8}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_8$
+          comment:  ''
+      "ucee::Re{c9}" :
+          central: -0.318268105
+          min:     -0.318268105
+          max:     -0.318268105
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_9^{(e)}$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "ucee::Im{c9}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_9^{(e)}$
+          comment:  ''
+      "ucee::Re{c10}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{10}^{(e)}$
+          comment:  ''
+      "ucee::Im{c10}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{10}^{(e)}$
+          comment:  ''
+      "ucmumu::Re{c9}" :
+          central: -0.318268105
+          min:     -0.318268105
+          max:     -0.318268105
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_9^{(\mu)}$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "ucmumu::Im{c9}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_9^{(\mu)}$
+          comment:  ''
+      "ucmumu::Re{c10}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{10}^{(\mu)}$
+          comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
+      "ucmumu::Im{c10}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{10}^{(\mu)}$
+          comment:  ''
+
+      # Primed Wilson coefficients are negligible in the SM
+      "uc::Re{c7'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{7}^{\prime}$
+          comment:  ''
+      "uc::Im{c7'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{7}^{\prime}$
+          comment:  ''
+      "uc::Re{c8'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{8'}$
+          comment:  ''
+      "uc::Im{c8'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{8'}$
+          comment:  ''
+      "ucee::Re{c9'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{9}^{\prime(e)}$
+          comment:  ''
+      "ucee::Im{c9'}" :
+          central: +0.0
+          min:     -15.0
+          max:     +15.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{9}^{\prime(e)}$
+          comment:  ''
+      "ucee::Re{c10'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{10}^{\prime(e)}$
+          comment:  ''
+      "ucee::Im{c10'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{10}^{\prime(e)}$
+          comment:  ''
+      "ucmumu::Re{c9'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{9}^{\prime(\mu)}$
+          comment:  ''
+      "ucmumu::Im{c9'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{9}^{\prime(\mu)}$
+          comment:  ''
+      "ucmumu::Re{c10'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{10}^{\prime(\mu)}$
+          comment:  ''
+      "ucmumu::Im{c10'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{10}^{\prime(\mu)}$
+          comment:  ''
+
+      # scalar, pseudoscalar, and tensor c -> u ll coefficients
+      "ucee::Re{cS}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{S}^{(e)}$
+          comment:  ''
+      "ucee::Im{cS}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{S}^{(e)}$
+          comment:  ''
+      "ucee::Re{cS'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{S}^{\prime(e)}$
+          comment:  ''
+      "ucee::Im{cS'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{S}^{\prime(e)}$
+          comment:  ''
+      "ucee::Re{cP}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{P}^{(e)}$
+          comment:  ''
+      "ucee::Im{cP}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{P}^{(e)}$
+          comment:  ''
+      "ucee::Re{cP'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{P}^{\prime(e)}$
+          comment:  ''
+      "ucee::Im{cP'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{P}^{\prime(e)}$
+          comment:  ''
+      "ucee::Re{cT}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{T}^{(e)}$
+          comment:  ''
+      "ucee::Im{cT}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{T}^{(e)}$
+          comment:  ''
+      "ucee::Re{cT5}" :
+          central: +0.0
+          min:     -1.0
+          max:     +1.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{T5}^{(e)}$
+          comment:  ''
+      "ucee::Im{cT5}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{T5}^{(e)}$
+          comment:  ''
+      "ucmumu::Re{cS}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{S}^{(\mu)}$
+          comment:  ''
+      "ucmumu::Im{cS}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{S}^{(\mu)}$
+          comment:  ''
+      "ucmumu::Re{cS'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{S}^{\prime(\mu)}$
+          comment:  ''
+      "ucmumu::Im{cS'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{S}^{\prime(\mu)}$
+          comment:  ''
+      "ucmumu::Re{cP}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{P}^{(\mu)}$
+          comment:  ''
+      "ucmumu::Im{cP}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{P}^{(\mu)}$
+          comment:  ''
+      "ucmumu::Re{cP'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{P}^{\prime(\mu)}$
+          comment:  ''
+      "ucmumu::Im{cP'}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{P}^{\prime(\mu)}$
+          comment:  ''
+      "ucmumu::Re{cT}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{T}^{(\mu)}$
+          comment:  ''
+      "ucmumu::Im{cT}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{T}^{(\mu)}$
+          comment:  ''
+      "ucmumu::Re{cT5}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Re}\, \mathcal{C}_{T5}^{(\mu)}$
+          comment:  ''
+      "ucmumu::Im{cT5}" :
+          central: +0.0
+          min:     +0.0
+          max:     +0.0
+          unit:     '1'
+          latex:    $\mathrm{Im}\, \mathcal{C}_{T5}^{(\mu)}$
+          comment:  ''
   # }}}
 
   # b -> s {qqbar, gamma, l^+l^-} WET Parameters

--- a/eos/parameters/sm-and-eft.yaml
+++ b/eos/parameters/sm-and-eft.yaml
@@ -500,12 +500,12 @@ groups:
           latex:    '$\mu^{uc}$'
           comments: ''
 
-      # Wilson coefficients C1 - C6 at mu = 1.3 GeV to NLL accuracy as calculated in the SM by EOS's StandardModel class.
+      # Wilson coefficients C1 - C6 at mu = 1.3 GeV to NNLL accuracy as calculated in the SM by EOS's StandardModel class.
       # For the calculations, cf. [dBMS:2016A].
       "uc::Re{c1}" :
-          central: -0.721090
-          min:     -0.721090
-          max:     -0.721090
+          central: -0.6511905155
+          min:     -0.6511905155
+          max:     -0.6511905155
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_1$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -517,9 +517,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_1$
           comment:  ''
       "uc::Re{c2}" :
-          central: +1.039098
-          min:     +1.039098
-          max:     +1.039098
+          central: +1.035740588
+          min:     +1.035740588
+          max:     +1.035740588
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_2$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -531,9 +531,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_2$
           comment:  ''
       "uc::Re{c3}" :
-          central: -0.006528
-          min:     -0.006528
-          max:     -0.006528
+          central: -0.008919680307
+          min:     -0.008919680307
+          max:     -0.008919680307
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_3$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -545,9 +545,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_3$
           comment:  ''
       "uc::Re{c4}" :
-          central: -0.095337
-          min:     -0.095337
-          max:     -0.095337
+          central: -0.09917618128
+          min:     -0.09917618128
+          max:     -0.09917618128
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_4$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -559,9 +559,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_4$
           comment:  ''
       "uc::Re{c5}" :
-          central: +0.000422
-          min:     +0.000422
-          max:     +0.000422
+          central: +0.0005431321897
+          min:     +0.0005431321897
+          max:     +0.0005431321897
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_5$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -573,9 +573,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_5$
           comment:  ''
       "uc::Re{c6}" :
-          central: +0.000593
-          min:     +0.000593
-          max:     +0.000593
+          central: +0.001012196678
+          min:     +0.001012196678
+          max:     +0.001012196678
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_6$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -587,9 +587,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_6$
           comment:  ''
       "uc::Re{c7}" :
-          central: +0.122692956
-          min:     +0.122692956
-          max:     +0.122692956
+          central: +0.1287292333
+          min:     +0.1287292333
+          max:     +0.1287292333
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_7$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -601,9 +601,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_7$
           comment:  ''
       "uc::Re{c8}" :
-          central: -0.069421972
-          min:     -0.069421972
-          max:     -0.069421972
+          central: -0.08087769358
+          min:     -0.08087769358
+          max:     -0.08087769358
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_8$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -615,9 +615,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_8$
           comment:  ''
       "ucee::Re{c9}" :
-          central: -0.318268105
-          min:     -0.318268105
-          max:     -0.318268105
+          central: -0.4453671240
+          min:     -0.4453671240
+          max:     -0.4453671240
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_9^{(e)}$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'
@@ -643,9 +643,9 @@ groups:
           latex:    $\mathrm{Im}\, \mathcal{C}_{10}^{(e)}$
           comment:  ''
       "ucmumu::Re{c9}" :
-          central: -0.318268105
-          min:     -0.318268105
-          max:     -0.318268105
+          central: -0.4453671240
+          min:     -0.4453671240
+          max:     -0.4453671240
           unit:     '1'
           latex:    $\mathrm{Re}\, \mathcal{C}_9^{(\mu)}$
           comment:  'cf. @REF[dBMS:2016A]@, Tab. 1'

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -1254,6 +1254,11 @@ D0:2011A:
   inspire-id: Abazov:2011ry
   title: Measurement of the CP-violating phase $\phi_s^{J/\psi \phi}$ using the flavor-tagged
     decay $B_s^0 \rightarrow J/\psi \phi$ in 8 fb$^{-1}$ of $p \bar p$ collisions
+dB:2017A:
+  authors: de Boer, Stefan
+  inspire-id: deBoer:2017dgn
+  url: https://doi.org/10.17877/DE290R-18060
+  title: Probing the standard model with rare charm decays
 DBG:2013A:
   authors: Dutta, Rupak and Bhol, Anupama and Giri, Anjan K.
   eprint:

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -1261,6 +1261,13 @@ DBG:2013A:
     id: oai:arXiv.org:1307.6653
   inspire-id: Dutta:2013qaa
   title: Effective theory approach to new physics in $b \to u$ and $b \to c$ leptonic and semileptonic decays
+dBMS:2016A:
+  authors: de Boer, Stefan and Mueller, Bastian and Seidel, Dirk
+  eprint:
+    archive: arXiv
+    id: oai:arXiv.org:1606.05521
+  inspire-id: deBoer:2016dcg
+  title: Higher-order Wilson coefficients for $c\to u$ transitions in the standard model
 DD:2020A:
   authors: Das, Diganta and Das, Jaydeb
   eprint:

--- a/eos/utils/rge-impl.hh
+++ b/eos/utils/rge-impl.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2023-2026 Danny van Dyk
  * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
@@ -34,12 +34,14 @@ namespace eos
     {
             static constexpr double beta_0 = 23.0 / 3.0;
             static constexpr double beta_1 = 116.0 / 3.0;
+            static constexpr double beta_2 = 9769.0 / 54.0;
     };
 
     template <> struct QCDBetaFunction<4u>
     {
             static constexpr double beta_0 = 25.0 / 3.0;
             static constexpr double beta_1 = 154.0 / 3.0;
+            static constexpr double beta_2 = 21943.0 / 54.0;
     };
 
     template <unsigned nf_, unsigned dim_>
@@ -335,6 +337,222 @@ namespace eos
         }
 
         return std::tuple(result_LL, result_NLL);
+    }
+
+    template <unsigned nf_, unsigned dim_>
+    MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, nf_, dim_>::MultiplicativeRenormalizationGroupEvolution(
+            const std::array<double, dim_> & gamma_0_ev, const std::array<std::array<double, dim_>, dim_> & V, const std::array<std::array<double, dim_>, dim_> & gamma_1,
+            const std::array<std::array<double, dim_>, dim_> & gamma_2) :
+        _gamma_0_ev(gamma_0_ev),
+        _V(make_gsl_matrix(dim_, dim_)),
+        _Vinv(make_gsl_matrix(dim_, dim_)),
+        _G1(make_gsl_matrix(dim_, dim_)),
+        _G2(make_gsl_matrix(dim_, dim_)),
+        _U_0(make_gsl_matrix(dim_, dim_)),
+        _J1(make_gsl_matrix(dim_, dim_)),
+        _J2(make_gsl_matrix(dim_, dim_)),
+        _c_0_0(make_gsl_vector(dim_)),
+        _c_0_1(make_gsl_vector(dim_)),
+        _c_0_2(make_gsl_vector(dim_)),
+        _tmp_matrix(make_gsl_matrix(dim_, dim_)),
+        _tmp_matrix_2(make_gsl_matrix(dim_, dim_)),
+        _tmp_vector(make_gsl_vector(dim_)),
+        _tmp_vector_2(make_gsl_vector(dim_))
+    {
+        // V <- V
+        // G1 <- gamma_1
+        // G2 <- gamma_2
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            for (unsigned j = 0; j < dim_; ++j)
+            {
+                gsl_matrix_set(_V.get(), i, j, V[i][j]);
+                gsl_matrix_set(_G1.get(), i, j, gamma_1[i][j]);
+                gsl_matrix_set(_G2.get(), i, j, gamma_2[i][j]);
+            }
+        }
+
+        // tmp_matrix <- V
+        gsl_matrix_memcpy(_tmp_matrix.get(), _V.get());
+
+        gsl_permutation * p = gsl_permutation_alloc(dim_);
+        int               signum;
+        // tmp_matrix stores L, U from LU decomposition: P . V = L . U
+        gsl_linalg_LU_decomp(_tmp_matrix.get(), p, &signum);
+        // Vinv <- V^-1
+        gsl_linalg_LU_invert(_tmp_matrix.get(), p, _Vinv.get());
+
+        gsl_permutation_free(p);
+
+        // G1 = V^-1 . gamma_1^T . V, cf. [BBL:1995A], p. 34, eq. (III.96) and [BFS:2001A], p. 31, eq. (94)
+        // tmp_matrix <- V^-1 . gamma_1^T
+        gsl_blas_dgemm(CblasNoTrans, CblasTrans, 1.0, _Vinv.get(), _G1.get(), 0.0, _tmp_matrix.get());
+        // G1 <- tmp_matrix . V
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _tmp_matrix.get(), _V.get(), 0.0, _G1.get());
+
+        // G2 = V^-1 . gamma_2^T . V, cf. [BFS:2001A], p. 31, eq. (94)
+        // tmp_matrix <- V^-1 . gamma_2^T
+        gsl_blas_dgemm(CblasNoTrans, CblasTrans, 1.0, _Vinv.get(), _G2.get(), 0.0, _tmp_matrix.get());
+        // G2 <- tmp_matrix . V
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _tmp_matrix.get(), _V.get(), 0.0, _G2.get());
+
+        // J1 <- H1 = delta_ij gamma_0_ev_i beta_1 / (2 beta_0^2)
+        //          - G1_ij / (2 beta_0 + gamma_0_ev_i - gamma_0_ev_j)
+        // cf. [BBL:1995A], p. 34, eq. (III.97)
+        const double beta_0 = QCDBetaFunction<nf_>::beta_0;
+        const double beta_1 = QCDBetaFunction<nf_>::beta_1;
+        const double beta_2 = QCDBetaFunction<nf_>::beta_2;
+
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            for (unsigned j = 0; j < dim_; ++j)
+            {
+                double value = -1.0 * gsl_matrix_get(_G1.get(), i, j) / (2.0 * beta_0 + gamma_0_ev[i] - gamma_0_ev[j]);
+                if (i == j)
+                {
+                    value += gamma_0_ev[i] * beta_1 / (2.0 * beta_0 * beta_0);
+                }
+                gsl_matrix_set(_J1.get(), i, j, value);
+            }
+        }
+
+        // J2 <- H2 = delta_ij gamma_0_ev_i beta_2 / (4 beta_0^2)
+        //          + sum_k ((2 beta_0 + gamma_0_ev_i - gamma_0_ev_k)/(4 beta_0 + gamma_0_ev_i - gamma_0_ev_j)
+        //                   * ( H1[i,k]H1[k,j] - beta_1 / beta_0 H1[i,j] delta_jk ) )
+        //          - G2_ij / (4 beta_0 + gamma_0_ev_i - gamma_0_ev_j)
+        // cf. [BFS:2001A], p. 32, eq. (93)
+
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            for (unsigned j = 0; j < dim_; ++j)
+            {
+                double value = -1.0 * gsl_matrix_get(_G2.get(), i, j) / (4.0 * beta_0 + gamma_0_ev[i] - gamma_0_ev[j]);
+                if (i == j)
+                {
+                    value += gamma_0_ev[i] * beta_2 / (4.0 * beta_0 * beta_0);
+                }
+                for (unsigned k = 0; k < dim_; ++k)
+                {
+                    value += (2.0 * beta_0 + gamma_0_ev[i] - gamma_0_ev[k]) / (4.0 * beta_0 + gamma_0_ev[i] - gamma_0_ev[j])
+                             * (gsl_matrix_get(_J1.get(), i, k) * gsl_matrix_get(_J1.get(), k, j) - beta_1 / beta_0 * gsl_matrix_get(_J1.get(), i, j) * (j == k ? 1.0 : 0.0));
+                }
+                gsl_matrix_set(_J2.get(), i, j, value);
+            }
+        }
+
+        // tmp <- J1 . V^-1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _J1.get(), _Vinv.get(), 0.0, _tmp_matrix.get());
+        // J1 <- V . tmp
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _tmp_matrix.get(), 0.0, _J1.get());
+
+        // tmp <- J2 . V^-1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _J2.get(), _Vinv.get(), 0.0, _tmp_matrix.get());
+        // J2 <- V . tmp
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _tmp_matrix.get(), 0.0, _J2.get());
+    }
+
+    template <unsigned nf_, unsigned dim_>
+    std::array<double, dim_>
+    MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, nf_, dim_>::evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0,
+                                                                                   const std::array<double, dim_> & c_0_1, const std::array<double, dim_> & c_0_2) const
+    {
+        // NNLL evolution:
+        // cf. [BFS:2001A], p. 32, eq. (90)
+        //   U = (1 + a_s_mu J1 + a_s_mu^2 J2) . U_0 . (1 - a_s_0 J1 - a_s_0^2 (J2 - J1^2))
+        //   U_1 = (1 + a_s_mu J1) . U_0 . (1 - a_s_0 J1)
+        //   c(mu) = U . c(mu_0)
+        //         = U . c_0(mu_0) + a_s_0 . U_1 . c_0_1(mu_0)
+        //         + a_s_0^1 a_s_mu^2 J2 . U_0 . (1 - a_s_0 J1) . c_0_1(mu_0)
+        //         + a_s_0^2 U_0 . c_0_2(mu_0)
+        //         + a_s_0^2 (a_s_mu J1 + a_s_mu^2 J2) . U_0 . c_0_2(mu_0) + O(a_s_mu_0^3)
+        // where
+        //   a_s(x) = alpha_s(x) / (4 pi),
+        //   U_0 = V . diag[ eta^(gamma_0_ev / (2 * beta_0)) ] . V^-1
+        //   J1 = V . H1 . V^-1,
+        //   J2 = V . H2 . V^-1,
+        // since
+        //   gamma_0 = V^-1,T . diag[ gamma_0_ev ] . V^T,
+        //   H1 = delta_ij gamma_0_ev_i beta_1 / (2 beta_0^2) - G1_ij / (2 beta_0 + gamma_0_ev_i - gamma_0_ev_j),
+        //   H2 = delta_ij gamma_0_ev_i beta_2 / (4 beta_0^2)
+        //          + sum_k ((2 beta_0 + gamma_0_ev_i - gamma_0_ev_k)/(4 beta_0 + gamma_0_ev_i - gamma_0_ev_j)
+        //                   * ( H1[i,k]H1[k,j] - beta_1 / beta_0 H1[i,j] delta_jk ) )
+        //          - G2_ij / (4 beta_0 + gamma_0_ev_i - gamma_0_ev_j)
+        //   G1 = V^-1 . gamma_1^T . V
+        //   G2 = V^-1 . gamma_2^T . V
+
+        const double eta    = alpha_s_0 / alpha_s_mu;
+        const double beta_0 = QCDBetaFunction<nf_>::beta_0;
+
+        gsl_matrix_set_identity(_U_0.get());
+
+        // U_0 <- diag[ eta^(gamma_0_ev / (2 * beta_0)) ]
+        // cf. [BBL:1995A], p. 34, eq. (III.94)
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            gsl_matrix_set(_U_0.get(), i, i, std::pow(eta, _gamma_0_ev[i] / (2.0 * beta_0)));
+            gsl_vector_set(_c_0_0.get(), i, c_0_0[i]);
+            gsl_vector_set(_c_0_1.get(), i, c_0_1[i]);
+            gsl_vector_set(_c_0_2.get(), i, c_0_2[i]);
+        }
+        // tmp_matrix <- V . U_0
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _U_0.get(), 0.0, _tmp_matrix.get());
+        // U_0 <- tmp_matrix * V^-1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _tmp_matrix.get(), _Vinv.get(), 0.0, _U_0.get());
+
+        // tmp_vector := c_0_0 + alpha_s_0 / (4 pi) * (c_0_1 - J1 * c_0_0), cf. [BBL:1995A], p. 34, eq. (III.99)
+        //             + alpha_s_0^2 / (4 pi)^2 * ( - J2 * c_0_0 + J1^2 * c_0_0 - J1 * c_0_1 + c_0_2 )
+        // tmp_vector <- c_0_1
+        gsl_vector_memcpy(_tmp_vector.get(), _c_0_1.get());
+        // tmp_vector <- -1.0 * J1 * c_0_0 + 1.0 * tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, -1.0, _J1.get(), _c_0_0.get(), 1.0, _tmp_vector.get());
+        // tmp_vector <- c_0_0 + alpha_s(mu_0) / (4 pi) * tmp_vector
+        gsl_vector_axpby(1.0, _c_0_0.get(), alpha_s_0 / (4.0 * M_PI), _tmp_vector.get());
+
+        // tmp_matrix_1 <- J1 . J1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _J1.get(), _J1.get(), 0.0, _tmp_matrix.get());
+        // tmp_matrix_2 <- -J2
+        gsl_matrix_memcpy(_tmp_matrix_2.get(), _J2.get());
+        gsl_matrix_scale(_tmp_matrix_2.get(), -1.0);
+        // tmp_matrix <- tmp_matrix + tmp_matrix_2
+        gsl_matrix_add(_tmp_matrix.get(), _tmp_matrix_2.get());
+
+        // tmp_vector_2 <- c_0_2
+        gsl_vector_memcpy(_tmp_vector_2.get(), _c_0_2.get());
+        // tmp_vector_2 <- 1.0 * (J1^2-J2) * c_0_0 + 1.0 * tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix.get(), _c_0_0.get(), 1.0, _tmp_vector_2.get());
+        // tmp_vector_2 <- -1.0 * J1 * c_0_1 + 1.0 * tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, -1.0, _J1.get(), _c_0_1.get(), 1.0, _tmp_vector_2.get());
+        // tmp_vector_2 <- tmp_vector + alpha_s(mu_0)^2 / (4 pi)^2 * tmp_vector_2
+        gsl_vector_axpby(1.0, _tmp_vector.get(), alpha_s_0 * alpha_s_0 / (4.0 * M_PI * 4.0 * M_PI), _tmp_vector_2.get());
+
+        // tmp_matrix <- unit_matrix
+        gsl_matrix_set_zero(_tmp_matrix.get());
+        gsl_matrix_set_identity(_tmp_matrix.get());
+        // tmp_matrix2 <- alpha_s(mu) / (4 pi) * J1
+        gsl_matrix_memcpy(_tmp_matrix_2.get(), _J1.get());
+        gsl_matrix_scale(_tmp_matrix_2.get(), alpha_s_mu / (4.0 * M_PI));
+        // tmp_matrix <- tmp_matrix + tmp_matrix_2
+        gsl_matrix_add(_tmp_matrix.get(), _tmp_matrix_2.get());
+        // tmp_matrix2 <- alpha_s(mu)^2 / (4 pi)^2 * J2
+        gsl_matrix_memcpy(_tmp_matrix_2.get(), _J2.get());
+        gsl_matrix_scale(_tmp_matrix_2.get(), alpha_s_mu * alpha_s_mu / (4.0 * M_PI * 4.0 * M_PI));
+        // tmp_matrix <- tmp_matrix + tmp_matrix_2
+        gsl_matrix_add(_tmp_matrix.get(), _tmp_matrix_2.get());
+
+        // tmp_vector <- tmp_vector_2
+        gsl_vector_memcpy(_tmp_vector.get(), _tmp_vector_2.get());
+        // tmp_vector_2 <- U_0 . tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector.get(), 0.0, _tmp_vector_2.get());
+        // tmp_vector <- tmp_matrix . tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix.get(), _tmp_vector_2.get(), 0.0, _tmp_vector.get());
+
+        std::array<double, dim_> result;
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            result[i] = gsl_vector_get(_tmp_vector.get(), i);
+        }
+
+        return result;
     }
 } // namespace eos
 

--- a/eos/utils/rge-impl.hh
+++ b/eos/utils/rge-impl.hh
@@ -36,6 +36,12 @@ namespace eos
             static constexpr double beta_1 = 116.0 / 3.0;
     };
 
+    template <> struct QCDBetaFunction<4u>
+    {
+            static constexpr double beta_0 = 25.0 / 3.0;
+            static constexpr double beta_1 = 154.0 / 3.0;
+    };
+
     template <unsigned nf_, unsigned dim_>
     MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>::MultiplicativeRenormalizationGroupEvolution(const std::array<double, dim_> &                   gamma_0_ev,
                                                                                                                       const std::array<std::array<double, dim_>, dim_> & V) :

--- a/eos/utils/rge-impl.hh
+++ b/eos/utils/rge-impl.hh
@@ -357,7 +357,8 @@ namespace eos
         _tmp_matrix(make_gsl_matrix(dim_, dim_)),
         _tmp_matrix_2(make_gsl_matrix(dim_, dim_)),
         _tmp_vector(make_gsl_vector(dim_)),
-        _tmp_vector_2(make_gsl_vector(dim_))
+        _tmp_vector_2(make_gsl_vector(dim_)),
+        _tmp_vector_3(make_gsl_vector(dim_))
     {
         // V <- V
         // G1 <- gamma_1
@@ -553,6 +554,165 @@ namespace eos
         }
 
         return result;
+    }
+
+    template <unsigned nf_, unsigned dim_>
+    std::tuple<std::array<double, dim_>, std::array<double, dim_>, std::array<double, dim_>>
+    MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, nf_, dim_>::evolve_intermediate(const double & alpha_s_mu, const double & alpha_s_0,
+                                                                                                const std::array<double, dim_> & c_0_0, const std::array<double, dim_> & c_0_1,
+                                                                                                const std::array<double, dim_> & c_0_2) const
+    {
+        // NNLL evolution:
+        // cf. [BFS:2001A], p. 32, eq. (90)
+        //   U = (1 + a_s_mu J1 + a_s_mu^2 J2) . U_0 . (1 - a_s_0 J1 - a_s_0^2 (J2 - J1^2))
+        //   U_1 = (1 + a_s_mu J1) . U_0 . (1 - a_s_0 J1)
+        //   c(mu) = U . c(mu_0)
+        //         = U . c_0(mu_0) + a_s_0 . U_1 . c_0_1(mu_0)
+        //         + a_s_0^1 a_s_mu^2 J2 . U_0 . (1 - a_s_0 J1) . c_0_1(mu_0)
+        //         + a_s_0^2 U_0 . c_0_2(mu_0)
+        //         + a_s_0^2 (a_s_mu J1 + a_s_mu^2 J2) . U_0 . c_0_2(mu_0) + O(a_s_mu_0^3)
+        // where
+        //   a_s(x) = alpha_s(x) / (4 pi),
+        //   U_0 = V . diag[ eta^(gamma_0_ev / (2 * beta_0)) ] . V^-1
+        //   J1 = V . H1 . V^-1,
+        //   J2 = V . H2 . V^-1,
+        // since
+        //   gamma_0 = V^-1,T . diag[ gamma_0_ev ] . V^T,
+        //   H1 = delta_ij gamma_0_ev_i beta_1 / (2 beta_0^2) - G1_ij / (2 beta_0 + gamma_0_ev_i - gamma_0_ev_j),
+        //   H2 = delta_ij gamma_0_ev_i beta_2 / (4 beta_0^2)
+        //          + sum_k ((2 beta_0 + gamma_0_ev_i - gamma_0_ev_k)/(4 beta_0 + gamma_0_ev_i - gamma_0_ev_j)
+        //                   * ( H1[i,k]H1[k,j] - beta_1 / beta_0 H1[i,j] delta_jk ) )
+        //          - G2_ij / (4 beta_0 + gamma_0_ev_i - gamma_0_ev_j)
+        //   G1 = V^-1 . gamma_1^T . V
+        //   G2 = V^-1 . gamma_2^T . V
+
+        const double eta    = alpha_s_0 / alpha_s_mu;
+        const double beta_0 = QCDBetaFunction<nf_>::beta_0;
+
+        gsl_matrix_set_identity(_U_0.get());
+
+        // U_0 <- diag[ eta^(gamma_0_ev / (2 * beta_0)) ]
+        // cf. [BBL:1995A], p. 34, eq. (III.94)
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            gsl_matrix_set(_U_0.get(), i, i, std::pow(eta, _gamma_0_ev[i] / (2.0 * beta_0)));
+            gsl_vector_set(_c_0_0.get(), i, c_0_0[i]);
+            gsl_vector_set(_c_0_1.get(), i, c_0_1[i]);
+            gsl_vector_set(_c_0_2.get(), i, c_0_2[i]);
+        }
+        // tmp_matrix <- V . U_0
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _U_0.get(), 0.0, _tmp_matrix.get());
+        // U_0 <- tmp_matrix * V^-1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _tmp_matrix.get(), _Vinv.get(), 0.0, _U_0.get());
+
+        // tmp_vector <- U_0 . c_0_0
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _c_0_0.get(), 0.0, _tmp_vector.get());
+
+        std::array<double, dim_> result_LL;
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            result_LL[i] = gsl_vector_get(_tmp_vector.get(), i);
+        }
+
+        // tmp_vector := c_0_0 + alpha_s_0 / (4 pi) * (c_0_1 - J * c_0_0), cf. [BBL:1995A], p. 34, eq. (III.99)
+        // tmp_vector <- c_0_1
+        gsl_vector_memcpy(_tmp_vector.get(), _c_0_1.get());
+        // tmp_vector <- (-1.0 * J * c_0_0 + 1.0 * tmp_vector) * alpha_s(mu_0) / (4 pi)
+        gsl_blas_dgemv(CblasNoTrans, -1.0, _J1.get(), _c_0_0.get(), 1.0, _tmp_vector.get());
+        gsl_vector_scale(_tmp_vector.get(), alpha_s_0 / (4.0 * M_PI));
+
+        // tmp_matrix <- unit_matrix
+        gsl_matrix_set_zero(_tmp_matrix.get());
+        gsl_matrix_set_identity(_tmp_matrix.get());
+
+        // tmp_vector_2 <- U_0 . tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector.get(), 0.0, _tmp_vector_2.get());
+        // tmp_vector <- tmp_matrix . tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix.get(), _tmp_vector_2.get(), 0.0, _tmp_vector.get());
+        // tmp_vector_3 <- tmp_vector
+        gsl_vector_memcpy(_tmp_vector_3.get(), _tmp_vector.get());
+
+
+        // tmp_vector <- c_0_0
+        gsl_vector_memcpy(_tmp_vector.get(), _c_0_0.get());
+        // tmp_matrix2 <- alpha_s(mu) / (4 pi) * J
+        gsl_matrix_memcpy(_tmp_matrix_2.get(), _J1.get());
+        gsl_matrix_scale(_tmp_matrix_2.get(), alpha_s_mu / (4.0 * M_PI));
+
+        // tmp_vector_2 <- U_0 . tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector.get(), 0.0, _tmp_vector_2.get());
+        // tmp_vector <- tmp_matrix_2 . tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix_2.get(), _tmp_vector_2.get(), 0.0, _tmp_vector.get());
+        // tmp_vector <- tmp_vector + tmp_vector_3
+        gsl_vector_add(_tmp_vector.get(), _tmp_vector_3.get());
+        gsl_vector_scale(_tmp_vector.get(), (4.0 * M_PI) / alpha_s_mu);
+
+        std::array<double, dim_> result_NLL;
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            result_NLL[i] = gsl_vector_get(_tmp_vector.get(), i);
+        }
+
+        // tmp_vector <- c_0_1
+        gsl_vector_memcpy(_tmp_vector.get(), _c_0_1.get());
+        // tmp_vector <- -1.0 * J * c_0_0 + 1.0 * tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, -1.0, _J1.get(), _c_0_0.get(), 1.0, _tmp_vector.get());
+        // tmp_vector <- alpha_s(mu_0) / (4 pi) * tmp_vector
+        gsl_vector_scale(_tmp_vector.get(), alpha_s_0 / (4.0 * M_PI));
+
+        // tmp_vector_2 <- U_0 . tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector.get(), 0.0, _tmp_vector_2.get());
+        // tmp_vector <- tmp_matrix_2 . tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix_2.get(), _tmp_vector_2.get(), 0.0, _tmp_vector.get());
+
+        // tmp_matrix_1 <- J1 . J1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _J1.get(), _J1.get(), 0.0, _tmp_matrix.get());
+        // tmp_matrix_2 <- -J2
+        gsl_matrix_memcpy(_tmp_matrix_2.get(), _J2.get());
+        gsl_matrix_scale(_tmp_matrix_2.get(), -1.0);
+        // tmp_matrix <- tmp_matrix + tmp_matrix_2
+        gsl_matrix_add(_tmp_matrix.get(), _tmp_matrix_2.get());
+
+        // tmp_vector_2 <- c_0_2
+        gsl_vector_memcpy(_tmp_vector_2.get(), _c_0_2.get());
+        // tmp_vector_2 <- 1.0 * (J1^2-J2) * c_0_0 + 1.0 * tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix.get(), _c_0_0.get(), 1.0, _tmp_vector_2.get());
+        // tmp_vector_2 <- -1.0 * J1 * c_0_1 + 1.0 * tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, -1.0, _J1.get(), _c_0_1.get(), 1.0, _tmp_vector_2.get());
+        // tmp_vector_2 <- alpha_s(mu_0)^2 / (4 pi)^2 * tmp_vector_2
+        gsl_vector_scale(_tmp_vector_2.get(), alpha_s_0 * alpha_s_0 / (4.0 * M_PI * 4.0 * M_PI));
+
+        // tmp_vector_3 <- tmp_vector_2
+        gsl_vector_memcpy(_tmp_vector_3.get(), _tmp_vector_2.get());
+        // tmp_vector_2 <- U_0 . tmp_vector_3
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector_3.get(), 0.0, _tmp_vector_2.get());
+
+        // tmp_vector <- tmp_vector + tmp_vector_2
+        gsl_vector_add(_tmp_vector.get(), _tmp_vector_2.get());
+
+        // tmp_matrix2 <- alpha_s(mu)^2 / (4 pi)^2 * J2
+        gsl_matrix_memcpy(_tmp_matrix.get(), _J2.get());
+        gsl_matrix_scale(_tmp_matrix.get(), alpha_s_mu * alpha_s_mu / (4.0 * M_PI * 4.0 * M_PI));
+
+        // tmp_vector_2 <- c_0_0
+        gsl_vector_memcpy(_tmp_vector_2.get(), _c_0_0.get());
+        // tmp_vector_3 <- U_0 . tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector_2.get(), 0.0, _tmp_vector_3.get());
+        // tmp_vector_2 <- tmp_matrix . tmp_vector_3
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix.get(), _tmp_vector_3.get(), 0.0, _tmp_vector_2.get());
+
+        // tmp_vector <- tmp_vector + tmp_vector_2
+        gsl_vector_add(_tmp_vector.get(), _tmp_vector_2.get());
+
+        gsl_vector_scale(_tmp_vector.get(), (4.0 * M_PI) * (4.0 * M_PI) / alpha_s_mu / alpha_s_mu);
+
+        std::array<double, dim_> result_NNLL;
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            result_NNLL[i] = gsl_vector_get(_tmp_vector.get(), i);
+        }
+
+        return std::tuple(result_LL, result_NLL, result_NNLL);
     }
 } // namespace eos
 

--- a/eos/utils/rge-impl.hh
+++ b/eos/utils/rge-impl.hh
@@ -192,7 +192,7 @@ namespace eos
     {
         // NLL evolution:
         //   U = (1 + a_s_mu J) . U_0 . (1 - a_s_0 J)
-        //   c(mu) = U . c_0(mu_0) + a_s_0 * U_0 . c_0_1(mu_0)
+        //   c(mu) = U . c_0(mu_0) + a_s_0 * U_0 . c_0_1(mu_0) + a_s_mu a_s_0 * J . U_0 . c_0_1
         // where
         //   a_s(x) = alpha_s(x) / (4 pi),
         //   U_0 = V . diag[ eta^(gamma_0_ev / (2 * beta_0)) ] . V^-1
@@ -258,7 +258,7 @@ namespace eos
     {
         // NLL evolution:
         //   U = (1 + a_s_mu J) . U_0 . (1 - a_s_0 J)
-        //   c(mu) = U . c_0(mu_0) + a_s_0 * U_0 . c_0_1(mu_0)
+        //   c(mu) = U . c_0(mu_0) + a_s_0 * U_0 . c_0_1(mu_0) + a_s_mu a_s_0 * J . U_0 . c_0_1
         // where
         //   a_s(x) = alpha_s(x) / (4 pi),
         //   U_0 = V . diag[ eta^(gamma_0_ev / (2 * beta_0)) ] . V^-1

--- a/eos/utils/rge-impl.hh
+++ b/eos/utils/rge-impl.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -122,7 +123,8 @@ namespace eos
         _tmp_matrix(make_gsl_matrix(dim_, dim_)),
         _tmp_matrix_2(make_gsl_matrix(dim_, dim_)),
         _tmp_vector(make_gsl_vector(dim_)),
-        _tmp_vector_2(make_gsl_vector(dim_))
+        _tmp_vector_2(make_gsl_vector(dim_)),
+        _tmp_vector_3(make_gsl_vector(dim_))
     {
         // V <- V
         // G <- gamma_1
@@ -241,6 +243,92 @@ namespace eos
         }
 
         return result;
+    }
+
+    template <unsigned nf_, unsigned dim_>
+    std::tuple<std::array<double, dim_>, std::array<double, dim_>>
+    MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, nf_, dim_>::evolve_intermediate(const double & alpha_s_mu, const double & alpha_s_0,
+                                                                                               const std::array<double, dim_> & c_0_0, const std::array<double, dim_> & c_0_1) const
+    {
+        // NLL evolution:
+        //   U = (1 + a_s_mu J) . U_0 . (1 - a_s_0 J)
+        //   c(mu) = U . c_0(mu_0) + a_s_0 * U_0 . c_0_1(mu_0)
+        // where
+        //   a_s(x) = alpha_s(x) / (4 pi),
+        //   U_0 = V . diag[ eta^(gamma_0_ev / (2 * beta_0)) ] . V^-1
+        //   J = V . H . V^-1,
+        // since
+        //   gamma_0 = V^-1,T . diag[ gamma_0_ev ] . V^T,
+        //   H = delta_ij gamma_0_ev_i beta_1 / (2 beta_0^2) - G_ij / (2 beta_0 + gamma_0_ev_i - gamma_0_ev_j),
+        //   G = V^-1 . gamma_1^T . V
+
+        const double eta    = alpha_s_0 / alpha_s_mu;
+        const double beta_0 = QCDBetaFunction<nf_>::beta_0;
+
+        gsl_matrix_set_identity(_U_0.get());
+
+        // U_0 <- diag[ eta^(gamma_0_ev / (2 * beta_0)) ]
+        // cf. [BBL:1995A], p. 34, eq. (III.94)
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            gsl_matrix_set(_U_0.get(), i, i, std::pow(eta, _gamma_0_ev[i] / (2.0 * beta_0)));
+            gsl_vector_set(_c_0_0.get(), i, c_0_0[i]);
+            gsl_vector_set(_c_0_1.get(), i, c_0_1[i]);
+        }
+        // tmp_matrix <- V . U_0
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _V.get(), _U_0.get(), 0.0, _tmp_matrix.get());
+        // U_0 <- tmp_matrix * V^-1
+        gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, _tmp_matrix.get(), _Vinv.get(), 0.0, _U_0.get());
+
+        // tmp_vector <- U_0 . c_0_0
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _c_0_0.get(), 0.0, _tmp_vector.get());
+
+        std::array<double, dim_> result_LL;
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            result_LL[i] = gsl_vector_get(_tmp_vector.get(), i);
+        }
+
+        // tmp_vector := c_0_0 + alpha_s_0 / (4 pi) * (c_0_1 - J * c_0_0), cf. [BBL:1995A], p. 34, eq. (III.99)
+        // tmp_vector <- c_0_1
+        gsl_vector_memcpy(_tmp_vector.get(), _c_0_1.get());
+        // tmp_vector <- (-1.0 * J * c_0_0 + 1.0 * tmp_vector) * alpha_s(mu_0) / (4 pi)
+        gsl_blas_dgemv(CblasNoTrans, -1.0, _J.get(), _c_0_0.get(), 1.0, _tmp_vector.get());
+        gsl_vector_scale(_tmp_vector.get(), alpha_s_0 / (4.0 * M_PI));
+
+        // tmp_matrix <- unit_matrix
+        gsl_matrix_set_zero(_tmp_matrix.get());
+        gsl_matrix_set_identity(_tmp_matrix.get());
+
+        // tmp_vector_2 <- U_0 . tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector.get(), 0.0, _tmp_vector_2.get());
+        // tmp_vector <- tmp_matrix . tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix.get(), _tmp_vector_2.get(), 0.0, _tmp_vector.get());
+        // tmp_vector_3 <- tmp_vector
+        gsl_vector_memcpy(_tmp_vector_3.get(), _tmp_vector.get());
+
+
+        // tmp_vector <- c_0_0
+        gsl_vector_memcpy(_tmp_vector.get(), _c_0_0.get());
+        // tmp_matrix2 <- alpha_s(mu) / (4 pi) * J
+        gsl_matrix_memcpy(_tmp_matrix_2.get(), _J.get());
+        gsl_matrix_scale(_tmp_matrix_2.get(), alpha_s_mu / (4.0 * M_PI));
+
+        // tmp_vector_2 <- U_0 . tmp_vector
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _U_0.get(), _tmp_vector.get(), 0.0, _tmp_vector_2.get());
+        // tmp_vector <- tmp_matrix_2 . tmp_vector_2
+        gsl_blas_dgemv(CblasNoTrans, 1.0, _tmp_matrix_2.get(), _tmp_vector_2.get(), 0.0, _tmp_vector.get());
+        // tmp_vector <- tmp_vector + tmp_vector_3
+        gsl_vector_add(_tmp_vector.get(), _tmp_vector_3.get());
+        gsl_vector_scale(_tmp_vector.get(), (4.0 * M_PI) / alpha_s_mu);
+
+        std::array<double, dim_> result_NLL;
+        for (unsigned i = 0; i < dim_; ++i)
+        {
+            result_NLL[i] = gsl_vector_get(_tmp_vector.get(), i);
+        }
+
+        return std::tuple(result_LL, result_NLL);
     }
 } // namespace eos
 

--- a/eos/utils/rge.hh
+++ b/eos/utils/rge.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2023-2026 Danny van Dyk
  * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
@@ -32,6 +32,7 @@ namespace eos
     {
         struct LL;
         struct NLL;
+        struct NNLL;
     } // namespace accuracy
 
     template <unsigned nf_, unsigned dim_> class MultiplicativeRenormalizationGroupEvolution<accuracy::LL, nf_, dim_>
@@ -158,6 +159,70 @@ namespace eos
              */
             std::tuple<std::array<double, dim_>, std::array<double, dim_>>
             evolve_intermediate(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0, const std::array<double, dim_> & c_0_1) const;
+    };
+
+    // Next-to-next-to-leading logarithmic accuracy, see [BFS:2001A], p. 31, eq. (90)
+    template <unsigned nf_, unsigned dim_> class MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, nf_, dim_>
+    {
+        private:
+            // gamma_0 = V^-1,T . diag(gamma_0_ev) . V^T, see [BBL:1995A], p. 34, eq. (III.95)
+            std::array<double, dim_> _gamma_0_ev;
+            GSLMatrixPtr             _V, _Vinv;
+
+            // gamma_1 = V^-1,T . G . V^T, see [BBL:1995A], p. 34, eq. (III.96)
+            GSLMatrixPtr _G1;
+            GSLMatrixPtr _G2;
+
+            // evolution matrices
+            GSLMatrixPtr _U_0;
+            GSLMatrixPtr _J1;
+            GSLMatrixPtr _J2;
+
+            // initial conditions
+            GSLVectorPtr _c_0_0;
+            GSLVectorPtr _c_0_1;
+            GSLVectorPtr _c_0_2;
+
+            // temporary storage objects
+            GSLMatrixPtr _tmp_matrix, _tmp_matrix_2;
+            GSLVectorPtr _tmp_vector, _tmp_vector_2;
+
+        public:
+            /*!
+             * Constructor.
+             *
+             * This class expects provision with the anomalous mass dimension matrix (ADM) at LO and NLO,
+             * to provide RGE evolution to next-to-leading logarithmic accuracy. The LO gamma_0 matrix is
+             * diagonalized by the matrix V, see [BBL:1995A], p. 34, eq. (III.95):
+             *
+             *   gamma_0 = V^-1,T . diag(gamma_0_ev) . V^T
+             *
+             * Note that, as in [BBL:1995A], the ADM for the operators is expected, not the ADM for the
+             * Wilson coefficients, which is related to the operator ADM by transposition.
+             *
+             * @param gamma_0_ev The eigenvalues of the LO term for the anomalous dimension matrix.
+             * @param V The matrix that diagonalizes the LO term for the anomalous dimension matrix.
+             * @param gamma_1 The NLO term for the anomalous dimension matrix.
+             */
+            MultiplicativeRenormalizationGroupEvolution(const std::array<double, dim_> & gamma_0_ev, const std::array<std::array<double, dim_>, dim_> & V,
+                                                        const std::array<std::array<double, dim_>, dim_> & gamma_1, const std::array<std::array<double, dim_>, dim_> & gamma_2);
+
+            /*!
+             * Evolve the Wilson coefficients from the scale mu_0 to the scale mu at next-to-leading logarithmic accuracy.
+             *
+             * Expects the Wilson coefficients as a series in powers of alpha_(mu_0) / (4 pi):
+             *
+             *   c_0 = c_0_0 + alpha_(mu_0) / (4 pi) c_0_1 + (alpha_(mu) / (4 pi))^2 c_0_2 + O(alpha_(mu_0)^3)
+             *
+             * @param alpha_s_mu The value of the strong coupling constant at the scale mu.
+             * @param alpha_s_0 The value of the strong coupling constant at the scale mu_0.
+             * @param c_0_0 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^0
+             * @param c_0_1 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^1,
+             *              reduced by r^T . c_0_0, cf. [BBL:1995A], p. 34, eqs. (III.84) & (III.99).
+             * @param c_0_2 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^2,
+             */
+            std::array<double, dim_> evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0, const std::array<double, dim_> & c_0_1,
+                                            const std::array<double, dim_> & c_0_2) const;
     };
 } // namespace eos
 

--- a/eos/utils/rge.hh
+++ b/eos/utils/rge.hh
@@ -185,7 +185,7 @@ namespace eos
 
             // temporary storage objects
             GSLMatrixPtr _tmp_matrix, _tmp_matrix_2;
-            GSLVectorPtr _tmp_vector, _tmp_vector_2;
+            GSLVectorPtr _tmp_vector, _tmp_vector_2, _tmp_vector_3;
 
         public:
             /*!
@@ -223,6 +223,26 @@ namespace eos
              */
             std::array<double, dim_> evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0, const std::array<double, dim_> & c_0_1,
                                             const std::array<double, dim_> & c_0_2) const;
+
+            /*!
+             * Specialized version of evolve(...) with identical arguments.
+             * Returns the evolved Wilson coefficients using evolve() expanded as a series in powers of alpha(mu) / (4 pi),
+             * for further processes. This is needed, for example when running the c->ull Wilson coefficients from
+             * the electroweak matching scale down to the charm-quark scale, with intermediate matching at the bottom-quark scale.
+             *
+             *   c_0 = c_0_0 + alpha_(mu) / (4 pi) c_0_1 + (alpha_(mu) / (4 pi))^2 c_0_2 + O(alpha_(mu)^3)
+             *
+             * @param alpha_s_mu The value of the strong coupling constant at the scale mu.
+             * @param alpha_s_0 The value of the strong coupling constant at the scale mu_0.
+             * @param c_0_0 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^0
+             * @param c_0_1 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^1,
+             *              reduced by r^T . c_0_0, cf. [BBL:1995A], p. 34, eqs. (III.84) & (III.99).
+             * @param c_0_2 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^2
+             */
+            std::tuple<std::array<double, dim_>, std::array<double, dim_>, std::array<double, dim_>> evolve_intermediate(const double & alpha_s_mu, const double & alpha_s_0,
+                                                                                                                         const std::array<double, dim_> & c_0_0,
+                                                                                                                         const std::array<double, dim_> & c_0_1,
+                                                                                                                         const std::array<double, dim_> & c_0_2) const;
     };
 } // namespace eos
 

--- a/eos/utils/rge.hh
+++ b/eos/utils/rge.hh
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -103,7 +104,7 @@ namespace eos
 
             // temporary storage objects
             GSLMatrixPtr _tmp_matrix, _tmp_matrix_2;
-            GSLVectorPtr _tmp_vector, _tmp_vector_2;
+            GSLVectorPtr _tmp_vector, _tmp_vector_2, _tmp_vector_3;
 
         public:
             /*!
@@ -140,6 +141,23 @@ namespace eos
              */
             std::array<double, dim_> evolve(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0,
                                             const std::array<double, dim_> & c_0_1) const;
+
+            /*!
+             * Specialized version of evolve(...) with identical arguments.
+             * Returns the evolved Wilson coefficients using evolve() expanded as a series in powers of alpha(mu) / (4 pi),
+             * for further processes. This is needed, for example when running the c->ull Wilson coefficients from
+             * the electroweak matching scale down to the charm-quark scale, with intermediate matching at the bottom-quark scale.
+             *
+             *   c_0 = c_0_0 + alpha_(mu) / (4 pi) c_0_1 + O(alpha_(mu)^2)
+             *
+             * @param alpha_s_mu The value of the strong coupling constant at the scale mu.
+             * @param alpha_s_0 The value of the strong coupling constant at the scale mu_0.
+             * @param c_0_0 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^0
+             * @param c_0_1 The initial conditions for the Wilson coefficients at the scale mu_0 at order alpha_s^1,
+             *              reduced by r^T . c_0_0, cf. [BBL:1995A], p. 34, eqs. (III.84) & (III.99).
+             */
+            std::tuple<std::array<double, dim_>, std::array<double, dim_>>
+            evolve_intermediate(const double & alpha_s_mu, const double & alpha_s_0, const std::array<double, dim_> & c_0_0, const std::array<double, dim_> & c_0_1) const;
     };
 } // namespace eos
 

--- a/eos/utils/rge_TEST.cc
+++ b/eos/utils/rge_TEST.cc
@@ -275,3 +275,142 @@ class MultiplicativeRGENLLTest : public TestCase
             }
         }
 } multiplicative_rge_nll_test;
+
+class MultiplicativeRGENNLLTest : public TestCase
+{
+    public:
+        MultiplicativeRGENNLLTest() :
+            TestCase("multiplicative_rge_nnll_test")
+        {
+        }
+
+        virtual void
+        run() const
+        {
+            // trivial test case (nf = 5, dim = 10)
+            {
+                const std::array<double, 10u>                  gamma_0_ev{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+                const std::array<std::array<double, 10u>, 10u> V{
+                    { { 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0 } }
+                };
+                const std::array<std::array<double, 10u>, 10u> gamma_1{
+                    { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } }
+                };
+                const std::array<std::array<double, 10u>, 10u> gamma_2{
+                    { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },
+                     { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } }
+                };
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, 5u, 10u> rge(gamma_0_ev, V, gamma_1, gamma_2);
+                const std::array<double, 10u>                                              c_0_0{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+                const std::array<double, 10u>                                              c_0_1{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+                const std::array<double, 10u>                                              c_0_2{ 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+
+                const double            alpha_s_mu = 0.3 * 4.0 * M_PI;
+                const double            alpha_s_0  = 0.1 * 4.0 * M_PI;
+                std::array<double, 10u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1, c_0_2);
+
+                static const double eps = 1.0e-15;
+                TEST_CHECK_NEARLY_EQUAL(result[0], 0.111, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], 0.222, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[2], 0.333, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[3], 0.444, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[4], 0.555, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[5], 0.666, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[6], 0.777, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[7], 0.888, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[8], 0.999, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[9], 1.11, eps);
+            }
+
+            // current-current test case (nf = 5, dim = 2)
+            {
+                const double                                 sq2 = std::sqrt(2.0);
+                const std::array<double, 2u>                 gamma_0_ev{ -8.0, +4.0 };
+                const std::array<std::array<double, 2u>, 2u> V{
+                    {
+                     { -1.0 / sq2, +1.0 / sq2 },
+                     { +1.0 / sq2, +1.0 / sq2 },
+                     }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_1{
+                    { { -209.0 / 18.0, +41.0 / 6.0 }, { +41.0 / 6.0, -209.0 / 18.0 } }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_2{
+                    { { +239.0 / 18.0, -43.0 / 6.0 }, { -43.0 / 6.0, +239.0 / 18.0 } }
+                };
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, 5u, 2u> rge(gamma_0_ev, V, gamma_1, gamma_2);
+                const std::array<double, 2u>                                              c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u>                                              c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
+                const std::array<double, 2u>                                              c_0_2{ -9.0 / 2.0, -13.0 / 6.0 };
+
+                const double           alpha_s_mu = 0.218017;
+                const double           alpha_s_0  = 0.121864;
+                std::array<double, 2u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1, c_0_2);
+
+                static const double eps = 1.0e-8;
+                TEST_CHECK_NEARLY_EQUAL(result[0], -0.171944007908276, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], +1.072074409306490, eps);
+            }
+
+            // non-symmetric test case (nf = 5, dim = 2)
+            {
+                const std::array<double, 2u>                 gamma_0_ev{ -16.0, +2.0 };
+                const std::array<std::array<double, 2u>, 2u> V{
+                    {
+                     { 1.0 / 6.0, -4.0 / 3.0 },
+                     { 1.0, 1.0 },
+                     }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_1{
+                    {
+                     { -28.0 / 3.0, -374.0 / 3.0 },
+                     { -2044.0 / 27.0, -2975.0 / 18.0 },
+                     }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_2{
+                    {
+                     { -25.0 / 3.0, -377.0 / 3.0 },
+                     { -2047.0 / 27.0, -2978.0 / 18.0 },
+                     }
+                };
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, 5u, 2u> rge(gamma_0_ev, V, gamma_1, gamma_2);
+                const std::array<double, 2u>                                              c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u>                                              c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
+                const std::array<double, 2u>                                              c_0_2{ -9.0 / 2.0, -13.0 / 6.0 };
+
+                const double           alpha_s_mu = 0.218017;
+                const double           alpha_s_0  = 0.121864;
+                std::array<double, 2u> result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1, c_0_2);
+
+                static const double eps = 1.0e-8;
+                TEST_CHECK_NEARLY_EQUAL(result[0], +0.23134566937815798, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[1], +1.82581433200249621, eps);
+            }
+        }
+} multiplicative_rge_nnll_test;

--- a/eos/utils/rge_TEST.cc
+++ b/eos/utils/rge_TEST.cc
@@ -412,5 +412,53 @@ class MultiplicativeRGENNLLTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(result[0], +0.23134566937815798, eps);
                 TEST_CHECK_NEARLY_EQUAL(result[1], +1.82581433200249621, eps);
             }
+
+            // test case evolve_intermediate (nf = 5, dim = 2)
+            {
+                const std::array<double, 2u>                 gamma_0_ev{ -16.0, +2.0 };
+                const std::array<std::array<double, 2u>, 2u> V{
+                    {
+                     { 1.0 / 6.0, -4.0 / 3.0 },
+                     { 1.0, 1.0 },
+                     }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_1{
+                    {
+                     { -28.0 / 3.0, -374.0 / 3.0 },
+                     { -2044.0 / 27.0, -2975.0 / 18.0 },
+                     }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_2{
+                    {
+                     { -25.0 / 3.0, -377.0 / 3.0 },
+                     { -2047.0 / 27.0, -2978.0 / 18.0 },
+                     }
+                };
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::NNLL, 5u, 2u> rge(gamma_0_ev, V, gamma_1, gamma_2);
+                const std::array<double, 2u>                                              c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u>                                              c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
+                const std::array<double, 2u>                                              c_0_2{ -9.0 / 2.0, -13.0 / 6.0 };
+
+                const double                                                                             alpha_s_mu = 0.218017;
+                const double                                                                             alpha_s_0  = 0.121864;
+                const std::tuple<std::array<double, 2u>, std::array<double, 2u>, std::array<double, 2u>> result_int =
+                        rge.evolve_intermediate(alpha_s_mu, alpha_s_0, c_0_0, c_0_1, c_0_2);
+                const std::array<double, 2u> result = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1, c_0_2);
+
+                static const double eps = 1.0e-8;
+                static const double as  = (alpha_s_mu / (4 * M_PI));
+                TEST_CHECK_NEARLY_EQUAL(std::get<0>(result_int)[0], 0.13450413841219757694, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::get<0>(result_int)[1], 1.7339618486408014952, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::get<1>(result_int)[0] * as, 0.098644535758156973171, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::get<1>(result_int)[1] * as, 0.094811535670379365470, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::get<2>(result_int)[0] * as * as, -0.0021698664302199910381, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::get<2>(result_int)[1] * as * as, -0.0042409913794314302304, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[0],
+                                        std::get<0>(result_int)[0] + as * std::get<1>(result_int)[0] + as * as * std::get<2>(result_int)[0],
+                                        std::abs(20 * as * as * as * std::get<2>(result_int)[0]));
+                TEST_CHECK_NEARLY_EQUAL(result[1],
+                                        std::get<0>(result_int)[1] + as * std::get<1>(result_int)[1] + as * as * std::get<2>(result_int)[1],
+                                        std::abs(20 * as * as * as * std::get<2>(result_int)[1]));
+            }
         }
 } multiplicative_rge_nnll_test;

--- a/eos/utils/rge_TEST.cc
+++ b/eos/utils/rge_TEST.cc
@@ -3,6 +3,7 @@
 
 /*
  * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2026 Dominik Suelmann
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -229,6 +230,48 @@ class MultiplicativeRGENLLTest : public TestCase
                 static const double eps = 1.0e-6;
                 TEST_CHECK_NEARLY_EQUAL(result[0], +0.229589, eps);
                 TEST_CHECK_NEARLY_EQUAL(result[1], +1.826340, eps);
+            }
+
+            // test case evolve_intermediate (nf = 5, dim = 2)
+            {
+                const std::array<double, 2u>                 gamma_0_ev{ -16.0, +2.0 };
+                const std::array<std::array<double, 2u>, 2u> V{
+                    {
+                     { 1.0 / 6.0, -4.0 / 3.0 },
+                     { 1.0, 1.0 },
+                     }
+                };
+                const std::array<std::array<double, 2u>, 2u> gamma_1{
+                    {
+                     { -28.0 / 3.0, -374.0 / 3.0 },
+                     { -2044.0 / 27.0, -2975.0 / 18.0 },
+                     }
+                };
+                const MultiplicativeRenormalizationGroupEvolution<accuracy::NLL, 5u, 2u> rge(gamma_0_ev, V, gamma_1);
+                const std::array<double, 2u>                                             c_0_0{ 0.0, 1.0 };
+                const std::array<double, 2u>                                             c_0_1{ 11.0 / 2.0, -11.0 / 6.0 };
+
+                const double                                                     alpha_s_mu = 0.121864;
+                const double                                                     alpha_s_0  = 0.121864;
+                const std::tuple<std::array<double, 2u>, std::array<double, 2u>> result_int = rge.evolve_intermediate(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
+                const std::array<double, 2u>                                     result     = rge.evolve(alpha_s_mu, alpha_s_0, c_0_0, c_0_1);
+
+                static const double eps = 1.0e-6;
+                static const double as  = (alpha_s_mu / (4 * M_PI));
+                TEST_CHECK_NEARLY_EQUAL(std::get<0>(result_int)[0], 0.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::get<0>(result_int)[1], 1.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::get<1>(result_int)[0], 11.0 / 2.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::get<1>(result_int)[1], -11.0 / 6.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(result[0], std::get<0>(result_int)[0] + as * std::get<1>(result_int)[0], std::abs(10 * as * as * std::get<1>(result_int)[0]));
+                TEST_CHECK_NEARLY_EQUAL(result[1], std::get<0>(result_int)[1] + as * std::get<1>(result_int)[1], std::abs(10 * as * as * std::get<1>(result_int)[1]));
+
+                const double                                                     alpha_s_mu2 = 0.218017;
+                const std::tuple<std::array<double, 2u>, std::array<double, 2u>> result_int2 = rge.evolve_intermediate(alpha_s_mu2, alpha_s_0, c_0_0, c_0_1);
+                const std::array<double, 2u>                                     result2     = rge.evolve(alpha_s_mu2, alpha_s_0, c_0_0, c_0_1);
+                static const double                                              as2         = (alpha_s_mu2 / (4 * M_PI));
+
+                TEST_CHECK_NEARLY_EQUAL(result2[0], std::get<0>(result_int2)[0] + as2 * std::get<1>(result_int2)[0], std::abs(10 * as2 * as2 * std::get<1>(result_int2)[0]));
+                TEST_CHECK_NEARLY_EQUAL(result2[1], std::get<0>(result_int2)[1] + as2 * std::get<1>(result_int2)[1], std::abs(10 * as2 * as2 * std::get<1>(result_int2)[1]));
             }
         }
 } multiplicative_rge_nll_test;


### PR DESCRIPTION
I implement the WET Wilson coefficients for c -> u l l transitions by making the following changes: 

- Add basis for WCs with Delta c = Delta u = 1 transitions
- Add method `evolve_intermediate` to `MultiplicativeRenormalizationGroupEquation`  template that returns for NLL the same result as evolve as a series in alpha_s
- Add SM matching and RGEs at NLL with matching performed at mu_W and mu_b
- Add checks comparing results with own mathematica code
- Add general NNLL template for `MultiplicativeRenormalizationGroupEquation` with an `evolve_intermediate`  method
- Update UC WCs to NNLL including checks again