### PR TITLE
Alter times of coverage and weekly reports

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,8 +1,8 @@
 on:
-  # Run once weekly, 2h before the ``Report Activity`` workflow
-  # (which runs at '5 7 * * TUE').
+  # Run once weekly, 3h before the ``Report Activity`` workflow
+  # (which runs at '17 4 * * TUE'), as well as on new releases.
   schedule:
-    - cron: '5 5 * * TUE'
+    - cron: '17 1 * * TUE'
 
   # Allow manual triggering.
   workflow_dispatch:

--- a/.github/workflows/report-activity.yaml
+++ b/.github/workflows/report-activity.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '5 7 * * TUE'
+    - cron: '17 4 * * TUE'
 
   workflow_dispatch:
 


### PR DESCRIPTION
Shift coverage and weekly report workflows earlier so they are hopefully always done by the weekly meeting.

Closes #1173 