### PR TITLE
Small changes to the figure framework

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,20 +19,28 @@
   - `B_(s)->D_(s)^*::FormFactors@HPQCD:2023A` -> `B_(s)->D_(s)^*::FormFactors[HQETBasis]@HPQCD:2023A`
   - `B_(s)->D_(s)^*::FormFactors[TraditionalBasis]@HPQCD:2023A` -> `B_(s)->D_(s)^*::FormFactors@HPQCD:2023A`
 - Impose the exact relation `f+(0) = f0(0)` in the BGL parameterisation of P -> P form factors (M. Reboud)
+- Bump the Ubuntu image to resolute and the PyPI container (D. van Dyk)
+- Reorganize the structure of constraints (F. Herren)
 
 
 ### Added
 
 - Add functionality to figure framework to allow export to multiple files at once (M. Kirk)
-- Export `wilson-polynomials` to python (M. Reboud)
-- Add missing references to bibliography (M. Kirk, E. McPartland)
+- Export `wilson-polynomials` to python (M. Reboud, D. van Dyk)
+- Add missing references to bibliography and implement a commit hook to check for missing references (M. Kirk, E. McPartland)
 - Implement a new figure item to plot constraints residues (M. Reboud)
 - Update the examples and the tests of the figure framework (M. Reboud)
+- Implements an observable option to specify which option needs to be plotted in an uncertainty band item (M. Reboud)
+- Implements B_c -> J/psi ell nu decays (C. Bolognani, M. Reboud)
+- Add basis for WCs with Delta c = Delta u = 1 transitions (D. Sue)
+- Extend the WC RGE and test it (D. Sue)
+- Implement L_c -> neutron ell nu decays (C. Bolognani)
 
 
 ### Removed
 
 - Purge `integrate1d` (M. Reboud, F. Herren)
+- Remove the matplotlib backend choice (M. Kirk)
 
 
 ### Fixed
@@ -40,7 +48,9 @@
 - Correct references list (M. Kirk, E. McPartland)
 - Fix bugs in the figure framework (M. Reboud)
 - Fix the constraint `B_(s)->D_(s)^*::FormFactors@HPQCD:2023A` (M. Reboud)
-
+- Fix the bound saturations in the BGL parameterisation (M. Reboud)
+- Fix the font used by matplotlib (M. Kirk)
+- Fix a race condition in TreadPool (D. van Dyk)
 
 
 ## [v1.0.19] - 2025-12-02

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl vim: set sw=8 sts=8 noet ft=config foldmethod=marker foldmarker={{{,}}}:
 
-AC_INIT([EOS],[1.0.19])
+AC_INIT([EOS],[1.0.20])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([])
 AC_CONFIG_AUX_DIR(config)

--- a/python/eos/figure/figure.py
+++ b/python/eos/figure/figure.py
@@ -237,6 +237,7 @@ class GridFigure(Figure):
     plots:list[Plot]
     padding:tuple[float,float]=field(default=(0.2, 0.2))
     shape:tuple[int, int]
+    watermark:Watermark=field(default_factory=Watermark)
 
     _api_doc = inspect.cleandoc("""
     Producing a Figure with a Grid of Plots
@@ -273,6 +274,7 @@ class GridFigure(Figure):
         for idx, plot in enumerate(self.plots):
             plot.prepare()
             plot.draw(self._axes[idx])
+            self.watermark.draw(self._axes[idx])
 
         self._gridspec.tight_layout(self._figure)
         if output is not None:

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -263,6 +263,8 @@ class UncertaintyBandItem(Item):
     :type resolution: int
     :param variable: The name of the kinematic variable that is plotted on the x-axis. Defaults to the first kinematic variable recorded in the data file.
     :type variable: str | None
+    :param observable: The name of the observable that is plotted. This name can include options. Defaults to the first observable recorded in the data file.
+    :type observable: str | None
 
     Example:
 
@@ -271,7 +273,7 @@ class UncertaintyBandItem(Item):
         figure_args = '''
         plot:
           xaxis: { label: r'$q^2$', unit: r'$\\textnormal{GeV}^2$', range: [0.0, 11.63] }
-          yaxis: { label: r'$d\\mathcal{B}/dq^2$',                 range: [0.0,  5e-3] }
+          yaxis: { label: r'$d\\mathcal{B}/dq^2$',                  range: [0.0,  5e-3] }
           legend: { position: 'upper center' }
           items:
             - { type: 'uncertainty', label: r'$\\ell=\\mu$',
@@ -293,6 +295,7 @@ class UncertaintyBandItem(Item):
     range:tuple[float, float]|None=field(default=None)
     resolution:int=field(default=100)
     variable:str|None=field(default=None)
+    observable:str|None=field(default=None)
 
     _api_doc = inspect.cleandoc("""\
     Plotting Uncertainty Bands
@@ -318,6 +321,7 @@ class UncertaintyBandItem(Item):
         * ``range`` (*tuple* of two *float* values) -- The range of the kinematic variable to be plotted on the x-axis. Defaults to the full range of the variable in the data file.
         * ``resolution`` (*int*) -- The number of points to be used for the interpolation of the band. Defaults to 100.
         * ``variable`` (*str*) -- The name of the kinematic variable that is plotted on the x-axis. Defaults to the first kinematic variable in the data file.
+        * ``observable`` (*str*) -- The name of the observable that is plotted. This name can include options. Defaults to the first observable in the data file.
 
     Example:
 
@@ -376,7 +380,7 @@ class UncertaintyBandItem(Item):
             raise ValueError(f"Data file '{self.datafile}' does not contain any predictions")
 
         self._variable = self.variable
-        if self._variable is not None:
+        if self._variable is None:
             # assume that the first prediction has only one kinematic variable,
             # which we adopt as the variable to plot
             kinematics = self._datafile.varied_parameters[0]['kinematics']
@@ -384,15 +388,38 @@ class UncertaintyBandItem(Item):
                 raise ValueError(f"Data file '{self.datafile}' contains more than one kinematic variable; specify 'variable' to determine which is supposed to be used")
             self._variable = list(kinematics.keys())[0]
 
+        self._observable = self.observable
+        if self._observable is None:
+            # assume that only one observable was predicted
+            observables = {obs.split(';')[0] for obs in list(self._datafile.lookup_table.keys())}
+            if len(observables) > 1:
+                raise ValueError(f"Data file '{self.datafile}' contains more than one predicted observable; specify 'observable' to determine which is supposed to be used")
+            if len(observables) == 0:
+                raise ValueError(f"Data file '{self.datafile}' contains no observable, check predictions")
+            self._observable = observables.pop()
+        self._observable = eos.QualifiedName(self._observable)
+
+        # Filter the x values and the predictions based on _variable and _observable
         _xvalues = []
+        _observable_mask = []
         for idx, vp in enumerate(self._datafile.varied_parameters):
             kinematics = vp['kinematics']
             if self._variable not in kinematics:
                 raise ValueError(f"Prediction #{idx} in data file '{self.datafile}' does not depend on the chosen kinematic variable '{self._variable}'")
             _xvalues.append(kinematics[self._variable])
 
-        _xvalues = _np.array(_xvalues)
-        _samples = self._datafile.samples
+            valid_observable = (self._observable == eos.QualifiedName(vp["name"])) # Check that the observable names match
+            for k, v in self._observable.options_part(): # Check that thre specified options match
+                if k in vp["options"] and not vp["options"][k] == v:
+                    valid_observable = False
+
+            _observable_mask.append(valid_observable)
+
+        if not _np.any(_observable_mask):
+            raise ValueError(f"No observable of the data file matches the specified observable '{self.observable}'")
+
+        _xvalues = _np.array(_xvalues)[_observable_mask]
+        _samples = self._datafile.samples[:, _observable_mask]
         _weights = self._datafile.weights
 
         _ovalues_lower   = []

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -400,7 +400,7 @@ class UncertaintyBandItem(Item):
         _ovalues_higher  = []
         INTERVAL = [0.15865, 0.5, 0.84135]  # central 68% interval
         for i in range(len(_samples[0])):
-            lower, central, higher = eos.plot.Plotter._weighted_quantiles(_samples[:, i], INTERVAL, _weights)
+            lower, central, higher = _np.quantile(_samples[:, i], q = INTERVAL, weights = _weights, method='inverted_cdf', axis=0)
             _ovalues_lower.append(lower)
             _ovalues_central.append(central)
             _ovalues_higher.append(higher)


### PR DESCRIPTION
I would like these changes to appear in the next release, but I agree that all of this needs to be tested (it works with my analysis notebooks).

This PR:
- Gets rid of the `eos.plot.Plotter._weighted_quantiles`
- Adds the EOS watermark to all the subplots of the GridFigure
- Implements an `observable` option to specify which option needs to be plotted in an uncertainty band item