### PR TITLE
Add an unbinned 1D log-likelihood with resolution function (DFT-based convolution)

### DIFF
--- a/.github/workflows/pypi-build+check+deploy.yaml
+++ b/.github/workflows/pypi-build+check+deploy.yaml
@@ -55,8 +55,8 @@ jobs:
                 CIBW_BUILD: ${{ matrix.version}}-*
                 CIBW_SKIP: \*-musllinux_*
                 CIBW_ARCHS: ${{ matrix.arch}}
-                CIBW_MANYLINUX_X86_64_IMAGE: eoshep/manylinux_2_34@sha256:d03c3f78b81854177d386a455048f83496d10bfd15ddd35584024a99108c41b0
-                CIBW_MANYLINUX_AARCH64_IMAGE: eoshep/manylinux_2_34@sha256:2acfa216598ace77ad17f662e9601caed6b98d375d30faf873f900019c305153
+                CIBW_MANYLINUX_X86_64_IMAGE: eoshep/manylinux_2_34@sha256:e898974e68ef3a917bdf935d98a31c43bd03baf0d6debe1dbccd357cbd3382c8
+                CIBW_MANYLINUX_AARCH64_IMAGE: eoshep/manylinux_2_34@sha256:607f5624b69dc7bc04869332868849686ee9a0a2c415f0f414b34b98fce9cb79
                 CIBW_BEFORE_BUILD_LINUX: |
                   pushd {project}
                   ./autogen.bash

--- a/.github/workflows/ubuntu-build+check+deploy.yaml
+++ b/.github/workflows/ubuntu-build+check+deploy.yaml
@@ -24,7 +24,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 60
         container:
-            image: eoshep/ubuntu-${{ matrix.cfg.os }}:2315df29acac4d7723224dd904b59d02ef89ecf6
+            image: eoshep/ubuntu-${{ matrix.cfg.os }}:13b778882bb6b4129bf7622adab216921bb5d3b9
         steps:
             - name: Checkout git repository
               uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 60
         container:
-            image: eoshep/ubuntu-${{ matrix.cfg.os }}:2315df29acac4d7723224dd904b59d02ef89ecf6
+            image: eoshep/ubuntu-${{ matrix.cfg.os }}:13b778882bb6b4129bf7622adab216921bb5d3b9
         steps:
             - name: Download configured source as artifact
               uses: actions/download-artifact@v4
@@ -141,7 +141,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 60
         container:
-            image: eoshep/ubuntu-${{ matrix.cfg.os }}:2315df29acac4d7723224dd904b59d02ef89ecf6
+            image: eoshep/ubuntu-${{ matrix.cfg.os }}:13b778882bb6b4129bf7622adab216921bb5d3b9
         steps:
             - name: Download configured source as artifact
               uses: actions/download-artifact@v4
@@ -173,7 +173,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 60
         container:
-            image: eoshep/ubuntu-${{ matrix.cfg.os }}:2315df29acac4d7723224dd904b59d02ef89ecf6
+            image: eoshep/ubuntu-${{ matrix.cfg.os }}:13b778882bb6b4129bf7622adab216921bb5d3b9
         steps:
             - name: Download configured source as artifact
               uses: actions/download-artifact@v4
@@ -215,7 +215,7 @@ jobs:
         runs-on: ubuntu-24.04
         timeout-minutes: 60
         container:
-            image: eoshep/ubuntu-${{ matrix.cfg.os }}:2315df29acac4d7723224dd904b59d02ef89ecf6
+            image: eoshep/ubuntu-${{ matrix.cfg.os }}:13b778882bb6b4129bf7622adab216921bb5d3b9
         steps:
             - name: Checkout git repository
               uses: actions/checkout@v4
@@ -308,7 +308,7 @@ jobs:
         name: Deploy documentation on ${{ matrix.cfg.os }}
         runs-on: ubuntu-24.04
         container:
-            image: eoshep/ubuntu-${{ matrix.cfg.os }}:2315df29acac4d7723224dd904b59d02ef89ecf6
+            image: eoshep/ubuntu-${{ matrix.cfg.os }}:13b778882bb6b4129bf7622adab216921bb5d3b9
         steps:
             - name: Create repository
               shell: bash

--- a/Changelog.md
+++ b/Changelog.md
@@ -58,6 +58,10 @@
 - Add ``tight_layout`` and ``shared_axes`` options to ``grid`` figures (D. van Dyk)
 - Provide a sensible default ``legend()`` entry for most figure item types (D. van Dyk)
 - Make the tick label format configurable via a ``format`` field on the ``xticks`` and ``yticks`` of a plot (D. van Dyk)
+- Add the unbinned log-likelihood block ``LogLikelihoodBlock::Unbinned1D`` (Python: ``eos.LogLikelihoodBlock.Unbinned1D``), which convolves a signal PDF with a resolution function on a grid via a discrete Fourier transform (D. van Dyk)
+- Add classes for discrete Fourier transforms, ``eos::dft::Container`` and ``eos::dft::Plan`` (D. van Dyk)
+- Add ``SignalPDF::evaluate_linear()`` to evaluate a signal PDF on the linear scale (D. van Dyk)
+- Allow registering a custom ``SignalPDF`` at run time via ``SignalPDFs::insert`` (Python: ``eos.SignalPDFs.insert``) (D. van Dyk)
 
 ### Deprecated
 
@@ -97,6 +101,7 @@
 - Fix bug in (non-)packaging of constraint files (D. van Dyk)
 - Fix the default ``Item.legend`` to return a list rather than a tuple (D. van Dyk)
 - Fix the type annotation of ``MaskComponent.description`` (D. van Dyk)
+- Do not draw an empty legend (D. van Dyk)
 
 
 ## [v1.0.20] - 2026-04-28

--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,57 @@ LIBS=$_LIBS
 dnl }}}
 dnl }}}
 
+dnl {{{ use FFTW3 path if supplied via --with-fftw3=, otherwise use pkg-config; check for FFTW3
+AC_ARG_WITH([fftw3],
+	[AS_HELP_STRING([--with-fftw3], [used for DFTs in e.g. unbinned likelihoods])]
+	[],
+	[])
+if test "x$with_fftw3" == xno ; then
+	AC_MSG_FAILURE(["Cannot build EOS without FFTW3"])
+fi
+if test "x$with_fftw3" != x -a "x$with_fftw3" != xyes ; then
+	if ! test -d "$with_fftw3" ; then
+	AC_MSG_FAILURE(["$with_fftw3 is not a directory. Please check the manual for how to compile with FFTW3."])
+	fi
+	FFTW_CXXFLAGS="-I$with_fftw3/include"
+	FFTW_LDFLAGS="-L$with_fftw3/lib"
+else # use pkg-config
+	PKG_CHECK_MODULES([FFTW],
+		[fftw3],
+		[
+			FFTW_CXXFLAGS="$FFTW_CFLAGS"
+			FFTW_LDFLAGS="`pkg-config --libs-only-L fftw3`"
+			AC_MSG_NOTICE([using pkg-config for FFTW3 location])
+		],
+		[
+			FFTW_CXXFLAGS=""
+			FFTW_LDFLAGS=""
+			AC_MSG_NOTICE([falling back to default for FFTW3 location])
+		])
+fi
+
+_CXXFLAGS=$CXXFLAGS
+_LDFLAGS=$LDFLAGS
+_LIBS=$LIBS
+
+CXXFLAGS="$FFTW_CXXFLAGS $CXXFLAGS"
+LDFLAGS="$FFTW_LDFLAGS $LDFLAGS"
+LIBS=""
+
+AC_CHECK_LIB(fftw3, main,
+	[],
+	[AC_MSG_ERROR([you do seem to be lacking the FFTW3 library (http://www.fftw.org/).])],
+	[-lfftw3 -lm])
+
+CXXFLAGS=$_CXXFLAGS
+LDFLAGS=$_LDFLAGS
+LIBS=$_LIBS
+
+AC_SUBST([FFTW_LDFLAGS])
+AC_SUBST([FFTW_CXXFLAGS])
+dnl }}}
+
+
 dnl {{{ use GSL path if supplied via --with-gsl=, otherwise use pkg-config; check for GSL
 AC_ARG_WITH([gsl],
 	[AS_HELP_STRING([--with-gsl], [used for e.g. RNG, special functions, linear algebra])]

--- a/eos/maths/Makefile.am
+++ b/eos/maths/Makefile.am
@@ -10,6 +10,7 @@ libeosmaths_la_SOURCES = \
 	angular-integrals.cc angular-integrals.hh \
 	complex.hh \
 	derivative.cc derivative.hh \
+	dft-container.cc dft-container.hh dft-container-impl.hh \
 	gegenbauer-polynomial.cc gegenbauer-polynomial.hh \
 	gsl-interface.hh \
 	integrate.cc integrate.hh integrate-impl.hh \
@@ -27,11 +28,12 @@ libeosmaths_la_SOURCES = \
 	szego-polynomial.hh
 
 libeosmaths_la_LIBADD = \
-	-lgsl -lgslcblas -lm
+	-lfftw3 -lgsl -lgslcblas -lm
 libeosmaths_la_CXXFLAGS = $(AM_CXXFLAGS) \
 	-DEOS_DATADIR='"$(datadir)"' \
-	$(GSL_CXXFLAGS)
-libeosmaths_la_LDFLAGS = $(AM_LDFLAGS) $(GSL_LDFLAGS)
+	$(GSL_CXXFLAGS) \
+	$(FFTW_CXXFLAGS)
+libeosmaths_la_LDFLAGS = $(AM_LDFLAGS) $(GSL_LDFLAGS) $(FFTW_LDFLAGS)
 
 EXTRA_DIST = \
 	polylog_TEST_dilog.bin \
@@ -44,6 +46,7 @@ include_eos_utils_HEADERS = \
     angular-integrals.hh \
 	complex.hh \
 	derivative.hh \
+	dft-container.hh \
 	gegenbauer-polynomial.hh \
 	gsl-interface.hh \
 	integrate.hh \
@@ -65,6 +68,7 @@ AM_TESTS_ENVIRONMENT = \
 
 TESTS = \
     angular-integrals_TEST \
+	dft-container_TEST \
 	derivative_TEST \
 	gegenbauer-polynomial_TEST \
 	gsl-interface_TEST \
@@ -89,6 +93,8 @@ LDADD = \
 check_PROGRAMS = $(TESTS)
 
 angular_integrals_TEST_SOURCES = angular-integrals_TEST.cc
+
+dft_container_TEST_SOURCES = dft-container_TEST.cc
 
 derivative_TEST_SOURCES = derivative_TEST.cc
 

--- a/eos/maths/Makefile.am
+++ b/eos/maths/Makefile.am
@@ -11,6 +11,7 @@ libeosmaths_la_SOURCES = \
 	complex.hh \
 	derivative.cc derivative.hh \
 	dft-container.cc dft-container.hh dft-container-impl.hh \
+	dft-plan.cc dft-plan.hh dft-plan-impl.hh \
 	gegenbauer-polynomial.cc gegenbauer-polynomial.hh \
 	gsl-interface.hh \
 	integrate.cc integrate.hh integrate-impl.hh \
@@ -47,6 +48,7 @@ include_eos_utils_HEADERS = \
 	complex.hh \
 	derivative.hh \
 	dft-container.hh \
+	dft-plan.hh \
 	gegenbauer-polynomial.hh \
 	gsl-interface.hh \
 	integrate.hh \
@@ -69,6 +71,7 @@ AM_TESTS_ENVIRONMENT = \
 TESTS = \
     angular-integrals_TEST \
 	dft-container_TEST \
+	dft-plan_TEST \
 	derivative_TEST \
 	gegenbauer-polynomial_TEST \
 	gsl-interface_TEST \
@@ -95,6 +98,8 @@ check_PROGRAMS = $(TESTS)
 angular_integrals_TEST_SOURCES = angular-integrals_TEST.cc
 
 dft_container_TEST_SOURCES = dft-container_TEST.cc
+
+dft_plan_TEST_SOURCES = dft-plan_TEST.cc
 
 derivative_TEST_SOURCES = derivative_TEST.cc
 

--- a/eos/maths/dft-container-impl.hh
+++ b/eos/maths/dft-container-impl.hh
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_MATHS_DFT_CONTAINER_IMPL_HH
+#define EOS_GUARD_EOS_MATHS_DFT_CONTAINER_IMPL_HH 1
+
+#include <eos/maths/dft-container.hh>
+
+#include <eos/utils/exception.hh>
+
+#include <algorithm>
+#include <cstring>
+#include <format>
+#include <functional>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+
+#include <fftw3.h>
+
+namespace eos
+{
+    namespace dft
+    {
+        namespace impl
+        {
+            template <std::size_t rank_>
+            std::size_t size_from_dimensions(const std::array<std::size_t, rank_> & dimensions)
+            {
+                std::size_t result = 1;
+                for (std::size_t d : dimensions)
+                {
+                    result *= d;
+                }
+
+                return result;
+            }
+
+            template <std::size_t rank_>
+            std::size_t index_from_multi_index(const std::array<std::size_t, rank_> & multi_index, const std::array<std::size_t, rank_> & dimensions)
+            {
+                // computing the index in row-major order, i.e. the last index is contiguous in memory
+                std::size_t result = 0, stride = 1;
+
+                for (std::size_t i = rank_ - 1; i > 0 ; --i)
+                {
+                    result += multi_index[i] * stride;
+                    stride *= dimensions[i];
+                }
+
+                result += multi_index[0] * stride;
+
+                return result;
+            }
+        } // namespace eos::dft::impl
+
+        // partial specialization for T_ == double
+
+        template <std::size_t rank_>
+        Container<double, rank_>::Container(const std::array<std::size_t, rank_> & dimensions) :
+            _size(impl::size_from_dimensions(dimensions)),
+            _data(fftw_alloc_real(this->_size)),
+            _dimensions(dimensions)
+        {
+            if (nullptr == this->_data)
+            {
+                throw std::bad_alloc();
+            }
+        }
+
+        template <std::size_t rank_>
+        Container<double, rank_>::Container(const Container & other) :
+            _size(other._size),
+            _data(fftw_alloc_real(this->_size)),
+            _dimensions(other._dimensions)
+        {
+            if (nullptr == this->_data)
+            {
+                throw std::bad_alloc();
+            }
+
+            memcpy(this->_data, other._data, this->_size * sizeof(double));
+        }
+
+        template <std::size_t rank_>
+        Container<double, rank_>::Container(Container && other) :
+            _size(other._size),
+            _data(other._data),
+            _dimensions(other._dimensions)
+        {
+            other._data = nullptr;
+            other._size = 0;
+        }
+
+        template <std::size_t rank_>
+        Container<double, rank_> & Container<double, rank_>::operator=(const Container & other)
+        {
+            if (this == &other)
+            {
+                return *this;
+            }
+
+            if (nullptr != this->_data)
+            {
+                fftw_free(this->_data);
+                this->_data = nullptr;
+                this->_size = 0;
+            }
+
+            this->_size = other._size;
+            this->_data = fftw_alloc_real(this->_size);
+
+            if (nullptr == this->_data)
+            {
+                throw std::bad_alloc();
+            }
+
+            this->_dimensions = other._dimensions;
+            std::memcpy(this->_data, other._data, this->_size * sizeof(double));
+
+            return *this;
+        }
+
+        template <std::size_t rank_>
+        Container<double, rank_> & Container<double, rank_>::operator=(Container && other)
+        {
+            if (this == &other)
+            {
+                return *this;
+            }
+
+            if (nullptr != this->_data)
+            {
+                fftw_free(this->_data);
+                this->_data = nullptr;
+                this->_size = 0;
+            }
+
+            this->_size = other._size;
+            this->_data = other._data;
+            this->_dimensions = other._dimensions;
+
+            other._data = nullptr;
+            other._size = 0;
+
+            return *this;
+        }
+
+        template <std::size_t rank_>
+        Container<double, rank_>::~Container()
+        {
+            if (nullptr != this->_data)
+            {
+                fftw_free(this->_data);
+                this->_data = nullptr;
+                this->_size = 0;
+            }
+        }
+
+        template <std::size_t rank_>
+        const std::array<std::size_t, rank_> & Container<double, rank_>::dimensions() const
+        {
+            return this->_dimensions;
+        }
+
+        template <std::size_t rank_>
+        double & Container<double, rank_>::operator()(const std::array<std::size_t, rank_> & index)
+        {
+            std::size_t _index = impl::index_from_multi_index(index, this->_dimensions);
+            if (_index >= this->_size)
+            {
+                throw std::out_of_range(std::format("dft::Container<double, {}>: index out of bounds", rank_));
+            }
+
+            return this->_data[_index];
+        }
+
+        template <std::size_t rank_>
+        const double & Container<double, rank_>::operator()(const std::array<std::size_t, rank_> & index) const
+        {
+            std::size_t _index = impl::index_from_multi_index(index, this->_dimensions);
+
+            if (_index >= this->_size)
+            {
+                throw std::out_of_range(std::format("dft::Container<double, {}>: index out of bounds", rank_));
+            }
+
+            return this->_data[_index];
+        }
+
+        // partial specialization for T_ == std::complex<double>
+
+        template <std::size_t rank_>
+        Container<std::complex<double>, rank_>::Container(const std::array<std::size_t, rank_> & dimensions) :
+            _size(impl::size_from_dimensions(dimensions)),
+            _data(reinterpret_cast<std::complex<double> *>(fftw_alloc_complex(this->_size))),
+            _dimensions(dimensions)
+        {
+            static_assert(sizeof(std::complex<double>) == 2 * sizeof(double), "std::complex<double> is not compatible with fftw_complex (size mismatch)");
+            static_assert(alignof(std::complex<double>) == alignof(fftw_complex), "std::complex<double> is not compatible with fftw_complex (alignment mismatch)");
+            static_assert(std::is_trivially_copyable<std::complex<double>>::value, "std::complex<double> is not compatible with fftw_complex (not trivially copyable)");
+
+            if (nullptr == this->_data)
+            {
+                throw std::bad_alloc();
+            }
+        }
+
+        template <std::size_t rank_>
+        Container<std::complex<double>, rank_>::Container(const Container & other) :
+            _size(other._size),
+            _data(reinterpret_cast<std::complex<double> *>(fftw_alloc_complex(this->_size))),
+            _dimensions(other._dimensions)
+        {
+            if (nullptr == this->_data)
+            {
+                throw std::bad_alloc();
+            }
+
+            std::memcpy(this->_data, other._data, this->_size * 2 * sizeof(double));
+        }
+
+        template <std::size_t rank_>
+        Container<std::complex<double>, rank_>::Container(Container && other) :
+            _size(other._size),
+            _data(other._data),
+            _dimensions(other._dimensions)
+        {
+            other._data = nullptr;
+            other._size = 0;
+        }
+
+        template <std::size_t rank_>
+        Container<std::complex<double>, rank_> & Container<std::complex<double>, rank_>::operator=(const Container & other)
+        {
+            if (this == &other)
+            {
+                return *this;
+            }
+
+            if (nullptr != this->_data)
+            {
+                fftw_free(this->_data);
+            }
+
+            this->_size = other._size;
+            this->_data = reinterpret_cast<std::complex<double> *>(fftw_alloc_complex(this->_size));
+
+            if (nullptr == this->_data)
+            {
+                throw std::bad_alloc();
+            }
+
+            this->_dimensions = other._dimensions;
+            std::memcpy(this->_data, other._data, this->_size * 2 * sizeof(double));
+
+            return *this;
+        }
+
+        template <std::size_t rank_>
+        Container<std::complex<double>, rank_> & Container<std::complex<double>, rank_>::operator=(Container && other)
+        {
+            if (this == &other)
+            {
+                return *this;
+            }
+
+            if (nullptr != this->_data)
+            {
+                fftw_free(this->_data);
+                this->_data = nullptr;
+            }
+
+            this->_size = other._size;
+            this->_data = other._data;
+            this->_dimensions = other._dimensions;
+
+            other._data = nullptr;
+            other._size = 0;
+
+            return *this;
+        }
+
+        template <std::size_t rank_>
+        Container<std::complex<double>, rank_>::~Container()
+        {
+            if (nullptr != this->_data)
+            {
+                fftw_free(this->_data);
+                this->_data = nullptr;
+                this->_size = 0;
+            }
+        }
+
+        template <std::size_t rank_>
+        const std::array<std::size_t, rank_> & Container<std::complex<double>, rank_>::dimensions() const
+        {
+            return this->_dimensions;
+        }
+
+        template <std::size_t rank_>
+        std::complex<double> & Container<std::complex<double>, rank_>::operator()(const std::array<std::size_t, rank_> & index)
+        {
+            std::size_t _index = impl::index_from_multi_index(index, this->_dimensions);
+            if (_index >= this->_size)
+            {
+                throw std::out_of_range(std::format("dft::Container<std::complex<double>, {}>: index out of bounds", rank_));
+            }
+
+            return this->_data[_index];
+        }
+
+        template <std::size_t rank_>
+        const std::complex<double> & Container<std::complex<double>, rank_>::operator()(const std::array<std::size_t, rank_> & index) const
+        {
+            std::size_t _index = impl::index_from_multi_index(index, this->_dimensions);
+
+            if (_index >= this->_size)
+            {
+                throw std::out_of_range(std::format("dft::Container<std::complex<double>, {}>: index out of bounds", rank_));
+            }
+
+            return this->_data[_index];
+        }
+
+        template <std::size_t rank_>
+        Container<std::complex<double>, rank_> & Container<std::complex<double>, rank_>::operator*=(const Container & rhs)
+        {
+            if (this->_dimensions != rhs._dimensions)
+            {
+                throw InternalError(std::format("dft::Container<std::complex<double>, {}>: dimension mismatch in operator*=", rank_));
+            }
+
+            std::transform(this->_data, this->_data + this->_size, rhs._data, this->_data,
+                std::multiplies<>{});
+
+            return *this;
+        }
+    }
+}
+
+#endif

--- a/eos/maths/dft-container.cc
+++ b/eos/maths/dft-container.cc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <eos/maths/dft-container-impl.hh>
+
+ namespace eos
+ {
+    namespace dft
+    {
+        template class Container<double, 1>;
+        template class Container<double, 2>;
+        template class Container<double, 3>;
+        template class Container<double, 4>;
+
+        template class Container<std::complex<double>, 1>;
+        template class Container<std::complex<double>, 2>;
+        template class Container<std::complex<double>, 3>;
+        template class Container<std::complex<double>, 4>;
+    }
+ }

--- a/eos/maths/dft-container.hh
+++ b/eos/maths/dft-container.hh
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_MATHS_DFT_CONTAINER_HH
+#define EOS_GUARD_EOS_MATHS_DFT_CONTAINER_HH 1
+
+#include <array>
+#include <complex>
+
+namespace eos
+{
+    namespace dft
+    {
+        template <typename T_, std::size_t rank_>
+        class Container;
+
+        template <std::size_t rank_>
+        class Container<double, rank_>
+        {
+            private:
+                std::size_t _size;
+                double * _data;
+                std::array<std::size_t, rank_> _dimensions;
+
+            public:
+                Container(const std::array<std::size_t, rank_> & dimensions);
+                Container(const Container & other);
+                Container(Container && other);
+                Container & operator=(const Container & other);
+                Container & operator=(Container && other);
+                ~Container();
+
+                const std::array<std::size_t, rank_> & dimensions() const;
+
+                double & operator()(const std::array<std::size_t, rank_> & index);
+                const double & operator()(const std::array<std::size_t, rank_> & index) const;
+
+                inline double * data() { return this->_data; };
+                inline const double * data() const { return this->_data; };
+        };
+
+        extern template class Container<double, 1>;
+        extern template class Container<double, 2>;
+        extern template class Container<double, 3>;
+        extern template class Container<double, 4>;
+
+        template <std::size_t rank_>
+        class Container<std::complex<double>, rank_>
+        {
+            private:
+                std::size_t _size;
+                std::complex<double> * _data;
+                std::array<std::size_t, rank_> _dimensions;
+
+            public:
+                Container(const std::array<std::size_t, rank_> & dimensions);
+                Container(const Container & other);
+                Container(Container && other);
+                Container & operator=(const Container & other);
+                Container & operator=(Container && other);
+                ~Container();
+
+                const std::array<std::size_t, rank_> & dimensions() const;
+
+                std::complex<double> & operator()(const std::array<std::size_t, rank_> & index);
+                const std::complex<double> & operator()(const std::array<std::size_t, rank_> & index) const;
+
+                inline std::complex<double> * data() { return this->_data; };
+                inline const std::complex<double> * data() const { return this->_data; };
+
+                Container & operator*=(const Container & rhs);
+        };
+
+        template <std::size_t rank_>
+        Container<std::complex<double>, rank_> operator*(Container<std::complex<double>, rank_> lhs, const Container<std::complex<double>, rank_> & rhs)
+        {
+            lhs *= rhs;
+            return lhs;
+        }
+
+        extern template class Container<std::complex<double>, 1>;
+        extern template class Container<std::complex<double>, 2>;
+        extern template class Container<std::complex<double>, 3>;
+        extern template class Container<std::complex<double>, 4>;
+    } // namespace eos::dft
+} // namespace eos
+
+#endif

--- a/eos/maths/dft-container_TEST.cc
+++ b/eos/maths/dft-container_TEST.cc
@@ -1,0 +1,532 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <test/test.hh>
+#include <eos/maths/dft-container.hh>
+#include <eos/utils/exception.hh>
+
+using namespace test;
+using namespace eos;
+
+class DftContainerDoubleRankOneTest :
+    public TestCase
+{
+    public:
+        DftContainerDoubleRankOneTest() :
+            TestCase("dft_container_double_rank_one_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // standard initialisation and access for a rank 1 container
+            {
+                dft::Container<double, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = static_cast<double>(i);
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(container({i}), static_cast<double>(i), eps);
+                }
+            }
+
+            // copy constructor and assignment operator
+            {
+                dft::Container<double, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = static_cast<double>(i);
+                }
+
+                dft::Container<double, 1> copy(container);
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(copy({i}), static_cast<double>(i), eps);
+                }
+
+                dft::Container<double, 1> assigned = container;
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(assigned({i}), static_cast<double>(i), eps);
+                }
+            }
+
+            // move constructor and assignment operator
+            {
+                dft::Container<double, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = static_cast<double>(i);
+                }
+
+                dft::Container<double, 1> moved(std::move(container));
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(moved({i}), static_cast<double>(i), eps);
+                }
+
+                dft::Container<double, 1> assigned = std::move(moved);
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(assigned({i}), static_cast<double>(i), eps);
+                }
+            }
+
+            // assignment operator: self-assignment must not cause issues
+            {
+                dft::Container<double, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = static_cast<double>(i);
+                }
+
+                container = container;
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(container({i}), static_cast<double>(i), eps);
+                }
+            }
+
+            // assignment operator: check result of copy assignment
+            {
+                dft::Container<double, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = static_cast<double>(i);
+                }
+
+                dft::Container<double, 1> assigned({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    assigned({i}) = static_cast<double>(10 - i);
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(container({i}), static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(assigned({i}), static_cast<double>(10 - i), eps);
+                }
+
+                assigned = container;
+
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(assigned({i}), static_cast<double>(i), eps);
+                }
+            }
+
+            // assignment operator: self-move-assignment must not cause issues
+            {
+                dft::Container<double, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = static_cast<double>(i);
+                }
+
+                container = std::move(container);
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(container({i}), static_cast<double>(i), eps);
+                }
+            }
+
+            // assignment operator: check result of move assignment
+            {
+                dft::Container<double, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = static_cast<double>(i);
+                }
+
+                dft::Container<double, 1> assigned({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    assigned({i}) = static_cast<double>(10 - i);
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(container({i}), static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(assigned({i}), static_cast<double>(10 - i), eps);
+                }
+
+                assigned = std::move(container);
+
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(assigned({i}), static_cast<double>(i), eps);
+                }
+            }
+
+            // out-of-bounds access: must throw
+            {
+                dft::Container<double, 1> container({10});
+                TEST_CHECK_THROWS(std::out_of_range, container({10}));
+            }
+        }
+} dft_container_double_rank_one_test;
+
+class DftContainerComplexDoubleRankOneTest :
+    public TestCase
+{
+    public:
+        DftContainerComplexDoubleRankOneTest() :
+            TestCase("dft_container_complex_double_rank_one_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // standard initialisation and access for a rank 1 container
+            {
+                dft::Container<std::complex<double>, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = static_cast<std::complex<double>>(static_cast<double>(i));
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(container({i}), static_cast<std::complex<double>>(static_cast<double>(i)), eps);
+                }
+            }
+
+            // copy constructor and assignment operator
+            {
+                dft::Container<std::complex<double>, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = std::complex<double>(static_cast<double>(i), -static_cast<double>(i + 1));
+                }
+
+                dft::Container<std::complex<double>, 1> copy(container);
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(copy({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(copy({i})), -static_cast<double>(i + 1), eps);
+                }
+
+                dft::Container<std::complex<double>, 1> assigned = container;
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(assigned({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(assigned({i})), -static_cast<double>(i + 1), eps);
+                }
+            }
+
+            // move constructor and assignment operator
+            {
+                dft::Container<std::complex<double>, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = std::complex<double>(static_cast<double>(i), -static_cast<double>(i + 1));
+                }
+
+                dft::Container<std::complex<double>, 1> moved(std::move(container));
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(moved({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(moved({i})), -static_cast<double>(i + 1), eps);
+                }
+
+                dft::Container<std::complex<double>, 1> assigned = std::move(moved);
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(assigned({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(assigned({i})), -static_cast<double>(i + 1), eps);
+                }
+            }
+
+            // assignment operator: self-assignment must not cause issues
+            {
+                dft::Container<std::complex<double>, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = std::complex<double>(static_cast<double>(i), -static_cast<double>(i + 1));
+                }
+
+                container = container;
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(container({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(container({i})), -static_cast<double>(i + 1), eps);
+                }
+            }
+
+            // assignment operator: check result of copy assignment
+            {
+                dft::Container<std::complex<double>, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = std::complex<double>(static_cast<double>(i), -static_cast<double>(i + 1));
+                }
+
+                dft::Container<std::complex<double>, 1> assigned({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    assigned({i}) = std::complex<double>(static_cast<double>(10 - i), -static_cast<double>(10 - i + 1));
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(container({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(container({i})), -static_cast<double>(i + 1), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::real(assigned({i})), +static_cast<double>(10 - i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(assigned({i})), -static_cast<double>(10 - i + 1), eps);
+                }
+
+                assigned = container;
+
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(assigned({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(assigned({i})), -static_cast<double>(i + 1), eps);
+                }
+            }
+
+            // assignment operator: self-move-assignment must not cause issues
+            {
+                dft::Container<std::complex<double>, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = std::complex<double>(static_cast<double>(i), -static_cast<double>(i + 1));
+                }
+
+                container = std::move(container);
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(container({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(container({i})), -static_cast<double>(i + 1), eps);
+                }
+            }
+
+            // assignment operator: check result of move assignment
+            {
+                dft::Container<std::complex<double>, 1> container({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    container({i}) = std::complex<double>(static_cast<double>(i), -static_cast<double>(i + 1));
+                }
+
+                dft::Container<std::complex<double>, 1> assigned({10});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    assigned({i}) = std::complex<double>(static_cast<double>(10 - i), -static_cast<double>(10 - i + 1));
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(container({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(container({i})), -static_cast<double>(i + 1), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::real(assigned({i})), +static_cast<double>(10 - i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(assigned({i})), -static_cast<double>(10 - i + 1), eps);
+                }
+
+                assigned = std::move(container);
+
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(std::real(assigned({i})), +static_cast<double>(i), eps);
+                    TEST_CHECK_NEARLY_EQUAL(std::imag(assigned({i})), -static_cast<double>(i + 1), eps);
+                }
+            }
+
+            // out-of-bounds access: must throw
+            {
+                dft::Container<std::complex<double>, 1> container({10});
+                TEST_CHECK_THROWS(std::out_of_range, container({10}));
+            }
+        }
+} dft_container_complex_double_rank_one_test;
+
+class DftContainerDoubleRanksTest : public TestCase
+{
+    public:
+        DftContainerDoubleRanksTest() :
+            TestCase("dft_container_double_ranks_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            // test rank 2 container layout: FFTW3 uses row-major order, so the last index should be contiguous in memory
+            {
+                dft::Container<double, 2> container({10, 20});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    for (std::size_t j = 0; j < 20; ++j)
+                    {
+                        container({i, j}) = static_cast<double>(i * 20 + j);
+                    }
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                double * data = container.data();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    for (std::size_t j = 0; j < 20; ++j)
+                    {
+                        TEST_CHECK_NEARLY_EQUAL(data[i * 20 + j], static_cast<double>(i * 20 + j), eps);
+                    }
+                }
+            }
+
+            // test rank 3 container layout: FFTW3 uses row-major order, so the last index should be contiguous in memory
+            {
+                dft::Container<double, 3> container({10, 20, 30});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    for (std::size_t j = 0; j < 20; ++j)
+                    {
+                        for (std::size_t k = 0; k < 30; ++k)
+                        {
+                            container({i, j, k}) = static_cast<double>(i * 600 + j * 30 + k);
+                        }
+                    }
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                double * data = container.data();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    for (std::size_t j = 0; j < 20; ++j)
+                    {
+                        for (std::size_t k = 0; k < 30; ++k)
+                        {
+                            TEST_CHECK_NEARLY_EQUAL(data[i * 600 + j * 30 + k], static_cast<double>(i * 600 + j * 30 + k), eps);
+                        }
+                    }
+                }
+            }
+
+            // test rank 4 container layout: FFTW3 uses row-major order, so the last index should be contiguous in memory
+            {
+                dft::Container<double, 4> container({10, 20, 30, 40});
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    for (std::size_t j = 0; j < 20; ++j)
+                    {
+                        for (std::size_t k = 0; k < 30; ++k)
+                        {
+                            for (std::size_t l = 0; l < 40; ++l)
+                            {
+                                container({i, j, k, l}) = static_cast<double>(i * 24000 + j * 1200 + k * 40 + l);
+                            }
+                        }
+                    }
+                }
+
+                const double eps = std::numeric_limits<double>::epsilon();
+                double * data = container.data();
+                for (std::size_t i = 0; i < 10; ++i)
+                {
+                    for (std::size_t j = 0; j < 20; ++j)
+                    {
+                        for (std::size_t k = 0; k < 30; ++k)
+                        {
+                            for (std::size_t l = 0; l < 40; ++l)
+                            {
+                                TEST_CHECK_NEARLY_EQUAL(data[i * 24000 + j * 1200 + k * 40 + l], static_cast<double>(i * 24000 + j * 1200 + k * 40 + l), eps);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+} dft_container_double_ranks_test;
+
+class DftContainerComplexDoubleMultiplicationTest :
+    public TestCase
+{
+    public:
+        DftContainerComplexDoubleMultiplicationTest() :
+            TestCase("dft_container_complex_double_multiplication_test")
+        {
+        }
+
+        virtual void run() const
+        {
+            const double eps = std::numeric_limits<double>::epsilon();
+
+            // operator*=: result is correct
+            {
+                dft::Container<std::complex<double>, 1> lhs({4}), rhs({4});
+                lhs({0}) = { 1.0,  2.0}; rhs({0}) = { 3.0,  4.0};
+                lhs({1}) = { 5.0,  6.0}; rhs({1}) = { 7.0,  8.0};
+                lhs({2}) = { 9.0, 10.0}; rhs({2}) = {11.0, 12.0};
+                lhs({3}) = {13.0, 14.0}; rhs({3}) = {15.0, 16.0};
+
+                lhs *= rhs;
+
+                TEST_CHECK_NEARLY_EQUAL(std::real(lhs({0})), 1.0 * 3.0 - 2.0 * 4.0,   eps);
+                TEST_CHECK_NEARLY_EQUAL(std::imag(lhs({0})), 1.0 * 4.0 + 2.0 * 3.0,   eps);
+                TEST_CHECK_NEARLY_EQUAL(std::real(lhs({1})), 5.0 * 7.0 - 6.0 * 8.0,   eps);
+                TEST_CHECK_NEARLY_EQUAL(std::imag(lhs({1})), 5.0 * 8.0 + 6.0 * 7.0,   eps);
+                TEST_CHECK_NEARLY_EQUAL(std::real(lhs({2})), 9.0 * 11.0 - 10.0 * 12.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::imag(lhs({2})), 9.0 * 12.0 + 10.0 * 11.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::real(lhs({3})), 13.0 * 15.0 - 14.0 * 16.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::imag(lhs({3})), 13.0 * 16.0 + 14.0 * 15.0, eps);
+            }
+
+            // operator*: result is correct and operands are unchanged
+            {
+                dft::Container<std::complex<double>, 1> lhs({2}), rhs({2});
+                lhs({0}) = {1.0, 2.0}; rhs({0}) = {3.0, 4.0};
+                lhs({1}) = {5.0, 6.0}; rhs({1}) = {7.0, 8.0};
+
+                dft::Container<std::complex<double>, 1> result = lhs * rhs;
+
+                TEST_CHECK_NEARLY_EQUAL(std::real(result({0})), 1.0 * 3.0 - 2.0 * 4.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::imag(result({0})), 1.0 * 4.0 + 2.0 * 3.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::real(result({1})), 5.0 * 7.0 - 6.0 * 8.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::imag(result({1})), 5.0 * 8.0 + 6.0 * 7.0, eps);
+
+                // operands must be unchanged
+                TEST_CHECK_NEARLY_EQUAL(std::real(lhs({0})), 1.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::imag(lhs({0})), 2.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::real(rhs({0})), 3.0, eps);
+                TEST_CHECK_NEARLY_EQUAL(std::imag(rhs({0})), 4.0, eps);
+            }
+
+            // operator*=: dimension mismatch must throw
+            {
+                dft::Container<std::complex<double>, 1> lhs({4}), rhs({5});
+                TEST_CHECK_THROWS(eos::InternalError, lhs *= rhs);
+            }
+        }
+} dft_container_complex_double_multiplication_test;

--- a/eos/maths/dft-plan-impl.hh
+++ b/eos/maths/dft-plan-impl.hh
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_MATHS_DFT_PLAN_IMPL_HH
+#define EOS_GUARD_EOS_MATHS_DFT_PLAN_IMPL_HH 1
+
+#include <eos/maths/dft-plan.hh>
+#include <eos/utils/exception.hh>
+#include <eos/utils/private_implementation_pattern-impl.hh>
+
+#include <algorithm>
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <format>
+
+#include <fftw3.h>
+
+namespace eos
+{
+    namespace dft
+    {
+        namespace impl
+        {
+            template <std::size_t rank_>
+            inline std::array<std::size_t, rank_> frequency_dimensions(const std::array<std::size_t, rank_> & dimensions)
+            {
+                std::array<std::size_t, rank_> frequency_dimensions;
+
+                // For a real-valued input of size N, the DFT is symmetric and only the first N/2 + 1 complex coefficients are unique.
+                // Therefore, the size of the frequency domain container is N/2 + 1 in the last dimension, and the same as the input dimensions in the other dimensions.
+                frequency_dimensions[rank_ - 1] = dimensions[rank_ - 1] / 2 + 1;
+
+                for (std::size_t i = 0; i + 1 < rank_; ++i)
+                {
+                    frequency_dimensions[i] = dimensions[i];
+                }
+
+                return frequency_dimensions;
+            }
+
+            template <std::size_t rank_>
+            inline void check_dimensions(const std::array<std::size_t, rank_> & dimensions)
+            {
+                // The real-to-complex (and complex-to-real) transforms implemented here rely on each dimension being even,
+                // both for the size N/2 + 1 of the frequency-domain container and for the symmetry assumptions of the transform.
+                for (std::size_t i = 0; i < rank_; ++i)
+                {
+                    if (dimensions[i] % 2 != 0)
+                    {
+                        throw InternalError(std::format("dft::Plan<{}>: dimension {} (= {}) must be even", rank_, i, dimensions[i]));
+                    }
+                }
+            }
+
+            template <std::size_t rank_, Direction direction_>
+            struct PlanTraits;
+
+            template <>
+            struct PlanTraits<1, Direction::Forward>
+            {
+                static fftw_plan alloc(const std::array<std::size_t, 1> & dimensions, const dft::Container<double, 1> & time_domain_container, const dft::Container<std::complex<double>, 1> & frequency_domain_container)
+                {
+                    static const unsigned flags = FFTW_MEASURE | FFTW_DESTROY_INPUT;
+
+                    double * time_domain_data = const_cast<double *>(time_domain_container.data());
+                    fftw_complex * frequency_domain_data = const_cast<fftw_complex *>(reinterpret_cast<const fftw_complex *>(frequency_domain_container.data()));
+
+                    return fftw_plan_dft_r2c_1d(dimensions[0], time_domain_data, frequency_domain_data, flags);
+                }
+            };
+
+            template <>
+            struct PlanTraits<1, Direction::Backward>
+            {
+                static fftw_plan alloc(const std::array<std::size_t, 1> & dimensions, const dft::Container<double, 1> & time_domain_container, const dft::Container<std::complex<double>, 1> & frequency_domain_container)
+                {
+                    static const unsigned flags = FFTW_MEASURE | FFTW_DESTROY_INPUT;
+
+                    double * time_domain_data = const_cast<double *>(time_domain_container.data());
+                    fftw_complex * frequency_domain_data = const_cast<fftw_complex *>(reinterpret_cast<const fftw_complex *>(frequency_domain_container.data()));
+
+                    return fftw_plan_dft_c2r_1d(dimensions[0], frequency_domain_data, time_domain_data, flags);
+                }
+            };
+
+            template <>
+            struct PlanTraits<2, Direction::Forward>
+            {
+                static fftw_plan alloc(const std::array<std::size_t, 2> & dimensions, const dft::Container<double, 2> & time_domain_container, const dft::Container<std::complex<double>, 2> & frequency_domain_container)
+                {
+                    static const unsigned flags = FFTW_MEASURE | FFTW_DESTROY_INPUT;
+
+                    double * time_domain_data = const_cast<double *>(time_domain_container.data());
+                    fftw_complex * frequency_domain_data = const_cast<fftw_complex *>(reinterpret_cast<const fftw_complex *>(frequency_domain_container.data()));
+
+                    return fftw_plan_dft_r2c_2d(dimensions[0], dimensions[1], time_domain_data, frequency_domain_data, flags);
+                }
+            };
+
+            template <>
+            struct PlanTraits<2, Direction::Backward>
+            {
+                static fftw_plan alloc(const std::array<std::size_t, 2> & dimensions, const dft::Container<double, 2> & time_domain_container, const dft::Container<std::complex<double>, 2> & frequency_domain_container)
+                {
+                    static const unsigned flags = FFTW_MEASURE | FFTW_DESTROY_INPUT;
+
+                    double * time_domain_data = const_cast<double *>(time_domain_container.data());
+                    fftw_complex * frequency_domain_data = const_cast<fftw_complex *>(reinterpret_cast<const fftw_complex *>(frequency_domain_container.data()));
+
+                    return fftw_plan_dft_c2r_2d(dimensions[0], dimensions[1], frequency_domain_data, time_domain_data, flags);
+                }
+            };
+
+            template <>
+            struct PlanTraits<3, Direction::Forward>
+            {
+                static fftw_plan alloc(const std::array<std::size_t, 3> & dimensions, const dft::Container<double, 3> & time_domain_container, const dft::Container<std::complex<double>, 3> & frequency_domain_container)
+                {
+                    static const unsigned flags = FFTW_MEASURE | FFTW_DESTROY_INPUT;
+
+                    double * time_domain_data = const_cast<double *>(time_domain_container.data());
+                    fftw_complex * frequency_domain_data = const_cast<fftw_complex *>(reinterpret_cast<const fftw_complex *>(frequency_domain_container.data()));
+
+                    return fftw_plan_dft_r2c_3d(dimensions[0], dimensions[1], dimensions[2], time_domain_data, frequency_domain_data, flags);
+                }
+            };
+
+            template <>
+            struct PlanTraits<3, Direction::Backward>
+            {
+                static fftw_plan alloc(const std::array<std::size_t, 3> & dimensions, const dft::Container<double, 3> & time_domain_container, const dft::Container<std::complex<double>, 3> & frequency_domain_container)
+                {
+                    static const unsigned flags = FFTW_MEASURE | FFTW_DESTROY_INPUT;
+
+                    double * time_domain_data = const_cast<double *>(time_domain_container.data());
+                    fftw_complex * frequency_domain_data = const_cast<fftw_complex *>(reinterpret_cast<const fftw_complex *>(frequency_domain_container.data()));
+
+                    return fftw_plan_dft_c2r_3d(dimensions[0], dimensions[1], dimensions[2], frequency_domain_data, time_domain_data, flags);
+                }
+            };
+
+            template <>
+            struct PlanTraits<4, Direction::Forward>
+            {
+                static fftw_plan alloc(const std::array<std::size_t, 4> & dimensions, const dft::Container<double, 4> & time_domain_container, const dft::Container<std::complex<double>, 4> & frequency_domain_container)
+                {
+                    static const unsigned flags = FFTW_MEASURE | FFTW_DESTROY_INPUT;
+
+                    std::array<int, 4> n;
+                    std::transform(dimensions.begin(), dimensions.end(), n.begin(),
+                        [](std::size_t d) { return static_cast<int>(d); });
+
+                    double * time_domain_data = const_cast<double *>(time_domain_container.data());
+                    fftw_complex * frequency_domain_data = const_cast<fftw_complex *>(reinterpret_cast<const fftw_complex *>(frequency_domain_container.data()));
+
+                    return fftw_plan_dft_r2c(4, n.data(), time_domain_data, frequency_domain_data, flags);
+                }
+            };
+
+            template <>
+            struct PlanTraits<4, Direction::Backward>
+            {
+                static fftw_plan alloc(const std::array<std::size_t, 4> & dimensions, const dft::Container<double, 4> & time_domain_container, const dft::Container<std::complex<double>, 4> & frequency_domain_container)
+                {
+                    static const unsigned flags = FFTW_MEASURE | FFTW_DESTROY_INPUT;
+
+                    std::array<int, 4> n;
+                    std::transform(dimensions.begin(), dimensions.end(), n.begin(),
+                        [](std::size_t d) { return static_cast<int>(d); });
+
+                    double * time_domain_data = const_cast<double *>(time_domain_container.data());
+                    fftw_complex * frequency_domain_data = const_cast<fftw_complex *>(reinterpret_cast<const fftw_complex *>(frequency_domain_container.data()));
+
+                    return fftw_plan_dft_c2r(4, n.data(), frequency_domain_data, time_domain_data, flags);
+                }
+            };
+        }
+    }
+
+    template <std::size_t rank_, dft::Direction direction_>
+    struct Implementation<dft::Plan<rank_, direction_>>
+    {
+        dft::Container<double, rank_> time_domain_container;
+        dft::Container<std::complex<double>, rank_> frequency_domain_container;
+
+        fftw_plan plan;
+
+        std::array<std::size_t, rank_> dimensions;
+
+        Implementation(const std::array<std::size_t, rank_> & dimensions) :
+            // validate the dimensions before allocating any containers or the FFTW plan
+            time_domain_container((dft::impl::check_dimensions(dimensions), dimensions)),
+            frequency_domain_container(dft::impl::frequency_dimensions(dimensions)),
+            plan(dft::impl::PlanTraits<rank_, direction_>::alloc(dimensions, time_domain_container, frequency_domain_container)),
+            dimensions(dimensions)
+        {
+        }
+
+        ~Implementation()
+        {
+            fftw_destroy_plan(this->plan);
+        }
+    };
+
+    namespace dft
+    {
+        template <std::size_t rank_, Direction direction_>
+        Plan<rank_, direction_>::Plan(const std::array<std::size_t, rank_> & dimensions) :
+            PrivateImplementationPattern<dft::Plan<rank_, direction_>>(new Implementation<dft::Plan<rank_, direction_>>(dimensions))
+        {
+        }
+
+        template <std::size_t rank_, Direction direction_>
+        Plan<rank_, direction_>::Plan(Plan && other) = default;
+
+        template <std::size_t rank_, Direction direction_>
+        Plan<rank_, direction_> & Plan<rank_, direction_>::operator=(Plan && other) = default;
+
+        template <std::size_t rank_, Direction direction_>
+        Plan<rank_, direction_>::~Plan() = default;
+
+        template <std::size_t rank_, Direction direction_>
+        const std::array<std::size_t, rank_> & Plan<rank_, direction_>::dimensions() const
+        {
+            return this->_imp->dimensions;
+        }
+
+        template <std::size_t rank_, Direction direction_>
+        void Plan<rank_, direction_>::transform()
+        {
+            fftw_execute(this->_imp->plan);
+        }
+
+        template <std::size_t rank_, Direction direction_>
+        Container<double, rank_> & Plan<rank_, direction_>::time_domain_container()
+        {
+            return this->_imp->time_domain_container;
+        }
+
+        template <std::size_t rank_, Direction direction_>
+        Container<std::complex<double>, rank_> & Plan<rank_, direction_>::frequency_domain_container()
+        {
+            return this->_imp->frequency_domain_container;
+        }
+    } // namespace eos::dft
+} // namespace eos
+
+#endif

--- a/eos/maths/dft-plan.cc
+++ b/eos/maths/dft-plan.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <eos/maths/dft-plan-impl.hh>
+
+namespace eos
+{
+    namespace dft
+    {
+        template class Plan<1, Direction::Forward>;
+        template class Plan<1, Direction::Backward>;
+
+        template class Plan<2, Direction::Forward>;
+        template class Plan<2, Direction::Backward>;
+
+        template class Plan<3, Direction::Forward>;
+        template class Plan<3, Direction::Backward>;
+
+        template class Plan<4, Direction::Forward>;
+        template class Plan<4, Direction::Backward>;
+    } // namespace eos::dft
+} // namespace eos

--- a/eos/maths/dft-plan.hh
+++ b/eos/maths/dft-plan.hh
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_MATHS_DFT_PLAN_HH
+#define EOS_GUARD_EOS_MATHS_DFT_PLAN_HH 1
+
+#include <eos/maths/dft-container.hh>
+#include <eos/utils/private_implementation_pattern.hh>
+
+namespace eos
+{
+    namespace dft
+    {
+        enum class Direction
+        {
+            Forward,
+            Backward
+        };
+
+        template <std::size_t rank_, Direction direction_>
+        class Plan : public PrivateImplementationPattern<dft::Plan<rank_, direction_>>
+        {
+            public:
+                Plan(const std::array<std::size_t, rank_> & dimensions);
+
+                // A Plan owns an FFTW plan and its scratch buffers. Copying would either alias them (via the
+                // shared_ptr PIMPL) or require rebuilding the FFTW plan, so Plan is move-only.
+                Plan(const Plan & other) = delete;
+                Plan(Plan && other);
+                Plan & operator=(const Plan & other) = delete;
+                Plan & operator=(Plan && other);
+                ~Plan();
+
+                const std::array<std::size_t, rank_> & dimensions() const;
+
+                // Forward: transforms from the time domain to the frequency domain.
+                // Backward: transforms from the frequency domain to the time domain.
+                void transform();
+
+                Container<double, rank_> & time_domain_container();
+                Container<std::complex<double>, rank_> & frequency_domain_container();
+        };
+
+        extern template class Plan<1, Direction::Forward>;
+        extern template class Plan<1, Direction::Backward>;
+
+        extern template class Plan<2, Direction::Forward>;
+        extern template class Plan<2, Direction::Backward>;
+
+        extern template class Plan<3, Direction::Forward>;
+        extern template class Plan<3, Direction::Backward>;
+
+        extern template class Plan<4, Direction::Forward>;
+        extern template class Plan<4, Direction::Backward>;
+    } // namespace eos::dft
+} // namespace eos
+
+#endif

--- a/eos/maths/dft-plan_TEST.cc
+++ b/eos/maths/dft-plan_TEST.cc
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <test/test.hh>
+#include <eos/maths/dft-plan-impl.hh>
+
+
+using namespace test;
+using namespace eos;
+
+class DftPlanImplementationDetailsTestCase :
+    public TestCase
+{
+    public:
+        DftPlanImplementationDetailsTestCase() :
+            TestCase("dft_plan_implementation_details_test")
+        {
+        }
+
+        virtual void run() const override
+        {
+            // 1D
+            {
+                std::array<std::size_t, 1> time_domain_dimensions = { 16 };
+
+                std::array<std::size_t, 1> frequency_domain_dimensions = dft::impl::frequency_dimensions<1>(time_domain_dimensions);
+
+                TEST_CHECK(frequency_domain_dimensions[0] == 9);
+            }
+
+            // 2D
+            {
+                std::array<std::size_t, 2> time_domain_dimensions = { 32, 64 };
+
+                std::array<std::size_t, 2> frequency_domain_dimensions = dft::impl::frequency_dimensions<2>(time_domain_dimensions);
+
+                TEST_CHECK(frequency_domain_dimensions[0] == 32);
+                TEST_CHECK(frequency_domain_dimensions[1] == 33);
+            }
+        }
+} dft_plan_implementation_details_test;
+
+class DftPlanOddDimensionsTest :
+    public TestCase
+{
+    public:
+        DftPlanOddDimensionsTest() :
+            TestCase("dft_plan_odd_dimensions_test")
+        {
+        }
+
+        virtual void run() const override
+        {
+            // odd dimensions must throw upon plan construction
+
+            // 1D
+            {
+                std::array<std::size_t, 1> dimensions{ 15 };
+                TEST_CHECK_THROWS(eos::InternalError, (dft::Plan<1, dft::Direction::Forward>(dimensions)));
+            }
+
+            // 2D: odd in the last dimension
+            {
+                std::array<std::size_t, 2> dimensions{ 4, 7 };
+                TEST_CHECK_THROWS(eos::InternalError, (dft::Plan<2, dft::Direction::Forward>(dimensions)));
+            }
+
+            // 2D: odd in a leading dimension
+            {
+                std::array<std::size_t, 2> dimensions{ 3, 8 };
+                TEST_CHECK_THROWS(eos::InternalError, (dft::Plan<2, dft::Direction::Backward>(dimensions)));
+            }
+
+            // 4D: odd in an interior dimension
+            {
+                std::array<std::size_t, 4> dimensions{ 2, 4, 5, 4 };
+                TEST_CHECK_THROWS(eos::InternalError, (dft::Plan<4, dft::Direction::Forward>(dimensions)));
+            }
+        }
+} dft_plan_odd_dimensions_test;
+
+class DftPlanRankOneTest :
+    public TestCase
+{
+    public:
+        DftPlanRankOneTest() :
+            TestCase("dft_plan_rank_one_test")
+        {
+        }
+
+        virtual void run() const override
+        {
+            static const std::array<std::size_t, 1> dimensions{ 256 };
+            static const std::array<double, 256> data{
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.00390244,
+                 0.0310059,  0.0577354,  0.0840912,  0.110073,   0.135681,   0.160915,   0.185776,   0.210262,
+                 0.234375,   0.258114,   0.281479,   0.30447,    0.327087,   0.349331,   0.371201,   0.392696,
+                 0.413818,   0.434566,   0.454941,   0.474941,   0.494568,   0.513821,   0.5327,     0.551205,
+                 0.569336,   0.587093,   0.604477,   0.621487,   0.638123,   0.654385,   0.670273,   0.685787,
+                 0.700928,   0.715694,   0.730087,   0.744106,   0.75856,    0.771854,   0.784775,   0.797323,
+                 0.809499,   0.821302,   0.832732,   0.84379,    0.854476,   0.864789,   0.874729,   0.884298,
+                 0.893494,   0.902319,   0.910772,   0.918853,   0.926562,   0.9339,     0.940867,   0.947463,
+                 0.953689,   0.959544,   0.965028,   0.970143,   0.974888,   0.979264,   0.983271,   0.986909,
+                 0.99018,    0.993083,   0.99562,    0.99779,    0.999595,   1.00104,    1.00211,    1.00283,
+                 1.00318,    1.00318,    1.00281,    1.00209,    1.00102,    0.999598,   0.997825,   0.995709,
+                 0.993251,   0.990459,   0.987337,   0.983892,   0.980133,   0.976071,   0.971718,   0.967089,
+                 0.962205,   0.957091,   0.951777,   0.946304,   0.940727,   0.935117,   0.929569,   0.924217,
+                 0.919249,   0.914938,   0.911691,   0.910138,   0.911296,   0.916891,   0.930053,   0.956933,
+                 1.01102,    1.12675,    1.41501,    2.40647,    10.0072,    14.1563,    2.68786,    1.42151,
+                 1.05902,    0.90139,    0.814085,   0.757068,   0.715084,   0.681302,   0.652295,   0.626191,
+                 0.601898,   0.578742,   0.556291,   0.534257,   0.512443,   0.490707,   0.46895,    0.447097,
+                 0.425093,   0.402894,   0.380469,   0.357792,   0.334842,   0.311603,   0.288062,   0.264208,
+                 0.240033,   0.215529,   0.190691,   0.165513,   0.139991,   0.114121,   0.0879005,  0.0613267,
+                 0.0343973,  0.00711023, 0.00303869, 0.00288261, 0.00273826, 0.00260448, 0.00248028, 0.00236475,
+                 0.00225711, 0.00215665, 0.00206276, 0.00197486, 0.00189247, 0.00181512, 0.00174242, 0.00167401,
+                 0.00160954, 0.00154873, 0.00149131, 0.00143701, 0.00138563, 0.00133696, 0.0012908,  0.001247,
+                 0.00120539, 0.00116583, 0.00112818, 0.00109233, 0.00105816, 0.00102556, 0.000994456,0.000964742,
+                 0.000936339,0.000909173,0.000883172,0.000858271,0.000834408,0.000811527,0.0,        0.0,
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,
+                 0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0,        0.0
+            };
+
+            // Create plan for forward transformation
+            dft::Plan<1, dft::Direction::Forward> forward_plan(dimensions);
+            dft::Container<double, 1> & time_domain_container = forward_plan.time_domain_container();
+            dft::Container<std::complex<double>, 1> & frequency_domain_container = forward_plan.frequency_domain_container();
+
+            TEST_CHECK_EQUAL(dimensions, time_domain_container.dimensions());
+            TEST_CHECK_EQUAL(dimensions[0] / 2 + 1, frequency_domain_container.dimensions()[0]);
+
+            // Execute forward plan
+            std::copy(data.begin(), data.end(), forward_plan.time_domain_container().data());
+            forward_plan.transform();
+
+            // Expected values obtained from Mathematica's Fourier[] with the FFTW3 convention
+            // (negative exponent, no normalisation).
+            static const std::array<std::complex<double>, 129> expected{{
+                {  127.799,       0.0        },  // k=0
+                {  -88.256,      23.5526     },  // k=1
+                {   11.0419,    -28.9844     },  // k=2
+                {   34.2744,     12.6913     },  // k=3
+                {  -29.1046,     12.7161     },  // k=4
+                {    2.84081,   -28.0943     },  // k=5
+                {   18.1886,     22.1584     },  // k=6
+                {  -26.2979,      0.16831    },  // k=7
+                {   17.6264,    -21.8945     },  // k=8
+                {    5.35677,    26.7939     },  // k=9
+                {  -25.2374,    -11.5946     },  // k=10
+                {   24.5858,    -11.9222     },  // k=11
+                {   -5.06143,    26.0222     },  // k=12
+                {  -16.7516,    -20.3811     },  // k=13
+                {   25.5603,     -0.337285   },  // k=14
+                {  -15.8668,     20.3451     },  // k=15
+                {   -5.72062,   -24.7116     },  // k=16
+                {   23.0344,     10.5391     },  // k=17
+                {  -22.3772,     11.177      },  // k=18
+                {    4.78953,   -24.0565     },  // k=19
+                {   15.5613,     18.6817     },  // k=20
+                {  -23.7924,      0.507591   },  // k=21
+                {   14.4204,    -18.8779     },  // k=22
+                {    5.60399,    22.7266     },  // k=23
+                {  -21.2193,     -9.52464    },  // k=24
+                {   20.4473,    -10.4762     },  // k=25
+                {   -4.29418,    22.1864     },  // k=26
+                {  -14.4654,    -17.0555     },  // k=27
+                {   21.9519,     -0.679903   },  // k=28
+                {  -13.0689,     17.4856     },  // k=29
+                {   -5.41148,   -20.8311     },  // k=30
+                {   19.549,       8.54759    },  // k=31
+                {  -18.644,       9.8169     },  // k=32
+                {    3.75532,   -20.4041     },  // k=33
+                {   13.4365,     15.4963     },  // k=34
+                {  -20.1502,      0.854899   },  // k=35
+                {   11.7799,    -16.1627     },  // k=36
+                {    5.20868,    19.0179     },  // k=37
+                {  -17.9761,     -7.60421    },  // k=38
+                {   16.9306,     -9.19644    },  // k=39
+                {   -3.20933,    18.7025     },  // k=40
+                {  -12.4645,    -13.9983     },  // k=41
+                {   18.4092,     -1.03327    },  // k=42
+                {  -10.5418,     14.9037     },  // k=43
+                {   -5.01323,   -17.2796     },  // k=44
+                {   16.4828,      6.69083    },  // k=45
+                {  -15.2914,      8.61234    },  // k=46
+                {    2.6662,    -17.0748     },  // k=47
+                {   11.5436,     12.5555     },  // k=48
+                {  -16.7321,      1.21572    },  // k=49
+                {    9.34737,   -13.7035     },  // k=50
+                {    4.83112,    15.6097     },  // k=51
+                {  -15.0587,     -5.80385    },  // k=52
+                {   13.7163,     -8.06227    },  // k=53
+                {   -2.12857,    15.5146     },  // k=54
+                {  -10.6693,    -11.1622     },  // k=55
+                {   15.1165,     -1.40298    },  // k=56
+                {   -8.1909,     12.5576     },  // k=57
+                {   -4.66458,   -14.0013     },  // k=58
+                {   13.6964,      4.93977    },  // k=59
+                {  -12.1973,      7.54405    },  // k=60
+                {    1.59653,   -14.0156     },  // k=61
+                {    9.83774,     9.81292    },  // k=62
+                {  -13.5579,      1.59577    },  // k=63
+                {    7.06739,   -11.4612     },  // k=64
+                {    4.51438,    12.4482     },  // k=65
+                {  -12.3896,     -4.09519    },  // k=66
+                {   10.7278,     -7.05563    },  // k=67
+                {   -1.06908,    12.572      },  // k=68
+                {   -9.04534,    -8.50242    },  // k=69
+                {   12.0511,     -1.79487    },  // k=70
+                {   -5.97217,    10.4102     },  // k=71
+                {   -4.38071,   -10.9443     },  // k=72
+                {   11.1325,      3.26677    },  // k=73
+                {   -9.30152,     6.59508    },  // k=74
+                {    0.544775,  -11.1781     },  // k=75
+                {    8.2889,      7.22548    },  // k=76
+                {  -10.5909,      2.00106    },  // k=77
+                {    4.90077,    -9.40025    },  // k=78
+                {    4.26349,     9.48357    },  // k=79
+                {   -9.91992,    -2.45125    },  // k=80
+                {    7.91245,    -6.16058    },  // k=81
+                {   -0.021896,    9.8283     },  // k=82
+                {   -7.56535,    -5.97707    },  // k=83
+                {    9.17184,    -2.21514    },  // k=84
+                {   -3.84889,     8.42744    },  // k=85
+                {   -4.16252,    -8.0603     },  // k=86
+                {    8.7469,      1.64541    },  // k=87
+                {   -6.55501,     5.75041    },  // k=88
+                {   -0.501393,   -8.51732    },  // k=89
+                {    6.8718,      4.75226    },  // k=90
+                {   -7.78847,     2.43798    },  // k=91
+                {    2.8123,     -7.48792    },  // k=92
+                {    4.07757,     6.66887    },  // k=93
+                {   -7.60869,    -0.846065   },  // k=94
+                {    5.22373,    -5.36296    },  // k=95
+                {    1.02702,     7.23999    },  // k=96
+                {   -6.20548,    -3.54621    },  // k=97
+                {    6.43548,    -2.67044    },  // k=98
+                {   -1.78689,     6.57797    },  // k=99
+                {   -4.00841,    -5.30376    },  // k=100
+                {    6.5007,      0.0500586  },  // k=101
+                {   -3.91329,     4.99668    },  // k=102
+                {   -1.55695,    -5.99125    },  // k=103
+                {    5.56374,     2.35416    },  // k=104
+                {   -5.10763,     2.91345    },  // k=105
+                {    0.768571,   -5.694      },  // k=106
+                {    3.95484,     3.9596     },  // k=107
+                {   -5.41852,     0.745752   },  // k=108
+                {    2.61847,    -4.65014    },  // k=109
+                {    2.09323,     4.76618    },  // k=110
+                {   -4.94405,    -1.1714     },  // k=111
+                {    3.79975,    -3.16797    },  // k=112
+                {    0.246689,    4.83253    },  // k=113
+                {   -3.91671,    -2.63108    },  // k=114
+                {    4.35784,    -1.54451    },  // k=115
+                {   -1.33414,     4.32196    },  // k=116
+                {   -2.63792,    -3.55992    },  // k=117
+                {    4.34395,    -0.00673168 },  // k=118
+                {   -2.5067,      3.435      },  // k=119
+                {   -1.26292,    -3.99013    },  // k=120
+                {    3.89387,     1.31295    },  // k=121
+                {   -3.31442,     2.34937    },  // k=122
+                {    0.0551965,  -4.01086    },  // k=123
+                {    3.19315,     2.36773    },  // k=124
+                {   -3.76109,     1.18489    },  // k=125
+                {    1.2234,     -3.71559    },  // k=126
+                {    2.28415,     3.1635     },  // k=127
+                {   -3.88627,     0.0        },  // k=128
+            }};
+
+            for (std::size_t k = 0; k < 129; ++k)
+            {
+                TEST_CHECK_NEARLY_EQUAL(frequency_domain_container.data()[k], expected[k], 1.0e-2);
+            }
+        }
+} dft_plan_rank_one_test;
+
+class DftPlanRankTwoTest :
+    public TestCase
+{
+    public:
+        DftPlanRankTwoTest() :
+            TestCase("dft_plan_rank_two_test")
+        {
+        }
+
+        virtual void run() const override
+        {
+            static const std::array<std::size_t, 2> dimensions{ 4, 8 };
+
+            // check dimension reporting
+            {
+                dft::Plan<2, dft::Direction::Forward> forward_plan(dimensions);
+
+                TEST_CHECK_EQUAL(dimensions, forward_plan.time_domain_container().dimensions());
+
+                static const std::array<std::size_t, 2> expected_freq_dims{ 4, 5 };
+                TEST_CHECK_EQUAL(expected_freq_dims, forward_plan.frequency_domain_container().dimensions());
+            }
+
+            // round-trip test: forward followed by backward (with 1/N normalisation) recovers the input
+            {
+                static const std::array<double, 4 * 8> input{{
+                     0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,
+                     8.0,  9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                    16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0,
+                    24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0
+                }};
+
+                dft::Plan<2, dft::Direction::Forward> forward_plan(dimensions);
+                std::copy(input.begin(), input.end(), forward_plan.time_domain_container().data());
+                forward_plan.transform();
+
+                dft::Plan<2, dft::Direction::Backward> backward_plan(dimensions);
+                std::copy(
+                    forward_plan.frequency_domain_container().data(),
+                    forward_plan.frequency_domain_container().data() + 4 * 5,
+                    backward_plan.frequency_domain_container().data());
+                backward_plan.transform();
+
+                const double norm = 1.0 / (4.0 * 8.0);
+                const double eps = 1.0e-10;
+                for (std::size_t n = 0; n < 4 * 8; ++n)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(backward_plan.time_domain_container().data()[n] * norm, input[n], eps);
+                }
+            }
+        }
+} dft_plan_rank_two_test;
+
+class DftPlanRankThreeTest :
+    public TestCase
+{
+    public:
+        DftPlanRankThreeTest() :
+            TestCase("dft_plan_rank_three_test")
+        {
+        }
+
+        virtual void run() const override
+        {
+            static const std::array<std::size_t, 3> dimensions{ 4, 4, 8 };
+
+            // check dimension reporting
+            {
+                dft::Plan<3, dft::Direction::Forward> forward_plan(dimensions);
+
+                TEST_CHECK_EQUAL(dimensions, forward_plan.time_domain_container().dimensions());
+
+                static const std::array<std::size_t, 3> expected_freq_dims{ 4, 4, 5 };
+                TEST_CHECK_EQUAL(expected_freq_dims, forward_plan.frequency_domain_container().dimensions());
+            }
+
+            // round-trip test: forward followed by backward (with 1/N normalisation) recovers the input
+            {
+                dft::Plan<3, dft::Direction::Forward> forward_plan(dimensions);
+                double * time_in = forward_plan.time_domain_container().data();
+                for (std::size_t n = 0; n < 4 * 4 * 8; ++n)
+                {
+                    time_in[n] = static_cast<double>(n);
+                }
+
+                forward_plan.transform();
+
+                dft::Plan<3, dft::Direction::Backward> backward_plan(dimensions);
+                std::copy(
+                    forward_plan.frequency_domain_container().data(),
+                    forward_plan.frequency_domain_container().data() + 4 * 4 * 5,
+                    backward_plan.frequency_domain_container().data());
+                backward_plan.transform();
+
+                const double norm = 1.0 / (4.0 * 4.0 * 8.0);
+                const double eps = 1.0e-10;
+                for (std::size_t n = 0; n < 4 * 4 * 8; ++n)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(backward_plan.time_domain_container().data()[n] * norm, static_cast<double>(n), eps);
+                }
+            }
+        }
+} dft_plan_rank_three_test;
+
+class DftPlanRankFourTest :
+    public TestCase
+{
+    public:
+        DftPlanRankFourTest() :
+            TestCase("dft_plan_rank_four_test")
+        {
+        }
+
+        virtual void run() const override
+        {
+            static const std::array<std::size_t, 4> dimensions{ 2, 4, 4, 4 };
+
+            // check dimension reporting
+            {
+                dft::Plan<4, dft::Direction::Forward> forward_plan(dimensions);
+
+                TEST_CHECK_EQUAL(dimensions, forward_plan.time_domain_container().dimensions());
+
+                static const std::array<std::size_t, 4> expected_freq_dims{ 2, 4, 4, 3 };
+                TEST_CHECK_EQUAL(expected_freq_dims, forward_plan.frequency_domain_container().dimensions());
+            }
+
+            // round-trip test: forward followed by backward (with 1/N normalisation) recovers the input
+            {
+                dft::Plan<4, dft::Direction::Forward> forward_plan(dimensions);
+                double * time_in = forward_plan.time_domain_container().data();
+                for (std::size_t n = 0; n < 2 * 4 * 4 * 4; ++n)
+                {
+                    time_in[n] = static_cast<double>(n);
+                }
+
+                forward_plan.transform();
+
+                dft::Plan<4, dft::Direction::Backward> backward_plan(dimensions);
+                std::copy(
+                    forward_plan.frequency_domain_container().data(),
+                    forward_plan.frequency_domain_container().data() + 2 * 4 * 4 * 3,
+                    backward_plan.frequency_domain_container().data());
+                backward_plan.transform();
+
+                const double norm = 1.0 / (2.0 * 4.0 * 4.0 * 4.0);
+                const double eps = 1.0e-10;
+                for (std::size_t n = 0; n < 2 * 4 * 4 * 4; ++n)
+                {
+                    TEST_CHECK_NEARLY_EQUAL(backward_plan.time_domain_container().data()[n] * norm, static_cast<double>(n), eps);
+                }
+            }
+        }
+} dft_plan_rank_four_test;

--- a/eos/observable.cc
+++ b/eos/observable.cc
@@ -52,7 +52,7 @@ namespace eos
 {
     namespace test
     {
-        // PDF = (1/2 L_0 + 1/3 L_1 + 1/4 L_2) / 2
+        // Unnormalized PDF = z (4 - z) = 4 z - z^2; zeros at z = 0 and z = 4, maximum at z = 2.
         class Legendre1DPDF : public ParameterUser
         {
             public:
@@ -67,13 +67,13 @@ namespace eos
                 double
                 pdf(const double & z) const
                 {
-                    return (9.0 + 8.0 * z + 9.0 * z * z);
+                    return (4.0 * z - z * z);
                 }
 
                 double
                 norm(const double & z_min, const double & z_max) const
                 {
-                    return (9.0 * (z_max - z_min) + 4.0 * (power_of<2>(z_max) - power_of<2>(z_min)) + 3.0 * (power_of<3>(z_max) - power_of<3>(z_min)));
+                    return (2.0 * (power_of<2>(z_max) - power_of<2>(z_min)) - (power_of<3>(z_max) - power_of<3>(z_min)) / 3.0);
                 }
 
                 static ObservableEntry::OptionIterator
@@ -93,7 +93,7 @@ namespace eos
 
         const std::set<ReferenceName> Legendre1DPDF::references{};
 
-        const std::string Legendre1DPDF::description = "1D PDF up to 2nd order in z; used for unit tests only.";
+        const std::string Legendre1DPDF::description = "1D PDF, quadratic in z with zeros at z = 0 and z = 4 and a maximum at z = 2; used for unit tests only.";
     } // namespace test
 
     Observable::~Observable() = default;

--- a/eos/signal-pdf.cc
+++ b/eos/signal-pdf.cc
@@ -30,6 +30,7 @@
 #include <eos/utils/private_implementation_pattern-impl.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <ostream>
@@ -75,6 +76,17 @@ namespace eos
     }
 
     SignalPDFEntries::~SignalPDFEntries() = default;
+
+    void
+    SignalPDFEntries::insert_or_assign(const QualifiedName & key, const std::shared_ptr<const SignalPDFEntry> & value)
+    {
+        auto result = _entries->insert_or_assign(key, value);
+
+        if (! result.second)
+        {
+            Log::instance()->message("[SignalPDFEntries.insert_or_assign]", ll_warning) << "Entry for signal PDF " << key.str() << " has been replaced.";
+        }
+    }
 
     SignalPDFNameError::SignalPDFNameError(const std::string & name) :
         Exception("SignalPDF name '" + name + "' is malformed")
@@ -236,11 +248,8 @@ namespace eos
     {
             std::vector<SignalPDFSection> signal_pdf_sections;
 
-            std::map<QualifiedName, SignalPDFEntryPtr> signal_pdf_entries;
-
             Implementation() :
-                signal_pdf_sections(SignalPDFSections::instance()->sections()),
-                signal_pdf_entries(SignalPDFEntries::instance()->entries())
+                signal_pdf_sections(SignalPDFSections::instance()->sections())
             {
             }
     };
@@ -255,8 +264,10 @@ namespace eos
     SignalPDFEntryPtr
     SignalPDFs::operator[] (const QualifiedName & qn) const
     {
-        auto i = _imp->signal_pdf_entries.find(qn);
-        if (i != _imp->signal_pdf_entries.end())
+        const auto & signal_pdf_entries = SignalPDFEntries::instance()->entries();
+
+        auto i = signal_pdf_entries.find(qn);
+        if (i != signal_pdf_entries.end())
         {
             return i->second;
         }
@@ -267,13 +278,17 @@ namespace eos
     SignalPDFs::SignalPDFIterator
     SignalPDFs::begin() const
     {
-        return SignalPDFIterator(_imp->signal_pdf_entries.begin());
+        const auto & signal_pdf_entries = SignalPDFEntries::instance()->entries();
+
+        return SignalPDFIterator(signal_pdf_entries.begin());
     }
 
     SignalPDFs::SignalPDFIterator
     SignalPDFs::end() const
     {
-        return SignalPDFIterator(_imp->signal_pdf_entries.end());
+        const auto & signal_pdf_entries = SignalPDFEntries::instance()->entries();
+
+        return SignalPDFIterator(signal_pdf_entries.end());
     }
 
     SignalPDFs::SectionIterator
@@ -286,5 +301,43 @@ namespace eos
     SignalPDFs::end_sections() const
     {
         return SectionIterator(_imp->signal_pdf_sections.end());
+    }
+
+    void
+    SignalPDFs::insert(const QualifiedName & name, const std::string & description, const Options & options, const QualifiedName & numerator,
+                       const std::vector<std::string> & numerator_kinematic_names, const QualifiedName & normalization,
+                       const std::vector<std::string> & normalization_kinematic_names) const
+    {
+        const auto & observable_entries = ObservableEntries::instance()->entries();
+
+        // the numerator and normalization must reference known observables; fail fast otherwise
+        if (observable_entries.end() == observable_entries.find(numerator))
+        {
+            throw UnknownObservableError("Cannot create SignalPDF '" + name.str() + "': its numerator '" + numerator.str() + "' is not a known observable");
+        }
+
+        if (observable_entries.end() == observable_entries.find(normalization))
+        {
+            throw UnknownObservableError("Cannot create SignalPDF '" + name.str() + "': its normalization '" + normalization.str() + "' is not a known observable");
+        }
+
+        // each sampling variable 'v' (a numerator kinematic variable) should have matching bounds 'v_min' and 'v_max'
+        // among the normalization kinematic variables; the Python sampling layer relies on this convention, so warn if it is not met
+        for (const auto & variable : numerator_kinematic_names)
+        {
+            for (const auto & bound : { variable + "_min", variable + "_max" })
+            {
+                if (normalization_kinematic_names.end() == std::find(normalization_kinematic_names.begin(), normalization_kinematic_names.end(), bound))
+                {
+                    Log::instance()->message("[SignalPDFs.insert]", ll_warning)
+                            << "SignalPDF '" << name.str() << "': the normalization is missing the bound '" << bound << "' for the sampling variable '" << variable
+                            << "'; sampling from this PDF may not work as expected";
+                }
+            }
+        }
+
+        SignalPDFEntry * entry = new ConcreteSignalPDFEntry(name, description, options, numerator, normalization, numerator_kinematic_names, normalization_kinematic_names);
+
+        SignalPDFEntries::instance()->insert_or_assign(name, std::shared_ptr<const SignalPDFEntry>(entry));
     }
 } // namespace eos

--- a/eos/signal-pdf.hh
+++ b/eos/signal-pdf.hh
@@ -54,6 +54,9 @@ namespace eos
 
             virtual double evaluate() const = 0;
 
+            // Evaluate the unnormalized PDF on the linear scale, clamping non-positive values to zero.
+            virtual double evaluate_linear() const = 0;
+
             virtual double normalization() const = 0;
 
             virtual Kinematics kinematics() = 0;

--- a/eos/signal-pdf.hh
+++ b/eos/signal-pdf.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2015-2023 Danny van Dyk
+ * Copyright (c) 2015-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -32,6 +32,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace eos
 {
@@ -214,6 +215,22 @@ namespace eos
             SectionIterator begin_sections() const;
             SectionIterator end_sections() const;
             ///@}
+
+            /*!
+             * Insert a new SignalPDF that is built at run time from two existing observables.
+             *
+             * @param name                            The name of the new SignalPDF.
+             * @param description                      A human-readable description of the new SignalPDF.
+             * @param options                          A set of options that applies to both backing observables.
+             * @param numerator                        The name of the observable that provides the unnormalized PDF.
+             * @param numerator_kinematic_names        The kinematic variables of the unnormalized PDF; these are the PDF's sampling variables.
+             * @param normalization                    The name of the observable that provides the normalization.
+             * @param normalization_kinematic_names    The kinematic variables of the normalization; for each sampling variable @c v
+             *                                         this should contain the bounds @c v_min and @c v_max.
+             */
+            void insert(const QualifiedName & name, const std::string & description, const Options & options, const QualifiedName & numerator,
+                        const std::vector<std::string> & numerator_kinematic_names, const QualifiedName & normalization,
+                        const std::vector<std::string> & normalization_kinematic_names) const;
     };
 
     extern template class WrappedForwardIterator<SignalPDFs::SignalPDFIteratorTag, const std::pair<const QualifiedName, SignalPDFEntryPtr>>;
@@ -236,6 +253,8 @@ namespace eos
             {
                 return *_entries;
             }
+
+            void insert_or_assign(const QualifiedName & key, const std::shared_ptr<const SignalPDFEntry> & value);
     };
 
     /*!

--- a/eos/signal-pdf_TEST.cc
+++ b/eos/signal-pdf_TEST.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2023-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -16,10 +16,15 @@
  */
 
 #include <eos/signal-pdf.hh>
+#include <eos/utils/exception.hh>
+#include <eos/utils/kinematic.hh>
 #include <eos/utils/options.hh>
+#include <eos/utils/parameters.hh>
 #include <eos/utils/units.hh>
 
 #include <test/test.hh>
+
+#include <cmath>
 
 using namespace test;
 using namespace eos;
@@ -44,3 +49,75 @@ class SignalPDFTest : public TestCase
         }
 
 } signal_pdf_test;
+
+class SignalPDFRuntimeInsertionTest : public TestCase
+{
+    public:
+        SignalPDFRuntimeInsertionTest() :
+            TestCase("signal_pdf_runtime_insertion_test")
+        {
+        }
+
+        virtual void
+        run() const
+        {
+            // insert a new signal PDF at run time that reuses the observables backing the
+            // built-in 'TestLegendre1D::P(z)' PDF: pdf(z) = z (4 - z), int_0^4 dz pdf(z) = 32 / 3
+            {
+                auto signal_pdfs = SignalPDFs();
+
+                // referencing an unknown numerator or normalization must fail fast
+                TEST_CHECK_THROWS(UnknownObservableError,
+                                  signal_pdfs.insert("TestLegendre1D::RuntimeP(z)",
+                                                     "runtime-inserted test PDF",
+                                                     Options{},
+                                                     "TestLegendre1D::Unknown(z)",
+                                                     { "z" },
+                                                     "TestLegendre1D::NormalizationPDF(z)",
+                                                     { "z_min", "z_max" }));
+
+                TEST_CHECK_THROWS(UnknownObservableError,
+                                  signal_pdfs.insert("TestLegendre1D::RuntimeP(z)",
+                                                     "runtime-inserted test PDF",
+                                                     Options{},
+                                                     "TestLegendre1D::UnnormalizedPDF(z)",
+                                                     { "z" },
+                                                     "TestLegendre1D::Unknown(z)",
+                                                     { "z_min", "z_max" }));
+
+                // a valid insertion referencing the existing test observables
+                signal_pdfs.insert("TestLegendre1D::RuntimeP(z)",
+                                   "runtime-inserted test PDF",
+                                   Options{},
+                                   "TestLegendre1D::UnnormalizedPDF(z)",
+                                   { "z" },
+                                   "TestLegendre1D::NormalizationPDF(z)",
+                                   { "z_min", "z_max" });
+
+                // the new PDF must be visible through the container ...
+                TEST_CHECK(signal_pdfs["TestLegendre1D::RuntimeP(z)"] != nullptr);
+
+                // ... and through a freshly created container (the registry is shared)
+                TEST_CHECK(SignalPDFs()["TestLegendre1D::RuntimeP(z)"] != nullptr);
+
+                Parameters p = Parameters::Defaults();
+                Kinematics k{
+                    {     "z", 2.0 },
+                    { "z_min", 0.0 },
+                    { "z_max", 4.0 }
+                };
+                Options o;
+
+                auto pdf = SignalPDF::make("TestLegendre1D::RuntimeP(z)", p, k, o);
+                TEST_CHECK(pdf != nullptr);
+                TEST_CHECK_EQUAL(pdf->name(), QualifiedName("TestLegendre1D::RuntimeP(z)"));
+
+                // evaluate() returns the logarithm of the unnormalized PDF; pdf(z = 2) = 4
+                TEST_CHECK_NEARLY_EQUAL(pdf->evaluate(), std::log(4.0), 1.0e-10);
+
+                // normalization() returns the logarithm of the normalization integral = 32 / 3
+                TEST_CHECK_NEARLY_EQUAL(pdf->normalization(), std::log(32.0 / 3.0), 1.0e-10);
+            }
+        }
+
+} signal_pdf_runtime_insertion_test;

--- a/eos/statistics/Makefile.am
+++ b/eos/statistics/Makefile.am
@@ -12,9 +12,11 @@ libeosstatistics_la_SOURCES = \
 	log-posterior.cc log-posterior.hh log-posterior-fwd.hh \
 	log-prior.cc log-prior.hh log-prior-fwd.hh \
 	test-statistic.cc test-statistic.hh test-statistic-impl.hh
-libeosstatistics_la_LIBADD = -lpthread -lgsl -lgslcblas -lm -lyaml-cpp
-libeosstatistics_la_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS) $(YAMLCPP_CXXFLAGS)
-libeosstatistics_la_LDFLAGS = $(AM_LDFLAGS) $(GSL_LDFLAGS) $(YAMLCPP_LDFLAGS)
+libeosstatistics_la_LIBADD = \
+	$(top_builddir)/eos/maths/libeosmaths.la \
+	-lpthread -lgsl -lgslcblas -lm -lyaml-cpp
+libeosstatistics_la_CXXFLAGS = $(AM_CXXFLAGS) $(FFTW_CXXFLAGS) $(GSL_CXXFLAGS) $(YAMLCPP_CXXFLAGS)
+libeosstatistics_la_LDFLAGS = $(AM_LDFLAGS) $(FFTW_LDFLAGS) $(GSL_LDFLAGS) $(YAMLCPP_LDFLAGS)
 
 include_eos_statisticsdir = $(includedir)/eos/statistics
 include_eos_statistics_HEADERS = \

--- a/eos/statistics/log-likelihood.cc
+++ b/eos/statistics/log-likelihood.cc
@@ -20,6 +20,8 @@
 
 #include <eos/statistics/log-likelihood.hh>
 #include <eos/statistics/test-statistic-impl.hh>
+#include <eos/maths/dft-plan-impl.hh>
+#include <eos/signal-pdf.hh>
 #include <eos/utils/log.hh>
 #include <eos/utils/observable_cache.hh>
 #include <eos/maths/power-of.hh>
@@ -29,6 +31,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <format>
 #include <limits>
 #include <map>
 
@@ -1180,6 +1183,261 @@ namespace eos
                 return LogLikelihoodBlockPtr(new UniformBoundBlock(cache, std::move(ids), bound, uncertainty));
             }
         };
+
+        template <std::size_t rank_>
+        struct Unbinned1DLikelihoodBlock :
+            public LogLikelihoodBlock
+        {
+            ObservableCache cache;
+
+            QualifiedName pdf_name;
+            std::vector<Kinematics> kinematics_data;
+            Options options;
+
+            std::vector<SignalPDFPtr> signal_pdfs;
+            std::vector<double> resolution_data;
+
+            // The events that were actually observed, expressed as kinematic variables.
+            std::vector<Kinematics> observations_data;
+
+            std::array<std::size_t, rank_> dimensions;
+
+            mutable dft::Plan<rank_, dft::Direction::Forward>  forward_plan;
+            mutable dft::Plan<rank_, dft::Direction::Backward> backward_plan;
+
+            // Pre-computed DFT of the resolution function.
+            dft::Container<std::complex<double>, rank_> resolution_dft;
+
+            // Row-major strides into the (time-domain) grid containers.
+            std::array<std::size_t, rank_> strides;
+
+            // The pre-computed multilinear interpolation data for each observation. Because both the grid and the
+            // observations are fixed at construction, the lower-corner grid index and the fractional offsets along
+            // each axis can be computed once; only the convolved PDF values on the grid change between evaluations.
+            struct InterpolationWeights
+            {
+                std::size_t               base;     // flat index of the lower corner of the enclosing grid cell
+                std::array<double, rank_> fraction; // fractional offset within the cell along each axis, in [0, 1]
+            };
+            std::vector<InterpolationWeights> interpolation;
+
+            unsigned _number_of_observations;
+
+            Unbinned1DLikelihoodBlock(const ObservableCache & cache,
+                                    const QualifiedName & pdf_name,
+                                    const std::vector<Kinematics> & kinematics,
+                                    const Options & options,
+                                    const std::vector<double> & resolution,
+                                    const std::vector<Kinematics> & observations,
+                                    const std::array<std::size_t, rank_> & dimensions) :
+                cache(cache),
+                pdf_name(pdf_name),
+                kinematics_data(kinematics),
+                options(options),
+                resolution_data(resolution),
+                observations_data(observations),
+                dimensions(dimensions),
+                forward_plan(dimensions),
+                backward_plan(dimensions),
+                resolution_dft(dft::impl::frequency_dimensions<rank_>(dimensions)),
+                _number_of_observations(observations.size())
+            {
+                signal_pdfs.reserve(kinematics.size());
+                for (const auto & k : kinematics)
+                    signal_pdfs.push_back(SignalPDF::make(pdf_name, cache.parameters(), k, options));
+
+                // Pre-compute the DFT of the resolution function.
+                std::copy(resolution.begin(), resolution.end(),
+                          forward_plan.time_domain_container().data());
+                forward_plan.transform();
+                resolution_dft = forward_plan.frequency_domain_container();
+
+                // Pre-compute the interpolation data that maps each observation onto the grid.
+                this->setup_interpolation();
+            }
+
+            // Retrieve the value of a kinematic variable from a Kinematics object.
+            static double coordinate(const Kinematics & k, const std::string & name)
+            {
+                return k[name].evaluate();
+            }
+
+            // Determine the grid geometry and the per-observation interpolation weights.
+            //
+            // The grid is assumed to be a uniform tensor-product grid stored in row-major order (the same layout the
+            // DFT containers use): along axis d the coordinate is x_0[d] + i * dx[d]. Stepping the flat index by
+            // strides[d] therefore advances the index along axis d by one while leaving the other axes unchanged,
+            // which lets us identify the variable that parametrises each axis and the corresponding grid spacing.
+            void setup_interpolation()
+            {
+                // Row-major strides.
+                strides[rank_ - 1] = 1;
+                for (std::size_t d = rank_ - 1 ; d-- > 0 ; )
+                    strides[d] = strides[d + 1] * dimensions[d + 1];
+
+                // The total number of grid points must match the number of supplied grid kinematics.
+                const std::size_t grid_size = strides[0] * dimensions[0];
+                if (grid_size != kinematics_data.size())
+                    throw InternalError(std::format("Unbinned1DLikelihoodBlock: grid has {} points but {} kinematics were supplied", grid_size, kinematics_data.size()));
+
+                // Identify the axis variable, origin, and spacing for each dimension.
+                std::array<std::string, rank_> axis_names;
+                std::array<double, rank_>      origin;
+                std::array<double, rank_>      spacing;
+                for (std::size_t d = 0 ; d < rank_ ; ++d)
+                {
+                    const Kinematics & lower = kinematics_data[0];
+                    const Kinematics & upper = kinematics_data[strides[d]];
+
+                    // The axis variable is the one whose value differs between the two neighbouring grid points.
+                    bool found = false;
+                    for (auto v = lower.begin() ; v != lower.end() ; ++v)
+                    {
+                        const std::string & name = v->name();
+                        const double dx = coordinate(upper, name) - coordinate(lower, name);
+                        if (dx != 0.0)
+                        {
+                            axis_names[d] = name;
+                            origin[d]     = coordinate(lower, name);
+                            spacing[d]    = dx;
+                            found         = true;
+                            break;
+                        }
+                    }
+
+                    if (! found)
+                        throw InternalError(std::format("Unbinned1DLikelihoodBlock: cannot determine the kinematic variable for grid axis {}", d));
+                }
+
+                // Pre-compute the interpolation weights for each observation.
+                interpolation.reserve(observations_data.size());
+                for (const auto & obs : observations_data)
+                {
+                    InterpolationWeights w;
+                    w.base = 0;
+                    for (std::size_t d = 0 ; d < rank_ ; ++d)
+                    {
+                        const double p = (coordinate(obs, axis_names[d]) - origin[d]) / spacing[d];
+
+                        if ((p < 0.0) || (p > static_cast<double>(dimensions[d] - 1)))
+                            throw InternalError(std::format("Unbinned1DLikelihoodBlock: observation lies outside the grid along axis '{}'", axis_names[d]));
+
+                        // Lower corner index, clamped so that the upper corner (index + 1) is always valid.
+                        std::size_t j = static_cast<std::size_t>(std::floor(p));
+                        double      t = p - static_cast<double>(j);
+                        if (j >= dimensions[d] - 1)
+                        {
+                            j = dimensions[d] - 2;
+                            t = 1.0;
+                        }
+
+                        w.base       += j * strides[d];
+                        w.fraction[d] = t;
+                    }
+                    interpolation.push_back(w);
+                }
+            }
+
+            virtual ~Unbinned1DLikelihoodBlock() = default;
+
+            virtual std::string as_string() const
+            {
+                return std::format("Unbinned<{}>: {} events on a grid of {} points", rank_, observations_data.size(), signal_pdfs.size());
+            }
+
+            virtual double evaluate() const
+            {
+                // Evaluate all signal PDFs on the linear scale and fill the time-domain container. The convolution
+                // with the resolution function operates on the linear density; non-positive values are clamped to
+                // zero by evaluate_linear().
+                double * time_data = forward_plan.time_domain_container().data();
+                for (std::size_t i = 0 ; i < signal_pdfs.size() ; ++i)
+                {
+                    time_data[i] = signal_pdfs[i]->evaluate_linear();
+                }
+
+                // Forward DFT of the signal values.
+                forward_plan.transform();
+
+                // Multiply the signal spectrum by the pre-computed resolution spectrum, leaving the result in the
+                // backward plan's frequency-domain buffer. The data must be copied in place: assigning the container
+                // (operator=) would reallocate its buffer and invalidate the pointer the backward FFTW plan was
+                // created with, causing a use-after-free in transform() below.
+                const auto  freq_dims = dft::impl::frequency_dimensions<rank_>(dimensions);
+                std::size_t freq_size = 1;
+                for (const auto & d : freq_dims)
+                    freq_size *= d;
+
+                const std::complex<double> * forward_freq_data  = forward_plan.frequency_domain_container().data();
+                std::complex<double> *       backward_freq_data = backward_plan.frequency_domain_container().data();
+                std::copy(forward_freq_data, forward_freq_data + freq_size, backward_freq_data);
+                backward_plan.frequency_domain_container() *= resolution_dft;
+
+                // Backward DFT.  The DFT is unnormalised, so the result is N times the
+                // circular convolution; we divide by N below.
+                backward_plan.transform();
+
+                const double norm = 1.0 / static_cast<double>(signal_pdfs.size());
+                const double * result = backward_plan.time_domain_container().data();
+
+                // The backward DFT yields the resolution-convolved PDF sampled on the grid points. The likelihood,
+                // however, is a product over the *observed* events, so we evaluate the convolved PDF at each
+                // observation by multilinear interpolation from the surrounding grid points.
+                double log_likelihood = 0.0;
+                for (const auto & w : interpolation)
+                {
+                    double value = 0.0;
+                    for (std::size_t corner = 0 ; corner < (std::size_t(1) << rank_) ; ++corner)
+                    {
+                        double      weight = 1.0;
+                        std::size_t offset = 0;
+                        for (std::size_t d = 0 ; d < rank_ ; ++d)
+                        {
+                            const bool upper = (corner >> d) & 1u;
+                            weight *= upper ? w.fraction[d] : (1.0 - w.fraction[d]);
+                            offset += upper ? strides[d] : 0;
+                        }
+                        value += weight * result[w.base + offset];
+                    }
+
+                    // Treat a non-positive interpolated density (from numerical roundoff, or a resolution kernel
+                    // with negative lobes) as a zero-probability event, yielding -infinity rather than a NaN from
+                    // std::log() that would silently poison downstream minimization/sampling.
+                    const double density = value * norm;
+                    if (density > 0.0) [[likely]]
+                        log_likelihood += std::log(density);
+                    else
+                        return -std::numeric_limits<double>::infinity();
+                }
+
+                return log_likelihood;
+            }
+
+            virtual unsigned number_of_observations() const
+            {
+                return _number_of_observations;
+            }
+
+            virtual double sample(gsl_rng * /* rng */) const
+            {
+                throw InternalError("Unbinned1DLikelihoodBlock::sample() is not implemented");
+            }
+
+            virtual double significance() const
+            {
+                throw InternalError("Unbinned1DLikelihoodBlock::significance() is not implemented");
+            }
+
+            virtual TestStatistic primary_test_statistic() const
+            {
+                return test_statistics::Empty();
+            }
+
+            virtual LogLikelihoodBlockPtr clone(ObservableCache cache) const
+            {
+                return LogLikelihoodBlockPtr(new Unbinned1DLikelihoodBlock<rank_>(cache, pdf_name, kinematics_data, options, resolution_data, observations_data, dimensions));
+            }
+        };
     }
 
     LogLikelihoodBlock::~LogLikelihoodBlock()
@@ -1309,6 +1567,27 @@ namespace eos
         }
 
         return LogLikelihoodBlockPtr(new implementation::MultivariateGaussianBlock(cache, std::move(ids), mean, covariance, response, number_of_observations));
+    }
+
+    LogLikelihoodBlockPtr
+    LogLikelihoodBlock::Unbinned1D(ObservableCache cache,
+                                   const QualifiedName & pdf_name,
+                                   const std::vector<Kinematics> & kinematics,
+                                   const Options & options,
+                                   const std::vector<double> & resolution,
+                                   const std::vector<Kinematics> & observations)
+    {
+        if (kinematics.empty())
+            throw InternalError("LogLikelihoodBlock::Unbinned1D: kinematics must not be empty");
+
+        if (kinematics.size() != resolution.size())
+            throw InternalError("LogLikelihoodBlock::Unbinned1D: kinematics and resolution must have the same size");
+
+        if (observations.empty())
+            throw InternalError("LogLikelihoodBlock::Unbinned1D: observations must not be empty");
+
+        return LogLikelihoodBlockPtr(new implementation::Unbinned1DLikelihoodBlock<1>(cache, pdf_name, kinematics, options, resolution, observations,
+            std::array<std::size_t, 1>{ kinematics.size() }));
     }
 
     LogLikelihoodBlockPtr

--- a/eos/statistics/log-likelihood.hh
+++ b/eos/statistics/log-likelihood.hh
@@ -1,8 +1,8 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011, 2013, 2014, 2017 Danny van Dyk
- * Copyright (c) 2011 Frederik Beaujean
+ * Copyright (c) 2011-2026 Danny van Dyk
+ * Copyright (c) 2011      Frederik Beaujean
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -299,6 +299,45 @@ namespace eos
              */
             static LogLikelihoodBlockPtr UniformBound(ObservableCache cache, const std::vector<ObservablePtr> & observables,
                                                       const double & bound, const double & uncertainty);
+
+            /*!
+             * Create a new LogLikelihoodBlock for an unbinned likelihood with a resolution function.
+             *
+             * The signal PDF is evaluated on the supplied grid and convolved with the resolution function
+             * via a discrete Fourier transform, yielding the resolution-smeared PDF sampled on the grid.
+             * The log-likelihood is then the sum over the observed events of the logarithm of the smeared
+             * PDF, evaluated at each observation by linear interpolation from the surrounding grid points.
+             *
+             * @param cache        The observable cache used by the total log-likelihood.
+             * @param pdf_name     The name of the SignalPDF to evaluate at each grid point.
+             * @param kinematics   One Kinematics object per grid point, fixing the observable.
+             *                     Must describe a uniform grid in the relevant kinematic variable.
+             * @param options      Options forwarded to SignalPDF::make.
+             * @param resolution   Discretised resolution function on the same grid. Must have the same size
+             *                     as @p kinematics.
+             *
+             *                     The convolution is carried out as a circular (cyclic) convolution via the
+             *                     discrete Fourier transform. The resolution function must therefore be supplied
+             *                     in wrap-around ("FFT-native") order, *not* centred in the array:
+             *                       - index 0 holds the value at zero offset (the peak of a symmetric kernel);
+             *                       - ascending indices 1, 2, ... hold increasing positive offsets;
+             *                       - the highest indices N-1, N-2, ... hold the negative offsets -1, -2, ... .
+             *                     Storing the kernel centred in the array instead shifts the convolved result by
+             *                     N/2 grid points and yields incorrect likelihoods.
+             *
+             *                     Because the convolution is circular, the kernel that runs off one end of the
+             *                     grid re-enters at the other end. The grid must therefore be padded with a
+             *                     sufficiently large region in which both the PDF and the resolution function are
+             *                     negligible, so that no appreciable density wraps across the boundary.
+             * @param observations The observed events, expressed as kinematic variables. Each must lie
+             *                     within the range spanned by @p kinematics.
+             */
+            static LogLikelihoodBlockPtr Unbinned1D(ObservableCache cache,
+                                                    const QualifiedName & pdf_name,
+                                                    const std::vector<Kinematics> & kinematics,
+                                                    const Options & options,
+                                                    const std::vector<double> & resolution,
+                                                    const std::vector<Kinematics> & observations);
     };
 
     /*!

--- a/eos/statistics/log-likelihood_TEST.cc
+++ b/eos/statistics/log-likelihood_TEST.cc
@@ -23,6 +23,7 @@
 #include <eos/statistics/log-posterior_TEST.hh>
 #include <eos/maths/power-of.hh>
 #include <algorithm>
+#include <cmath>
 
 using namespace test;
 using namespace eos;
@@ -658,4 +659,148 @@ namespace eos
                 }
             }
     } log_likelihood_test;
+
+    class UnbinnedLogLikelihoodTest :
+        public TestCase
+    {
+        public:
+            UnbinnedLogLikelihoodTest() :
+                TestCase("unbinned_log_likelihood_test")
+            {
+            }
+
+            virtual void run() const
+            {
+                // The convolution of the test PDF 'TestLegendre1D::P(z)' with a Gaussian resolution
+                // function (mean 0, standard deviation 0.1), evaluated on a uniform grid of N = 2^8
+                // points spanning the smeared domain [z_smeared_min, z_smeared_max] = [-1.5, 5.5].
+                //
+                // The reference values below are the resolution-smeared density on that grid, computed
+                // independently with Mathematica. They were generated with a grid spacing of 7/(N-1)
+                // (inclusive endpoints), whereas the periodic grid underlying the discrete Fourier
+                // transform has spacing 7/N; the factor (N-1)/N = 255/256 below corrects for this.
+                static const std::size_t N = 256;
+                static const double      z_smeared_min = -1.5;
+                static const double      z_smeared_max = +5.5;
+                static const double      dz            = (z_smeared_max - z_smeared_min) / N; // = 7/256
+                static const double      sigma         = 0.1;
+
+                static const std::array<double, N> reference{{
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 9.8096750507335319e-11, 4.8994547536473863e-10,
+                2.2808818915303313e-09, 9.9003955209872559e-09, 4.0081628049196628e-08, 1.5140779927891626e-07,
+                5.3388787147320642e-07, 1.7581873495209658e-06, 5.4105051871749915e-06, 1.5568520639437843e-05,
+                4.1919296052406931e-05, 0.00010570750226186107, 0.00024988876108756496, 0.00055440287373774097,
+                0.0011558617225092187, 0.0022679740834220794, 0.0041953727246893521, 0.0073309847622660407,
+                0.012128152463587722, 0.019044987204231922, 0.028468940703678169, 0.04064010963427709,
+                0.055596606477380954, 0.073160581334740057, 0.092970184593649696, 0.11454685534998099,
+                0.1373763355568024, 0.1609803899497354, 0.18496366568521261, 0.2090315355161908,
+                0.23298444582654129, 0.25669891391220345, 0.28010488476152967, 0.30316582942180786,
+                0.32586420951757183, 0.34819226096975547, 0.37014681131077348, 0.3917266630519648,
+                0.41293139836227799, 0.43376088240169014, 0.45421507490612867, 0.47429396474657715,
+                0.49399754907484072, 0.51332582721581699, 0.53227879902127051, 0.55085646446104319,
+                0.56905882352944925, 0.58688587622549537, 0.60433762254902035, 0.62141406250000009,
+                0.63811519607843126, 0.65444102328431364, 0.67039154411764701, 0.68596675857843137,
+                0.7011666666666666, 0.71599126838235294, 0.73044056372549016, 0.74451455269607825,
+                0.75821323529411755, 0.77153661151960795, 0.78448468137254912, 0.79705744485294128,
+                0.80925490196078442, 0.82107705269607856, 0.83252389705882368, 0.84359543504901957,
+                0.85429166666666667, 0.86461259191176476, 0.87455821078431406, 0.88412852328431379,
+                0.89332352941176485, 0.90214322916666678, 0.9105876225490197, 0.91865670955882361,
+                0.92635049019607851, 0.9336689644607844, 0.9406121323529415, 0.94717999387254914,
+                0.95337254901960788, 0.95918979779411773, 0.96463174019607867, 0.96969837622549004,
+                0.97438970588235285, 0.97870572916666654, 0.98264644607843143, 0.98621185661764721,
+                0.98940196078431364, 0.99221675857843128, 0.99465625000000024, 0.9967204350490193,
+                0.99840931372549024, 0.99972288602941162, 1.0006611519607844, 1.0012241115196079,
+                1.0014117647058822, 1.0012241115196079, 1.0006611519607844, 0.99972288602941184,
+                0.99840931372549013, 0.99672043504901953, 0.99465625000000024, 0.9922167585784315,
+                0.98940196078431386, 0.98621185661764721, 0.98264644607843143, 0.97870572916666676,
+                0.97438970588235307, 0.96969837622549027, 0.96463174019607867, 0.95918979779411773,
+                0.95337254901960788, 0.94717999387254914, 0.9406121323529415, 0.93366896446078418,
+                0.92635049019607829, 0.91865670955882339, 0.9105876225490197, 0.90214322916666678,
+                0.89332352941176463, 0.88412852328431357, 0.87455821078431406, 0.86461259191176443,
+                0.85429166666666678, 0.84359543504901946, 0.83252389705882368, 0.82107705269607856,
+                0.80925490196078442, 0.79705744485294128, 0.78448468137254912, 0.77153661151960784,
+                0.75821323529411766, 0.74451455269607847, 0.73044056372549027, 0.71599126838235305,
+                0.70116666666666672, 0.68596675857843148, 0.67039154411764712, 0.65444102328431386,
+                0.63811519607843137, 0.62141406250000009, 0.60433762254902035, 0.58688587622549537,
+                0.56905882352944925, 0.55085646446104319, 0.53227879902127051, 0.51332582721581699,
+                0.49399754907484072, 0.47429396474657715, 0.45421507490612856, 0.43376088240169008,
+                0.41293139836227799, 0.3917266630519648, 0.37014681131077348, 0.34819226096975542,
+                0.32586420951757178, 0.30316582942180792, 0.28010488476152967, 0.2566989139122034,
+                0.23298444582654129, 0.2090315355161908, 0.18496366568521261, 0.16098038994973554,
+                0.13737633555680248, 0.11454685534998099, 0.092970184593649793, 0.073160581334740071,
+                0.055596606477381003, 0.040640109634277083, 0.028468940703678156, 0.019044987204231999,
+                0.012128152463587784, 0.0073309847622661031, 0.0041953727246893035, 0.0022679740834221449,
+                0.0011558617225092449, 0.00055440287373768361, 0.00024988876108765246, 0.00010570750226200931,
+                4.1919296052469313e-05, 1.5568520639573728e-05, 5.4105051872746119e-06, 1.7581873495215873e-06,
+                5.3388787161756879e-07, 1.5140779946748343e-07, 4.0081628093235466e-08, 9.9003956910643878e-09,
+                2.2808819007805453e-09, 4.8994546284965436e-10, 9.8096741187619583e-11, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0,
+                0, 0, 0, 0
+                }};
+
+                Parameters    p = Parameters::Defaults();
+                ObservableCache cache(p);
+
+                // Build the grid of kinematics at which the PDF is evaluated, and the resolution function
+                // sampled on the same grid in wrap-around ("FFT-native") order: index 0 is the zero offset,
+                // ascending indices are positive offsets, the high indices are the negative offsets.
+                // The resolution evaluations span [-3.5, +3.5] (= [-N/2, N/2] grid steps from zero).
+                //
+                // The factor 1/4 = 1/max(z (4 - z)) peak-normalizes the *unnormalized* test PDF that the
+                // block evaluates via SignalPDF::evaluate_linear() (whose maximum is 4 at z = 2), so that
+                // the convolved grid matches the unit-peak reference values.
+                std::vector<Kinematics> kinematics;
+                std::vector<double>     resolution(N);
+                for (std::size_t i = 0 ; i < N ; ++i)
+                {
+                    Kinematics k;
+                    k.declare("z",     z_smeared_min + i * dz);
+                    k.declare("z_min", z_smeared_min);
+                    k.declare("z_max", z_smeared_max);
+                    kinematics.push_back(k);
+
+                    const double offset = (i <= N / 2 ? static_cast<double>(i) : static_cast<double>(static_cast<long>(i) - static_cast<long>(N))) * dz;
+                    resolution[i] = std::exp(-offset * offset / (2.0 * sigma * sigma)) / (sigma * std::sqrt(2.0 * M_PI)) * dz / 4.0;
+                }
+
+                // Place one observation at each grid point at which the smeared density is safely positive,
+                // so that interpolation returns the grid value and std::log() stays well-conditioned.
+                std::vector<Kinematics> observations;
+                double                  expected = 0.0;
+                for (std::size_t i = 0 ; i < N ; ++i)
+                {
+                    const double value = reference[i] * 255.0 / 256.0;
+                    if (value < 1.0e-3)
+                        continue;
+
+                    Kinematics k;
+                    k.declare("z",     z_smeared_min + i * dz);
+                    k.declare("z_min", z_smeared_min);
+                    k.declare("z_max", z_smeared_max);
+                    observations.push_back(k);
+
+                    expected += std::log(value);
+                }
+
+                auto block = LogLikelihoodBlock::Unbinned1D(cache, "TestLegendre1D::P(z)", kinematics, Options{}, resolution, observations);
+
+                // The block convolves the PDF with the resolution and sums the logarithm of the smeared
+                // density evaluated at each observation; this must reproduce the reference values.
+                TEST_CHECK_NEARLY_EQUAL(block->evaluate(), expected, 1.0e-6);
+            }
+    } unbinned_log_likelihood_test;
 }

--- a/eos/utils/concrete-signal-pdf.cc
+++ b/eos/utils/concrete-signal-pdf.cc
@@ -60,6 +60,17 @@ namespace eos
     }
 
     double
+    ConcreteSignalPDF::evaluate_linear() const
+    {
+        if (auto result = _unnormalized_pdf->evaluate(); result > 0.0) [[likely]]
+        {
+            return result;
+        }
+
+        return 0.0;
+    }
+
+    double
     ConcreteSignalPDF::normalization() const
     {
         if (auto result = _normalization->evaluate(); result > 0.0) [[likely]]

--- a/eos/utils/concrete-signal-pdf.hh
+++ b/eos/utils/concrete-signal-pdf.hh
@@ -279,6 +279,8 @@ namespace eos
 
             virtual double evaluate() const;
 
+            virtual double evaluate_linear() const;
+
             virtual double normalization() const;
 
             virtual Parameters parameters();

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -17,6 +17,7 @@ EXTRA_DIST = \
 	eos/datasets_file_description.py \
 	eos/deserializable.py \
 	eos/ipython.py \
+	eos/log_likelihood.py \
 	eos/observable.py \
 	eos/parameter.py \
 	eos/reference.py \
@@ -80,6 +81,7 @@ eos_SCRIPTS = \
 	eos/datasets_file_description.py \
 	eos/deserializable.py \
 	eos/ipython.py \
+	eos/log_likelihood.py \
 	eos/observable.py \
 	eos/parameter.py \
 	eos/reference.py \

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -640,7 +640,17 @@ BOOST_PYTHON_MODULE(_eos)
             :rtype: eos.LogLikelihoodBlock
         )",
                  args("cache", "factory"))
-            .staticmethod("External");
+            .staticmethod("External")
+            .def("_Unbinned1D", &LogLikelihoodBlock::Unbinned1D, R"(
+            Internal binding for the unbinned log-likelihood block; use :py:meth:`eos.LogLikelihoodBlock.Unbinned1D` instead.
+
+            This binding expects the resolution function in wrap-around ("FFT-native") order, with the zero
+            offset at index 0 and the negative offsets at the high end of the array. The public
+            :py:meth:`eos.LogLikelihoodBlock.Unbinned1D` wrapper accepts the resolution in natural (centred)
+            order and converts it before calling this binding.
+        )",
+                 args("cache", "pdf_name", "kinematics", "options", "resolution", "observations"))
+            .staticmethod("_Unbinned1D");
 
     // LogLikelihood
     class_<LogLikelihood>("LogLikelihood", R"(
@@ -687,6 +697,7 @@ BOOST_PYTHON_MODULE(_eos)
     register_ptr_to_python<std::shared_ptr<LogPrior>>();
     ::impl::iterable_to_std_vector_converter<QualifiedName>       iterable_to_std_vector_converter_QualifiedName;
     ::impl::iterable_to_std_vector_converter<double>              iterable_to_std_vector_converter_double;
+    ::impl::iterable_to_std_vector_converter<Kinematics>          iterable_to_std_vector_converter_Kinematics;
     ::impl::iterable_to_std_vector_converter<std::vector<double>> iterable_to_std_vector_converter_vector_double;
     class_<LogPrior, boost::noncopyable>("LogPrior", R"(
             Represents a Bayesian prior on the log scale.

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1097,9 +1097,29 @@ BOOST_PYTHON_MODULE(_eos)
 
     // SignalPDFs
     ::impl::std_pair_to_python_converter<const QualifiedName, SignalPDFEntryPtr> converter_signalpdfs_iter;
+    ::impl::iterable_to_std_vector_converter<std::string>                        iterable_to_std_vector_converter_string;
     class_<SignalPDFs>("_SignalPDFs")
             .def("__getitem__", &SignalPDFs::operator[])
             .def("__iter__", range(&SignalPDFs::begin, &SignalPDFs::end))
+            .def("insert", &SignalPDFs::insert, R"(
+            Insert a new signal PDF to EOS, built at run time from two existing observables.
+
+            :param name: The name of the new signal PDF.
+            :type name: eos.QualifiedName
+            :param description: A human-readable description of the new signal PDF.
+            :type description: std::string
+            :param options: The set of options relevant to this new signal PDF. These options apply to **both** backing observables.
+            :type options: eos.Options
+            :param numerator: The name of the observable that provides the unnormalized PDF.
+            :type numerator: eos.QualifiedName
+            :param numerator_kinematic_variables: The kinematic variables of the unnormalized PDF; these are the PDF's sampling variables.
+            :type numerator_kinematic_variables: list of str
+            :param normalization: The name of the observable that provides the normalization.
+            :type normalization: eos.QualifiedName
+            :param normalization_kinematic_variables: The kinematic variables of the normalization; for each sampling variable ``v`` this should contain the bounds ``v_min`` and ``v_max``.
+            :type normalization_kinematic_variables: list of str
+        )",
+                 args("name", "description", "options", "numerator", "numerator_kinematic_variables", "normalization", "normalization_kinematic_variables"))
             .def("sections", range(&SignalPDFs::begin_sections, &SignalPDFs::end_sections));
 
     // Analytic Charm Loops

--- a/python/eos/__init__.py
+++ b/python/eos/__init__.py
@@ -40,6 +40,7 @@ except NameError:
     _pkg_data_dir = __pkg_data_dir__
     pass
 
+from . import log_likelihood # patches LogLikelihoodBlock.Unbinned1D to accept the resolution in natural order
 from .data import *
 from .plot import *
 from .datasets import DataSets

--- a/python/eos/figure/plot.py
+++ b/python/eos/figure/plot.py
@@ -51,6 +51,10 @@ class Legend(Deserializable):
         :type entries: list[tuple[matplotlib.artist.Artist, str]] | None
         """
         if entries is not None:
+            # Nothing labelled to show: drawing an empty legend is pointless and, as of
+            # matplotlib 3.10, passing empty handles/labels raises instead of warning.
+            if not entries:
+                return
             handles = [entry[0] for entry in entries]
             labels = [entry[1] for entry in entries]
             ax.legend(loc=self.position, handles=handles, labels=labels)

--- a/python/eos/figure/plot_TEST.py
+++ b/python/eos/figure/plot_TEST.py
@@ -84,6 +84,19 @@ class LegendTests(unittest.TestCase):
         except Exception as e:
             self.fail(f"Error when drawing Legend: {e}")
 
+    def test_draw_empty_entries(self):
+        from eos.figure.plot import Legend
+
+        # an empty list of entries (no labelled items) must not draw a legend and must not
+        # raise: matplotlib >= 3.10 rejects empty handles/labels instead of warning.
+        _, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        try:
+            Legend().draw(ax, entries=[])
+        except Exception as e:
+            self.fail(f"Error when drawing Legend with empty entries: {e}")
+        self.assertIsNone(ax.get_legend())
+
 
 class GridTests(unittest.TestCase):
 

--- a/python/eos/log_likelihood.py
+++ b/python/eos/log_likelihood.py
@@ -1,0 +1,64 @@
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from _eos import LogLikelihoodBlock
+import numpy as np
+
+
+def _unbinned_1d(cache, pdf_name, kinematics, options, resolution, observations):
+    """
+    Create a new unbinned log-likelihood block with a resolution function.
+
+    The named SignalPDF is evaluated on the supplied grid and convolved with the resolution
+    function via a discrete Fourier transform, yielding the resolution-smeared PDF sampled on
+    the grid. The log-likelihood is then the sum over the observed events of the logarithm of
+    the smeared PDF, evaluated at each observation by linear interpolation from the surrounding
+    grid points.
+
+    :param cache: The observable cache used by the total log-likelihood.
+    :type cache: eos.ObservableCache
+    :param pdf_name: The name of the SignalPDF to evaluate at each grid point.
+    :type pdf_name: eos.QualifiedName
+    :param kinematics: One Kinematics object per grid point.
+    :type kinematics: list of eos.Kinematics
+    :param options: Options forwarded to the SignalPDF constructor.
+    :type options: eos.Options
+    :param resolution: Discretised resolution function on the same grid, in natural (centred) order,
+        i.e. the zero offset (the peak of a symmetric kernel) sits at the centre of the array.
+        The kernel is converted to the wrap-around order expected by the underlying circular
+        convolution via :func:`numpy.fft.ifftshift` before the block is constructed.
+    :type resolution: list of float
+    :param observations: The observed events, expressed as kinematic variables.
+    :type observations: list of eos.Kinematics
+
+    :returns: The new block.
+    :rtype: eos.LogLikelihoodBlock
+
+    .. note::
+        The convolution underlying the unbinned likelihood is circular. The grid must therefore be
+        padded with a sufficiently large region in which both the PDF and the resolution function
+        are negligible, so that no appreciable density wraps across the boundary.
+    """
+    # Convert the resolution from natural (centred) order to the wrap-around ("FFT-native") order
+    # expected by the underlying binding: ifftshift moves the central (zero-offset) sample to index 0.
+    resolution = np.fft.ifftshift(np.asarray(resolution, dtype=float))
+
+    return LogLikelihoodBlock._Unbinned1D(cache, pdf_name, kinematics, options, resolution.tolist(), observations)
+
+
+# Expose the wrapper as the public factory method on the native LogLikelihoodBlock class.
+LogLikelihoodBlock.Unbinned1D = staticmethod(_unbinned_1d)

--- a/python/eos_TEST.py
+++ b/python/eos_TEST.py
@@ -256,10 +256,11 @@ class SignalPDFTests(unittest.TestCase):
         from math import log
 
         # 'TestLegendre1D::P(z)' is a PDF provided for testing purposes:
-        # its unnormalized density is pdf(z) = 9 + 8 z + 9 z^2.
+        # its unnormalized density is pdf(z) = z (4 - z) = 4 z - z^2, with zeros at z = 0
+        # and z = 4 and a maximum at z = 2.
         try:
             pdf = SignalPDF.make('TestLegendre1D::P(z)', Parameters.Defaults(),
-                    Kinematics(z=0.0, z_min=-1.0, z_max=+1.0), Options())
+                    Kinematics(z=2.0, z_min=0.0, z_max=4.0), Options())
         except Exception as e:
             self.fail(f'cannot create SignalPDF: {e}')
 
@@ -272,8 +273,8 @@ class SignalPDFTests(unittest.TestCase):
             self.fail(f'cannot evaluate SignalPDF: {e}')
 
         # evaluate() returns the logarithm of the unnormalized PDF;
-        # pdf(z=0) = 9 + 8 * 0 + 9 * 0^2 = 9
-        self.assertAlmostEqual(value, log(9.0), delta=1.0e-10)
+        # pdf(z=2) = 4 * 2 - 2^2 = 4
+        self.assertAlmostEqual(value, log(4.0), delta=1.0e-10)
 
         try:
             norm = pdf.normalization()
@@ -281,8 +282,8 @@ class SignalPDFTests(unittest.TestCase):
             self.fail(f'cannot evaluate SignalPDF normalization: {e}')
 
         # normalization() returns the logarithm of the normalization integral;
-        # int_{-1}^{+1} dz (9 + 8 z + 9 z^2) = 9 * 2 + 0 + 3 * 2 = 24
-        self.assertAlmostEqual(norm, log(24.0), delta=1.0e-10)
+        # int_{0}^{4} dz (4 z - z^2) = 2 * 16 - 64 / 3 = 32 / 3
+        self.assertAlmostEqual(norm, log(32.0 / 3.0), delta=1.0e-10)
 
 
 class LoggingTests(unittest.TestCase):

--- a/python/eos_TEST.py
+++ b/python/eos_TEST.py
@@ -285,6 +285,43 @@ class SignalPDFTests(unittest.TestCase):
         # int_{0}^{4} dz (4 z - z^2) = 2 * 16 - 64 / 3 = 32 / 3
         self.assertAlmostEqual(norm, log(32.0 / 3.0), delta=1.0e-10)
 
+    def test_runtime_insertion(self):
+        "Check that a new SignalPDF can be inserted at run time and evaluated."
+        from eos import SignalPDF, SignalPDFs, Parameters, Kinematics, Options
+        from math import log
+
+        signal_pdfs = SignalPDFs()
+
+        # reuse the observables backing the built-in 'TestLegendre1D::P(z)' PDF:
+        # pdf(z) = z (4 - z), int_{0}^{4} dz pdf(z) = 32 / 3
+        try:
+            signal_pdfs.insert('TestLegendre1D::RuntimePyP(z)', 'runtime-inserted test PDF', Options(),
+                    'TestLegendre1D::UnnormalizedPDF(z)', ['z'],
+                    'TestLegendre1D::NormalizationPDF(z)', ['z_min', 'z_max'])
+        except Exception as e:
+            self.fail(f'cannot insert SignalPDF: {e}')
+
+        # referencing an unknown observable must raise
+        with self.assertRaisesRegex(RuntimeError, "is not a known observable"):
+            signal_pdfs.insert('TestLegendre1D::RuntimePyBad(z)', 'bad', Options(),
+                    'TestLegendre1D::Unknown(z)', ['z'],
+                    'TestLegendre1D::NormalizationPDF(z)', ['z_min', 'z_max'])
+
+        try:
+            pdf = SignalPDF.make('TestLegendre1D::RuntimePyP(z)', Parameters.Defaults(),
+                    Kinematics(z=2.0, z_min=0.0, z_max=4.0), Options())
+        except Exception as e:
+            self.fail(f'cannot create runtime-inserted SignalPDF: {e}')
+
+        self.assertIsNotNone(pdf, 'lookup of runtime-inserted SignalPDF failed')
+        self.assertEqual(pdf.name(), 'TestLegendre1D::RuntimePyP(z)', 'cannot obtain SignalPDF name')
+
+        # evaluate() returns log(pdf(z = 2)) = log(4)
+        self.assertAlmostEqual(pdf.evaluate(), log(4.0), delta=1.0e-10)
+
+        # normalization() returns log(32 / 3)
+        self.assertAlmostEqual(pdf.normalization(), log(32.0 / 3.0), delta=1.0e-10)
+
 
 class LoggingTests(unittest.TestCase):
 


### PR DESCRIPTION
- d3af593b Add ``SignalPDF::evaluate_linear()``, which evaluates the unnormalized signal PDF on the linear scale and clamps non-positive values to zero. It complements ``SignalPDF::evaluate()``, which works on the log scale and maps non-positive values to -infinity.
- dc6f2d18 Change the test-only PDF ``TestLegendre1D`` to the unnormalized density ``z (4 - z)`` (zeros at z = 0 and z = 4, maximum at z = 2). Adapt the normalization integral and the Python test kinematics to the new support [0, 4].
- 17c605c7 Do not draw an empty legend when using the ``figure`` framework. This breaks with an up-to-date version of ``matplotlib`` due to the latter raising an exception.
- 1d160bc3 Update the images for the ``ubuntu`` and ``pypi``. The new images include the FFTW3 library.
- 17843874 Add container classes for the discrete Fourier transform (``eos::dft::Container`` for real and complex data) backed by FFTW3 storage. Add FFTW3 detection to ``configure.ac`` and unit tests for the containers.
- 695637b5 Add the discrete Fourier transform plan classes (``eos::dft::Plan``) wrapping the FFTW3 real-to-complex and complex-to-real transforms for ranks 1 through 4. Enforce a run-time check that all dimensions are even and add unit tests.
- 0ef80ce9 Add the C++ log-likelihood block ``LogLikelihoodBlock::Unbinned1D`` for unbinned 1D likelihoods. It convolves a signal PDF, evaluated on a grid, with a resolution function via the DFT, then sums the logarithm of the resolution-smeared density evaluated at each observed event by linear interpolation from the surrounding grid points. Includes an end-to-end test against a reference convolution.
- e6da8721 Export ``LogLikelihoodBlock::Unbinned1D`` to the Python module as ``eos.LogLikelihoodBlock.Unbinned1D``. Wrap the native binding so that the resolution function is supplied in natural (centred) order and converted to the wrap-around order expected by the underlying circular convolution.
- 477ab6d1 Add means to register a custom ``SignalPDF`` on the C++ side.
- e6e94974 Export custom ``SignalPDF`` registry to Python.
- a476a08 Update the changelog for PR #1177.