### PR TITLE
Fix font issue in jupyter notebook vs CLI figures

### DIFF
--- a/python/eos/figure/config.py
+++ b/python/eos/figure/config.py
@@ -17,12 +17,6 @@
 import matplotlib
 from matplotlib import rcParams
 
-try:
-    if __IPYTHON__:
-        pass
-except NameError as e:
-    matplotlib.use('pgf')
-
 # set some default values for plotting
 matplotlib.rcParams['font.family'] = 'serif'
 matplotlib.rcParams['font.serif'] = ['Computer Modern Roman', 'cmr10']

--- a/python/eos/figure/config.py
+++ b/python/eos/figure/config.py
@@ -25,7 +25,7 @@ except NameError as e:
 
 # set some default values for plotting
 matplotlib.rcParams['font.family'] = 'serif'
-matplotlib.rcParams['font.serif'] = ['Computer Modern', 'cmr10']
+matplotlib.rcParams['font.serif'] = ['Computer Modern Roman', 'cmr10']
 matplotlib.rcParams['font.sans-serif'] = ['Computer Modern Sans Serif', 'cmss10' ]
 matplotlib.rcParams['font.size'] = 14
 matplotlib.rcParams['font.weight'] = 'normal'

--- a/python/eos/figure/config.py
+++ b/python/eos/figure/config.py
@@ -26,6 +26,7 @@ except NameError as e:
 # set some default values for plotting
 matplotlib.rcParams['font.family'] = 'serif'
 matplotlib.rcParams['font.serif'] = ['Computer Modern', 'cmr10']
+matplotlib.rcParams['font.sans-serif'] = ['Computer Modern Sans Serif', 'cmss10' ]
 matplotlib.rcParams['font.size'] = 14
 matplotlib.rcParams['font.weight'] = 'normal'
 

--- a/python/eos/plot/config.py
+++ b/python/eos/plot/config.py
@@ -17,12 +17,6 @@
 import matplotlib
 from matplotlib import rcParams
 
-try:
-    if __IPYTHON__:
-        pass
-except NameError as e:
-    matplotlib.use('pgf')
-
 # set some default values for plotting
 matplotlib.rcParams['font.family'] = 'serif'
 matplotlib.rcParams['font.serif'] = ['Computer Modern Roman', 'cmr10']

--- a/python/eos/plot/config.py
+++ b/python/eos/plot/config.py
@@ -25,7 +25,7 @@ except NameError as e:
 
 # set some default values for plotting
 matplotlib.rcParams['font.family'] = 'serif'
-matplotlib.rcParams['font.serif'] = ['Computer Modern', 'cmr10']
+matplotlib.rcParams['font.serif'] = ['Computer Modern Roman', 'cmr10']
 matplotlib.rcParams['font.sans-serif'] = ['Computer Modern Sans Serif', 'cmss10' ]
 matplotlib.rcParams['font.size'] = 14
 matplotlib.rcParams['font.weight'] = 'normal'

--- a/python/eos/plot/config.py
+++ b/python/eos/plot/config.py
@@ -26,6 +26,7 @@ except NameError as e:
 # set some default values for plotting
 matplotlib.rcParams['font.family'] = 'serif'
 matplotlib.rcParams['font.serif'] = ['Computer Modern', 'cmr10']
+matplotlib.rcParams['font.sans-serif'] = ['Computer Modern Sans Serif', 'cmss10' ]
 matplotlib.rcParams['font.size'] = 14
 matplotlib.rcParams['font.weight'] = 'normal'
 


### PR DESCRIPTION
Drawing a figure using the `eos-figure` / `eos-plot` CLI vs inside a jupyter notebook resulted in a different sans-serif font for the EOS watermark.
This is because in scripts, we use the `pgf` matplotlib backend, while in ipython/jupyter notebooks we let it use its own interactive backend (see below)
https://github.com/eos/eos/blob/bb373b3c42f0ffb8e6e153412061400805ac7a3c/python/eos/figure/config.py#L20-L24
When saving a PDF file (or PNG as I think these are just converted from PDF -> PNG), *something* different happens with the treatment of fonts in the `pgf` backend vs the `pdf` backend (which is what ipython/jupyter fall back to when saving a file). The result is that in a script it uses Deja Vu Sans Serif which is the matplotlib default sans serif font, while in jupyter notebooks, it ends up using Computer Modern Sans Serif (third in the list of matplotlib defaults).

This PR changes three things:
1) Explicitly sets that we want to use Computer Modern Sans Serif as the sans serif font
2) Removes the distinction in matplotlib backend between scripts and jupyter notebooks. The only benefit of the `pgf` backend is that one can save a plot as text file which can be copied directly into a latex document to be compiled alongside the text, but I suspect no-one ever does this. (I guess historically @dvandyk used this, or thought this was a useful thing)
3) The serif font name as used in matplotlib is `Computer Modern Roman` not `Computer Modern` (at least this is what this is called in the default rcParams). It was working fine as `cmr10`  is present in the matplotlib install anyway.