### PR TITLE
Replace ``boost::filesystem`` and ``boost::format`` use with ``std::filesystem`` and ``std::format``

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,8 @@
 - Allow the characters `|`, `(`, `)`, and `*` in ``qnp::OptionValue`` (D. van Dyk)
 - Switch ``Options`` to use ``qnp::OptionValue`` in lieu of ``std::string`` for its option values; hard-coded option values are now expressed using the ``_ov`` user-defined literal (D. van Dyk)
 - Use ``qnp::OptionValue`` keys in the the factory method ``Model::make`` (D. van Dyk)
+- Use ``std::filesystem`` in lieu of ``boost::filesystem`` (D. van Dyk)
+- Use ``std::format`` in lieu of ``boost::format`` when templating parameters (D. van Dyk)
 
 ### Added
 

--- a/eos/constraint.cc
+++ b/eos/constraint.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker foldmarker={{{,}}} : */
 
 /*
- * Copyright (c) 2011-2025 Danny van Dyk
+ * Copyright (c) 2011-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -2777,7 +2777,7 @@ namespace eos
 
             if (! fs::is_directory(base))
             {
-                throw InternalError("Expect '" + base.string() + " to be a directory");
+                throw InternalError("Expect '" + base.string() + "' to be a directory");
             }
 
             for (fs::directory_iterator f(base), f_end; f != f_end; ++f)

--- a/eos/constraint.cc
+++ b/eos/constraint.cc
@@ -31,19 +31,15 @@
 #include <eos/utils/stringify.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
-#include <boost/filesystem/directory.hpp>
-#include <boost/filesystem/file_status.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <config.h>
+#include <filesystem>
 #include <map>
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace eos
 {
@@ -2756,19 +2752,19 @@ namespace eos
         if (std::getenv("EOS_TESTS_CONSTRAINTS"))
         {
             std::string envvar = std::string(std::getenv("EOS_TESTS_CONSTRAINTS"));
-            base_list.push_back(fs::system_complete(envvar) / "experimental");
-            base_list.push_back(fs::system_complete(envvar) / "theoretical");
+            base_list.push_back(fs::absolute(envvar) / "experimental");
+            base_list.push_back(fs::absolute(envvar) / "theoretical");
         }
         else if (std::getenv("EOS_HOME"))
         {
             std::string envvar = std::string(std::getenv("EOS_HOME"));
-            base_list.push_back(fs::system_complete(envvar) / "constraints/experimental");
-            base_list.push_back(fs::system_complete(envvar) / "constraints/theoretical");
+            base_list.push_back(fs::absolute(envvar) / "constraints/experimental");
+            base_list.push_back(fs::absolute(envvar) / "constraints/theoretical");
         }
         else
         {
-            base_list.push_back(fs::system_complete(EOS_DATADIR "/eos/constraints/experimental"));
-            base_list.push_back(fs::system_complete(EOS_DATADIR "/eos/constraints/theoretical"));
+            base_list.push_back(fs::absolute(EOS_DATADIR "/eos/constraints/experimental"));
+            base_list.push_back(fs::absolute(EOS_DATADIR "/eos/constraints/theoretical"));
         }
 
         // Go over all subdirectories

--- a/eos/reference.cc
+++ b/eos/reference.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker foldmarker={{{,}}} : */
 
 /*
- * Copyright (c) 2019 Danny van Dyk
+ * Copyright (c) 2019-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -118,14 +118,14 @@ namespace eos
 
                 if (! fs::is_directory(base))
                 {
-                    throw InternalError("Expect '" + base.string() + " to be a directory");
+                    throw InternalError("Expect '" + base.string() + "' to be a directory");
                 }
 
                 auto file_path = base / "references.yaml";
 
                 if (! fs::is_regular_file(status(file_path)))
                 {
-                    throw InternalError("Expect '" + file_path.string() + " to be a regular file");
+                    throw InternalError("Expect '" + file_path.string() + "' to be a regular file");
                 }
 
                 std::string file = file_path.string();

--- a/eos/reference.cc
+++ b/eos/reference.cc
@@ -21,17 +21,13 @@
 #include <eos/utils/private_implementation_pattern-impl.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
-#include <boost/filesystem/directory.hpp>
-#include <boost/filesystem/file_status.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
-
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace eos
 {
@@ -103,16 +99,16 @@ namespace eos
                 if (std::getenv("EOS_TESTS_REFERENCES"))
                 {
                     std::string envvar = std::string(std::getenv("EOS_TESTS_REFERENCES"));
-                    base               = fs::system_complete(envvar);
+                    base               = fs::absolute(envvar);
                 }
                 else if (std::getenv("EOS_HOME"))
                 {
                     std::string envvar = std::string(std::getenv("EOS_HOME"));
-                    base               = fs::system_complete(envvar);
+                    base               = fs::absolute(envvar);
                 }
                 else
                 {
-                    base = fs::system_complete(EOS_DATADIR "/eos/");
+                    base = fs::absolute(EOS_DATADIR "/eos/");
                 }
 
                 if (! fs::exists(base))

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -28,21 +28,18 @@
 #include <eos/utils/stringify.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
-#include <boost/filesystem/directory.hpp>
-#include <boost/filesystem/file_status.hpp>
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/format.hpp>
 
 #include <cmath>
 #include <config.h>
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <random>
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace eos
 {
@@ -248,16 +245,16 @@ namespace eos
                 if (std::getenv("EOS_TESTS_PARAMETERS"))
                 {
                     std::string envvar = std::string(std::getenv("EOS_TESTS_PARAMETERS"));
-                    base               = fs::system_complete(envvar);
+                    base               = fs::absolute(envvar);
                 }
                 else if (std::getenv("EOS_HOME"))
                 {
                     std::string envvar = std::string(std::getenv("EOS_HOME"));
-                    base               = fs::system_complete(envvar) / "parameters";
+                    base               = fs::absolute(envvar) / "parameters";
                 }
                 else
                 {
-                    base = fs::system_complete(EOS_DATADIR "/eos/parameters/");
+                    base = fs::absolute(EOS_DATADIR "/eos/parameters/");
                 }
 
                 if (! fs::exists(base))

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -28,11 +28,11 @@
 #include <eos/utils/stringify.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
-#include <boost/format.hpp>
-
+#include <cctype>
 #include <cmath>
 #include <config.h>
 #include <filesystem>
+#include <format>
 #include <iostream>
 #include <map>
 #include <random>
@@ -40,6 +40,81 @@
 #include <yaml-cpp/yaml.h>
 
 namespace fs = std::filesystem;
+
+namespace
+{
+    // std::make_format_args requires a parameter pack, but the substitution list for a
+    // templated parameter is a runtime-sized, homogeneous (all std::string) vector. Bridge
+    // the two by dispatching on the number of substitutions.
+    std::string
+    vformat_n(const std::string & fmt, const std::vector<std::string> & a)
+    {
+        using eos::InternalError;
+
+        switch (a.size())
+        {
+            case 0:  return fmt;
+            case 1:  return std::vformat(fmt, std::make_format_args(a[0]));
+            case 2:  return std::vformat(fmt, std::make_format_args(a[0], a[1]));
+            case 3:  return std::vformat(fmt, std::make_format_args(a[0], a[1], a[2]));
+            case 4:  return std::vformat(fmt, std::make_format_args(a[0], a[1], a[2], a[3]));
+            case 5:  return std::vformat(fmt, std::make_format_args(a[0], a[1], a[2], a[3], a[4]));
+            default: throw InternalError("Templated parameter uses more than 5 substitutions, which is not supported");
+        }
+    }
+
+    // Render a boost::format-style positional template ("%1%", "%2%", ...) using std::vformat.
+    // The entries of 'args' are substituted 1-based, i.e. args[0] replaces "%1%", args[1]
+    // replaces "%2%", and so on. Literal braces are escaped so that brace-rich strings (e.g.
+    // LaTeX such as "x^{y}") pass through unchanged.
+    std::string
+    render_template(const std::string & tmpl, const std::vector<std::string> & args)
+    {
+        std::string fmt;
+        fmt.reserve(tmpl.size());
+
+        for (std::size_t i = 0; i < tmpl.size();)
+        {
+            const char c = tmpl[i];
+
+            if (('{' == c) || ('}' == c)) // escape literal braces for std::format
+            {
+                fmt += c;
+                fmt += c;
+                ++i;
+            }
+            else if (('%' == c) && (i + 1 < tmpl.size()) && std::isdigit(static_cast<unsigned char>(tmpl[i + 1])))
+            {
+                std::size_t j = i + 1;
+                while ((j < tmpl.size()) && std::isdigit(static_cast<unsigned char>(tmpl[j])))
+                {
+                    ++j;
+                }
+
+                if ((j < tmpl.size()) && ('%' == tmpl[j])) // a "%N%" token
+                {
+                    const int n  = std::stoi(tmpl.substr(i + 1, j - i - 1));
+                    fmt         += '{';
+                    fmt         += std::to_string(n - 1); // boost::format is 1-based, std::format is 0-based
+                    fmt         += '}';
+                    i            = j + 1;
+                }
+                else // a stray '%', keep it literal
+                {
+                    fmt += c;
+                    ++i;
+                }
+            }
+            else
+            {
+                fmt += c;
+                ++i;
+            }
+        }
+
+        return vformat_n(fmt, args);
+    }
+} // namespace
 
 namespace eos
 {
@@ -530,35 +605,29 @@ namespace eos
 
                                         for (auto cp_it = cp.begin(); cp.end() != cp_it; ++cp_it)
                                         {
-                                            boost::format templated_name(name);
-                                            boost::format templated_latex(latex);
+                                            std::vector<std::string> name_args;
+                                            std::vector<std::string> latex_args;
 
                                             for (auto && i : *cp_it)
                                             {
-                                                templated_name = templated_name % i;
+                                                name_args.push_back(i);
 
-                                                std::string mapped_i;
-                                                auto        latex_map_it = latex_map.find(i);
-                                                if (latex_map.end() != latex_map_it)
-                                                {
-                                                    mapped_i = latex_map_it->second;
-                                                }
-                                                else
-                                                {
-                                                    mapped_i = i;
-                                                }
-                                                templated_latex = templated_latex % mapped_i;
+                                                auto latex_map_it = latex_map.find(i);
+                                                latex_args.push_back(latex_map.end() != latex_map_it ? latex_map_it->second : i);
                                             }
 
-                                            QualifiedName qn(templated_name.str());
+                                            const std::string templated_name  = render_template(name, name_args);
+                                            const std::string templated_latex = render_template(latex, latex_args);
+
+                                            QualifiedName qn(templated_name);
 
                                             if (_map.end() != _map.find(qn))
                                             {
                                                 throw ParameterInputDuplicateError(file, qn.str());
                                             }
 
-                                            _data->data.push_back(Parameter::Data(Parameter::Template{ qn, min, central, max, templated_latex.str(), unit }, idx));
-                                            _map[templated_name.str()] = idx;
+                                            _data->data.push_back(Parameter::Data(Parameter::Template{ qn, min, central, max, templated_latex, unit }, idx));
+                                            _map[templated_name] = idx;
                                             group_parameters.push_back(Parameter(_data, idx));
 
                                             ++idx;

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010-2024 Danny van Dyk
+ * Copyright (c) 2010-2026 Danny van Dyk
  * Copyright (c) 2021 Philip Lüghausen
  * Copyright (c) 2010 Christian Wacker
  *
@@ -339,7 +339,7 @@ namespace eos
 
                 if (! fs::is_directory(base))
                 {
-                    throw InternalError("Expect '" + base.string() + " to be a directory");
+                    throw InternalError("Expect '" + base.string() + "' to be a directory");
                 }
 
                 unsigned idx = _data->data.size();

--- a/eos/utils/parameters_TEST.cc
+++ b/eos/utils/parameters_TEST.cc
@@ -159,5 +159,45 @@ class ParametersTest : public TestCase
                     TEST_CHECK_NEARLY_EQUAL(p2_tau.evaluate(), +1.00, 1e-12); // default value
                 }
             }
+
+            // Loading of templated parameters
+            {
+                Parameters p = Parameters::Defaults();
+
+                // 'B->pi::a^%1%_%2%@G2026' is templated over the cartesian product of
+                //   - %1% in { "f+", "f0", "fT" }
+                //   - %2% in { 0, 1, 2, 3, 4 }
+                // with the latex template '$a_%2%^{%1%,B \to \pi,\mathrm{G2026}}$' and the
+                // latex substitutions { "f+" -> "f_+", "f0" -> "f_0", "fT" -> "f_T" }.
+
+                // all instances of the cartesian product must be present, ...
+                for (const std::string & ff : { "f+", "f0", "fT" })
+                {
+                    for (unsigned i = 0; i <= 4; ++i)
+                    {
+                        const std::string name = "B->pi::a^" + ff + "_" + std::to_string(i) + "@G2026";
+                        TEST_CHECK_MSG(p.has(name), "templated parameter '" + name + "' is missing");
+                    }
+                }
+
+                // ... while instances outside of the cartesian product must be absent.
+                // (the raw template name 'a^%1%_%2%' cannot be queried directly, since '%'
+                // is not a valid character in a QualifiedName.)
+                TEST_CHECK(! p.has("B->pi::a^f+_5@G2026"));
+                TEST_CHECK(! p.has("B->pi::a^fX_0@G2026"));
+
+                // the positional substitutions (note: %2% precedes %1% in the latex template)
+                // and the latex map must be applied correctly.
+                Parameter a_fp_0 = p["B->pi::a^f+_0@G2026"];
+                TEST_CHECK_EQUAL(a_fp_0.name(), "B->pi::a^f+_0@G2026");
+                TEST_CHECK_EQUAL(a_fp_0.latex(), R"($a_0^{f_+,B \to \pi,\mathrm{G2026}}$)");
+                TEST_CHECK_NEARLY_EQUAL(a_fp_0.central(), 0.0, 1e-12);
+                TEST_CHECK_NEARLY_EQUAL(a_fp_0.min(), -1.0, 1e-12);
+                TEST_CHECK_NEARLY_EQUAL(a_fp_0.max(), +1.0, 1e-12);
+
+                Parameter a_fT_2 = p["B->pi::a^fT_2@G2026"];
+                TEST_CHECK_EQUAL(a_fT_2.name(), "B->pi::a^fT_2@G2026");
+                TEST_CHECK_EQUAL(a_fT_2.latex(), R"($a_2^{f_T,B \to \pi,\mathrm{G2026}}$)");
+            }
         }
 } parameters_test;


### PR DESCRIPTION
- 98ea24902a77a5190c3f10d950892674e6f72e97 Switch to using ``std::filesystem`` in lieu of ``boost::filesystem``. This commit only changes the includes and replaces ``fs::system_complete()`` with ``fs::absolute``.
- 333434da81901157e0040bd21ec6e2d75524686d Add test case covering the templating of parameters.
- d4951c2e210c19fc95f7aa74e058ccc000b86341 Use ``std::format`` for templating of parameters. The format of the template in the YAML files is unchanged. The code replaces ``%n%`` with ``{n}`` and escapes literal braces that appear through the parameter set.
- dac733513ffef9a0cc2425d6f27d39548c7a9359 Fix missing quote in error messages when loading references.
- a90839c78dd9dcf9f95fe409e5be9962bfe9cdb3 Fix missing quote in error messages when loading references.
- ab3cc6baf599457a2c3ce2b99e05da03372e0e6d Fix missing quote in error messages when loading references.
- cb60342b2b7e337a20b616ec8239d4cd15a0588b Update changelog for PR #1184.