### PR TITLE
Add workflow to determine the code coverage

### DIFF
--- a/.github/scripts/coverage-summary.py
+++ b/.github/scripts/coverage-summary.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# vim: set sw=4 sts=4 et tw=120 :
+
+"""Compute the overall C++, Python, and combined code coverage, append the
+result to a CSV file, and generate an SVG badge from the most recent entry.
+
+This script does *not* create a full coverage report; it only processes the
+intermediate summary files produced by ``gcovr`` and ``coverage.py``.
+"""
+
+import argparse
+import csv
+import json
+import os
+
+
+def cpp_line_counts(summary_path):
+    """Return (covered, total) C++ lines from a gcovr JSON summary file."""
+    with open(summary_path) as f:
+        data = json.load(f)
+    total   = int(data.get('line_total', 0))
+    covered = int(data.get('line_covered', 0))
+    return covered, total
+
+
+def python_line_counts(json_path):
+    """Return (covered, total) Python statements from a coverage.py JSON file."""
+    with open(json_path) as f:
+        data = json.load(f)
+    totals  = data.get('totals', {})
+    covered = int(totals.get('covered_lines', 0))
+    total   = int(totals.get('num_statements', 0))
+    return covered, total
+
+
+def percentage(covered, total):
+    """Return the coverage percentage, guarding against division by zero."""
+    return 100.0 * covered / total if total > 0 else 0.0
+
+
+def append_csv(csv_path, date, cpp, python, combined):
+    """Append a row to the coverage CSV, creating the header if necessary."""
+    is_new = not os.path.exists(csv_path) or os.path.getsize(csv_path) == 0
+    with open(csv_path, 'a', newline='') as f:
+        writer = csv.writer(f)
+        if is_new:
+            writer.writerow(['date', 'cpp', 'python', 'combined'])
+        writer.writerow([date, f'{cpp:.2f}', f'{python:.2f}', f'{combined:.2f}'])
+
+
+def most_recent_entry(csv_path):
+    """Return the most recent (cpp, python, combined) tuple from the CSV."""
+    with open(csv_path, newline='') as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        raise RuntimeError(f'no entries found in {csv_path}')
+    last = rows[-1]
+    return float(last['cpp']), float(last['python']), float(last['combined'])
+
+
+def colour_for(value):
+    """Return a shields.io-style colour for the given coverage percentage."""
+    if value >= 90.0:
+        return '#4c1'    # brightgreen
+    if value >= 75.0:
+        return '#97ca00' # green
+    if value >= 60.0:
+        return '#a4a61d' # yellowgreen
+    if value >= 45.0:
+        return '#dfb317' # yellow
+    if value >= 30.0:
+        return '#fe7d37' # orange
+    return '#e05d44'     # red
+
+
+def text_width(text):
+    """A crude monospace-ish width estimate (in px) for the badge text."""
+    return int(len(text) * 6.5) + 10
+
+
+def make_badge(badge_path, cpp, python, combined):
+    """Write an SVG badge displaying the three coverage percentages."""
+    # The badge consists of a grey label segment followed by one coloured
+    # segment per coverage figure.
+    segments = [('coverage', '#555')]
+    for label, value in (('C++', cpp), ('py', python), ('all', combined)):
+        segments.append((f'{label} {value:.0f}%', colour_for(value)))
+
+    widths  = [text_width(text) for text, _ in segments]
+    total   = sum(widths)
+    height  = 20
+
+    parts = []
+    parts.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'xmlns:xlink="http://www.w3.org/1999/xlink" width="{total}" height="{height}" '
+        f'role="img" aria-label="code coverage">'
+    )
+    parts.append(
+        f'<title>coverage: C++ {cpp:.0f}%, py {python:.0f}%, all {combined:.0f}%</title>'
+    )
+    # Rounded-corner clip and subtle gradient for the classic badge look.
+    parts.append(
+        f'<linearGradient id="s" x2="0" y2="100%">'
+        f'<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>'
+        f'<stop offset="1" stop-opacity=".1"/></linearGradient>'
+    )
+    parts.append(
+        f'<clipPath id="r"><rect width="{total}" height="{height}" rx="3" fill="#fff"/></clipPath>'
+    )
+    parts.append('<g clip-path="url(#r)">')
+
+    x = 0
+    for (text, colour), width in zip(segments, widths):
+        parts.append(f'<rect x="{x}" width="{width}" height="{height}" fill="{colour}"/>')
+        x += width
+    parts.append(f'<rect width="{total}" height="{height}" fill="url(#s)"/>')
+    parts.append('</g>')
+
+    parts.append(
+        '<g fill="#fff" text-anchor="middle" '
+        'font-family="Verdana,Geneva,DejaVu Sans,sans-serif" '
+        'text-rendering="geometricPrecision" font-size="11">'
+    )
+    x = 0
+    for (text, _), width in zip(segments, widths):
+        cx = x + width / 2
+        # Drop shadow for legibility, then the actual text.
+        parts.append(
+            f'<text x="{cx:.1f}" y="15" fill="#010101" fill-opacity=".3">{text}</text>'
+        )
+        parts.append(f'<text x="{cx:.1f}" y="14">{text}</text>')
+        x += width
+    parts.append('</g>')
+    parts.append('</svg>')
+
+    with open(badge_path, 'w') as f:
+        f.write('\n'.join(parts) + '\n')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--date',        required=True, help='date of this coverage run (YYYY-MM-DD)')
+    parser.add_argument('--cpp-summary', required=True, help='path to the gcovr JSON summary file')
+    parser.add_argument('--python-json', required=True, help='path to the coverage.py JSON file')
+    parser.add_argument('--csv',         required=True, help='path to the coverage CSV file to append to')
+    parser.add_argument('--badge',       required=True, help='path to the SVG badge file to (re)generate')
+    args = parser.parse_args()
+
+    cpp_covered, cpp_total       = cpp_line_counts(args.cpp_summary)
+    python_covered, python_total = python_line_counts(args.python_json)
+
+    cpp_pct      = percentage(cpp_covered, cpp_total)
+    python_pct   = percentage(python_covered, python_total)
+    combined_pct = percentage(cpp_covered + python_covered, cpp_total + python_total)
+
+    print(f'C++      coverage: {cpp_pct:6.2f}%  ({cpp_covered}/{cpp_total} lines)')
+    print(f'Python   coverage: {python_pct:6.2f}%  ({python_covered}/{python_total} statements)')
+    print(f'Combined coverage: {combined_pct:6.2f}%  '
+          f'({cpp_covered + python_covered}/{cpp_total + python_total})')
+
+    append_csv(args.csv, args.date, cpp_pct, python_pct, combined_pct)
+
+    # The badge always reflects the most recent entry in the CSV file.
+    cpp_latest, python_latest, combined_latest = most_recent_entry(args.csv)
+    make_badge(args.badge, cpp_latest, python_latest, combined_latest)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,170 @@
+on:
+  # Run once weekly, 2h before the ``Report Activity`` workflow
+  # (which runs at '5 7 * * TUE').
+  schedule:
+    - cron: '5 5 * * TUE'
+
+  # Allow manual triggering.
+  workflow_dispatch:
+
+  # Also run when a GitHub release is published.
+  release:
+    types: [ published ]
+
+name: Determine Code Coverage
+
+concurrency:
+  group: Coverage
+  cancel-in-progress: true
+
+jobs:
+    coverage:
+        # In contrast to the PyPI and Ubuntu builds we only build on the most
+        # recent Ubuntu EOS image, using g++ so that we can use gcov/gcovr to
+        # determine the C++ code coverage.
+        name: Determine C++ and Python code coverage
+        runs-on: ubuntu-24.04
+        timeout-minutes: 120
+        container:
+            image: eoshep/ubuntu-resolute:2315df29acac4d7723224dd904b59d02ef89ecf6
+        env:
+            CXX: g++
+            # Disable optimisation/LTO and enable gcov instrumentation so that
+            # the C++ coverage data is meaningful and complete.
+            CXXFLAGS: "-O0 -g --coverage -fprofile-update=atomic"
+            LDFLAGS: "--coverage"
+            # Collect the Python coverage data files in a single, fixed location.
+            COVERAGE_FILE: "${{ github.workspace }}/.coverage"
+            COVERAGE_RCFILE: "${{ github.workspace }}/.coveragerc"
+        steps:
+            - name: Checkout git repository
+              uses: actions/checkout@v5
+              with:
+                path: _src/
+
+            - name: Fetch tags
+              shell: bash
+              run: |
+                pushd _src
+                git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+                popd
+
+            - name: Install coverage tooling
+              shell: bash
+              run: |
+                python3 -m pip install --upgrade 'gcovr>=6.0' coverage \
+                  || python3 -m pip install --break-system-packages --upgrade 'gcovr>=6.0' coverage
+
+            - name: Create coverage configuration
+              shell: bash
+              run: |
+                # Restrict the Python coverage to the 'eos' package and run in
+                # parallel mode, since 'make check' executes each test in its
+                # own process.
+                cat > "${COVERAGE_RCFILE}" <<'EOF'
+                [run]
+                parallel = True
+                source = eos
+                EOF
+
+            - name: Configure
+              shell: bash
+              run: |
+                pushd _src
+                ./autogen.bash
+                popd
+                mkdir -p _build
+                pushd _build
+                which ${CXX} || ( echo c++ compiler not found ; exit 1 )
+                ../_src/configure \
+                  --enable-python \
+                  --prefix=/opt/venv/ \
+                  || ( cat config.log ; exit 2 )
+                popd
+
+            - name: Build
+              shell: bash
+              run: |
+                pushd _build
+                make -j4 all
+                popd
+
+            - name: Run tests with coverage instrumentation
+              shell: bash
+              run: |
+                pushd _build
+                # Run 'make check' wrapping the Python interpreter with
+                # 'coverage run' so that the Python tests are instrumented.
+                # The C++ tests are instrumented at compile time via gcov.
+                # Do not abort on test failures so that the coverage data is
+                # collected regardless.
+                make check PYTHON="python3 -m coverage run" || echo "::warning::Some tests failed; coverage data still collected"
+                popd
+
+            - name: Determine C++ coverage
+              shell: bash
+              run: |
+                mkdir -p _intermediate
+                # Produce only the machine-readable summary needed for the
+                # overall percentage (printing a human-readable summary to the
+                # log). The full intermediate report is far too large to commit.
+                gcovr \
+                  --root _src \
+                  --object-directory _build \
+                  --filter '_src/eos/' \
+                  --exclude '.*_TEST\.' \
+                  --gcov-ignore-parse-errors \
+                  --json-summary _intermediate/coverage-cpp-summary.json \
+                  --txt
+
+            - name: Determine Python coverage
+              shell: bash
+              run: |
+                # Combine the per-process coverage data files ...
+                python3 -m coverage combine || echo "::warning::No Python coverage data to combine"
+                # ... and produce only the summary needed for the overall
+                # percentage (printing a human-readable summary to the log).
+                # If there is no coverage data, 'coverage json' fails with
+                # "No data to report"; fall back to an empty totals object so
+                # that the CSV and badge are still generated.
+                python3 -m coverage json -o _intermediate/coverage-python.json \
+                  || echo '{"totals": {}}' > _intermediate/coverage-python.json
+                python3 -m coverage report || true
+
+            - name: Check out the coverage repository
+              uses: actions/checkout@v5
+              with:
+                repository: eos/coverage
+                token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+                path: _coverage
+
+            - name: Update summary and badge
+              shell: bash
+              run: |
+                export DATE=$(date -u +%Y-%m-%d)
+                # Append the overall percentages to 'coverage.csv' and generate
+                # 'badge.svg' from the most recent entry.
+                python3 _src/.github/scripts/coverage-summary.py \
+                  --date "${DATE}" \
+                  --cpp-summary _intermediate/coverage-cpp-summary.json \
+                  --python-json _intermediate/coverage-python.json \
+                  --csv _coverage/coverage.csv \
+                  --badge _coverage/badge.svg
+
+            - name: Commit and push the coverage results
+              shell: bash
+              run: |
+                export DATE=$(date -u +%Y-%m-%d)
+                # Include the release tag in the commit message when triggered
+                # by a published release.
+                COMMIT_MSG="Update code coverage for ${DATE}"
+                if [[ "${{ github.event_name }}" == "release" ]] ; then
+                    COMMIT_MSG="${COMMIT_MSG} (release ${{ github.event.release.tag_name }})"
+                fi
+                pushd _coverage
+                git config user.name  "EOS"
+                git config user.email "eos-developers@googlegroups.com"
+                git add --all
+                git commit --allow-empty -m "${COMMIT_MSG}"
+                git push
+                popd

--- a/Changelog.md
+++ b/Changelog.md
@@ -44,6 +44,7 @@
   - `B_s->D_s^*lnu::P(q2,cos(theta_l),cos(theta_D_s),phi)`
   - `B^+->pi^+pi^-lnu::PDF(q2,k2,cos(theta_pi))`
 - Expand the unit test coverage of the Python interface (D. van Dyk)
+- Add a workflow to determine code coverage with test cases (D. van Dyk)
 
 ### Removed
 


### PR DESCRIPTION
The new workflow named ``Determine Code Coverage`` is run
- scheduled 2h before the ``Report Activity`` worklflow;
- on demand via ``workflow_dispatch``;
- and when publishing a release.

It also generates a badge that we can display on the website and the README.md:
![code coverage](https://raw.githubusercontent.com/eos/coverage/main/badge.svg)

Github: resolves #1111