### PR TITLE
Add an action to check for Changelog.md updates

### DIFF
--- a/.github/workflows/changelog-updates.yaml
+++ b/.github/workflows/changelog-updates.yaml
@@ -1,0 +1,35 @@
+on:
+  pull_request_target:
+    branches:
+      - master
+
+name: Check if Changelog.md has been updated
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # download all history across all branches
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check for Changelog update
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          echo "Checking changed files between $BASE_SHA and $HEAD_SHA"
+          changed_files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          if grep -Fxq 'Changelog.md' <<< "$changed_files"
+          then
+            echo 'Changelog.md was updated in this pull request, not commenting.'
+            exit 0
+          else
+            echo 'PRs should update Changelog.md, commenting on PR.'
+            gh pr comment ${{ github.event.pull_request.number }} -b 'Please add a summary of your changes to `Changelog.md`'
+            exit 1
+          fi

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,10 +5,16 @@
 ### Changed
 
 ### Added
+- Add G2026 form factor parameterisation (N. Gubernari)
+- Add B(s) -> K(*) constraints from BGMT:2025A (N. Gubernari)
+- Add BSZ:2025A constraints in the Traditional Basis (N. Gubernari)
+- Add B->pi f0 and f+ constraints from FLAG:2024A (N. Gubernari)
 
 ### Removed
 
 ### Fixed
+- Fix some linewidth and linestyles arguments in figure framework (D. Suelmann)
+
 
 ## [v1.0.20] - 2026-04-28
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,16 @@
 
 ### Changed
 
+### Added
+
+### Removed
+
+### Fixed
+
+## [v1.0.20] - 2026-04-28
+
+### Changed
+
 - Rename the following constraints (M. Kirk, M. Reboud)
   - `B->pi::FormFactors[parametric,LCSR+LQCD]@LvDM:2021A` -> `LMvD:2021A`
   - `B_s->D_s^*::A_1[s_max]@HPQCD:2019A` -> `HPQCD:2019B`
@@ -101,5 +111,6 @@
 
 
 
+[v1.0.20]: https://github.com/eos/eos/releases/tag/v1.0.20
 [v1.0.19]: https://github.com/eos/eos/releases/tag/v1.0.19
 [v1.0.18]: https://github.com/eos/eos/releases/tag/v1.0.18


### PR DESCRIPTION
Adds an action to check PRs for changes to `Changelog.md` and fails and comments if it hasn't been changed.

Also adds the changes since v1.0.20 to the Changelog, (including stealing your commit 0980b101481897822214a062796a56f2e875dde7 @dvandyk from the SignalPDF PR)

Closes #1155 