### PR TITLE
Various changes to the Python code / ``eos.figure``

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -51,6 +51,13 @@
 - Add comparison operators for ``qnp::OptionValue`` (D. van Dyk)
 - Add an output stream operator for ``qnp::OptionValue`` (D. van Dyk)
 - Document the user-facing classes and methods of the ``eos`` Python modules, and auto-generate the analysis file format reference from the ``eos.analysis_file_description`` classes (D. van Dyk)
+- Add a ``vertical`` plot item that draws a vertical line at a fixed position on the x axis, e.g. to mark a kinematic threshold (D. van Dyk)
+- Add an optional ``size`` field to ``grid`` figures to set the figure size explicitly (D. van Dyk)
+- Add an optional ``watermark_plot`` field to ``grid`` figures to stamp the watermark on a single panel, addressed either by a flattened index or by a ``(row, col)`` pair (D. van Dyk)
+- Allow an explicit anchor (``xy``) and a configurable ``offset`` for the figure ``watermark`` (D. van Dyk)
+- Add ``tight_layout`` and ``shared_axes`` options to ``grid`` figures (D. van Dyk)
+- Provide a sensible default ``legend()`` entry for most figure item types (D. van Dyk)
+- Make the tick label format configurable via a ``format`` field on the ``xticks`` and ``yticks`` of a plot (D. van Dyk)
 
 ### Deprecated
 

--- a/python/eos/figure/common.py
+++ b/python/eos/figure/common.py
@@ -29,12 +29,30 @@ class Watermark(Deserializable):
     :type position: str
     :param preliminary: If true, marks the figure as a preliminary version.
     :type preliminary: bool
+    :param xy: An explicit anchor point in axes fraction. If given, it overrides the
+        coordinates derived from ``position``, while the text alignment is still taken
+        from ``position``. Defaults to None (use the ``position`` preset).
+    :type xy: tuple[float, float] | None
+    :param offset: The offset from the edges for the ``position`` presets, given as a
+        single fraction (used for both axes) or as a ``(xdelta, ydelta)`` pair.
+        Defaults to None (i.e. 0.04 on both axes).
+    :type offset: float | tuple[float, float] | None
     """
     position:str=field(default='upper right')
     preliminary:bool=field(default=False)
+    xy:tuple[float, float]|None=field(default=None)
+    offset:float|tuple[float, float]|None=field(default=None)
 
     def __post_init__(self):
-        xdelta, ydelta = (0.04, 0.04)
+        if self.offset is None:
+            xdelta, ydelta = (0.04, 0.04)
+        elif isinstance(self.offset, (int, float)):
+            xdelta, ydelta = (self.offset, self.offset)
+        else:
+            if len(self.offset) != 2:
+                raise ValueError(f"'offset' must be a number or an (xdelta, ydelta) pair, got {self.offset!r}")
+            xdelta, ydelta = self.offset
+
         vpos, hpos = self.position.split(' ')
 
         if hpos == 'right':
@@ -55,6 +73,13 @@ class Watermark(Deserializable):
             self._valign = 'top'
         else:
             raise ValueError(f'invalid vertical position \'{vpos}\'')
+
+        # an explicit anchor overrides the preset-derived coordinates;
+        # the text alignment is still taken from `position`
+        if self.xy is not None:
+            if len(self.xy) != 2:
+                raise ValueError(f"'xy' must be an (x, y) pair in axes fraction, got {self.xy!r}")
+            self._x, self._y = self.xy
 
         if self.preliminary:
             self._color = 'red'

--- a/python/eos/figure/common_TEST.py
+++ b/python/eos/figure/common_TEST.py
@@ -54,6 +54,55 @@ class WatermarkTests(unittest.TestCase):
         # a centered horizontal position is also valid
         self.assertAlmostEqual(Watermark.from_dict(position='upper center')._x, 0.5)
 
+    def test_explicit_xy(self):
+        "Check that an explicit xy anchor overrides the position preset."
+        from eos.figure.common import Watermark
+
+        wm = Watermark.from_dict(xy=[0.3, 0.7])
+        self.assertAlmostEqual(wm._x, 0.3)
+        self.assertAlmostEqual(wm._y, 0.7)
+        # the text alignment is still taken from the (default) position
+        self.assertEqual(wm._halign, 'right')
+        self.assertEqual(wm._valign, 'top')
+
+    def test_xy_invalid_length(self):
+        "Check that an xy anchor of the wrong length is rejected with a clear error."
+        from eos.figure.common import Watermark
+
+        with self.assertRaises(ValueError):
+            Watermark.from_dict(xy=[0.3, 0.5, 0.7])
+
+    def test_offset_scalar(self):
+        "Check that a scalar offset replaces the default 0.04 on both axes."
+        from eos.figure.common import Watermark
+
+        wm = Watermark.from_dict(offset=0.1)
+        self.assertAlmostEqual(wm._x, 0.9)
+        self.assertAlmostEqual(wm._y, 0.9)
+
+    def test_offset_tuple(self):
+        "Check that a (xdelta, ydelta) offset is applied per axis."
+        from eos.figure.common import Watermark
+
+        wm = Watermark.from_dict(position='lower left', offset=[0.1, 0.2])
+        self.assertAlmostEqual(wm._x, 0.1)
+        self.assertAlmostEqual(wm._y, 0.2)
+
+    def test_offset_invalid_length(self):
+        "Check that an offset sequence of the wrong length is rejected with a clear error."
+        from eos.figure.common import Watermark
+
+        with self.assertRaises(ValueError):
+            Watermark.from_dict(offset=[0.1, 0.2, 0.3])
+
+    def test_xy_overrides_offset(self):
+        "Check that an explicit xy wins over offset for the coordinates."
+        from eos.figure.common import Watermark
+
+        wm = Watermark.from_dict(xy=[0.25, 0.25], offset=0.1)
+        self.assertAlmostEqual(wm._x, 0.25)
+        self.assertAlmostEqual(wm._y, 0.25)
+
     def test_invalid_position(self):
         "Check that invalid positions are rejected."
         from eos.figure.common import Watermark

--- a/python/eos/figure/figure.py
+++ b/python/eos/figure/figure.py
@@ -279,6 +279,8 @@ class GridFigure(Figure):
     :type plots: list[:class:`Plot <eos.figure.Plot>`]
     :param shape: The tuple specifying the shape of the figure's grid, specifying the number of rows and columns in that order.
     :type shape: tuple[int, int]
+    :param size: The size of the figure in inches. Defaults to (3.0 * ncol, 3.0 * nrow).
+    :type size: tuple[float, float]
     """
 
     type:str=field(repr=False, init=False, default='grid')
@@ -286,6 +288,7 @@ class GridFigure(Figure):
     plots:list[Plot]
     padding:tuple[float,float]=field(default=(0.2, 0.2))
     shape:tuple[int, int]
+    size:tuple[float, float]|None=field(default=None)
     watermark:Watermark=field(default_factory=Watermark)
 
     _api_doc = inspect.cleandoc("""
@@ -302,11 +305,16 @@ class GridFigure(Figure):
 
         * ``shape`` (*tuple[int, int]*) -- The shape of the figure's grid, specifying the number of rows and columns in that order.
 
+    The following keys are optional:
+
+        * ``size`` (*tuple[float, float]*) -- The size of the figure in inches. Defaults to (3.0 * ncol, 3.0 * nrow).
+
 
     """)
     def __post_init__(self):
         nrow, ncol = self.shape
-        self._figure = plt.figure(figsize=(3.0 * ncol, 3.0 * nrow))
+        figsize = self.size if self.size is not None else (3.0 * ncol, 3.0 * nrow)
+        self._figure = plt.figure(figsize=figsize)
         self._gridspec = self._figure.add_gridspec(nrow, ncol, hspace=self.padding[0], wspace=self.padding[1])
         axes = self._gridspec.subplots()
         self._axes = axes.flatten('C') # flatten to row-major style

--- a/python/eos/figure/figure.py
+++ b/python/eos/figure/figure.py
@@ -283,6 +283,10 @@ class GridFigure(Figure):
     :type size: tuple[float, float]
     :param watermark_plot: The plot that carries the watermark, as a flattened (row-major) index or a 2D ``(row, col)`` address. If None, every plot is stamped.
     :type watermark_plot: int | tuple[int, int] | None
+    :param tight_layout: If True (default), the grid spec is laid out with ``tight_layout``. Set to False to keep an explicit ``padding``, e.g. ``(0, 0)`` for abutting panels.
+    :type tight_layout: bool
+    :param shared_axes: Which axes the panels share, one of ``None``, ``'x'``, ``'y'``, or ``'both'``. ``'x'`` shares the x-axis per column (``sharex='col'``), ``'y'`` shares the y-axis per row (``sharey='row'``), and ``'both'`` shares both; a shared axis gives one common range per group and tick labels only on the outer edge. Defaults to None (independent axes).
+    :type shared_axes: str | None
     """
 
     type:str=field(repr=False, init=False, default='grid')
@@ -293,6 +297,8 @@ class GridFigure(Figure):
     size:tuple[float, float]|None=field(default=None)
     watermark:Watermark=field(default_factory=Watermark)
     watermark_plot:int|tuple[int, int]|None=field(default=None)
+    tight_layout:bool=field(default=True)
+    shared_axes:str|None=field(default=None)
 
     _api_doc = inspect.cleandoc("""
     Producing a Figure with a Grid of Plots
@@ -315,6 +321,13 @@ class GridFigure(Figure):
         * ``watermark_plot`` (*int* or *tuple[int, int]*) -- The plot that carries the watermark, given either as a flattened
             (row-major) index or as a 2D ``(row, col)`` address. If omitted, every plot is stamped.
 
+        * ``tight_layout`` (*bool*) -- Whether to lay out the grid with ``tight_layout``. Defaults to True. Set to False to keep an
+            explicit ``padding`` (e.g. ``(0, 0)`` for abutting panels), which ``tight_layout`` would otherwise undo.
+
+        * ``shared_axes`` (*str* or *None*) -- Which axes the panels share, one of ``None``, ``'x'``, ``'y'``, or ``'both'``. ``'x'`` shares
+            the x-axis per column, ``'y'`` shares the y-axis per row, ``'both'`` shares both; a shared axis gives one common range per group
+            and tick labels only on the outer edge. Defaults to None (independent axes).
+
 
     """)
     def __post_init__(self):
@@ -322,7 +335,12 @@ class GridFigure(Figure):
         figsize = self.size if self.size is not None else (3.0 * ncol, 3.0 * nrow)
         self._figure = plt.figure(figsize=figsize)
         self._gridspec = self._figure.add_gridspec(nrow, ncol, hspace=self.padding[0], wspace=self.padding[1])
-        axes = self._gridspec.subplots()
+        if self.shared_axes not in (None, 'x', 'y', 'both'):
+            raise ValueError(f"'shared_axes' must be one of None, 'x', 'y', 'both', got {self.shared_axes!r}")
+        sharex = 'col' if self.shared_axes in ('x', 'both') else False
+        sharey = 'row' if self.shared_axes in ('y', 'both') else False
+        # squeeze=False keeps axes a 2D array even for a 1x1 grid, so flatten() is always valid
+        axes = self._gridspec.subplots(sharex=sharex, sharey=sharey, squeeze=False)
         self._axes = axes.flatten('C') # flatten to row-major style
         self._watermark_idx = self._resolve_watermark_plot(nrow, ncol)
 
@@ -367,7 +385,8 @@ class GridFigure(Figure):
             if self._watermark_idx is None or self._watermark_idx == idx:
                 plot.draw_watermark(self._axes[idx], self.watermark)
 
-        self._gridspec.tight_layout(self._figure)
+        if self.tight_layout:
+            self._gridspec.tight_layout(self._figure)
         if output is not None:
             if isinstance(output, list):
                 for out in output:

--- a/python/eos/figure/figure.py
+++ b/python/eos/figure/figure.py
@@ -281,6 +281,8 @@ class GridFigure(Figure):
     :type shape: tuple[int, int]
     :param size: The size of the figure in inches. Defaults to (3.0 * ncol, 3.0 * nrow).
     :type size: tuple[float, float]
+    :param watermark_plot: The plot that carries the watermark, as a flattened (row-major) index or a 2D ``(row, col)`` address. If None, every plot is stamped.
+    :type watermark_plot: int | tuple[int, int] | None
     """
 
     type:str=field(repr=False, init=False, default='grid')
@@ -290,6 +292,7 @@ class GridFigure(Figure):
     shape:tuple[int, int]
     size:tuple[float, float]|None=field(default=None)
     watermark:Watermark=field(default_factory=Watermark)
+    watermark_plot:int|tuple[int, int]|None=field(default=None)
 
     _api_doc = inspect.cleandoc("""
     Producing a Figure with a Grid of Plots
@@ -309,6 +312,9 @@ class GridFigure(Figure):
 
         * ``size`` (*tuple[float, float]*) -- The size of the figure in inches. Defaults to (3.0 * ncol, 3.0 * nrow).
 
+        * ``watermark_plot`` (*int* or *tuple[int, int]*) -- The plot that carries the watermark, given either as a flattened
+            (row-major) index or as a 2D ``(row, col)`` address. If omitted, every plot is stamped.
+
 
     """)
     def __post_init__(self):
@@ -318,6 +324,33 @@ class GridFigure(Figure):
         self._gridspec = self._figure.add_gridspec(nrow, ncol, hspace=self.padding[0], wspace=self.padding[1])
         axes = self._gridspec.subplots()
         self._axes = axes.flatten('C') # flatten to row-major style
+        self._watermark_idx = self._resolve_watermark_plot(nrow, ncol)
+
+    def _resolve_watermark_plot(self, nrow, ncol):
+        "Resolve the watermark_plot field to a single flattened (row-major) index, or None for all plots."
+        wp = self.watermark_plot
+        if wp is None:
+            return None
+
+        nplots = len(self.plots)
+        if isinstance(wp, bool):
+            # bool is a subclass of int; reject it so that e.g. 'watermark_plot: true'
+            # does not silently select plot index 1
+            raise ValueError(f"'watermark_plot' must be an int or a (row, col) pair, got {wp!r}")
+        elif isinstance(wp, int):
+            idx = wp
+        else: # 2D (row, col) address; a YAML list arrives here as well
+            if len(wp) != 2:
+                raise ValueError(f"'watermark_plot' must be an int or a (row, col) pair, got {wp}")
+            row, col = wp
+            if not (0 <= row < nrow and 0 <= col < ncol):
+                raise ValueError(f"'watermark_plot' {tuple(wp)} is outside the {nrow}x{ncol} grid")
+            idx = row * ncol + col
+
+        if not (0 <= idx < nplots):
+            raise ValueError(f"'watermark_plot' resolves to plot {idx}, but there are only {nplots} plots")
+
+        return idx
 
     def draw(self, context:AnalysisFileContext=None, output:str|list[str]|None=None):
         """Draw the grid figure.
@@ -331,7 +364,8 @@ class GridFigure(Figure):
         for idx, plot in enumerate(self.plots):
             plot.prepare()
             plot.draw(self._axes[idx])
-            plot.draw_watermark(self._axes[idx], self.watermark)
+            if self._watermark_idx is None or self._watermark_idx == idx:
+                plot.draw_watermark(self._axes[idx], self.watermark)
 
         self._gridspec.tight_layout(self._figure)
         if output is not None:

--- a/python/eos/figure/figure_TEST.py
+++ b/python/eos/figure/figure_TEST.py
@@ -186,6 +186,17 @@ class GridFigureTests(unittest.TestCase):
         self.assertAlmostEqual(size[0], 6.0) # 3.0 * ncol = 3.0 * 2
         self.assertAlmostEqual(size[1], 3.0) # 3.0 * nrow = 3.0 * 1
 
+    def test_single_cell(self):
+
+        # a 1x1 grid must work: subplots() squeezes to a bare Axes by default, which
+        # would break the flatten() logic without squeeze=False.
+        try:
+            figure = eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 1]', 1))
+            self.assertEqual(len(figure._axes), 1)
+            figure.draw()
+        except Exception as e:
+            self.fail(f"Error when testing a 1x1 grid figure: {e}")
+
     @staticmethod
     def _has_watermark(ax):
         return any('EOS' in t.get_text() for t in ax.texts)
@@ -250,6 +261,79 @@ class GridFigureTests(unittest.TestCase):
         # A boolean is rejected rather than silently treated as the int 0/1.
         with self.assertRaises(Exception):
             eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 2]', 2, extra='watermark_plot: true'))
+
+    @staticmethod
+    def _two_range_grid(extra=''):
+        # a single column with two panels carrying different x-ranges
+        return f"""
+        type: 'grid'
+        shape: [2, 1]
+        {extra}
+        plots:
+          - xaxis: {{ label: '$q^2$', range: [0.1, 1.0] }}
+            yaxis: {{ label: '$d\\mathcal{{B}}/dq^2$' }}
+            items:
+              - type: 'observable'
+                observable: 'B->Dlnu::dBR/dq2'
+                options: {{ 'l': 'e' }}
+                variable: 'q2'
+                range: [0.1, 1.0]
+                resolution: 100
+          - xaxis: {{ label: '$q^2$', range: [2.0, 5.0] }}
+            yaxis: {{ label: '$d\\mathcal{{B}}/dq^2$' }}
+            items:
+              - type: 'observable'
+                observable: 'B->Dlnu::dBR/dq2'
+                options: {{ 'l': 'mu' }}
+                variable: 'q2'
+                range: [2.0, 5.0]
+                resolution: 100
+        """
+
+    def test_tight_layout_disabled(self):
+
+        try:
+            figure = eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 2]', 2, extra='tight_layout: false'))
+            self.assertFalse(figure.tight_layout)
+            figure.draw()
+        except Exception as e:
+            self.fail(f"Error when drawing grid figure with tight_layout disabled: {e}")
+
+    def test_shared_axes_x(self):
+
+        # With shared_axes 'x' the panels are joined in x and end up with one common x-range.
+        figure = eos.figure.FigureFactory.from_yaml(self._two_range_grid(extra="shared_axes: 'x'"))
+        self.assertTrue(figure._axes[0].get_shared_x_axes().joined(figure._axes[0], figure._axes[1]))
+        self.assertFalse(figure._axes[0].get_shared_y_axes().joined(figure._axes[0], figure._axes[1]))
+        figure.draw()
+        self.assertEqual(figure._axes[0].get_xlim(), figure._axes[1].get_xlim())
+
+    def test_shared_axes_y(self):
+
+        # 'y' shares the y-axis per row. The 2x1 single-column grid has one panel
+        # per row, so use a 1x2 grid to exercise row sharing.
+        figure = eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 2]', 2, extra="shared_axes: 'y'"))
+        self.assertTrue(figure._axes[0].get_shared_y_axes().joined(figure._axes[0], figure._axes[1]))
+        self.assertFalse(figure._axes[0].get_shared_x_axes().joined(figure._axes[0], figure._axes[1]))
+
+    def test_shared_axes_both(self):
+
+        figure = eos.figure.FigureFactory.from_yaml(self._grid_yaml('[2, 2]', 4, extra="shared_axes: 'both'"))
+        # column-shared x and row-shared y
+        self.assertTrue(figure._axes[0].get_shared_x_axes().joined(figure._axes[0], figure._axes[2]))
+        self.assertTrue(figure._axes[0].get_shared_y_axes().joined(figure._axes[0], figure._axes[1]))
+
+    def test_shared_axes_default_independent(self):
+
+        # Without shared_axes (the default) the panels keep independent axes.
+        figure = eos.figure.FigureFactory.from_yaml(self._two_range_grid())
+        self.assertFalse(figure._axes[0].get_shared_x_axes().joined(figure._axes[0], figure._axes[1]))
+        self.assertFalse(figure._axes[0].get_shared_y_axes().joined(figure._axes[0], figure._axes[1]))
+
+    def test_shared_axes_invalid(self):
+
+        with self.assertRaises(Exception):
+            eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 2]', 2, extra="shared_axes: 'diagonal'"))
 
 
 class CornerFigureTests(unittest.TestCase):

--- a/python/eos/figure/figure_TEST.py
+++ b/python/eos/figure/figure_TEST.py
@@ -186,6 +186,71 @@ class GridFigureTests(unittest.TestCase):
         self.assertAlmostEqual(size[0], 6.0) # 3.0 * ncol = 3.0 * 2
         self.assertAlmostEqual(size[1], 3.0) # 3.0 * nrow = 3.0 * 1
 
+    @staticmethod
+    def _has_watermark(ax):
+        return any('EOS' in t.get_text() for t in ax.texts)
+
+    @staticmethod
+    def _grid_yaml(shape, nplots, extra=''):
+        plots = "".join("""
+          - xaxis: { label: '$q^2$' }
+            yaxis: { label: '$d\\mathcal{B}/dq^2$' }
+            items:
+              - type: 'observable'
+                observable: 'B->Dlnu::dBR/dq2'
+                options: { 'l': 'e' }
+                variable: 'q2'
+                range: [0.1, 1.0]
+                resolution: 100""" for _ in range(nplots))
+        return f"""
+        type: 'grid'
+        shape: {shape}
+        {extra}
+        plots:{plots}
+        """
+
+    def test_watermark_plot_single(self):
+
+        # A flattened index selects a single panel; only that panel is stamped.
+        input = self._grid_yaml('[1, 2]', 2, extra='watermark_plot: 1')
+        figure = eos.figure.FigureFactory.from_yaml(input)
+        figure.draw()
+        self.assertFalse(self._has_watermark(figure._axes[0]))
+        self.assertTrue(self._has_watermark(figure._axes[1]))
+
+    def test_watermark_plot_tuple(self):
+
+        # A 2D (row, col) address resolves to flat index row * ncol + col.
+        # (1, 0) in a 2x2 grid -> flat index 2.
+        input = self._grid_yaml('[2, 2]', 4, extra='watermark_plot: [1, 0]')
+        figure = eos.figure.FigureFactory.from_yaml(input)
+        figure.draw()
+        for idx in range(4):
+            self.assertEqual(self._has_watermark(figure._axes[idx]), idx == 2)
+
+    def test_watermark_plot_default(self):
+
+        # Without 'watermark_plot', every panel is stamped (backward-compatible).
+        input = self._grid_yaml('[1, 2]', 2)
+        figure = eos.figure.FigureFactory.from_yaml(input)
+        figure.draw()
+        self.assertTrue(self._has_watermark(figure._axes[0]))
+        self.assertTrue(self._has_watermark(figure._axes[1]))
+
+    def test_watermark_plot_out_of_range(self):
+
+        # An out-of-range flattened index is rejected at construction.
+        with self.assertRaises(Exception):
+            eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 2]', 2, extra='watermark_plot: 5'))
+
+        # An out-of-range 2D address is rejected as well.
+        with self.assertRaises(Exception):
+            eos.figure.FigureFactory.from_yaml(self._grid_yaml('[2, 2]', 4, extra='watermark_plot: [0, 9]'))
+
+        # A boolean is rejected rather than silently treated as the int 0/1.
+        with self.assertRaises(Exception):
+            eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 2]', 2, extra='watermark_plot: true'))
+
 
 class CornerFigureTests(unittest.TestCase):
 

--- a/python/eos/figure/figure_TEST.py
+++ b/python/eos/figure/figure_TEST.py
@@ -124,6 +124,68 @@ class GridFigureTests(unittest.TestCase):
         except Exception as e:
             self.fail(f"Error when testing figure of type 'grid': {e}")
 
+    def test_size(self):
+
+        input = """
+        type: 'grid'
+        shape: [1, 2]
+        size: [8.0, 6.0]
+        plots:
+          - xaxis: { label: '$q^2$' }
+            yaxis: { label: '$d\\mathcal{B}/dq^2$' }
+            items:
+              - type: 'observable'
+                observable: 'B->Dlnu::dBR/dq2'
+                options: { 'l': 'e' }
+                variable: 'q2'
+                range: [0.1, 1.0]
+                resolution: 100
+          - xaxis: { label: '$q^2$' }
+            yaxis: { label: '$d\\mathcal{B}/dq^2$' }
+            items:
+              - type: 'observable'
+                observable: 'B->Dlnu::dBR/dq2'
+                options: { 'l': 'mu' }
+                variable: 'q2'
+                range: [0.1, 1.0]
+                resolution: 100
+        """
+        figure = eos.figure.FigureFactory.from_yaml(input)
+        size = figure._figure.get_size_inches()
+        self.assertAlmostEqual(size[0], 8.0)
+        self.assertAlmostEqual(size[1], 6.0)
+
+    def test_default_size(self):
+
+        # When 'size' is omitted, the figure falls back to (3.0 * ncol, 3.0 * nrow).
+        input = """
+        type: 'grid'
+        shape: [1, 2]
+        plots:
+          - xaxis: { label: '$q^2$' }
+            yaxis: { label: '$d\\mathcal{B}/dq^2$' }
+            items:
+              - type: 'observable'
+                observable: 'B->Dlnu::dBR/dq2'
+                options: { 'l': 'e' }
+                variable: 'q2'
+                range: [0.1, 1.0]
+                resolution: 100
+          - xaxis: { label: '$q^2$' }
+            yaxis: { label: '$d\\mathcal{B}/dq^2$' }
+            items:
+              - type: 'observable'
+                observable: 'B->Dlnu::dBR/dq2'
+                options: { 'l': 'mu' }
+                variable: 'q2'
+                range: [0.1, 1.0]
+                resolution: 100
+        """
+        figure = eos.figure.FigureFactory.from_yaml(input)
+        size = figure._figure.get_size_inches()
+        self.assertAlmostEqual(size[0], 6.0) # 3.0 * ncol = 3.0 * 2
+        self.assertAlmostEqual(size[1], 3.0) # 3.0 * nrow = 3.0 * 1
+
 
 class CornerFigureTests(unittest.TestCase):
 

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -1921,6 +1921,45 @@ class BandItem(Item):
         return entries
 
 @dataclass(kw_only=True)
+class VerticalLineItem(Item):
+    r"""Plots a vertical line at a fixed position on the x axis.
+
+    This item type is used to mark a particular value on the x axis, e.g. a
+    kinematic threshold. The line's appearance is controlled by the inherited
+    ``color``, ``linestyle``, ``linewidth``, and ``alpha`` fields.
+
+    :param x: The x-axis position of the vertical line.
+    :type x: float
+
+    Example:
+
+    .. code-block::
+
+        plot:
+          xaxis: { label: '$\sqrt{s}$ [GeV]', range: [3.73, 4.085] }
+          yaxis: { label: '$\sigma$ [nb]' }
+          items:
+            - { type: 'vertical', x: 3.875, color: 'gray', linestyle: 'dashed', label: r'$D\bar{D}^*$ threshold' }
+    """
+
+    x:float|None=field(default=None)
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.x is None:
+            raise ValueError("'x' must be specified to define a vertical line")
+
+    def prepare(self, context:AnalysisFileContext=None):
+        "Prepare the vertical line for drawing."
+        pass
+
+    def draw(self, ax):
+        "Draw the vertical line on the axes."
+        ax.axvline(self.x, alpha=self.alpha, color=self.color,
+                   linestyle=self.linestyle, linewidth=self.linewidth)
+
+@dataclass(kw_only=True)
 class SignalPDFItem(Item):
     """Plots a single EOS signal PDF w/o uncertainties as a function of one kinematic variable
 
@@ -2300,6 +2339,7 @@ class ItemFactory:
         'kde1D': OneDimensionalKernelDensityEstimateItem,
         'kde2D': TwoDimensionalKernelDensityEstimateItem,
         'band': BandItem,
+        'vertical': VerticalLineItem,
         'signal-pdf': SignalPDFItem,
         'complex-plane': ComplexPlaneItem,
         'errorbars': ErrorBarsItem,

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -22,6 +22,10 @@ from eos.deserializable import Deserializable
 import inspect
 import eos
 import matplotlib as _matplotlib
+import matplotlib.collections
+import matplotlib.container
+import matplotlib.lines
+import matplotlib.patches
 import numpy as _np
 import os
 import scipy as _scipy
@@ -98,11 +102,52 @@ class Item(Deserializable):
         """
         raise NotImplementedError
 
+    def _legend_line(self, alpha=None):
+        "A line swatch matching a plotted curve; pass the item's alpha if it draws with one."
+        if not self.label:
+            return []
+        handle = _matplotlib.lines.Line2D((0, 1), (0, 0), color=self.color, lw=self.linewidth, ls=self.linestyle, alpha=alpha)
+        return [(handle, self.label)]
+
+    def _legend_patch(self):
+        "A translucent filled swatch matching a band or histogram."
+        if not self.label:
+            return []
+        handle = _matplotlib.patches.Rectangle((0, 0), 1, 1, color=self.color, alpha=self.alpha)
+        return [(handle, self.label)]
+
+    def _legend_marker(self, marker, alpha=None):
+        "A point-marker swatch matching error bars; pass the item's alpha if it draws with one."
+        if not self.label:
+            return []
+        handle = _matplotlib.lines.Line2D((0,), (0,), color=self.color, marker=marker, linestyle='none', alpha=alpha)
+        return [(handle, self.label)]
+
+    def _legend_errorbar(self, marker='_', has_xerr=False, has_yerr=True, alpha=None):
+        """An error-bar swatch (capped bar) matching :class:`ErrorBarsItem`.
+
+        Returns an :class:`matplotlib.container.ErrorbarContainer`, which the default legend
+        renders via ``HandlerErrorbar`` as a central marker with caps and a connecting bar.
+        The central element is a marker (not a full-width line) and the caps are sized to
+        ``2 * errorbar.capsize`` -- matplotlib's own convention -- so the swatch reproduces
+        the error bars as the items actually draw them (no connecting line, capped bar). The
+        template artists below carry the visual properties (colour, width, marker size, alpha);
+        the handler copies them onto the swatch geometry it builds.
+        """
+        if not self.label:
+            return []
+        capsize  = 2.0 * _matplotlib.rcParams['errorbar.capsize']
+        line     = _matplotlib.lines.Line2D((0,), (0,), color=self.color, marker=marker, linestyle='none', alpha=alpha)
+        capline  = _matplotlib.lines.Line2D((0,), (0,), color=self.color, marker='_', linestyle='none', markersize=capsize, alpha=alpha)
+        barlines = _matplotlib.collections.LineCollection([[(0, 0), (0, 1)]], colors=self.color, linewidths=self.linewidth, alpha=alpha)
+        handle   = _matplotlib.container.ErrorbarContainer((line, [capline], [barlines]), has_xerr=has_xerr, has_yerr=has_yerr)
+        return [(handle, self.label)]
+
     def legend(self):
         """Return the item's legend entry as a list of handle/label pairs.
 
         The default implementation returns an empty list, i.e. the item contributes no
-        dedicated legend entry. Subclasses that require a custom legend handle override this.
+        dedicated legend entry. Subclasses that require a custom legend handle override this
 
         :returns: A list of ``(handle, label)`` pairs to be added to the plot legend.
         :rtype: list[tuple[matplotlib.artist.Artist, str]]
@@ -288,6 +333,10 @@ class ObservableItem(Item):
         :param kwargs: Additional keyword arguments forwarded to :meth:`matplotlib.axes.Axes.plot`.
         """
         ax.plot(self._xvalues, self._yvalues, label=self.label, color=self.color, lw=self.linewidth, ls=self.linestyle, **kwargs)
+
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        return self._legend_line()
 
 
 @dataclass(kw_only=True)
@@ -525,6 +574,10 @@ class UncertaintyBandItem(Item):
         if 'median' in self.band:
             ax.plot(self._xvalues, self._ovalues_central,                             alpha=self.alpha, color=self.color, label=label, lw=self.linewidth, ls=self.linestyle)
 
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        return self._legend_patch()
+
 
 @dataclass(kw_only=True)
 class BinnedUncertaintyItem(Item):
@@ -621,6 +674,10 @@ class BinnedUncertaintyItem(Item):
             ax.plot([xmin, xmax], [ocentral, ocentral], color=self.color, alpha=self.alpha, lw=self.linewidth, ls=self.linestyle)
             ax.plot([xmin, xmax], [ohi,      ohi],      color=self.color, alpha=self.alpha, lw=self.linewidth, ls=self.linestyle)
             label = None
+
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        return self._legend_patch()
 
 
 @dataclass(kw_only=True)
@@ -739,6 +796,10 @@ class OneDimensionalHistogramItem(Item):
         ax.hist(self.samples, weights=self._datafile.weights, range=self.range,
                 alpha=self.alpha, bins=self.bins, color=self.color, density=True, label=self.label)
 
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        return self._legend_patch()
+
 @dataclass
 class TwoDimensionalHistogramItem(Item):
     """Plots a two-dimensional histogram.
@@ -832,6 +893,11 @@ class TwoDimensionalHistogramItem(Item):
         """
         ax.hist2d(self.samples[:, 0], self.samples[:, 1], weights=self.weights, range=[self.xrange, self.yrange],
                   bins=self.bins, label=self.label, rasterized=True, cmap='Greys')
+
+    def legend(self):
+        # a 2D density (colormap) has no faithful single-swatch representation,
+        # so it deliberately contributes no legend entry (use a colorbar instead).
+        return []
 
 
 @dataclass(kw_only=True)
@@ -1000,6 +1066,10 @@ class OneDimensionalKernelDensityEstimateItem(Item):
                                             facecolor=self.color, alpha=self.alpha)
 
         ax.plot(self.xvalues, self.pdf, color=self.color, lw=self.linewidth, ls=self.linestyle, label=self.label)
+
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        return self._legend_line()
 
 @dataclass(kw_only=True)
 class TwoDimensionalKernelDensityEstimateItem(Item):
@@ -1507,6 +1577,15 @@ class ConstraintItem(Item):
             # disable the label for subsequent plots
             label = None
 
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        # the constraint is drawn as capped error bars (always a y error, plus an x error
+        # for binned constraints), so the swatch must match. The x error is only known
+        # after prepare(); fall back to a y-only swatch if the data is not yet available.
+        xerrors = getattr(self, '_xerrors', None)
+        has_xerr = xerrors is not None and any(xe is not None for xe in xerrors)
+        return self._legend_errorbar(has_xerr=has_xerr, has_yerr=True)
+
 
 @dataclass(kw_only=True)
 class ConstraintResidueItem(Item):
@@ -1815,6 +1894,15 @@ class ConstraintResidueItem(Item):
             # disable the label for subsequent plots
             label = None
 
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        # the residues are drawn as capped error bars (always a y error, plus an x error
+        # for binned constraints), so the swatch must match. The x error is only known
+        # after prepare(); fall back to a y-only swatch if the data is not yet available.
+        xerrors = getattr(self, '_xerrors', None)
+        has_xerr = xerrors is not None and any(xe is not None for xe in xerrors)
+        return self._legend_errorbar(has_xerr=has_xerr, has_yerr=True)
+
 
 @dataclass(kw_only=True)
 class BandItem(Item):
@@ -1912,13 +2000,7 @@ class BandItem(Item):
         :returns: A list containing a single ``(handle, label)`` pair if a label is set, otherwise empty.
         :rtype: list[tuple[matplotlib.artist.Artist, str]]
         """
-        entries = []
-
-        if self.label:
-            handle = _matplotlib.pyplot.Rectangle((0,0),1,1, alpha=self.alpha, color=self.color)
-            entries.append((handle, self.label))
-
-        return entries
+        return self._legend_patch()
 
 @dataclass(kw_only=True)
 class VerticalLineItem(Item):
@@ -1958,6 +2040,10 @@ class VerticalLineItem(Item):
         "Draw the vertical line on the axes."
         ax.axvline(self.x, alpha=self.alpha, color=self.color,
                    linestyle=self.linestyle, linewidth=self.linewidth)
+
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        return self._legend_line(alpha=self.alpha)
 
 @dataclass(kw_only=True)
 class SignalPDFItem(Item):
@@ -2086,6 +2172,10 @@ class SignalPDFItem(Item):
 
         ax.plot(xvalues, _np.exp(pvalues), alpha=self.alpha, color=self.color, label=self.label, lw=self.linewidth, ls=self.linestyle)
 
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        return self._legend_line(alpha=self.alpha)
+
 @dataclass(kw_only=True)
 class ComplexPlaneItem(Item):
     """Plots a single observable as a function on the complex plan
@@ -2211,6 +2301,11 @@ class ComplexPlaneItem(Item):
         """
         ax.pcolor(self._xvalues, self._yvalues, self._ovalues, cmap='viridis', rasterized=True)
 
+    def legend(self):
+        # a pseudocolor plot has no faithful single-swatch representation,
+        # so it deliberately contributes no legend entry (use a colorbar instead).
+        return []
+
 
 @dataclass(kw_only=True)
 class ErrorBarsItem(Item):
@@ -2319,6 +2414,10 @@ class ErrorBarsItem(Item):
         ax.errorbar(self._x, self._y, xerr=self._xerr, yerr=self._yerr, fmt='none', color=self.color,
                     alpha=self.alpha, elinewidth=self.linewidth, linestyle=self.linestyle, label=self.label)
         ax.plot(self._x, self._y, marker=self.marker, linestyle='none', color=self.color, alpha=self.alpha)
+
+    def legend(self):
+        """Return the item's legend entry in form of its handle(s) and label(s)."""
+        return self._legend_errorbar(marker=self.marker, has_xerr=self.xerrors is not None, has_yerr=self.yerrors is not None, alpha=self.alpha)
 
 class ItemFactory:
     """Factory that creates :class:`Item` instances from their YAML or dictionary description.

--- a/python/eos/figure/item_TEST.py
+++ b/python/eos/figure/item_TEST.py
@@ -21,6 +21,9 @@ import os
 
 from eos.analysis_file_description import AnalysisFileContext
 from matplotlib import pyplot as plt
+from matplotlib.container import ErrorbarContainer
+from matplotlib.lines import Line2D
+from matplotlib.patches import Rectangle
 
 class ItemColorCyclerTests(unittest.TestCase):
 
@@ -62,6 +65,34 @@ class ObservableItemTests(unittest.TestCase):
             item.draw(ax)
         except Exception as e:
             self.fail(f"Error when testing item of type 'observable': {e}")
+
+    def test_legend(self):
+
+        # a labelled observable contributes a single line entry
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: observable
+        observable: 'B->Dlnu::dBR/dq2'
+        variable: q2
+        range: [0.1, 1.0]
+        resolution: 10
+        label: 'foo'
+        """)
+        entries = item.legend()
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0][0], Line2D)
+        self.assertEqual(entries[0][1], 'foo')
+        # the observable is drawn opaque, so its swatch is opaque too
+        self.assertIsNone(entries[0][0].get_alpha())
+
+        # an unlabelled item contributes no entry
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: observable
+        observable: 'B->Dlnu::dBR/dq2'
+        variable: q2
+        range: [0.1, 1.0]
+        resolution: 10
+        """)
+        self.assertEqual(list(item.legend()), [])
 
 class UncertaintyBandItemTests(unittest.TestCase):
 
@@ -121,6 +152,31 @@ class ConstraintItemTests(unittest.TestCase):
         except Exception as e:
             self.fail(f"Error when testing item of type 'constraint': {e}")
 
+    def test_legend(self):
+
+        # a labelled constraint contributes a single error-bar entry (a capped bar rendered
+        # by HandlerErrorbar), not just the central marker
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: constraint
+        label: 'Belle'
+        constraints: 'B^0->D^+e^-nu::BRs@Belle:2015A'
+        observable: 'B->Dlnu::BR'
+        variable: 'q2'
+        rescale_by_width: true
+        """)
+        entries = item.legend()
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0][0], ErrorbarContainer)
+        self.assertTrue(entries[0][0].has_yerr)
+        self.assertEqual(entries[0][1], 'Belle')
+
+        # after prepare(), the binned constraint also carries an x error bar
+        item.prepare()
+        entry = item.legend()[0][0]
+        self.assertIsInstance(entry, ErrorbarContainer)
+        self.assertTrue(entry.has_xerr)
+        self.assertTrue(entry.has_yerr)
+
 class ConstraintResidueItemTests(unittest.TestCase):
 
     def test_full(self):
@@ -141,6 +197,30 @@ class ConstraintResidueItemTests(unittest.TestCase):
             item.draw(ax)
         except Exception as e:
             self.fail(f"Error when testing item of type 'constraint': {e}")
+
+    def test_legend(self):
+
+        # a labelled residue item contributes a single error-bar entry (a capped bar
+        # rendered by HandlerErrorbar), matching how the residues are drawn
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: 'constraint-residue'
+        label: 'Belle'
+        constraints: 'B^0->D^+e^-nu::BRs@Belle:2015A'
+        observable: 'B->Dlnu::BR'
+        variable: 'q2'
+        rescale_by_width: true
+        """)
+        entries = item.legend()
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0][0], ErrorbarContainer)
+        self.assertTrue(entries[0][0].has_yerr)
+        self.assertEqual(entries[0][1], 'Belle')
+
+        # after prepare(), the binned constraint also carries an x error bar
+        item.prepare()
+        entry = item.legend()[0][0]
+        self.assertTrue(entry.has_xerr)
+        self.assertTrue(entry.has_yerr)
 
 class OneDimensionalHistogramItemTests(unittest.TestCase):
 
@@ -175,6 +255,17 @@ class TwoDimensionalHistogramItemTests(unittest.TestCase):
             item.draw(ax)
         except Exception as e:
             self.fail(f"Error when testing item of type 'constraint': {e}")
+
+    def test_legend(self):
+
+        # a 2D density has no faithful swatch and contributes no entry, even when labelled
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: 'histogram2D'
+        variables: ['CKM::abs(V_ub)', 'B->pi::f_+(0)@BCL2008']
+        datafile: 'eos/data/importance_samples_TEST.d/samples'
+        label: 'should be ignored'
+        """)
+        self.assertEqual(list(item.legend()), [])
 
 class OneDimensionalKernelDensityItemTests(unittest.TestCase):
 
@@ -250,6 +341,28 @@ class BandItemTests(unittest.TestCase):
         except Exception as e:
             self.fail(f"Error when testing item of type 'band': {e}")
 
+    def test_legend(self):
+
+        # a labelled band contributes a single patch entry
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: band
+        x: [-0.1, +0.1]
+        color: 'blue'
+        label: 'foo'
+        """)
+        entries = item.legend()
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0][0], Rectangle)
+        self.assertEqual(entries[0][1], 'foo')
+
+        # an unlabelled band contributes no entry
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: band
+        y: [-0.1, +0.1]
+        color: 'orange'
+        """)
+        self.assertEqual(list(item.legend()), [])
+
 class SignalPDFItemTests(unittest.TestCase):
 
     def test_full(self):
@@ -293,6 +406,19 @@ class ComplexPlaneItemTests(unittest.TestCase):
         except Exception as e:
             self.fail(f"Error when testing item of type 'complex-plane': {e}")
 
+    def test_legend(self):
+
+        # a pseudocolor plot has no faithful swatch and contributes no entry, even when labelled
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: 'complex-plane'
+        observable: 'b->s::Re{F17}(Re{q2},Im{q2})'
+        variables: ['Re{q2}', 'Im{q2}']
+        ranges: [[-1.0, +1.0], [-1.0, +1.0]]
+        resolution: 10
+        label: 'should be ignored'
+        """)
+        self.assertEqual(list(item.legend()), [])
+
 class ErrorBarsItemTests(unittest.TestCase):
 
     def test_full(self):
@@ -311,6 +437,86 @@ class ErrorBarsItemTests(unittest.TestCase):
             item.draw(ax)
         except Exception as e:
             self.fail(f"Error when testing item of type 'signal-pdf': {e}")
+
+    def test_legend(self):
+
+        # a labelled error-bar item contributes a single error-bar entry (a capped bar
+        # rendered by HandlerErrorbar), not just the central marker
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: 'errorbars'
+        positions: [[1, 2], [2, 3]]
+        yerrors: [0.2, 0.3]
+        marker: 'o'
+        label: 'data'
+        """)
+        entries = item.legend()
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0][0], ErrorbarContainer)
+        # only the y error is present, so the swatch carries the y bar but not the x bar
+        self.assertFalse(entries[0][0].has_xerr)
+        self.assertTrue(entries[0][0].has_yerr)
+        self.assertEqual(entries[0][1], 'data')
+
+        # an item with both x and y errors carries both bars
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: 'errorbars'
+        positions: [[1, 2]]
+        xerrors: [0.4]
+        yerrors: [0.3]
+        label: 'data'
+        """)
+        entries = item.legend()
+        self.assertIsInstance(entries[0][0], ErrorbarContainer)
+        self.assertTrue(entries[0][0].has_xerr)
+        self.assertTrue(entries[0][0].has_yerr)
+
+        # an unlabelled item contributes no legend entry
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: 'errorbars'
+        positions: [[1, 2]]
+        yerrors: [0.3]
+        """)
+        self.assertEqual(list(item.legend()), [])
+
+class VerticalLineItemTests(unittest.TestCase):
+
+    def test_full(self):
+
+        try:
+            input = """
+            type: 'vertical'
+            x: 3.8
+            color: 'gray'
+            linestyle: 'dashed'
+            """
+            item = eos.figure.ItemFactory.from_yaml(input)
+            item.prepare()
+            _, ax = plt.subplots()
+            item.draw(ax)
+        except Exception as e:
+            self.fail(f"Error when testing item of type 'vertical': {e}")
+
+    def test_legend(self):
+
+        # a labelled vertical line contributes a single line entry
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: 'vertical'
+        x: 3.8
+        label: 'threshold'
+        """)
+        entries = item.legend()
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0][0], Line2D)
+        self.assertEqual(entries[0][1], 'threshold')
+        # the line is drawn with the item's alpha, so the swatch matches it
+        self.assertEqual(entries[0][0].get_alpha(), item.alpha)
+
+        # an unlabelled vertical line contributes no entry
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: 'vertical'
+        x: 3.8
+        """)
+        self.assertEqual(list(item.legend()), [])
 
 if __name__ == '__main__':
     unittest.main(verbosity=5)

--- a/python/eos/figure/plot.py
+++ b/python/eos/figure/plot.py
@@ -95,11 +95,14 @@ class XTicks(Deserializable):
     :type position: str
     :param visible: Whether the ticks are visible. Defaults to True.
     :type visible: bool
+    :param format: A printf-style format string for the major tick labels, e.g. '%.2f'. Defaults to None (matplotlib's default formatter).
+    :type format: str | None
     """
 
     minor:bool=field(default=True)
     position:str=field(default='bottom')
     visible:bool=field(default=True)
+    format:str|None=field(default=None)
 
     def __post_init__(self):
         POSITIONS = ['bottom', 'top', 'both']
@@ -130,6 +133,8 @@ class XTicks(Deserializable):
                     ax.xaxis.set_minor_locator(matplotlib.ticker.AutoMinorLocator())
                 else:
                     ax.xaxis.set_minor_locator(matplotlib.ticker.LogLocator(base=10.0, subs='auto'))
+            if self.format is not None:
+                ax.xaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter(self.format))
             ax.xaxis.set_tick_params(
                 which = 'both' if self.minor else 'major',
                 bottom=(self.position == 'bottom' or self.position == 'both'),
@@ -212,11 +217,14 @@ class YTicks(Deserializable):
     :type position: str
     :param visible: Whether the ticks are visible. Defaults to True.
     :type visible: bool
+    :param format: A printf-style format string for the major tick labels, e.g. '%.2f'. Defaults to None (matplotlib's default formatter).
+    :type format: str | None
     """
 
     minor:bool=field(default=True)
     position:str=field(default='left')
     visible:bool=field(default=True)
+    format:str|None=field(default=None)
 
     def __post_init__(self):
         POSITIONS = ['left', 'right', 'both']
@@ -247,6 +255,8 @@ class YTicks(Deserializable):
                     ax.yaxis.set_minor_locator(matplotlib.ticker.AutoMinorLocator())
                 else:
                     ax.yaxis.set_minor_locator(matplotlib.ticker.LogLocator(base=10.0, subs='auto'))
+            if self.format is not None:
+                ax.yaxis.set_major_formatter(matplotlib.ticker.FormatStrFormatter(self.format))
             ax.yaxis.set_tick_params(
                 left=(self.position == 'left' or self.position == 'both'),
                 right=(self.position == 'right' or self.position == 'both')

--- a/python/eos/figure/plot_TEST.py
+++ b/python/eos/figure/plot_TEST.py
@@ -146,6 +146,26 @@ class XTicksTests(unittest.TestCase):
         except Exception as e:
             self.fail(f"Error when drawing XTicks: {e}")
 
+    def test_format(self):
+        import matplotlib.ticker
+        from eos.figure.plot import XTicks
+
+        # defaults to None (matplotlib's default formatter)
+        self.assertIsNone(XTicks.from_dict().format)
+        self.assertEqual(XTicks.from_dict(format='%.2f').format, '%.2f')
+
+        # a format string installs a FormatStrFormatter on the major ticks
+        _, ax = plt.subplots()
+        XTicks.from_dict(format='%.2f').draw(ax)
+        formatter = ax.xaxis.get_major_formatter()
+        self.assertIsInstance(formatter, matplotlib.ticker.FormatStrFormatter)
+        self.assertEqual(formatter.fmt, '%.2f')
+
+        # without a format, the major formatter is left untouched (not a FormatStrFormatter)
+        _, ax = plt.subplots()
+        XTicks.from_dict().draw(ax)
+        self.assertNotIsInstance(ax.xaxis.get_major_formatter(), matplotlib.ticker.FormatStrFormatter)
+
 
 class YTicksTests(unittest.TestCase):
 
@@ -178,6 +198,26 @@ class YTicksTests(unittest.TestCase):
             YTicks.from_dict(visible=False).draw(ax)
         except Exception as e:
             self.fail(f"Error when drawing YTicks: {e}")
+
+    def test_format(self):
+        import matplotlib.ticker
+        from eos.figure.plot import YTicks
+
+        # defaults to None (matplotlib's default formatter)
+        self.assertIsNone(YTicks.from_dict().format)
+        self.assertEqual(YTicks.from_dict(format='%.2f').format, '%.2f')
+
+        # a format string installs a FormatStrFormatter on the major ticks
+        _, ax = plt.subplots()
+        YTicks.from_dict(format='%.2f').draw(ax)
+        formatter = ax.yaxis.get_major_formatter()
+        self.assertIsInstance(formatter, matplotlib.ticker.FormatStrFormatter)
+        self.assertEqual(formatter.fmt, '%.2f')
+
+        # without a format, the major formatter is left untouched (not a FormatStrFormatter)
+        _, ax = plt.subplots()
+        YTicks.from_dict().draw(ax)
+        self.assertNotIsInstance(ax.yaxis.get_major_formatter(), matplotlib.ticker.FormatStrFormatter)
 
 
 class XAxisTests(unittest.TestCase):


### PR DESCRIPTION
- 710c3dc2 Add a vertical plot item that draws a vertical line at a fixed position on the x axis. Use it to mark kinematic thresholds and similar reference values.
- af5de6d8 Add an optional size field to grid figures so the figure dimensions can be set explicitly. Fall back to the previous shape-dependent default when the field is omitted.
- 0cc6bd7a Add an optional watermark_plot field to grid figures that selects a single panel to carry the watermark, addressed either by a flattened index or by a row and column pair. Stamp every panel, as before, when the field is omitted.
- b74275ba Allow an explicit anchor and a configurable offset for the figure watermark. Keep the corner-preset placement as the default when neither is given.
- dea38dc3 Add tight_layout and shared_axes options to grid figures. Use shared_axes to share the x and/or y axis across rows or columns, and disable tight_layout to preserve an explicit padding.
- e44d4087 Implement a sensible default legend entry for most figure item types, choosing a line, patch, or marker swatch to match how each item is drawn. Leave the pseudocolor item types without a legend entry, since they have no faithful single-swatch representation.
- 3cb71d41 Make the tick label format configurable through a format field on the x and y ticks of a plot. Leave the default formatter untouched when no format is given.
- 710c3dc2 Update the changelog for PR #1182.