### PR TITLE
Improve the test-case code coverage

### DIFF
--- a/.github/scripts/coverage-summary.py
+++ b/.github/scripts/coverage-summary.py
@@ -14,12 +14,46 @@ import json
 import os
 
 
-def cpp_line_counts(summary_path):
-    """Return (covered, total) C++ lines from a gcovr JSON summary file."""
-    with open(summary_path) as f:
+def cpp_line_counts(report_path):
+    """Return (covered, total) physical C++ lines from a gcovr JSON report.
+
+    A template header included in many translation units is instantiated once
+    per unit, and ``gcov`` emits a separate coverage record for each
+    instantiation *at the same physical source line*. ``gcovr``'s
+    ``--json-summary`` sums those records, so a 67-line header instantiated in
+    40 units is reported as ~2700 "lines" -- vastly over-weighting template-
+    heavy headers in the overall percentage.
+
+    To avoid this, we consume the detailed ``gcovr --json`` report (which lists
+    the individual per-line records) and deduplicate by ``(file, line)``: a
+    physical line counts once and is considered covered if it is executed in
+    *any* instantiation.
+
+    For robustness we fall back to the top-level ``line_total``/``line_covered``
+    fields when the report contains no per-line data (e.g. a ``--json-summary``
+    file); those numbers carry the inflation described above.
+    """
+    with open(report_path) as f:
         data = json.load(f)
-    total   = int(data.get('line_total', 0))
-    covered = int(data.get('line_covered', 0))
+
+    files = data.get('files')
+    if not files or 'lines' not in files[0]:
+        total   = int(data.get('line_total', 0))
+        covered = int(data.get('line_covered', 0))
+        return covered, total
+
+    # Maximum hit count seen for each physical (file, line).
+    best = {}
+    for entry in files:
+        fname = entry['file']
+        for line in entry.get('lines', []):
+            key   = (fname, line['line_number'])
+            count = line.get('count', 0)
+            if count > best.get(key, -1):
+                best[key] = count
+
+    total   = len(best)
+    covered = sum(1 for count in best.values() if count > 0)
     return covered, total
 
 
@@ -141,7 +175,8 @@ def make_badge(badge_path, cpp, python, combined):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--date',        required=True, help='date of this coverage run (YYYY-MM-DD)')
-    parser.add_argument('--cpp-summary', required=True, help='path to the gcovr JSON summary file')
+    parser.add_argument('--cpp-summary', required=True,
+                        help='path to the detailed gcovr JSON report (gcovr --json)')
     parser.add_argument('--python-json', required=True, help='path to the coverage.py JSON file')
     parser.add_argument('--csv',         required=True, help='path to the coverage CSV file to append to')
     parser.add_argument('--badge',       required=True, help='path to the SVG badge file to (re)generate')

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -105,16 +105,18 @@ jobs:
               shell: bash
               run: |
                 mkdir -p _intermediate
-                # Produce only the machine-readable summary needed for the
-                # overall percentage (printing a human-readable summary to the
-                # log). The full intermediate report is far too large to commit.
+                # Produce the detailed machine-readable report (deduplicated by
+                # 'coverage-summary.py' so that template headers instantiated in
+                # many translation units are not counted once per instantiation)
+                # while printing a human-readable summary to the log. Neither
+                # report is committed; only the CSV and badge are.
                 gcovr \
                   --root _src \
                   --object-directory _build \
                   --filter '_src/eos/' \
                   --exclude '.*_TEST\.' \
                   --gcov-ignore-parse-errors \
-                  --json-summary _intermediate/coverage-cpp-summary.json \
+                  --json _intermediate/coverage-cpp.json \
                   --txt
 
             - name: Determine Python coverage
@@ -146,7 +148,7 @@ jobs:
                 # 'badge.svg' from the most recent entry.
                 python3 _src/.github/scripts/coverage-summary.py \
                   --date "${DATE}" \
-                  --cpp-summary _intermediate/coverage-cpp-summary.json \
+                  --cpp-summary _intermediate/coverage-cpp.json \
                   --python-json _intermediate/coverage-python.json \
                   --csv _coverage/coverage.csv \
                   --badge _coverage/badge.svg

--- a/Changelog.md
+++ b/Changelog.md
@@ -72,6 +72,7 @@
 - Add a ``scaling_factor`` field to the ``xticks`` and ``yticks`` of a plot to rescale the displayed tick values (D. van Dyk)
 - Add the ``eos.reporting`` module with the ``AnalysisData``, ``PosteriorData``, and ``GoodnessOfFit`` classes, providing lazy, disk-driven access to the recorded results of an analysis for use in report templates (D. van Dyk)
 - Extend the ``inference`` example to find the best-fit point via a ``find-mode`` step and to report the goodness of fit (as a per-constraint table) and a corner figure for each posterior (D. van Dyk)
+- Add further test cases to cover the worst offenders in terms of code coverage (D. van Dyk)
 
 ### Deprecated
 

--- a/eos/constraint_TEST.cc
+++ b/eos/constraint_TEST.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker foldmarker={{{,}}} : */
 
 /*
- * Copyright (c) 2011-2025 Danny van Dyk
+ * Copyright (c) 2011-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -21,6 +21,8 @@
 #include <eos/maths/power-of.hh>
 #include <eos/observable.hh>
 #include <eos/statistics/log-likelihood.hh>
+#include <eos/utils/exception.hh>
+#include <eos/utils/options.hh>
 
 #include <test/test.hh>
 
@@ -1274,6 +1276,462 @@ class ConstraintDeserializationTest : public TestCase
                 p["mass::b(MSbar)"] = 4.6;
                 p["mass::c"]        = 1.3;
                 TEST_CHECK_NEARLY_EQUAL(llh(), -4.779399451, 1e-8);
+            }
+            // }}}
+
+            // {{{ Gaussian (deserialization errors)
+            {
+                // missing required key 'mean'
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::Gaussian",
+                                                            YAML::Load("type: Gaussian\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: {}\n"
+                                                                       "options: {}\n"
+                                                                       "sigma-stat: {hi: 0.1, lo: -0.1}\n"
+                                                                       "sigma-sys: {hi: 0.0, lo: -0.0}")));
+
+                // scalar key 'mean' mapped to a map
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::Gaussian",
+                                                            YAML::Load("type: Gaussian\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: {}\n"
+                                                                       "options: {}\n"
+                                                                       "mean: {a: 1}\n"
+                                                                       "sigma-stat: {hi: 0.1, lo: -0.1}\n"
+                                                                       "sigma-sys: {hi: 0.0, lo: -0.0}")));
+
+                // map key 'kinematics' mapped to a scalar
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::Gaussian",
+                                                            YAML::Load("type: Gaussian\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: 5\n"
+                                                                       "options: {}\n"
+                                                                       "mean: 4.3\n"
+                                                                       "sigma-stat: {hi: 0.1, lo: -0.1}\n"
+                                                                       "sigma-sys: {hi: 0.0, lo: -0.0}")));
+            }
+            // }}}
+
+            // {{{ LogGamma (deserialization errors)
+            {
+                // missing required key 'alpha'
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::LogGamma",
+                                                            YAML::Load("type: LogGamma\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: {}\n"
+                                                                       "options: {}\n"
+                                                                       "mode: 0.53\n"
+                                                                       "sigma: {hi: 0.1, lo: 0.19}\n"
+                                                                       "lambda: 0.0687907")));
+
+                // scalar key 'mode' mapped to a map
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::LogGamma",
+                                                            YAML::Load("type: LogGamma\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: {}\n"
+                                                                       "options: {}\n"
+                                                                       "mode: {a: 1}\n"
+                                                                       "sigma: {hi: 0.1, lo: 0.19}\n"
+                                                                       "alpha: 0.383056\n"
+                                                                       "lambda: 0.0687907")));
+
+                // map key 'sigma' mapped to a scalar
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::LogGamma",
+                                                            YAML::Load("type: LogGamma\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: {}\n"
+                                                                       "options: {}\n"
+                                                                       "mode: 0.53\n"
+                                                                       "sigma: 0.1\n"
+                                                                       "alpha: 0.383056\n"
+                                                                       "lambda: 0.0687907")));
+            }
+            // }}}
+
+            // {{{ Amoroso (deserialization errors)
+            {
+                // missing required key 'theta'
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::Amoroso",
+                                                            YAML::Load("type: Amoroso\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: {}\n"
+                                                                       "options: {}\n"
+                                                                       "physical-limit: 0.0\n"
+                                                                       "alpha: 8.2392613044e-01\n"
+                                                                       "beta: 1.6993290032")));
+
+                // scalar key 'alpha' mapped to a map
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::Amoroso",
+                                                            YAML::Load("type: Amoroso\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: {}\n"
+                                                                       "options: {}\n"
+                                                                       "physical-limit: 0.0\n"
+                                                                       "theta: 2.9708273062\n"
+                                                                       "alpha: {a: 1}\n"
+                                                                       "beta: 1.6993290032")));
+
+                // map key 'options' mapped to a scalar
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::Amoroso",
+                                                            YAML::Load("type: Amoroso\n"
+                                                                       "observable: mass::b(MSbar)\n"
+                                                                       "kinematics: {}\n"
+                                                                       "options: 5\n"
+                                                                       "physical-limit: 0.0\n"
+                                                                       "theta: 2.9708273062\n"
+                                                                       "alpha: 8.2392613044e-01\n"
+                                                                       "beta: 1.6993290032")));
+            }
+            // }}}
+
+            // {{{ MultivariateGaussian (deserialization errors)
+            {
+                // missing required key 'correlations'
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::MultivariateGaussian",
+                                                            YAML::Load("type: MultivariateGaussian\n"
+                                                                       "observables: [mass::b(MSbar), mass::c]\n"
+                                                                       "kinematics: [{}, {}]\n"
+                                                                       "options: [{}, {}]\n"
+                                                                       "means: [4.3, 1.1]\n"
+                                                                       "sigma-stat-hi: [0.1, 0.05]\n"
+                                                                       "sigma-stat-lo: [0.1, 0.05]\n"
+                                                                       "sigma-sys: [0, 0]")));
+
+                // sequence key 'means' mapped to a scalar
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::MultivariateGaussian",
+                                                            YAML::Load("type: MultivariateGaussian\n"
+                                                                       "observables: [mass::b(MSbar), mass::c]\n"
+                                                                       "kinematics: [{}, {}]\n"
+                                                                       "options: [{}, {}]\n"
+                                                                       "means: 4.3\n"
+                                                                       "sigma-stat-hi: [0.1, 0.05]\n"
+                                                                       "sigma-stat-lo: [0.1, 0.05]\n"
+                                                                       "sigma-sys: [0, 0]\n"
+                                                                       "correlations: [[1, 0], [0, 1]]")));
+            }
+            // }}}
+
+            // {{{ MultivariateGaussian(Covariance) (deserialization errors)
+            {
+                // missing required key 'covariance'
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::MultivariateGaussian(Covariance)",
+                                                            YAML::Load("type: MultivariateGaussian(Covariance)\n"
+                                                                       "observables: [mass::b(MSbar), mass::c]\n"
+                                                                       "kinematics: [{}, {}]\n"
+                                                                       "options: [{}, {}]\n"
+                                                                       "means: [4.3, 1.1]")));
+
+                // sequence key 'covariance' mapped to a scalar
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::MultivariateGaussian(Covariance)",
+                                                            YAML::Load("type: MultivariateGaussian(Covariance)\n"
+                                                                       "observables: [mass::b(MSbar), mass::c]\n"
+                                                                       "kinematics: [{}, {}]\n"
+                                                                       "options: [{}, {}]\n"
+                                                                       "means: [4.3, 1.1]\n"
+                                                                       "covariance: 0.01")));
+            }
+            // }}}
+
+            // {{{ UniformBound (deserialization errors)
+            {
+                // missing required key 'uncertainty'
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::UniformBound",
+                                                            YAML::Load("type: UniformBound\n"
+                                                                       "observables: [mass::b(MSbar)]\n"
+                                                                       "kinematics: [{}]\n"
+                                                                       "options: [{}]\n"
+                                                                       "bound: 1.0")));
+
+                // scalar key 'bound' mapped to a map
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::UniformBound",
+                                                            YAML::Load("type: UniformBound\n"
+                                                                       "observables: [mass::b(MSbar)]\n"
+                                                                       "kinematics: [{}]\n"
+                                                                       "options: [{}]\n"
+                                                                       "bound: {a: 1}\n"
+                                                                       "uncertainty: 0.1")));
+
+                // sequence key 'observables' mapped to a scalar
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::UniformBound",
+                                                            YAML::Load("type: UniformBound\n"
+                                                                       "observables: mass::b(MSbar)\n"
+                                                                       "kinematics: [{}]\n"
+                                                                       "options: [{}]\n"
+                                                                       "bound: 1.0\n"
+                                                                       "uncertainty: 0.1")));
+            }
+            // }}}
+
+            // {{{ Mixture (deserialization errors)
+            {
+                // missing required key 'weights'
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::Mixture",
+                                                            YAML::Load("type: Mixture\n"
+                                                                       "observables: [mass::b(MSbar), mass::c]\n"
+                                                                       "kinematics: [{}, {}]\n"
+                                                                       "options: [{}, {}]\n"
+                                                                       "components:\n"
+                                                                       "  - means: [4.3, 1.1]\n"
+                                                                       "    covariance: [[0.01, 0.003], [0.003, 0.0025]]\n"
+                                                                       "test statistics: {sigma: [], densities: []}")));
+
+                // sequence key 'components' mapped to a scalar
+                TEST_CHECK_THROWS(ConstraintDeserializationError,
+                                  ConstraintEntry::FromYAML("Test::Mixture",
+                                                            YAML::Load("type: Mixture\n"
+                                                                       "observables: [mass::b(MSbar), mass::c]\n"
+                                                                       "kinematics: [{}, {}]\n"
+                                                                       "options: [{}, {}]\n"
+                                                                       "components: 1\n"
+                                                                       "weights: [1.0]\n"
+                                                                       "test statistics: {sigma: [], densities: []}")));
+            }
+            // }}}
+
+            // {{{ FromYAML (dispatch errors)
+            {
+                // node is not a map
+                TEST_CHECK_THROWS(ConstraintDeserializationError, ConstraintEntry::FromYAML("Test::NotAMap", YAML::Load("[1, 2, 3]")));
+
+                // node has no key 'type'
+                TEST_CHECK_THROWS(ConstraintDeserializationError, ConstraintEntry::FromYAML("Test::NoType", YAML::Load("observable: mass::b(MSbar)")));
+
+                // unsupported type
+                TEST_CHECK_THROWS(ConstraintDeserializationError, ConstraintEntry::FromYAML("Test::BadType", YAML::Load("type: NoSuchType")));
+            }
+            // }}}
+
+            // {{{ make_prior (unimplemented types throw InternalError)
+            {
+                Parameters p = Parameters::Defaults();
+
+                {
+                    std::shared_ptr<ConstraintEntry> entry(ConstraintEntry::FromYAML("Test::Gaussian",
+                                                                                     YAML::Load("type: Gaussian\n"
+                                                                                                "observable: mass::b(MSbar)\n"
+                                                                                                "kinematics: {}\n"
+                                                                                                "options: {}\n"
+                                                                                                "mean: 4.3\n"
+                                                                                                "sigma-stat: {hi: 0.1, lo: -0.1}\n"
+                                                                                                "sigma-sys: {hi: 0.0, lo: -0.0}")));
+                    TEST_CHECK_THROWS(InternalError, entry->make_prior(p, Options{}));
+                }
+
+                {
+                    std::shared_ptr<ConstraintEntry> entry(ConstraintEntry::FromYAML("Test::LogGamma",
+                                                                                     YAML::Load("type: LogGamma\n"
+                                                                                                "observable: mass::b(MSbar)\n"
+                                                                                                "kinematics: {}\n"
+                                                                                                "options: {}\n"
+                                                                                                "mode: 0.53\n"
+                                                                                                "sigma: {hi: 0.1, lo: 0.19}\n"
+                                                                                                "alpha: 0.383056\n"
+                                                                                                "lambda: 0.0687907")));
+                    TEST_CHECK_THROWS(InternalError, entry->make_prior(p, Options{}));
+                }
+
+                {
+                    std::shared_ptr<ConstraintEntry> entry(ConstraintEntry::FromYAML("Test::Amoroso",
+                                                                                     YAML::Load("type: Amoroso\n"
+                                                                                                "observable: mass::b(MSbar)\n"
+                                                                                                "kinematics: {}\n"
+                                                                                                "options: {}\n"
+                                                                                                "physical-limit: 0.0\n"
+                                                                                                "theta: 2.9708273062\n"
+                                                                                                "alpha: 8.2392613044e-01\n"
+                                                                                                "beta: 1.6993290032")));
+                    TEST_CHECK_THROWS(InternalError, entry->make_prior(p, Options{}));
+                }
+
+                {
+                    std::shared_ptr<ConstraintEntry> entry(ConstraintEntry::FromYAML("Test::UniformBound",
+                                                                                     YAML::Load("type: UniformBound\n"
+                                                                                                "observables: [mass::b(MSbar)]\n"
+                                                                                                "kinematics: [{}]\n"
+                                                                                                "options: [{}]\n"
+                                                                                                "bound: 1.0\n"
+                                                                                                "uncertainty: 0.1")));
+                    TEST_CHECK_THROWS(InternalError, entry->make_prior(p, Options{}));
+                }
+
+                {
+                    std::shared_ptr<ConstraintEntry> entry(ConstraintEntry::FromYAML("Test::Mixture",
+                                                                                     YAML::Load("type: Mixture\n"
+                                                                                                "observables: [mass::b(MSbar), mass::c]\n"
+                                                                                                "kinematics: [{}, {}]\n"
+                                                                                                "options: [{}, {}]\n"
+                                                                                                "components:\n"
+                                                                                                "  - means: [4.3, 1.1]\n"
+                                                                                                "    covariance: [[0.01, 0.003], [0.003, 0.0025]]\n"
+                                                                                                "test statistics: {sigma: [], densities: []}\n"
+                                                                                                "weights: [1.0]\n"
+                                                                                                "dof: 2")));
+                    TEST_CHECK_THROWS(InternalError, entry->make_prior(p, Options{}));
+                }
+            }
+            // }}}
+
+            // {{{ make_prior (MultivariateGaussian: success and subset-option errors)
+            {
+                static const std::string input("type: MultivariateGaussian\n"
+                                               "observables: [mass::b(MSbar), mass::c]\n"
+                                               "kinematics: [{}, {}]\n"
+                                               "options: [{}, {}]\n"
+                                               "means: [4.3, 1.1]\n"
+                                               "sigma-stat-hi: [0.1, 0.05]\n"
+                                               "sigma-stat-lo: [0.1, 0.05]\n"
+                                               "sigma-sys: [0, 0]\n"
+                                               "correlations: [[1, 0.6], [0.6, 1]]\n"
+                                               "dof: 2");
+
+                std::shared_ptr<ConstraintEntry> entry(ConstraintEntry::FromYAML("Test::MultivariateGaussian", YAML::Load(input)));
+                TEST_CHECK(nullptr != entry.get());
+
+                Parameters  p = Parameters::Defaults();
+                LogPriorPtr prior;
+                TEST_CHECK_NO_THROW(prior = entry->make_prior(p, Options{}));
+                TEST_CHECK(nullptr != prior.get());
+
+                // end beyond the number of measurements
+                TEST_CHECK_THROWS(InvalidOptionValueError,
+                                  entry->make_prior(p,
+                                                    Options{
+                                                        { "end"_ok, "99"_ov }
+                }));
+
+                // begin >= end
+                TEST_CHECK_THROWS(InvalidOptionValueError,
+                                  entry->make_prior(p,
+                                                    Options{
+                                                        { "begin"_ok, "2"_ov },
+                                                        {   "end"_ok, "1"_ov }
+                }));
+            }
+            // }}}
+
+            // {{{ make_prior (MultivariateGaussian(Covariance): success and subset-option errors)
+            {
+                static const std::string input("type: MultivariateGaussian(Covariance)\n"
+                                               "observables: [mass::b(MSbar), mass::c]\n"
+                                               "kinematics: [{}, {}]\n"
+                                               "options: [{}, {}]\n"
+                                               "means: [4.3, 1.1]\n"
+                                               "covariance: [[0.0100, 0.0030], [0.0030, 0.0025]]\n"
+                                               "dof: 2");
+
+                std::shared_ptr<ConstraintEntry> entry(ConstraintEntry::FromYAML("Test::MultivariateGaussian(Covariance)", YAML::Load(input)));
+                TEST_CHECK(nullptr != entry.get());
+
+                Parameters  p = Parameters::Defaults();
+                LogPriorPtr prior;
+                TEST_CHECK_NO_THROW(prior = entry->make_prior(p, Options{}));
+                TEST_CHECK(nullptr != prior.get());
+
+                // end beyond the number of measurements
+                TEST_CHECK_THROWS(InvalidOptionValueError,
+                                  entry->make_prior(p,
+                                                    Options{
+                                                        { "end"_ok, "99"_ov }
+                }));
+
+                // begin >= end
+                TEST_CHECK_THROWS(InvalidOptionValueError,
+                                  entry->make_prior(p,
+                                                    Options{
+                                                        { "begin"_ok, "2"_ov },
+                                                        {   "end"_ok, "1"_ov }
+                }));
+            }
+            // }}}
+
+            // {{{ MultivariateGaussian(Covariance) (make: option and response errors)
+            {
+                static const std::string input("type: MultivariateGaussian(Covariance)\n"
+                                               "observables: [mass::b(MSbar), mass::c]\n"
+                                               "kinematics: [{}, {}]\n"
+                                               "options: [{}, {}]\n"
+                                               "means: [4.3, 1.1]\n"
+                                               "covariance: [[0.0100, 0.0030], [0.0030, 0.0025]]\n"
+                                               "dof: 2");
+
+                std::shared_ptr<ConstraintEntry> entry(ConstraintEntry::FromYAML("Test::MultivariateGaussian(Covariance)", YAML::Load(input)));
+
+                // end beyond the number of measurements
+                TEST_CHECK_THROWS(InvalidOptionValueError,
+                                  entry->make("Test::MultivariateGaussian(Covariance)",
+                                              Options{
+                                                  { "end"_ok, "99"_ov }
+                }));
+
+                // begin >= end
+                TEST_CHECK_THROWS(InvalidOptionValueError,
+                                  entry->make("Test::MultivariateGaussian(Covariance)",
+                                              Options{
+                                                  { "begin"_ok, "2"_ov },
+                                                  {   "end"_ok, "1"_ov }
+                }));
+
+                // response matrix together with a non-zero 'begin' is incompatible
+                static const std::string response_input("type: MultivariateGaussian(Covariance)\n"
+                                                        "observables: [mass::s(2GeV), mass::b(MSbar), mass::c]\n"
+                                                        "kinematics: [{}, {}, {}]\n"
+                                                        "options: [{}, {}, {}]\n"
+                                                        "means: [4.3, 1.1]\n"
+                                                        "covariance: [[0.0100, 0.0030], [0.0030, 0.0025]]\n"
+                                                        "response: [[0, 1, 0], [0, 0, 1]]\n"
+                                                        "dof: 2");
+
+                std::shared_ptr<ConstraintEntry> response_entry(ConstraintEntry::FromYAML("Test::MultivariateGaussian(Covariance)", YAML::Load(response_input)));
+                TEST_CHECK_THROWS(InternalError,
+                                  response_entry->make("Test::MultivariateGaussian(Covariance)",
+                                                       Options{
+                                                           { "begin"_ok, "1"_ov }
+                }));
+            }
+            // }}}
+
+            // {{{ Constraints (insert, lookup, and unknown-name errors)
+            {
+                static const std::string entry("type: Gaussian\n"
+                                               "observable: mass::b(MSbar)\n"
+                                               "kinematics: {}\n"
+                                               "options: {}\n"
+                                               "mean: 4.3\n"
+                                               "sigma-stat: {hi: 0.1, lo: -0.1}\n"
+                                               "sigma-sys: {hi: 0.0, lo: -0.0}");
+
+                // insert a new entry into the global registry from a YAML string
+                std::shared_ptr<const ConstraintEntry> inserted;
+                TEST_CHECK_NO_THROW(inserted = Constraints().insert("Test::Inserted", entry));
+                TEST_CHECK(nullptr != inserted.get());
+
+                // the string serialize() overload
+                TEST_CHECK(! inserted->serialize().empty());
+
+                // a freshly constructed Constraints re-reads the registry and finds it
+                TEST_CHECK_NO_THROW(Constraints()["Test::Inserted"]);
+                TEST_CHECK_NO_THROW(Constraint::make("Test::Inserted", Options{}));
+
+                // unknown-name lookups
+                TEST_CHECK_THROWS(UnknownConstraintError, Constraints()["Test::DoesNotExist"]);
+                TEST_CHECK_THROWS(UnknownConstraintError, Constraint::make("Test::DoesNotExist", Options{}));
             }
             // }}}
         }

--- a/eos/statistics/log-likelihood_TEST.cc
+++ b/eos/statistics/log-likelihood_TEST.cc
@@ -21,6 +21,7 @@
 #include <test/test.hh>
 #include <eos/statistics/log-likelihood.hh>
 #include <eos/statistics/log-posterior_TEST.hh>
+#include <eos/statistics/test-statistic-impl.hh>
 #include <eos/maths/power-of.hh>
 #include <algorithm>
 #include <cmath>
@@ -657,6 +658,172 @@ namespace eos
                     // ratio of pdfs at mode given by weight ratio
                     TEST_CHECK_RELATIVE_ERROR(pdf_favored, pdf_suppressed + std::log(weights[0] / weights[1]), 1e-12);
                 }
+
+                // A: UniformBound block (the factory is not exercised elsewhere)
+                {
+                    ObservablePtr   obs(new ObservableStub(p, "mass::c", k));
+                    ObservableCache cache(p);
+                    auto            block = LogLikelihoodBlock::UniformBound(cache, std::vector<ObservablePtr>{ obs }, 1.0, 0.1);
+
+                    TEST_CHECK(block->as_string().find("UniformBound") != std::string::npos);
+                    TEST_CHECK_EQUAL(block->number_of_observations(), 0u);
+
+                    gsl_rng * rng = gsl_rng_alloc(gsl_rng_mt19937);
+                    TEST_CHECK_EQUAL(block->sample(rng), 0.0);
+                    gsl_rng_free(rng);
+
+                    // saturation below the bound -> no penalty
+                    p["mass::c"] = 0.5;
+                    cache.update();
+                    TEST_CHECK_EQUAL(block->evaluate(), 0.0);
+                    TEST_CHECK_EQUAL(block->significance(), 0.0);
+
+                    // saturation above the bound -> Gaussian penalty and non-zero significance
+                    p["mass::c"] = 1.2;
+                    cache.update();
+                    TEST_CHECK_NEARLY_EQUAL(block->evaluate(), -0.5 * power_of<2>((1.2 - 1.0) / 0.1), eps);
+                    TEST_CHECK_NEARLY_EQUAL(block->significance(), (1.2 - 1.0) / 0.1, eps);
+                    TEST_CHECK_NO_THROW(block->primary_test_statistic());
+
+                    // clone reproduces the parent (both saturated at 1.2)
+                    Parameters      np = p.clone();
+                    ObservableCache ncache(np);
+                    auto            clone = block->clone(ncache);
+                    np["mass::c"] = 1.2;
+                    ncache.update();
+                    TEST_CHECK_NEARLY_EQUAL(clone->evaluate(), block->evaluate(), eps);
+
+                    // negative saturation is an error
+                    p["mass::c"] = -0.5;
+                    cache.update();
+                    TEST_CHECK_THROWS(InternalError, block->evaluate());
+                    TEST_CHECK_THROWS(InternalError, block->significance());
+
+                    // with a zero uncertainty, saturation above the bound yields -infinity
+                    auto block0 = LogLikelihoodBlock::UniformBound(cache, std::vector<ObservablePtr>{ ObservablePtr(new ObservableStub(p, "mass::c", k)) }, 1.0, 0.0);
+                    p["mass::c"] = 1.2;
+                    cache.update();
+                    TEST_CHECK(! std::isfinite(block0->evaluate()));
+                    TEST_CHECK(! std::isfinite(block0->significance()));
+                }
+
+                // B: as_string(), primary_test_statistic(), and clone() for the remaining block types
+                {
+                    // LogGamma
+                    ObservablePtr   obs(new ObservableStub(p, "mass::b(MSbar)", k));
+                    ObservableCache cache(p);
+                    auto            lg = LogLikelihoodBlock::LogGamma(cache, obs, 0.34, 0.53, 0.63, 0.383056, 0.0687907);
+                    p["mass::b(MSbar)"] = 0.53;
+                    cache.update();
+                    TEST_CHECK(! lg->as_string().empty());
+                    TEST_CHECK_NO_THROW(lg->primary_test_statistic());
+                    TEST_CHECK_NO_THROW(lg->clone(cache));
+                }
+                {
+                    // Mixture
+                    ObservableCache                    cache(p);
+                    std::vector<LogLikelihoodBlockPtr> comps{
+                        LogLikelihoodBlock::Gaussian(cache, ObservablePtr(new ObservableStub(p, "mass::c")), -5, -4, -3),
+                        LogLikelihoodBlock::Gaussian(cache, ObservablePtr(new ObservableStub(p, "mass::c")),  3,  4,  5)
+                    };
+                    std::vector<double>                weights{ 0.9, 0.1 };
+                    std::vector<std::array<double, 2>> test_stat{};
+                    auto                               mix = LogLikelihoodBlock::Mixture(comps, weights, test_stat);
+                    p["mass::c"] = -4;
+                    cache.update();
+                    TEST_CHECK(! mix->as_string().empty());
+                    TEST_CHECK_NO_THROW(mix->primary_test_statistic());
+                    TEST_CHECK_NO_THROW(mix->clone(cache));
+                }
+                {
+                    // MultivariateGaussian
+                    std::array<ObservablePtr, 2> obs{
+                        { ObservablePtr(new ObservableStub(p, "mass::b(MSbar)", k)), ObservablePtr(new ObservableStub(p, "mass::c", k)) }
+                    };
+                    ObservableCache cache(p);
+                    std::array<double, 2>                mean{ { 4.3, 1.1 } };
+                    std::array<std::array<double, 2>, 2> covariance;
+                    covariance[0][0] = 0.01;
+                    covariance[1][1] = 0.0025;
+                    covariance[0][1] = covariance[1][0] = 0.0;
+                    auto mvg = LogLikelihoodBlock::MultivariateGaussian<2>(cache, obs, mean, covariance);
+                    p["mass::b(MSbar)"] = 4.35;
+                    p["mass::c"]        = 1.1;
+                    cache.update();
+                    TEST_CHECK(! mvg->as_string().empty());
+                    TEST_CHECK_NO_THROW(mvg->primary_test_statistic());
+                }
+
+                // C: MixtureBlock::sample() is not implemented and must throw
+                {
+                    ObservableCache                    cache(p);
+                    std::vector<LogLikelihoodBlockPtr> comps{ LogLikelihoodBlock::Gaussian(cache, ObservablePtr(new ObservableStub(p, "mass::c")), -1, 0, 1) };
+                    std::vector<double>                weights{ 1.0 };
+                    std::vector<std::array<double, 2>> test_stat{};
+                    auto                               mix = LogLikelihoodBlock::Mixture(comps, weights, test_stat);
+
+                    gsl_rng * rng = gsl_rng_alloc(gsl_rng_mt19937);
+                    TEST_CHECK_THROWS(InternalError, mix->sample(rng));
+                    gsl_rng_free(rng);
+                }
+
+                // D: factory error paths
+                {
+                    ObservablePtr   obs(new ObservableStub(p, "mass::c", k));
+                    ObservableCache cache(p);
+
+                    // LogGamma
+                    TEST_CHECK_THROWS(InternalError, LogLikelihoodBlock::LogGamma(cache, obs, 0.6, 0.5, 0.7, 0.3, 0.06));  // min >= central
+                    TEST_CHECK_THROWS(InternalError, LogLikelihoodBlock::LogGamma(cache, obs, 0.3, 0.5, 0.4, 0.3, 0.06));  // max <= central
+                    TEST_CHECK_THROWS(InternalError, LogLikelihoodBlock::LogGamma(cache, obs, 0.3, 0.5, 0.7, -1.0, 0.06)); // alpha <= 0
+
+                    // Amoroso: mis-ordered limits (checked before the cdf-consistency checks)
+                    TEST_CHECK_THROWS(InternalError, LogLikelihoodBlock::Amoroso(cache, obs, 1.0, 0.5, 2.0, 3.0, 1.0, 1.0, 1.0)); // x_10 <= physical_limit
+                    TEST_CHECK_THROWS(InternalError, LogLikelihoodBlock::Amoroso(cache, obs, 1.0, 2.0, 0.5, 3.0, 1.0, 1.0, 1.0)); // x_50 <= physical_limit
+                    TEST_CHECK_THROWS(InternalError, LogLikelihoodBlock::Amoroso(cache, obs, 0.0, 1.0, 2.0, 1.5, 1.0, 1.0, 1.0)); // x_90 <= x_50
+
+                    // Mixture: components and weights sizes disagree
+                    {
+                        std::vector<LogLikelihoodBlockPtr> comps{ LogLikelihoodBlock::Gaussian(cache, obs, -1, 0, 1) };
+                        std::vector<double>                weights{ 0.5, 0.5 };
+                        std::vector<std::array<double, 2>> test_stat{};
+                        TEST_CHECK_THROWS(InternalError, LogLikelihoodBlock::Mixture(comps, weights, test_stat));
+                    }
+
+                    // Unbinned1D
+                    {
+                        std::vector<Kinematics> kinematics{ Kinematics{} };
+                        std::vector<double>     resolution{ 0.1 };
+                        std::vector<Kinematics> observations{ Kinematics{} };
+                        TEST_CHECK_THROWS(InternalError,
+                                          LogLikelihoodBlock::Unbinned1D(cache, "TestLegendre1D::P(z)", std::vector<Kinematics>{}, Options{}, resolution, observations)); // empty kinematics
+                        TEST_CHECK_THROWS(InternalError,
+                                          LogLikelihoodBlock::Unbinned1D(cache, "TestLegendre1D::P(z)", kinematics, Options{}, std::vector<double>{ 0.1, 0.2 }, observations)); // size mismatch
+                        TEST_CHECK_THROWS(InternalError,
+                                          LogLikelihoodBlock::Unbinned1D(cache, "TestLegendre1D::P(z)", kinematics, Options{}, resolution, std::vector<Kinematics>{})); // empty observations
+                    }
+                }
+
+                // E: externally-added likelihood blocks (LogLikelihood::add(block) and the external-block loops)
+                {
+                    Parameters    pe = Parameters::Defaults();
+                    LogLikelihood llh(pe);
+
+                    // add a standalone block directly (not via a constraint)
+                    llh.add(LogLikelihoodBlock::Gaussian(llh.observable_cache(), ObservablePtr(new ObservableStub(pe, "mass::c")), 1.1, 1.2, 1.3));
+
+                    pe["mass::c"] = 1.2;
+                    TEST_CHECK(std::isfinite(llh()));
+
+                    // cloning must carry the external block along
+                    LogLikelihood llh_clone = llh.clone();
+                    TEST_CHECK_NEARLY_EQUAL(llh_clone(), llh(), eps);
+
+                    // an external block evaluating to -infinity short-circuits the total likelihood
+                    llh.add(LogLikelihoodBlock::UniformBound(llh.observable_cache(), std::vector<ObservablePtr>{ ObservablePtr(new ObservableStub(pe, "mass::c")) }, 0.5, 0.0));
+                    pe["mass::c"] = 1.2;
+                    TEST_CHECK(! std::isfinite(llh()));
+                }
             }
     } log_likelihood_test;
 
@@ -801,6 +968,17 @@ namespace eos
                 // The block convolves the PDF with the resolution and sums the logarithm of the smeared
                 // density evaluated at each observation; this must reproduce the reference values.
                 TEST_CHECK_NEARLY_EQUAL(block->evaluate(), expected, 1.0e-6);
+
+                // exercise the remaining Unbinned1DLikelihoodBlock methods
+                TEST_CHECK(block->as_string().find("Unbinned") != std::string::npos);
+                TEST_CHECK_NO_THROW(block->primary_test_statistic());
+                TEST_CHECK_NO_THROW(block->clone(cache));
+
+                // sample() and significance() are not implemented and must throw
+                gsl_rng * rng = gsl_rng_alloc(gsl_rng_mt19937);
+                TEST_CHECK_THROWS(InternalError, block->sample(rng));
+                gsl_rng_free(rng);
+                TEST_CHECK_THROWS(InternalError, block->significance());
             }
     } unbinned_log_likelihood_test;
 }

--- a/eos/statistics/log-prior_TEST.cc
+++ b/eos/statistics/log-prior_TEST.cc
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2011 Frederik Beaujean
- * Copyright (c) 2011-2023 Danny van Dyk
+ * Copyright (c) 2011-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -22,6 +22,10 @@
 #include <eos/constraint.hh>
 #include <eos/statistics/log-prior.hh>
 #include <eos/maths/power-of.hh>
+#include <eos/utils/exception.hh>
+
+#include <cmath>
+#include <string>
 
 using namespace test;
 using namespace eos;
@@ -313,6 +317,181 @@ class LogPriorTest :
                 std::string s_gauss("Parameter: CKM::A, prior type: Gaussian, range: [0.774,0.834], x = 0.804 +- 0.01");
                 LogPriorPtr prior_gauss = LogPrior::Make(p, s_gauss);
                 TEST_CHECK_EQUAL(s_gauss, prior_gauss->as_string());
+            }
+
+            // A: informative(), as_string(), and clone() for every prior type
+            {
+                // informative(): Flat and Transform are non-informative, the rest are informative
+                TEST_CHECK_EQUAL(LogPrior::Flat(parameters, "mass::b(MSbar)", 4.2, 4.5)->informative(), false);
+                TEST_CHECK_EQUAL(LogPrior::Scale(parameters, "mass::b(MSbar)", 2.0, 10.0, mu_0, lambda)->informative(), true);
+                TEST_CHECK_EQUAL(LogPrior::Gaussian(parameters, "mass::b(MSbar)", 0.5, 0.25)->informative(), true);
+                TEST_CHECK_EQUAL(LogPrior::Poisson(parameters, "mass::b(MSbar)", 10.0)->informative(), true);
+
+                // as_string() for the types that are not round-tripped through Make()
+                TEST_CHECK(LogPrior::Scale(parameters, "mass::b(MSbar)", 2.0, 10.0, mu_0, lambda)->as_string().find("prior type: Scale") != std::string::npos);
+                TEST_CHECK(LogPrior::Gaussian(parameters, "mass::b(MSbar)", 0.5, 0.25)->as_string().find("prior type: gaussian") != std::string::npos);
+                TEST_CHECK(LogPrior::Poisson(parameters, "mass::b(MSbar)", 10.0)->as_string().find("prior type: poisson") != std::string::npos);
+
+                // CurtailedGauss as_string() with asymmetric uncertainties (sigma_upper != sigma_lower)
+                {
+                    LogPriorPtr        cg = LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", 4.15, 4.57, 4.2, 4.3, 4.5);
+                    const std::string  s  = cg->as_string();
+                    TEST_CHECK(s.find(" + ") != std::string::npos);
+                    TEST_CHECK(s.find(" - ") != std::string::npos);
+                    TEST_CHECK_EQUAL(cg->informative(), true);
+                }
+
+                // clone(): the clone is independent and reproduces operator()
+                {
+                    Parameters               independent = Parameters::Defaults();
+                    std::vector<LogPriorPtr> priors{
+                        LogPrior::Flat(parameters, "mass::b(MSbar)", 4.2, 4.5),
+                        LogPrior::Scale(parameters, "mass::b(MSbar)", 2.0, 10.0, mu_0, lambda),
+                        LogPrior::Gaussian(parameters, "mass::b(MSbar)", 0.5, 0.25),
+                        LogPrior::Poisson(parameters, "mass::b(MSbar)", 10.0)
+                    };
+
+                    for (const auto & prior : priors)
+                    {
+                        parameters["mass::b(MSbar)"]  = 4.3;
+                        independent["mass::b(MSbar)"] = 4.3;
+
+                        LogPriorPtr c = prior->clone(independent);
+                        TEST_CHECK_NEARLY_EQUAL((*c)(), (*prior)(), eps);
+                    }
+                }
+            }
+
+            // B: sample() and compute_cdf() for Flat, CurtailedGauss, and Transform
+            {
+                // Flat::compute_cdf
+                {
+                    LogPriorPtr flat  = LogPrior::Flat(parameters, "mass::b(MSbar)", 4.2, 4.5);
+                    Parameter   param = parameters["mass::b(MSbar)"];
+                    TEST_CHECK_NEARLY_EQUAL(cdf(flat, param, 4.35), 0.5, eps); // (4.35 - 4.2) / 0.3
+                }
+
+                // CurtailedGauss::sample (a valid inverse CDF) and compute_cdf (executed for
+                // coverage only: for asymmetric errors it is not a clean inverse of sample())
+                {
+                    LogPriorPtr cg    = LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", 4.15, 4.57, 4.2, 4.3, 4.5);
+                    Parameter   param = parameters["mass::b(MSbar)"];
+
+                    // sample(): a small generator value hits the lower branch, a large one the
+                    // upper branch; the result stays within [min, max] and increases with p
+                    const double x_lo  = inverse_cdf(cg, param, 0.1);
+                    const double x_mid = inverse_cdf(cg, param, 0.5);
+                    const double x_hi  = inverse_cdf(cg, param, 0.9);
+                    TEST_CHECK(std::isfinite(x_lo) && (x_lo >= 4.15) && (x_lo <= 4.57));
+                    TEST_CHECK(std::isfinite(x_hi) && (x_hi >= 4.15) && (x_hi <= 4.57));
+                    TEST_CHECK(x_lo < x_mid);
+                    TEST_CHECK(x_mid < x_hi);
+
+                    // compute_cdf(): exercise both branches (below and above the central value)
+                    TEST_CHECK(std::isfinite(cdf(cg, param, 4.25)));
+                    TEST_CHECK(std::isfinite(cdf(cg, param, 4.35)));
+                }
+
+                // Transform::compute_cdf + sample (round-trip), informative(), and clone()
+                {
+                    std::vector<double>              shift     = { 0.0, 0.0 };
+                    std::vector<std::vector<double>> transform = {
+                        {  0.707106, 0.707106 },
+                        { -0.707106, 0.707106 }
+                    };
+                    std::vector<double> min = { -2.0, -2.0 };
+                    std::vector<double> max = { 2.0, 2.0 };
+                    LogPriorPtr         tp  = LogPrior::Transform(parameters, { "scnuee::Re{cVL}", "scnuee::Re{cVR}" }, shift, transform, min, max);
+
+                    parameters["scnuee::Re{cVL}"] = 0.3;
+                    parameters["scnuee::Re{cVR}"] = -0.4;
+                    tp->compute_cdf();
+                    const double uL = parameters["scnuee::Re{cVL}"].evaluate_generator();
+                    const double uR = parameters["scnuee::Re{cVR}"].evaluate_generator();
+
+                    parameters["scnuee::Re{cVL}"].set_generator(uL);
+                    parameters["scnuee::Re{cVR}"].set_generator(uR);
+                    tp->sample();
+                    TEST_CHECK_NEARLY_EQUAL(parameters["scnuee::Re{cVL}"], 0.3, 1e-9);
+                    TEST_CHECK_NEARLY_EQUAL(parameters["scnuee::Re{cVR}"], -0.4, 1e-9);
+
+                    TEST_CHECK_EQUAL(tp->informative(), false);
+
+                    LogPriorPtr c = tp->clone(parameters); // Transform::clone
+                    parameters["scnuee::Re{cVL}"] = 0.0;
+                    parameters["scnuee::Re{cVR}"] = 0.0;
+                    TEST_CHECK_NEARLY_EQUAL((*c)(), (*tp)(), 1e-9);
+                }
+            }
+
+            // C: MultivariateGaussian operator(), as_string() (throws), and clone()
+            {
+                gsl_vector * mean = gsl_vector_alloc(2);
+                gsl_vector_set(mean, 0, 4.3);
+                gsl_vector_set(mean, 1, 1.1);
+                gsl_matrix * cov = gsl_matrix_alloc(2, 2);
+                gsl_matrix_set(cov, 0, 0, 0.01);
+                gsl_matrix_set(cov, 0, 1, 0.0);
+                gsl_matrix_set(cov, 1, 0, 0.0);
+                gsl_matrix_set(cov, 1, 1, 0.0025);
+
+                LogPriorPtr mvg = LogPrior::MultivariateGaussian(parameters, { "mass::b(MSbar)", "mass::c" }, mean, cov);
+
+                parameters["mass::b(MSbar)"] = 4.3;
+                parameters["mass::c"]        = 1.1;
+
+                TEST_CHECK(std::isfinite((*mvg)()));
+                TEST_CHECK_EQUAL(mvg->informative(), true);
+                TEST_CHECK_THROWS(InternalError, mvg->as_string());
+
+                LogPriorPtr c = mvg->clone(parameters);
+                TEST_CHECK_NEARLY_EQUAL((*c)(), (*mvg)(), eps);
+            }
+
+            // D: factory and constructor error paths
+            {
+                // Flat: min >= max (RangeError, derived from Exception)
+                TEST_CHECK_THROWS(Exception, LogPrior::Flat(parameters, "mass::b(MSbar)", 4.5, 4.2));
+
+                // CurtailedGauss: lower >= central, and upper <= central
+                TEST_CHECK_THROWS(InternalError, LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", 4.0, 5.0, 4.5, 4.3, 4.6));
+                TEST_CHECK_THROWS(InternalError, LogPrior::CurtailedGauss(parameters, "mass::b(MSbar)", 4.0, 5.0, 4.1, 4.3, 4.2));
+
+                // Scale: mu_0 <= 0, and lambda <= 1
+                TEST_CHECK_THROWS(InternalError, LogPrior::Scale(parameters, "mass::b(MSbar)", 2.0, 10.0, -1.0, 2.0));
+                TEST_CHECK_THROWS(InternalError, LogPrior::Scale(parameters, "mass::b(MSbar)", 2.0, 10.0, 4.0, 0.5));
+
+                // Transform: min >= max (thrown from compute_log_volume() during construction)
+                TEST_CHECK_THROWS(InternalError,
+                                  LogPrior::Transform(parameters,
+                                                      { "scnuee::Re{cVL}", "scnuee::Re{cVR}" },
+                                                      { 0.0, 0.0 },
+                                                      {
+                                                          { 1.0, 0.0 },
+                                                          { 0.0, 1.0 }
+                },
+                                                      { 2.0, 2.0 },
+                                                      { -2.0, -2.0 }));
+
+                // MultivariateGaussian: mean dimension does not match the (square) covariance
+                {
+                    gsl_vector * m = gsl_vector_alloc(3);
+                    gsl_matrix * c = gsl_matrix_alloc(2, 2);
+                    gsl_matrix_set_identity(c);
+                    TEST_CHECK_THROWS(InternalError, LogPrior::MultivariateGaussian(parameters, { "mass::b(MSbar)", "mass::c" }, m, c));
+                }
+            }
+
+            // E: Make() asymmetric-sigma parse branch and unknown-type error
+            {
+                Parameters p = Parameters::Defaults();
+
+                // asymmetric uncertainties exercise the non-"+-" branch of the parser
+                LogPriorPtr asym = LogPrior::Make(p, "Parameter: CKM::A, prior type: Gaussian, range: [0.774,0.834], x = 0.804 + 0.02 -0.01");
+                TEST_CHECK(asym.get() != nullptr);
+
+                // unrecognised type -> UnknownPriorError (derived from Exception)
+                TEST_CHECK_THROWS(Exception, LogPrior::Make(p, "Parameter: CKM::A, prior type: nonsense, range: [0,1]"));
             }
         }
 } log_prior_test;

--- a/eos/utils/Makefile.am
+++ b/eos/utils/Makefile.am
@@ -121,7 +121,12 @@ include_eos_utils_HEADERS = \
 	wrapped_forward_iterator.hh wrapped_forward_iterator-fwd.hh wrapped_forward_iterator-impl.hh
 
 AM_TESTS_ENVIRONMENT = \
-	export EOS_TESTS_PARAMETERS="$(top_srcdir)/eos/parameters";
+	export EOS_TESTS_PARAMETERS="$(top_srcdir)/eos/parameters"; \
+	export EOS_TESTS_PARAMETERS_FIXTURES="$(abs_srcdir)/parameters_TEST.d";
+
+EXTRA_DIST = \
+	parameters_TEST.d/override.yaml \
+	parameters_TEST.d/missing-central.yaml
 
 TESTS = \
 	cacheable-observable_TEST \

--- a/eos/utils/parameters_TEST.cc
+++ b/eos/utils/parameters_TEST.cc
@@ -1,8 +1,8 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011-2024 Danny van Dyk
- * Copyright (c) 2021 Philip Lüghausen
+ * Copyright (c) 2011-2026 Danny van Dyk
+ * Copyright (c) 2021      Philip Lüghausen
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -18,9 +18,14 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <eos/utils/exception.hh>
 #include <eos/utils/parameters.hh>
 
 #include <test/test.hh>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
 
 using namespace test;
 using namespace eos;
@@ -198,6 +203,134 @@ class ParametersTest : public TestCase
                 Parameter a_fT_2 = p["B->pi::a^fT_2@G2026"];
                 TEST_CHECK_EQUAL(a_fT_2.name(), "B->pi::a^fT_2@G2026");
                 TEST_CHECK_EQUAL(a_fT_2.latex(), R"($a_2^{f_T,B \to \pi,\mathrm{G2026}}$)");
+            }
+
+            // A: Parameters::override_from_file (override existing, add new, error paths)
+            {
+                const char * env         = std::getenv("EOS_TESTS_PARAMETERS_FIXTURES");
+                std::string  fixture_dir = env ? env : "parameters_TEST.d";
+
+                // override 'mass::c' and add 'test::override_new_param'
+                {
+                    Parameters p = Parameters::Defaults();
+                    TEST_CHECK_NO_THROW(p.override_from_file(fixture_dir + "/override.yaml"));
+
+                    // for an existing parameter, override_from_file sets the current value
+                    // (not the central value), the min/max, and the latex; the unit is parsed
+                    // but not applied.
+                    Parameter m_c = p["mass::c"];
+                    TEST_CHECK_NEARLY_EQUAL(m_c.evaluate(), 1.5, 1e-12);
+                    TEST_CHECK_NEARLY_EQUAL(m_c.min(), 1.0, 1e-12);
+                    TEST_CHECK_NEARLY_EQUAL(m_c.max(), 2.0, 1e-12);
+                    TEST_CHECK_EQUAL(m_c.latex(), "m_c");
+
+                    TEST_CHECK(p.has("test::override_new_param"));
+                    Parameter added = p["test::override_new_param"];
+                    TEST_CHECK_NEARLY_EQUAL(added.central(), 42.0, 1e-12);
+                    // in the absence of 'min'/'max' both default to the central value
+                    TEST_CHECK_NEARLY_EQUAL(added.min(), 42.0, 1e-12);
+                    TEST_CHECK_NEARLY_EQUAL(added.max(), 42.0, 1e-12);
+                }
+
+                // the override is local to the Parameters object: a fresh default set is unaffected
+                {
+                    Parameters q = Parameters::Defaults();
+                    TEST_CHECK(! q.has("test::override_new_param"));
+                }
+
+                // a non-existent file is reported as a ParameterInputFileParseError
+                TEST_CHECK_THROWS(ParameterInputFileParseError, Parameters::Defaults().override_from_file("/this/does/not/exist.yaml"));
+
+                // a malformed entry (missing 'central') is rethrown as a ParameterInputFileParseError
+                TEST_CHECK_THROWS(ParameterInputFileParseError, Parameters::Defaults().override_from_file(fixture_dir + "/missing-central.yaml"));
+            }
+
+            // B: iteration over sections and groups (ParameterSection / ParameterGroup accessors)
+            {
+                Parameters p = Parameters::Defaults();
+
+                unsigned n_sections = 0, n_groups = 0, n_parameters = 0;
+                for (auto s = p.begin_sections(), s_end = p.end_sections(); s != s_end; ++s)
+                {
+                    ++n_sections;
+                    TEST_CHECK(! s->name().empty());
+                    (void) s->description();
+
+                    for (auto g = s->begin(), g_end = s->end(); g != g_end; ++g)
+                    {
+                        ++n_groups;
+                        TEST_CHECK(! g->name().empty());
+                        (void) g->description();
+
+                        for (auto par = g->begin(), par_end = g->end(); par != par_end; ++par)
+                        {
+                            ++n_parameters;
+                        }
+                    }
+                }
+
+                TEST_CHECK(n_sections > 0);
+                TEST_CHECK(n_groups > 0);
+                TEST_CHECK(n_parameters > 0);
+            }
+
+            // C: Parameters::operator[] (Parameter::Id) including the invalid-id error path
+            {
+                Parameters p   = Parameters::Defaults();
+                Parameter  m_c = p["mass::c"];
+
+                TEST_CHECK_EQUAL(p[m_c.id()].name(), "mass::c");
+                TEST_CHECK_THROWS(InternalError, p[Parameter::Id(0xFFFFFFFFu)]);
+            }
+
+            // D: Parameters::declare_and_insert returns the existing instance on a duplicate name
+            {
+                Parameters p = Parameters::Defaults();
+
+                Parameter first  = p.declare_and_insert("test::dup", R"(\text{dup})", Unit::None(), 1.0, 0.0, 2.0);
+                Parameter second = p.declare_and_insert("test::dup", R"(\text{dup})", Unit::None(), 9.0, 0.0, 2.0);
+
+                TEST_CHECK_EQUAL(first.id(), second.id());
+                TEST_CHECK_NEARLY_EQUAL(second.central(), 1.0, 1e-12); // the original value, not the second call's
+            }
+
+            // E: Parameters::set unknown-name error; static Parameters::redirect (undone afterwards)
+            {
+                Parameters p = Parameters::Defaults();
+
+                TEST_CHECK_THROWS(UnknownParameterError, p.set("mass::nonexistent", 1.0));
+
+                // redirect a parameter name in the default set and immediately restore it, so that
+                // the change to the global defaults is undone.
+                Parameter::Id target   = p["mass::c"].id();
+                Parameter::Id original = p["mass::s(2GeV)"].id();
+                TEST_CHECK_NO_THROW(Parameters::redirect("mass::s(2GeV)", target));
+                TEST_CHECK_NO_THROW(Parameters::redirect("mass::s(2GeV)", original));
+            }
+
+            // F: Parameter::set_min / Parameter::set_max
+            {
+                Parameters p   = Parameters::Defaults();
+                Parameter  m_c = p["mass::c"];
+
+                m_c.set_min(0.5);
+                m_c.set_max(5.0);
+
+                TEST_CHECK_NEARLY_EQUAL(m_c.min(), 0.5, 1e-12);
+                TEST_CHECK_NEARLY_EQUAL(m_c.max(), 5.0, 1e-12);
+            }
+
+            // G: operator== (ParameterDescription, ParameterDescription)
+            {
+                Parameters p   = Parameters::Defaults();
+                MutablePtr mut = std::make_shared<Parameter>(p["mass::c"]);
+
+                ParameterDescription a{ mut, 0.0, 1.0, false };
+
+                TEST_CHECK((a == ParameterDescription{ mut, 0.0, 1.0, false }));   // all equal
+                TEST_CHECK(! (a == ParameterDescription{ mut, 9.0, 1.0, false })); // min differs
+                TEST_CHECK(! (a == ParameterDescription{ mut, 0.0, 9.0, false })); // max differs
+                TEST_CHECK(! (a == ParameterDescription{ mut, 0.0, 1.0, true }));  // nuisance differs
             }
         }
 } parameters_test;

--- a/eos/utils/parameters_TEST.d/missing-central.yaml
+++ b/eos/utils/parameters_TEST.d/missing-central.yaml
@@ -1,0 +1,5 @@
+# Fixture for ParametersTest: a parameter node lacking the required 'central'
+# key. Parameters::override_from_file() rethrows the resulting node error as a
+# ParameterInputFileParseError.
+test::bad:
+    min: 1.0

--- a/eos/utils/parameters_TEST.d/override.yaml
+++ b/eos/utils/parameters_TEST.d/override.yaml
@@ -1,0 +1,14 @@
+# Fixture for ParametersTest: exercises Parameters::override_from_file().
+# - the '@metadata@' key is skipped,
+# - 'mass::c' already exists and is overridden (value, min, max, latex, unit),
+# - 'test::override_new_param' does not exist and is added (central only).
+'@metadata@':
+    version: '1.0'
+mass::c:
+    central: 1.5
+    min: 1.0
+    max: 2.0
+    latex: 'm_c'
+    unit: 'GeV'
+test::override_new_param:
+    central: 42.0


### PR DESCRIPTION
This PR fixes the determination of the code coverage by test cases on the C++ side. Previously, multiple instantiations of a template were counted multiple times. This affected both the stated C++ value (``56%`` is actually ``>80%``, which we aim for) and the combined value.

Also, this PR instruments the five worst offenders with additional test cases (uncovering a genuine bug, see issue #1189).