### PR TITLE
Lc to pll

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,6 @@ python/eos/*pyhf*   @lorenzennio
 eos/b-decays        @Herren
 eos/form-factors    @Herren
 eos/scattering      @Herren
+
+# @DominikSue should review commits to:
+eos/rare-c-decays   @DominikSue

--- a/.gitlint
+++ b/.gitlint
@@ -7,7 +7,7 @@ line-length=120
 
 # T7
 [title-match-regex]
-regex=^\[(github|infra|scripts|clients|doc|examples|python|eos|test|utils|parameters|constraints|maths|statistics|models|form-factors|nonlocal-form-factors|nonleptonic-amplitudes|b-decays|rare-b-decays|c-decays|s-decays|tau-decays|meson-mixing|scattering)\]\s.*
+regex=^\[(github|infra|scripts|clients|doc|examples|python|eos|test|utils|parameters|constraints|maths|statistics|models|form-factors|nonlocal-form-factors|nonleptonic-amplitudes|b-decays|rare-b-decays|c-decays|rare-c-decays|s-decays|tau-decays|meson-mixing|scattering)\]\s.*
 
 # B5
 [body-min-length]

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - Add B(s) -> K(*) constraints from BGMT:2025A (N. Gubernari)
 - Add BSZ:2025A constraints in the Traditional Basis (N. Gubernari)
 - Add B->pi f0 and f+ constraints from FLAG:2024A (N. Gubernari)
+- Add Lambda_c->pll observables (D. Suelmann)
 
 ### Removed
 

--- a/configure.ac
+++ b/configure.ac
@@ -431,6 +431,7 @@ AC_CONFIG_FILES([Makefile
 	eos/nonleptonic-amplitudes/Makefile
 	eos/parameters/Makefile
 	eos/rare-b-decays/Makefile
+	eos/rare-c-decays/Makefile
 	eos/scattering/Makefile
 	eos/statistics/Makefile
 	eos/utils/Makefile

--- a/eos/Makefile.am
+++ b/eos/Makefile.am
@@ -15,6 +15,7 @@ SUBDIRS = \
 	nonleptonic-amplitudes \
 	rare-b-decays \
 	b-decays \
+	rare-c-decays \
 	c-decays \
 	s-decays \
 	tau-decays \
@@ -48,6 +49,7 @@ libeos_la_LIBADD = \
 	$(top_builddir)/eos/s-decays/libeossdecays.la \
 	$(top_builddir)/eos/tau-decays/libeostaudecays.la \
 	$(top_builddir)/eos/rare-b-decays/libeosrarebdecays.la \
+	$(top_builddir)/eos/rare-c-decays/libeosrarecdecays.la \
 	$(top_builddir)/eos/meson-mixing/libeosmesonmixing.la \
 	$(top_builddir)/eos/scattering/libeosscattering.la
 
@@ -79,6 +81,7 @@ LDADD = \
 	$(top_builddir)/eos/nonleptonic-amplitudes/libeosnonleptonicamplitudes.la \
 	$(top_builddir)/eos/nonlocal-form-factors/libeosnonlocalformfactors.la \
 	$(top_builddir)/eos/rare-b-decays/libeosrarebdecays.la \
+	$(top_builddir)/eos/rare-c-decays/libeosrarecdecays.la \
 	$(top_builddir)/eos/statistics/libeosstatistics.la \
 	$(top_builddir)/eos/scattering/libeosscattering.la \
 	$(top_builddir)/eos/tau-decays/libeostaudecays.la \

--- a/eos/observable.cc
+++ b/eos/observable.cc
@@ -30,6 +30,7 @@
 #include <eos/observable-impl.hh>
 #include <eos/observable.hh>
 #include <eos/rare-b-decays/observables.hh>
+#include <eos/rare-c-decays/observables.hh>
 #include <eos/s-decays/observables.hh>
 #include <eos/scattering/observables.hh>
 #include <eos/tau-decays/observables.hh>
@@ -57,16 +58,11 @@ namespace eos
     ObservableEntries::ObservableEntries() :
         _entries(&impl::observable_entries)
     {
-        std::vector<std::function<ObservableSection()>> section_makers = { make_form_factors_section,
-                                                                           make_nonlocal_form_factors_section,
-                                                                           make_nonleptonic_amplitudes_section,
-                                                                           make_b_decays_section,
-                                                                           make_c_decays_section,
-                                                                           make_rare_b_decays_section,
-                                                                           make_meson_mixing_section,
-                                                                           make_scattering_section,
-                                                                           make_s_decays_section,
-                                                                           make_tau_decays_section };
+        std::vector<std::function<ObservableSection()>> section_makers = {
+            make_form_factors_section,  make_nonlocal_form_factors_section, make_nonleptonic_amplitudes_section, make_b_decays_section,   make_c_decays_section,
+            make_rare_b_decays_section, make_rare_c_decays_section,         make_meson_mixing_section,           make_scattering_section, make_s_decays_section,
+            make_tau_decays_section
+        };
 
         for (const auto & section_maker : section_makers)
         {
@@ -133,6 +129,7 @@ namespace eos
                 _sections = std::vector<ObservableSection>({ make_b_decays_section(),
                                                              make_c_decays_section(),
                                                              make_rare_b_decays_section(),
+                                                             make_rare_c_decays_section(),
                                                              make_meson_mixing_section(),
                                                              make_nonleptonic_amplitudes_section(),
                                                              make_nonlocal_form_factors_section(),

--- a/eos/parameters/hadron-properties.yaml
+++ b/eos/parameters/hadron-properties.yaml
@@ -669,6 +669,27 @@ groups:
           unit:     's'
           latex:    '$\tau_{K_L}$'
           comments: 'cf. [PDG:2024A] p. 41'
+      'life_time::rho^0' :
+          central: +4.4655e-24
+          min:     +4.4412e-24
+          max:     +4.4897e-24
+          latex:   '$\tau_{\rho^0}$'
+          unit:     's'
+          comments: 'Extracted from width = 147.4+-0.8 MeV, cf. [PDG-Live], May 2026'
+      'life_time::omega' :
+          central: +7.5831e-23
+          min:     +7.4695e-23
+          max:     +7.6967e-23
+          latex:   '$\tau_{\omega}$'
+          unit:     's'
+          comments: 'Extracted from width = 8.68+-0.13 MeV, cf. [PDG-Live], May 2026'
+      'life_time::phi' :
+          central: +1.5491e-22
+          min:     +1.5444e-22
+          max:     +1.5538e-22
+          latex:   '$\tau_{\phi}$'
+          unit:     's'
+          comments: 'Extracted from width = 4.249+-0.013 MeV, cf. [PDG-Live], May 2026'
       'life_time::D_d' :
           central: +1.033e-12
           min:     +1.028e-12

--- a/eos/parameters/hadronic-matrix-elements.yaml
+++ b/eos/parameters/hadronic-matrix-elements.yaml
@@ -5274,6 +5274,50 @@ groups:
             - ["V", "A", "T", "T5"]
             - [0, 1, 2, 3, 4]
           comments: ''
+      # data-driven parameters for long-distance contributions to Lambda_c -> proton l l decays according to
+      # [GHM:2021A]
+      'Lambda_c->proton::res_a_rho@GHM2021':
+        central: +0.44
+        min: +0.0
+        max: +1.0
+        latex: '$a_{\rho}^{\Lambda_c\to p \ell\ell}$'
+        unit: 'GeV^2'
+        comments: ''
+      'Lambda_c->proton::res_a_omega@GHM2021':
+        central: +0.073
+        min: +0.0
+        max: +1.0
+        latex: '$a_{\omega}^{\Lambda_c\to p \ell\ell}$'
+        unit: 'GeV^2'
+        comments: ''
+      'Lambda_c->proton::res_a_phi@GHM2021':
+        central: +0.102
+        min: +0.0
+        max: +1.0
+        latex: '$a_{\phi}^{\Lambda_c\to p \ell\ell}$'
+        unit: 'GeV^2'
+        comments: ''
+      'Lambda_c->proton::res_delta_rho@GHM2021':
+        central: +0.0
+        min: -3.14
+        max: +3.14
+        latex: '$\delta_{\rho}^{\Lambda_c\to p \ell\ell}$'
+        unit: '1'
+        comments: ''
+      'Lambda_c->proton::res_delta_omega_m_rho@GHM2021':
+        central: +3.14
+        min: -3.14
+        max: +3.14
+        latex: '$\delta_{\omega}^{\Lambda_c\to p \ell\ell} - \delta_{\rho}^{\Lambda_c\to p \ell\ell}$'
+        unit: '1'
+        comments: ''
+      'Lambda_c->proton::res_delta_phi_m_rho@GHM2021':
+        central: +1.11
+        min: -3.14
+        max: +3.14
+        latex: '$\delta_{\phi}^{\Lambda_c\to p \ell\ell} - \delta_{\rho}^{\Lambda_c\to p \ell\ell}$'
+        unit: '1'
+        comments: ''
       # Form factor parameters for Lambda_b -> Lambda_c decay according to
       # [DKMR:2017A], use table 2 and supplemental material. For nominal fit all a_2 parameters are set to zero.
       # params for tensor FFs are included.

--- a/eos/rare-c-decays/Makefile.am
+++ b/eos/rare-c-decays/Makefile.am
@@ -1,0 +1,44 @@
+CLEANFILES = *~
+MAINTAINERCLEANFILES = Makefile.in
+
+AM_CXXFLAGS = @AM_CXXFLAGS@
+AM_LDFLAGS = @AM_LDFLAGS@
+
+lib_LTLIBRARIES = libeosrarecdecays.la
+libeosrarecdecays_la_SOURCES = \
+	lambda-c-to-proton-l-l.cc lambda-c-to-proton-l-l.hh \
+	observables.cc observables.hh
+libeosrarecdecays_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
+libeosrarecdecays_la_LDFLAGS = $(AM_LDFLAGS) $(GSL_LDFLAGS)
+libeosrarecdecays_la_LIBADD = \
+	$(top_builddir)/eos/utils/libeosutils.la \
+	$(top_builddir)/eos/maths/libeosmaths.la \
+	$(top_builddir)/eos/models/libeosmodels.la \
+	$(top_builddir)/eos/form-factors/libeosformfactors.la \
+	-lboost_filesystem \
+	-lgsl -lgslcblas -lm
+
+include_eos_rarecdecaysdir = $(includedir)/eos/rare-c-decays
+include_eos_rarecdecays_HEADERS = \
+	lambda-c-to-proton-l-l.hh \
+	observables.hh
+
+EXTRA_DIST =
+
+AM_TESTS_ENVIRONMENT = \
+	export EOS_TESTS_PARAMETERS="$(top_srcdir)/eos/parameters";
+
+TESTS = \
+	lambda-c-to-proton-l-l_TEST
+
+LDADD = \
+	$(top_builddir)/test/libeostest.la \
+	libeosrarecdecays.la \
+	$(top_builddir)/eos/form-factors/libeosformfactors.la \
+	$(top_builddir)/eos/utils/libeosutils.la \
+	$(top_builddir)/eos/maths/libeosmaths.la \
+	$(top_builddir)/eos/models/libeosmodels.la \
+	$(top_builddir)/eos/libeos.la
+
+check_PROGRAMS = $(TESTS)
+lambda_c_to_proton_l_l_TEST_SOURCES = lambda-c-to-proton-l-l_TEST.cc

--- a/eos/rare-c-decays/lambda-c-to-proton-l-l.cc
+++ b/eos/rare-c-decays/lambda-c-to-proton-l-l.cc
@@ -1,0 +1,499 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2019 Ahmet Kokulu
+ * Copyright (c) 2019,2021 Danny van Dyk
+ * Copyright (c) 2023 Méril Reboud
+ * Copyright (c) 2026 Dominik Suelmann
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <eos/form-factors/baryonic.hh>
+#include <eos/maths/complex.hh>
+#include <eos/maths/integrate-impl.hh>
+#include <eos/maths/integrate.hh>
+#include <eos/maths/power-of.hh>
+#include <eos/models/model.hh>
+#include <eos/rare-c-decays/lambda-c-to-proton-l-l.hh>
+#include <eos/utils/destringify.hh>
+#include <eos/utils/kinematic.hh>
+#include <eos/utils/log.hh>
+#include <eos/utils/memoise.hh>
+#include <eos/utils/options-impl.hh>
+#include <eos/utils/options.hh>
+#include <eos/utils/private_implementation_pattern-impl.hh>
+
+#include <cmath>
+#include <functional>
+#include <map>
+#include <string>
+
+namespace eos
+{
+    using namespace std::literals::string_literals;
+    using std::norm;
+
+    namespace lambda_c_to_proton_l_l
+    {
+        struct Amplitudes
+        {
+                double aU11;
+                double aL11;
+                double aU22;
+                double aL22;
+                double aP12;
+                double aS22;
+
+                double beta_l;
+                double beta_l_squared;
+                double four_m_l_squared;
+                double q2;
+                double norm_squared;
+        };
+
+        struct AngularObservables
+        {
+                std::array<double, 3> _k;
+
+                AngularObservables(const Amplitudes & a)
+                {
+                    using std::conj;
+                    using std::imag;
+                    using std::norm;
+                    using std::real;
+                    using std::sqrt;
+
+                    double beta_l           = a.beta_l;
+                    double beta_l_squared   = a.beta_l_squared;
+                    double four_m_l_squared = a.four_m_l_squared;
+                    double q2               = a.q2;
+                    double aU11U22          = a.aU11 + a.aU22;
+                    double aULS             = a.aU11 + a.aL11 + a.aS22;
+
+                    // cf. [GHM:2021A], eq. (20), p. 6.
+
+                    // K_{1ss}
+                    _k[0] = a.norm_squared * (q2 * beta_l_squared * (aU11U22 / 2.0 + a.aL11 + a.aL22) + four_m_l_squared * aULS);
+
+                    // K_{1cc}
+                    _k[1] = a.norm_squared * (q2 * beta_l_squared * aU11U22 + four_m_l_squared * aULS);
+
+                    // K_{1c}
+                    _k[2] = a.norm_squared * (-2.0 * q2 * beta_l * a.aP12);
+                }
+
+                AngularObservables(const std::array<double, 3> & k) :
+                    _k(k)
+                {
+                }
+
+                inline double
+                k1ss() const
+                {
+                    return _k[0];
+                }
+
+                inline double
+                k1cc() const
+                {
+                    return _k[1];
+                }
+
+                inline double
+                k1c() const
+                {
+                    return _k[2];
+                }
+
+                inline double
+                decay_width() const
+                {
+                    return 2.0 * k1ss() + k1cc();
+                }
+
+                inline double
+                a_fb_leptonic() const
+                {
+                    return 3.0 / 2.0 * k1c() / decay_width();
+                }
+
+                inline double
+                a_fb_leptonic_num() const
+                {
+                    return 3.0 / 2.0 * k1c();
+                }
+
+                inline double
+                f_l() const
+                {
+                    return (2.0 * k1ss() - k1cc()) / decay_width();
+                }
+
+                inline double
+                f_l_num() const
+                {
+                    return (2.0 * k1ss() - k1cc());
+                }
+
+                inline double
+                d2gamma(const double & c_lep) const
+                {
+                    const double c2_lep = c_lep * c_lep;
+                    const double s2_lep = 1.0 - c2_lep;
+
+                    // cf. [GHM:2021A], p. 6, eq. (9)
+                    return 3.0 / 2.0 * (k1ss() * s2_lep + k1cc() * c2_lep + k1c() * c_lep);
+                }
+        };
+    } // namespace lambda_c_to_proton_l_l
+
+    template <> struct Implementation<LambdaCToProtonLeptonLepton>
+    {
+            std::shared_ptr<Model> model;
+
+            Parameters parameters;
+
+            UsedParameter hbar;
+            UsedParameter tau_Lambda_c;
+
+            UsedParameter g_fermi;
+            UsedParameter alpha_e;
+
+            LeptonFlavorOption opt_l;
+            UsedParameter      m_l;
+
+            UsedParameter m_Lambda_c;
+            UsedParameter m_proton;
+            UsedParameter m_rho;
+            UsedParameter m_omega;
+            UsedParameter m_phi;
+            UsedParameter tau_rho;
+            UsedParameter tau_omega;
+            UsedParameter tau_phi;
+
+            // resonance parameters
+            UsedParameter a_rho;
+            UsedParameter a_omega;
+            UsedParameter a_phi;
+            UsedParameter delta_rho;
+            UsedParameter delta_omega_m_rho;
+            UsedParameter delta_phi_m_rho;
+
+            BooleanOption opt_cp_conjugate;
+
+            UsedParameter mu;
+
+            std::shared_ptr<FormFactors<OneHalfPlusToOneHalfPlus>> form_factors;
+
+            static const std::vector<OptionSpecification> options;
+
+            Implementation(const Parameters & p, const Options & o, ParameterUser & u) :
+                model(Model::make(o.get("model"_ok, "WET"), p, o)),
+                parameters(p),
+                hbar(p["QM::hbar"], u),
+                tau_Lambda_c(p["life_time::Lambda_c"], u),
+                g_fermi(p["WET::G_Fermi"], u),
+                alpha_e(p["QED::alpha_e(m_c)"], u),
+                opt_l(o, options, "l"_ok),
+                m_l(p["mass::" + opt_l.str()], u),
+                m_Lambda_c(p["mass::Lambda_c"], u),
+                m_proton(p["mass::proton"], u),
+                m_rho(p["mass::rho^0"], u),
+                m_omega(p["mass::omega"], u),
+                m_phi(p["mass::phi"], u),
+                tau_rho(p["life_time::rho^0"], u),
+                tau_omega(p["life_time::omega"], u),
+                tau_phi(p["life_time::phi"], u),
+                a_rho(p["Lambda_c->proton::res_a_rho@GHM2021"], u),
+                a_omega(p["Lambda_c->proton::res_a_omega@GHM2021"], u),
+                a_phi(p["Lambda_c->proton::res_a_phi@GHM2021"], u),
+                delta_rho(p["Lambda_c->proton::res_delta_rho@GHM2021"], u),
+                delta_omega_m_rho(p["Lambda_c->proton::res_delta_omega_m_rho@GHM2021"], u),
+                delta_phi_m_rho(p["Lambda_c->proton::res_delta_phi_m_rho@GHM2021"], u),
+                opt_cp_conjugate(o, options, "cp-conjugate"_ok),
+                mu(p["uc::mu"], u),
+                form_factors(FormFactorFactory<OneHalfPlusToOneHalfPlus>::create("Lambda_c->neutron::" + o.get("form-factors"_ok, "BMRvD2022"), p, o)) // using isospin
+            {
+                u.uses(*form_factors);
+                u.uses(*model);
+            }
+
+            const double
+            normalization(const double & q2) const
+            {
+                double lam = lambda(m_Lambda_c * m_Lambda_c, m_proton * m_proton, q2);
+
+                if ((lam <= 0) || (q2 <= 4.0 * m_l * m_l))
+                {
+                    return 0.0;
+                }
+                // there is no overall CKM factor in c -> u transitions, see [dBMS:2016A] eq. 4, instead the individual factors are applied in the amplitude calculation.
+                return g_fermi() * alpha_e() * std::sqrt(std::sqrt(1.0 - 4.0 * m_l * m_l / q2))
+                       * std::sqrt(std::sqrt(lam) / 3.0 / power_of<11>(2) / power_of<5>(M_PI) / power_of<3>(m_Lambda_c()));
+            }
+
+            lambda_c_to_proton_l_l::Amplitudes
+            amplitudes(const double & s)
+            {
+                using std::conj;
+                using std::imag;
+                using std::norm;
+                using std::real;
+                using std::sqrt;
+
+                lambda_c_to_proton_l_l::Amplitudes result;
+
+                const auto wc = model->wilson_coefficients_uc(opt_l.value(), opt_cp_conjugate.value());
+
+                complex<double> ckm_factor_ds = model->ckm_ud() * conj(model->ckm_cd()) + model->ckm_us() * conj(model->ckm_cs());
+                if (opt_cp_conjugate.value())
+                {
+                    ckm_factor_ds = conj(ckm_factor_ds);
+                };
+
+                const complex<double> c7minus  = (wc.c7() - wc.c7prime()) * ckm_factor_ds;
+                const complex<double> c7plus   = (wc.c7() + wc.c7prime()) * ckm_factor_ds;
+                const complex<double> c9minus  = (wc.c9() - wc.c9prime()) * ckm_factor_ds;
+                const complex<double> c9plus   = (wc.c9() + wc.c9prime()) * ckm_factor_ds;
+                const complex<double> c10minus = (wc.c10() - wc.c10prime()) * ckm_factor_ds;
+                const complex<double> c10plus  = (wc.c10() + wc.c10prime()) * ckm_factor_ds;
+
+                const double res_delta_rho   = delta_rho;
+                const double res_delta_omega = delta_omega_m_rho;
+                const double res_delta_phi   = delta_phi_m_rho;
+
+                const double hb = hbar;
+
+                const complex<double> c9R =
+                        (a_rho() / (complex<double>(s - m_rho * m_rho, m_rho * hb / tau_rho))
+                         + a_omega() * complex<double>(std::cos(res_delta_omega), std::sin(res_delta_omega)) / (complex<double>(s - m_omega * m_omega, m_omega * hb / tau_omega))
+                         + a_phi() * complex<double>(std::cos(res_delta_phi), std::sin(res_delta_phi)) / (complex<double>(s - m_phi * m_phi, m_phi * hb / tau_phi)));
+                const complex<double> cPhase(std::cos(res_delta_rho), std::sin(res_delta_rho));
+
+                // baryonic form factors (10)
+                const double fff0         = form_factors->f_time_v(s);  // f0
+                const double fffplus      = form_factors->f_long_v(s);  // fplus
+                const double fffperp      = form_factors->f_perp_v(s);  // fperp
+                const double ffg0         = form_factors->f_time_a(s);  // g0
+                const double ffgplus      = form_factors->f_long_a(s);  // gplus
+                const double ffgperp      = form_factors->f_perp_a(s);  // gperp
+                const double ffhplus      = form_factors->f_long_t(s);  // hplus
+                const double ffhtildeplus = form_factors->f_long_t5(s); // htildeplus
+                const double ffhperp      = form_factors->f_perp_t(s);  // hperp
+                const double ffhtildeperp = form_factors->f_perp_t5(s); // htildeperp
+                // running quark masses
+                const double mcatmu       = model->m_c_msbar(mu);
+
+                // kinematics
+                const double beta_l_squared   = (1.0 - 4.0 * m_l * m_l / s);
+                const double beta_l           = std::sqrt(beta_l_squared);
+                const double four_m_l_squared = 4.0 * m_l * m_l;
+                const double mplus            = m_Lambda_c + m_proton;
+                const double mminus           = m_Lambda_c - m_proton;
+                const double mplus_squared    = power_of<2>(mplus);
+                const double mminus_squared   = power_of<2>(mminus);
+                const double splus            = mplus_squared - s;
+                const double sminus           = mminus_squared - s;
+                const double sqrtsminussplus  = std::sqrt(sminus) * std::sqrt(splus);
+
+                // normalization
+                const complex<double> N = normalization(s);
+
+                // cf. [GHM:2021A], eq. (11), p. 6, excluding contributions from scalar and tensor operators.
+                result.aU11 = +4.0
+                              * ((norm(c7plus * 2.0 * mcatmu / s * mplus * ffhperp + c9plus * fffperp)
+                                  + 2.0 * real(conj(c7plus * 2.0 * mcatmu / s * mplus * ffhperp + c9plus * fffperp) * c9R * cPhase * fffperp) + norm(c9R * fffperp))
+                                         * sminus
+                                 + (norm(c7minus * 2.0 * mcatmu / s * mminus * ffhtildeperp + c9minus * ffgperp)
+                                    + 2.0 * real(conj(c7minus * 2.0 * mcatmu / s * mminus * ffhtildeperp + c9minus * ffgperp) * c9R * cPhase * ffgperp) + norm(c9R * ffgperp))
+                                           * splus);
+
+                result.aL11 = +2.0 / s
+                              * ((norm(c7plus * 2.0 * mcatmu * ffhplus + c9plus * mplus * fffplus)
+                                  + 2.0 * real(conj(c7plus * 2.0 * mcatmu * ffhplus + c9plus * mplus * fffplus) * c9R * cPhase * mplus * fffplus) + norm(c9R * mplus * fffplus))
+                                         * sminus
+                                 + (norm(c7minus * 2.0 * mcatmu * ffhtildeplus + c9minus * mminus * ffgplus)
+                                    + 2.0 * real(conj(c7minus * 2.0 * mcatmu * ffhtildeplus + c9minus * mminus * ffgplus) * c9R * cPhase * mminus * ffgplus)
+                                    + norm(c9R * mminus * ffgplus))
+                                           * splus);
+                result.aU22 = +4.0 * (norm(c10plus) * fffperp * fffperp * sminus + norm(c10minus) * ffgperp * ffgperp * splus);
+                result.aL22 = +2.0 / s * (norm(c10plus) * mplus_squared * fffplus * fffplus * sminus + norm(c10minus) * mminus_squared * ffgplus * ffgplus * splus);
+                result.aS22 = +2.0 / s * (norm(c10plus) * mminus_squared * fff0 * fff0 * splus + norm(c10minus) * mplus_squared * ffg0 * ffg0 * sminus);
+                result.aP12 =
+                        -8
+                        * (real(c7minus * conj(c10plus)) * mcatmu / s * mminus * fffperp * ffhtildeperp + real(c7plus * conj(c10minus)) * mcatmu / s * mplus * ffgperp * ffhperp
+                           + real((wc.c9() * ckm_factor_ds + c9R * cPhase) * conj(wc.c10() * ckm_factor_ds) - wc.c9prime() * ckm_factor_ds * conj(wc.c10prime() * ckm_factor_ds))
+                                     * ffgperp * fffperp)
+                        * sqrtsminussplus;
+
+                result.beta_l           = beta_l;
+                result.beta_l_squared   = beta_l_squared;
+                result.four_m_l_squared = four_m_l_squared;
+                result.q2               = s;
+                result.norm_squared     = norm(N);
+
+                return result;
+            }
+
+            std::array<double, 3>
+            _differential_angular_observables(const double & q2)
+            {
+                return lambda_c_to_proton_l_l::AngularObservables(this->amplitudes(q2))._k;
+            }
+
+            std::array<double, 3>
+            _integrated_angular_observables(const double & q2_min, const double & q2_max)
+            {
+                std::function<std::array<double, 3>(const double &)> integrand = [this](const double & q2) -> std::array<double, 3>
+                { return this->_differential_angular_observables(q2); };
+
+                return integrate<1, 3>(integrand, q2_min, q2_max, cubature::Config().epsrel(1e-5));
+            }
+
+            inline lambda_c_to_proton_l_l::AngularObservables
+            differential_angular_observables(const double & q2)
+            {
+                return lambda_c_to_proton_l_l::AngularObservables{ _differential_angular_observables(q2) };
+            }
+
+            inline lambda_c_to_proton_l_l::AngularObservables
+            integrated_angular_observables(const double & q2_min, const double & q2_max)
+            {
+                return lambda_c_to_proton_l_l::AngularObservables{ _integrated_angular_observables(q2_min, q2_max) };
+            }
+    };
+
+    const std::vector<OptionSpecification> Implementation<LambdaCToProtonLeptonLepton>::options{
+        Model::option_specification(),
+        { "cp-conjugate"_ok,   { "true"s, "false"s }, "false"s },
+        {            "l"_ok, { "e"s, "mu"s, "tau"s },    "mu"s },
+    };
+
+    LambdaCToProtonLeptonLepton::LambdaCToProtonLeptonLepton(const Parameters & p, const Options & o) :
+        PrivateImplementationPattern<LambdaCToProtonLeptonLepton>(new Implementation<LambdaCToProtonLeptonLepton>(p, o, *this))
+    {
+    }
+
+    LambdaCToProtonLeptonLepton::~LambdaCToProtonLeptonLepton() {}
+
+    /* for double-differential signal PDF */
+    double
+    LambdaCToProtonLeptonLepton::double_differential_decay_width(const double & q2, const double & c_lep) const
+    {
+        return _imp->differential_angular_observables(q2).d2gamma(c_lep);
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_decay_width(const double & q2_min, const double & q2_max) const
+    {
+        return _imp->integrated_angular_observables(q2_min, q2_max).decay_width();
+    }
+
+    /* q^2-differential observables */
+
+    double
+    LambdaCToProtonLeptonLepton::differential_branching_ratio(const double & q2) const
+    {
+        return _imp->differential_angular_observables(q2).decay_width() * _imp->tau_Lambda_c / _imp->hbar;
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::differential_a_fb_leptonic(const double & q2) const
+    {
+        return _imp->differential_angular_observables(q2).a_fb_leptonic();
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::differential_f_l(const double & q2) const
+    {
+        return _imp->differential_angular_observables(q2).f_l();
+    }
+
+    /* q^2-integrated observables */
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_branching_ratio(const double & s_min, const double & s_max) const
+    {
+        return _imp->integrated_angular_observables(s_min, s_max).decay_width() * _imp->tau_Lambda_c / _imp->hbar;
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_a_fb_leptonic(const double & s_min, const double & s_max) const
+    {
+        return _imp->integrated_angular_observables(s_min, s_max).a_fb_leptonic();
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_a_fb_leptonic_num(const double & s_min, const double & s_max) const
+    {
+        return _imp->integrated_angular_observables(s_min, s_max).a_fb_leptonic_num();
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_f_l(const double & s_min, const double & s_max) const
+    {
+        return _imp->integrated_angular_observables(s_min, s_max).f_l();
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_f_l_num(const double & s_min, const double & s_max) const
+    {
+        return _imp->integrated_angular_observables(s_min, s_max).f_l_num();
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_k1ss(const double & s_min, const double & s_max) const
+    {
+        auto o = _imp->integrated_angular_observables(s_min, s_max);
+        return o.k1ss() / o.decay_width();
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_k1cc(const double & s_min, const double & s_max) const
+    {
+        auto o = _imp->integrated_angular_observables(s_min, s_max);
+        return o.k1cc() / o.decay_width();
+    }
+
+    double
+    LambdaCToProtonLeptonLepton::integrated_k1c(const double & s_min, const double & s_max) const
+    {
+        auto o = _imp->integrated_angular_observables(s_min, s_max);
+        return o.k1c() / o.decay_width();
+    }
+
+    const std::string LambdaCToProtonLeptonLepton::description = "\
+      The decay Lambda_c -> proton lbar l, where lbar=e^+,mu^+,tau^+ is a charged antilepton.";
+
+    const std::string LambdaCToProtonLeptonLepton::kinematics_description_q2 = "\
+      The invariant mass of the lbar-l pair in GeV^2.";
+
+    const std::string LambdaCToProtonLeptonLepton::kinematics_description_c_theta_l = "\
+      The cosine of the helicity angle between the direction of flight of the charged antilepton and of the Lambda_c in the lbar-l rest frame.";
+
+    const std::set<ReferenceName> LambdaCToProtonLeptonLepton::references{ "GHM:2021A"_rn, "BMRvD:2022A"_rn, "dBMS:2016A"_rn };
+
+    std::vector<OptionSpecification>::const_iterator
+    LambdaCToProtonLeptonLepton::begin_options()
+    {
+        return Implementation<LambdaCToProtonLeptonLepton>::options.cbegin();
+    }
+
+    std::vector<OptionSpecification>::const_iterator
+    LambdaCToProtonLeptonLepton::end_options()
+    {
+        return Implementation<LambdaCToProtonLeptonLepton>::options.cend();
+    }
+} // namespace eos

--- a/eos/rare-c-decays/lambda-c-to-proton-l-l.hh
+++ b/eos/rare-c-decays/lambda-c-to-proton-l-l.hh
@@ -1,0 +1,78 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2019 Ahmet Kokulu
+ * Copyright (c) 2019 Danny van Dyk
+ * Copyright (c) 2023 Méril Reboud
+ * Copyright (c) 2026 Dominik Suelmann
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_RARE_C_DECAYS_LAMBDA_C_TO_PROTON_LEPTON_LEPTON_HH
+#define EOS_GUARD_EOS_RARE_C_DECAYS_LAMBDA_C_TO_PROTON_LEPTON_LEPTON_HH 1
+
+#include <eos/utils/options.hh>
+#include <eos/utils/parameters.hh>
+#include <eos/utils/private_implementation_pattern.hh>
+#include <eos/utils/reference-name.hh>
+
+namespace eos
+{
+    /*
+     * Decay: Lambda_c -> p l l
+     */
+    class LambdaCToProtonLeptonLepton : public ParameterUser, public PrivateImplementationPattern<LambdaCToProtonLeptonLepton>
+    {
+        public:
+            LambdaCToProtonLeptonLepton(const Parameters &, const Options &);
+            ~LambdaCToProtonLeptonLepton();
+
+            double double_differential_decay_width(const double & q2, const double & c_lep) const;
+            double integrated_decay_width(const double & q2_min, const double & q2_max) const;
+
+            double differential_branching_ratio(const double & q2) const;
+            double differential_a_fb_leptonic(const double & q2) const;
+            double differential_f_l(const double & q2) const;
+
+            double integrated_branching_ratio(const double & q2_min, const double & q2_max) const;
+            double integrated_a_fb_leptonic(const double & q2_min, const double & q2_max) const;
+            double integrated_a_fb_leptonic_num(const double & q2_min, const double & q2_max) const;
+            double integrated_f_l(const double & q2_min, const double & q2_max) const;
+            double integrated_f_l_num(const double & q2_min, const double & q2_max) const;
+            double integrated_k1ss(const double & q2_min, const double & q2_max) const;
+            double integrated_k1cc(const double & q2_min, const double & q2_max) const;
+            double integrated_k1c(const double & q2_min, const double & q2_max) const;
+
+            /*!
+             * Descriptions of the process and its kinematics.
+             */
+            static const std::string description;
+            static const std::string kinematics_description_q2;
+            static const std::string kinematics_description_c_theta_l;
+
+            /*!
+             * References used in the computation of our observables.
+             */
+            static const std::set<ReferenceName> references;
+
+            /*!
+             * Options used in the computation of our observables.
+             */
+            static std::vector<OptionSpecification>::const_iterator begin_options();
+            static std::vector<OptionSpecification>::const_iterator end_options();
+    };
+} // namespace eos
+
+#endif

--- a/eos/rare-c-decays/lambda-c-to-proton-l-l_TEST.cc
+++ b/eos/rare-c-decays/lambda-c-to-proton-l-l_TEST.cc
@@ -1,0 +1,163 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2023 Méril Reboud
+ * Copyright (c) 2026 Dominik Suelmann
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <eos/maths/complex.hh>
+#include <eos/observable.hh>
+#include <eos/rare-c-decays/lambda-c-to-proton-l-l.hh>
+
+#include <test/test.hh>
+
+using namespace test;
+using namespace eos;
+
+class LambdaCToProtonLeptonLeptonTest : public TestCase
+{
+    public:
+        LambdaCToProtonLeptonLeptonTest() :
+            TestCase("lambdac_to_proton_l_l_test")
+        {
+        }
+
+        virtual void
+        run() const
+        {
+            {
+                Parameters p = Parameters::Defaults();
+
+                p["Lambda_c->neutron::a^(t,V)_1@BMRvD2022"]     = +0.689012;
+                p["Lambda_c->neutron::a^(t,V)_2@BMRvD2022"]     = +0.399494;
+                p["Lambda_c->neutron::a^(t,A)_1@BMRvD2022"]     = +0.246169;
+                p["Lambda_c->neutron::a^(t,A)_2@BMRvD2022"]     = +0.284617;
+                p["Lambda_c->neutron::a^(0,V)_0@BMRvD2022"]     = +0.0423961;
+                p["Lambda_c->neutron::a^(0,V)_1@BMRvD2022"]     = +0.736818;
+                p["Lambda_c->neutron::a^(0,V)_2@BMRvD2022"]     = +0.413784;
+                p["Lambda_c->neutron::a^(0,A)_0@BMRvD2022"]     = -0.021022;
+                p["Lambda_c->neutron::a^(0,A)_1@BMRvD2022"]     = +0.189028;
+                p["Lambda_c->neutron::a^(0,A)_2@BMRvD2022"]     = +0.13737;
+                p["Lambda_c->neutron::a^(0,T)_0@BMRvD2022"]     = -0.294244;
+                p["Lambda_c->neutron::a^(0,T)_1@BMRvD2022"]     = +0.0525338;
+                p["Lambda_c->neutron::a^(0,T)_2@BMRvD2022"]     = +0.228615;
+                p["Lambda_c->neutron::a^(0,T5)_1@BMRvD2022"]    = +0.181135;
+                p["Lambda_c->neutron::a^(0,T5)_2@BMRvD2022"]    = +0.204599;
+                p["Lambda_c->neutron::a^(perp,V)_0@BMRvD2022"]  = -0.353174;
+                p["Lambda_c->neutron::a^(perp,V)_1@BMRvD2022"]  = +0.321992;
+                p["Lambda_c->neutron::a^(perp,V)_2@BMRvD2022"]  = +0.431261;
+                p["Lambda_c->neutron::a^(perp,A)_1@BMRvD2022"]  = +0.0665121;
+                p["Lambda_c->neutron::a^(perp,A)_2@BMRvD2022"]  = +0.201844;
+                p["Lambda_c->neutron::a^(perp,T)_1@BMRvD2022"]  = +0.569999;
+                p["Lambda_c->neutron::a^(perp,T)_2@BMRvD2022"]  = +0.393516;
+                p["Lambda_c->neutron::a^(perp,T5)_0@BMRvD2022"] = -0.0229303;
+                p["Lambda_c->neutron::a^(perp,T5)_1@BMRvD2022"] = +0.327394;
+                p["Lambda_c->neutron::a^(perp,T5)_2@BMRvD2022"] = +0.223455;
+
+                p["Lambda_c->proton::res_a_rho@GHM2021"]             = +0.54;
+                p["Lambda_c->proton::res_a_omega@GHM2021"]           = +0.074;
+                p["Lambda_c->proton::res_a_phi@GHM2021"]             = +0.106;
+                p["Lambda_c->proton::res_delta_rho@GHM2021"]         = +0.00;
+                p["Lambda_c->proton::res_delta_omega_m_rho@GHM2021"] = +M_PI;
+                p["Lambda_c->proton::res_delta_phi_m_rho@GHM2021"]   = +M_PI;
+
+                p["QED::alpha_e(m_c)"] = 7.606410e-03;
+                p["mass::rho^0"]       = 7.752600e-01;
+                p["mass::omega"]       = 7.826600e-01;
+                p["mass::phi"]         = 1.019461e+00;
+                p["life_time::rho^0"]  = 4.4654813900949794e-24;
+                p["life_time::omega"]  = 7.583087061059907e-23;
+                p["life_time::phi"]    = 1.5490985100023533e-22;
+
+                p["mass::Lambda_c"]      = 2.286460;
+                p["mass::proton"]        = 0.9382721;
+                p["life_time::Lambda_c"] = 2.015e-13;
+
+                p["uc::Re{c7}"]     = 0.0;
+                p["uc::Im{c7}"]     = 0.0;
+                p["ucmumu::Re{c9}"] = 0.0;
+                p["ucmumu::Im{c9}"] = 0.0;
+
+
+                Options oo{
+                    {        "model"_ok,       "WET" },
+                    { "form-factors"_ok, "BMRvD2022" },
+                    {            "l"_ok,        "mu" }
+                };
+
+                LambdaCToProtonLeptonLepton d(p, oo);
+
+                const double eps = 1e-6;
+
+                TEST_CHECK_RELATIVE_ERROR(d.differential_branching_ratio(0.75), 2.807053787938076e-07, eps);
+                TEST_CHECK_RELATIVE_ERROR(d.differential_branching_ratio(0.9), 1.8000240396675447e-07, eps);
+                TEST_CHECK_RELATIVE_ERROR(d.differential_branching_ratio(1.0), 5.383860135156469e-07, eps);
+                TEST_CHECK_RELATIVE_ERROR(d.differential_branching_ratio(1.1), 2.893673145090639e-08, eps);
+                TEST_CHECK_RELATIVE_ERROR(d.differential_branching_ratio(1.5), 2.489875903462182e-09, eps);
+
+                TEST_CHECK_RELATIVE_ERROR(d.integrated_branching_ratio(0.959, 1.122), 3.0625302416679804e-07, eps);
+
+                const complex<double> ckm_factor_ds(-5.383319178425827e-05, 1.427709577227314e-04);
+
+                p["uc::Re{c7}"]  = real(complex<double>(2.2, -1.1) / ckm_factor_ds);
+                p["uc::Im{c7}"]  = imag(complex<double>(2.2, -1.1) / ckm_factor_ds);
+                p["uc::Re{c7'}"] = real(complex<double>(1.2, 0.5) / ckm_factor_ds);
+                p["uc::Im{c7'}"] = imag(complex<double>(1.2, 0.5) / ckm_factor_ds);
+
+                p["ucmumu::Re{c9}"]  = real(complex<double>(0.3, -1.0) / ckm_factor_ds);
+                p["ucmumu::Im{c9}"]  = imag(complex<double>(0.3, -1.0) / ckm_factor_ds);
+                p["ucmumu::Re{c9'}"] = real(complex<double>(-0.6, 0.2) / ckm_factor_ds);
+                p["ucmumu::Im{c9'}"] = imag(complex<double>(-0.6, 0.2) / ckm_factor_ds);
+
+                p["ucmumu::Re{c10}"]  = real(complex<double>(2.0, 1.4) / ckm_factor_ds);
+                p["ucmumu::Im{c10}"]  = imag(complex<double>(2.0, 1.4) / ckm_factor_ds);
+                p["ucmumu::Re{c10'}"] = real(complex<double>(-1.2, 0.4) / ckm_factor_ds);
+                p["ucmumu::Im{c10'}"] = imag(complex<double>(-1.2, 0.4) / ckm_factor_ds);
+
+                Options oobar{
+                    {        "model"_ok,       "WET" },
+                    { "form-factors"_ok, "BMRvD2022" },
+                    {            "l"_ok,        "mu" },
+                    { "cp-conjugate"_ok,      "true" }
+                };
+
+                LambdaCToProtonLeptonLepton dNP(p, oo);
+                LambdaCToProtonLeptonLepton dNPbar(p, oobar);
+
+                // check NP contributions
+                TEST_CHECK_RELATIVE_ERROR(dNP.differential_a_fb_leptonic(1.5), 0.14922822534563807, eps);
+                TEST_CHECK_RELATIVE_ERROR(dNPbar.differential_a_fb_leptonic(1.5), 0.1565144188529763, eps);
+                TEST_CHECK_RELATIVE_ERROR(dNP.differential_f_l(1.5), 0.3114006688420309, eps);
+                TEST_CHECK_RELATIVE_ERROR(dNP.differential_branching_ratio(1.5), 1.2337106994356664e-06, eps);
+                TEST_CHECK_RELATIVE_ERROR(dNP.integrated_decay_width(0.4, 0.9), 7.547379484042708e-18, eps);
+
+                // Sigma
+                TEST_CHECK_RELATIVE_ERROR(0.5
+                                                  * (dNP.integrated_a_fb_leptonic_num(0.4, 0.9) / dNP.integrated_decay_width(0.4, 0.9)
+                                                     + dNPbar.integrated_a_fb_leptonic_num(0.4, 0.9) / dNPbar.integrated_decay_width(0.4, 0.9)),
+                                          0.11172676105989615,
+                                          eps);
+                // Delta
+                TEST_CHECK_RELATIVE_ERROR(0.5
+                                                  * (dNP.integrated_a_fb_leptonic_num(0.4, 0.9) / dNP.integrated_decay_width(0.4, 0.9)
+                                                     - dNPbar.integrated_a_fb_leptonic_num(0.4, 0.9) / dNPbar.integrated_decay_width(0.4, 0.9)),
+                                          -0.028616987399586513,
+                                          eps);
+                // FL
+                TEST_CHECK_RELATIVE_ERROR(dNP.integrated_f_l_num(0.4, 0.9) / dNP.integrated_decay_width(0.4, 0.9), 0.2657365230011504, eps);
+            }
+        }
+} lambdac_to_proton_l_l_test;

--- a/eos/rare-c-decays/observables.cc
+++ b/eos/rare-c-decays/observables.cc
@@ -1,0 +1,138 @@
+/* vim: set sw=4 sts=4 et tw=150 foldmethod=marker : */
+
+/*
+ * Copyright (c) 2026 Dominik Suelmann
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <eos/observable-impl.hh>
+#include <eos/rare-c-decays/lambda-c-to-proton-l-l.hh>
+#include <eos/utils/concrete-cacheable-observable.hh>
+#include <eos/utils/concrete_observable.hh>
+
+namespace eos
+{
+    // Lambda_c -> p l l decays
+    // {{{
+    ObservableGroup
+    make_lambdac_to_proton_l_l_group()
+    {
+        auto imp = new Implementation<ObservableGroup>(R"(Observables in $\Lambda_c \to p \ell^+ \ell^-$ decays)",
+                                                       R"(The option "l" selects the charged lepton flavor. The option
+                                                       "cp-conjugate" selects between the decay and its CP-conjugate. The option "model" selects
+                                                       the model for the Wilson coefficients. The option "form-factors" selects the form factor parameterization.)",
+                                                       {
+                                                           make_observable("Lambda_c->protonll::Gamma",
+                                                                           R"(\Gamma(\Lambda_c^+ \to p \ell^+ \ell^-))",
+                                                                           Unit::GeV(),
+                                                                           &LambdaCToProtonLeptonLepton::integrated_decay_width,
+                                                                           std::make_tuple("q2_min", "q2_max"),
+                                                                           Options{}),
+
+                                                           make_expression_observable("Lambda_c->protonll::BR",
+                                                                                      R"(\mathcal{B}(\Lambda_c^+ \to p \ell^+ \ell^-))",
+                                                                                      Unit::None(),
+                                                                                      R"(
+                        <<Lambda_c->protonll::Gamma>> * [[life_time::Lambda_c]] / [[QM::hbar]]
+                        )"),
+
+                                                           make_observable("Lambda_c->protonll::dBR/dq2",
+                                                                           R"(d\mathcal{B}(\Lambda_c^+ \to p \ell^+ \ell^-)/dq^2)",
+                                                                           Unit::InverseGeV2(),
+                                                                           &LambdaCToProtonLeptonLepton::differential_branching_ratio,
+                                                                           std::make_tuple("q2"),
+                                                                           Options{}),
+
+                                                           make_observable("Lambda_c->protonll::d^2Gamma/dq2/dcos(theta_l)",
+                                                                           R"(d^2\Gamma(\Lambda_c^+ \to p \ell^+ \ell^-)/dq^2 d\cos(\theta_\ell))",
+                                                                           Unit::InverseGeV(),
+                                                                           &LambdaCToProtonLeptonLepton::double_differential_decay_width,
+                                                                           std::make_tuple("q2", "cos(theta_l)"),
+                                                                           Options{}),
+
+                                                           make_observable("Lambda_c->protonll::F_L(q2)",
+                                                                           R"(F_{\mathrm{L}}(q^2)(\Lambda_c^+ \to p \ell^+ \ell^-))",
+                                                                           Unit::None(),
+                                                                           &LambdaCToProtonLeptonLepton::differential_f_l,
+                                                                           std::make_tuple("q2"),
+                                                                           Options{}),
+
+                                                           make_observable("Lambda_c->protonll::A_FB^l(q2)",
+                                                                           R"(A_{\mathrm{FB}}^\ell(q^2)(\Lambda_c^+ \to p \ell^+ \ell^-))",
+                                                                           Unit::None(),
+                                                                           &LambdaCToProtonLeptonLepton::differential_a_fb_leptonic,
+                                                                           std::make_tuple("q2"),
+                                                                           Options{}),
+
+                                                           make_observable("Lambda_c->protonll::F_L_numerator",
+                                                                           R"(\Gamma \cdot \langle F_{\mathrm{L}}(\Lambda_c^+ \to p \ell^+ \ell^-)\rangle)",
+                                                                           Unit::GeV(),
+                                                                           &LambdaCToProtonLeptonLepton::integrated_f_l_num,
+                                                                           std::make_tuple("q2_min", "q2_max"),
+                                                                           Options{}),
+
+                                                           make_observable("Lambda_c->protonll::A_FB^l_numerator",
+                                                                           R"(\Gamma \cdot \langle A_{\mathrm{FB}}^\ell(\Lambda_c^+ \to p \ell^+ \ell^-)\rangle)",
+                                                                           Unit::GeV(),
+                                                                           &LambdaCToProtonLeptonLepton::integrated_a_fb_leptonic_num,
+                                                                           std::make_tuple("q2_min", "q2_max"),
+                                                                           Options{}),
+
+                                                           make_expression_observable("Lambda_c->protonll::F_L",
+                                                                                      R"(\langle F_{\mathrm{L}}(\Lambda_c^+ \to p \ell^+ \ell^-)\rangle)",
+                                                                                      Unit::None(),
+                                                                                      R"(
+                        <<Lambda_c->protonll::F_L_numerator>> / <<Lambda_c->protonll::Gamma>>
+                        )"),
+
+                                                           make_expression_observable("Lambda_c->protonll::A_FB^l",
+                                                                                      R"(\langle A_{\mathrm{FB}}^\ell(\Lambda_c^+ \to p \ell^+ \ell^-)\rangle)",
+                                                                                      Unit::None(),
+                                                                                      R"(
+                        <<Lambda_c->protonll::A_FB^l_numerator>> / <<Lambda_c->protonll::Gamma>>
+                        )"),
+
+                                                           make_expression_observable("Lambda_c->protonll::Sigma_A_FB^l",
+                                                                                      R"(\Sigma\langle A_{\mathrm{FB}}^\ell(\Lambda_c^+ \to p \ell^+ \ell^-)\rangle)",
+                                                                                      Unit::None(),
+                                                                                      R"(
+                        0.5 * (<<Lambda_c->protonll::A_FB^l;cp-conjugate=false>> + <<Lambda_c->protonll::A_FB^l;cp-conjugate=true>>)
+                        )"),
+
+                                                           make_expression_observable("Lambda_c->protonll::Delta_A_FB^l",
+                                                                                      R"(\Delta\langle A_{\mathrm{FB}}^\ell(\Lambda_c^+ \to p \ell^+ \ell^-)\rangle)",
+                                                                                      Unit::None(),
+                                                                                      R"(
+                        0.5 * (<<Lambda_c->protonll::A_FB^l;cp-conjugate=false>> - <<Lambda_c->protonll::A_FB^l;cp-conjugate=true>>)
+                        )"),
+
+                                                       });
+
+        return ObservableGroup(imp);
+    }
+
+    // }}}
+
+    ObservableSection
+    make_rare_c_decays_section()
+    {
+        auto imp = new Implementation<ObservableSection>("Observables in rare $c$-hadron decays",
+                                                         "",
+                                                         { // Lc -> proton l^+ l^-
+                                                           make_lambdac_to_proton_l_l_group() });
+
+        return ObservableSection(imp);
+    }
+} // namespace eos

--- a/eos/rare-c-decays/observables.hh
+++ b/eos/rare-c-decays/observables.hh
@@ -1,0 +1,30 @@
+/* vim: set sw=4 sts=4 et tw=150 foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2026 Dominik Suelmann
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_RARE_C_DECAYS_OBSERVABLES_HH
+#define EOS_GUARD_EOS_RARE_C_DECAYS_OBSERVABLES_HH 1
+
+#include <eos/observable-fwd.hh>
+
+namespace eos
+{
+    ObservableSection make_rare_c_decays_section();
+}
+
+#endif

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -1640,6 +1640,13 @@ G:2026A:
     id: In preparation
   inspire-id: Gubernari:2026xxx
   title: Unitarity bounds and form factor predictions for $B$-meson decays
+GHM:2021A:
+  authors: Golz, Marcel and Hiller, Gudrun and Magorsch, Tom
+  eprint:
+    archive: arXiv
+    id: oai:arXiv.org:2107.13010
+  inspire-id: Golz:2021xtu
+  title: 'Probing for New Physics with Rare Charm Baryon $(\Lambda_c,\Xi_c,\Omega_c)$ Decays'
 GHMS:2012A:
   authors: Grigo, Jonathan and Hoff, Jens and Marquard, Peter and Steinhauser, Matthias
   eprint:


### PR DESCRIPTION
I implement observables of Lambda_c -> p l l decays, including branching ratio, FL, AFB and CP-asymmetries
following the notation in 2107.13010 and my own code.
So far I only added the long-distance contribution of vector resonances modeled via a Breit-Wigner
and short-distance Wilson coefficients. Not yet the two-loop virtual corrections driven by C1,C2 by Stefan De Boer available in 1707.00988.

@dvandyk have a look and let me know what you think
Thanks in advance.
