### PR TITLE
Convert classes in ``eos.data`` to use the base classes ``eos.Deserializable`` and the new ``eos.Serializable`` 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@
   - `B->K^*ll::d^2Gamma@LargeRecoil` -> `B->K^*ll::P(q2,cos(theta_l))`
 - Make ``pypmc`` an optional Python dependency and adjust the documentation (D. van Dyk)
 - Split the ``eos.data`` package into multiple modules, one per class (D. van Dyk)
+- Convert the ``eos.data`` classes (``MarkovChain``, ``Mode``, ``ImportanceSamples``, ``DynestyResults``, ``NabuLikelihood``, ``Prediction``, ``SampleMask``, ``PMCSampler``, and ``MixtureDensity``) to the new ``eos.Serializable``/``eos.Deserializable`` interface, and bump the on-disk format for ``eos.data.Mode`` (D. van Dyk)
 - Allow the characters `|`, `(`, `)`, and `*` in ``qnp::OptionValue`` (D. van Dyk)
 - Switch ``Options`` to use ``qnp::OptionValue`` in lieu of ``std::string`` for its option values; hard-coded option values are now expressed using the ``_ov`` user-defined literal (D. van Dyk)
 - Use ``qnp::OptionValue`` keys in the the factory method ``Model::make`` (D. van Dyk)
@@ -49,6 +50,7 @@
   - `B_s->D_s^*lnu::P(q2)`
   - `B_s->D_s^*lnu::P(q2,cos(theta_l),cos(theta_D_s),phi)`
   - `B^+->pi^+pi^-lnu::PDF(q2,k2,cos(theta_pi))`
+- Add the ``eos.Serializable`` base class and the ``eos.Deserializable.from_yaml_file()`` helper, with a type check in ``eos.Deserializable.from_yaml`` (D. van Dyk)
 - Expand the unit test coverage of the Python interface (D. van Dyk)
 - Add a workflow to determine code coverage with test cases (D. van Dyk)
 - Add comparison operators for ``qnp::OptionValue`` (D. van Dyk)

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -17,6 +17,7 @@ EXTRA_DIST = \
 	eos/datasets_TEST.d \
 	eos/datasets_file_description.py \
 	eos/deserializable.py \
+	eos/serializable.py \
 	eos/ipython.py \
 	eos/log_likelihood.py \
 	eos/observable.py \
@@ -90,6 +91,7 @@ eos_SCRIPTS = \
 	eos/datasets.py \
 	eos/datasets_file_description.py \
 	eos/deserializable.py \
+	eos/serializable.py \
 	eos/ipython.py \
 	eos/log_likelihood.py \
 	eos/observable.py \
@@ -150,6 +152,7 @@ TESTS = \
 	eos/analysis_file_description_TEST.py \
 	eos/datasets_TEST.py \
 	eos/datasets_file_description_TEST.py \
+	eos/serializable_TEST.py \
 	eos/tasks_TEST.py \
 	eos/data/dynesty_results_TEST.py \
 	eos/data/importance_samples_TEST.py \

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -161,6 +161,7 @@ TESTS = \
 	eos/data/markov_chain_TEST.py \
 	eos/data/mixture_density_TEST.py \
 	eos/data/mode_TEST.py \
+	eos/data/nabu_likelihood_TEST.py \
 	eos/data/sample_mask_TEST.py \
 	eos/data/pmc_sampler_TEST.py \
 	eos/data/prediction_TEST.py \

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -33,6 +33,7 @@ EXTRA_DIST = \
 	eos/tasks_TEST.py \
 	eos/pyhf_likelihood.py \
 	eos/data/__init__.py \
+	eos/data/_common.py \
 	eos/data/dynesty_results.py \
 	eos/data/dynesty_results_TEST.d \
 	eos/data/importance_samples.py \
@@ -105,6 +106,7 @@ eos_SCRIPTS = \
 eosdatadir = $(pkgpythondir)/data
 eosdata_SCRIPTS = \
 	eos/data/__init__.py \
+	eos/data/_common.py \
 	eos/data/dynesty_results.py \
 	eos/data/importance_samples.py \
 	eos/data/markov_chain.py \

--- a/python/eos/data/_common.py
+++ b/python/eos/data/_common.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from dataclasses import dataclass, field
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import numpy as _np
+import os as _os
+
+
+@dataclass(kw_only=True)
+class ParameterDescription(Serializable, Deserializable):
+    r"""Describes a single varied parameter recorded in a data object's ``description.yaml``.
+
+    :param name: The qualified name of the parameter.
+    :type name: str
+    :param min: The lower bound of the parameter's prior range. Defaults to :math:`-\infty`.
+    :type min: float
+    :param max: The upper bound of the parameter's prior range. Defaults to :math:`+\infty`.
+    :type max: float
+    """
+    name:str
+    min:float = field(default=-_np.inf)
+    max:float = field(default=+_np.inf)
+
+
+def load_array(directory:str, filename:str, *, ncols:int=None, nrows:int=None):
+    r"""Load a NumPy array stored beside a data object's description and validate its shape.
+
+    Centralizes the presence and shape checks that the individual :class:`eos.data` objects would
+    otherwise repeat when loading their ``.npy`` payloads. The optional ``ncols``/``nrows`` arguments
+    let the caller assert that the payload is consistent with the deserialized description (e.g. that
+    the number of sample columns matches the number of varied parameters).
+
+    :param directory: The storage directory that contains the array file.
+    :type directory: str
+    :param filename: The name of the ``.npy`` file within ``directory``.
+    :type filename: str
+    :param ncols: If given, require a 2D array with exactly this many columns.
+    :type ncols: int | None
+    :param nrows: If given, require exactly this many entries along the first axis.
+    :type nrows: int | None
+    :returns: The loaded array.
+    :rtype: numpy.ndarray
+    :raises RuntimeError: If the file is missing, is not a file, or its shape does not match.
+    """
+    path = _os.path.join(directory, filename)
+    if not _os.path.exists(path) or not _os.path.isfile(path):
+        raise RuntimeError(f'Data file {path} does not exist or is not a file')
+
+    array = _np.load(path)
+
+    if ncols is not None and (array.ndim != 2 or array.shape[1] != ncols):
+        raise RuntimeError(f'Data file {path} has shape {array.shape}, expected a 2D array with {ncols} columns')
+
+    if nrows is not None and (array.ndim < 1 or array.shape[0] != nrows):
+        raise RuntimeError(f'Data file {path} has shape {array.shape}, expected {nrows} entries along the first axis')
+
+    return array

--- a/python/eos/data/_common.py
+++ b/python/eos/data/_common.py
@@ -37,6 +37,23 @@ class ParameterDescription(Serializable, Deserializable):
     max:float = field(default=+_np.inf)
 
 
+@dataclass(kw_only=True)
+class GaussianComponentDescription(Serializable, Deserializable):
+    r"""Describes a single Gaussian component of a mixture density.
+
+    Shared by :class:`eos.data.MixtureDensity` and :class:`eos.data.PMCSampler`. The ``type: 'gauss'``
+    discriminator that :class:`MixtureDensity` stores on disk is handled by that class; this schema
+    holds only the mean vector and covariance matrix.
+
+    :param mu: The mean vector as a 1D list of floats.
+    :type mu: list
+    :param sigma: The covariance matrix as a 2D list of floats.
+    :type sigma: list
+    """
+    mu:list
+    sigma:list
+
+
 def load_array(directory:str, filename:str, *, ncols:int=None, nrows:int=None):
     r"""Load a NumPy array stored beside a data object's description and validate its shape.
 

--- a/python/eos/data/dynesty_results.py
+++ b/python/eos/data/dynesty_results.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2022-2023 Filip Novak
+# Copyright (c) 2026 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -13,11 +14,64 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field, asdict
+from eos.data._common import ParameterDescription
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
 import numpy as _np
-import dynesty
-import yaml
+
+
+@dataclass(kw_only=True)
+class DynestyResultsDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for a :class:`DynestyResults` object.
+
+    This is the single source of truth for the metadata stored alongside a nested-sampling run, and it
+    backs both the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`). The
+    ``type`` discriminator is validated on deserialization and is not part of the constructor.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param parameters: The descriptions of the varied parameters.
+    :type parameters: list[ParameterDescription]
+    """
+    version:str
+    parameters:list[ParameterDescription]
+    type:str = field(init=False, default='DynestyResults')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`DynestyResultsDescription` from its on-disk keyword description.
+
+        Validates the ``type`` discriminator and deserializes each entry of ``parameters`` into a
+        :class:`ParameterDescription`.
+
+        :raises ValueError: If the description does not identify a dynesty-results object.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type != 'DynestyResults':
+            raise ValueError(f'Expected a description of type \'DynestyResults\', got \'{_type}\'')
+
+        if 'parameters' in _kwargs:
+            _kwargs['parameters'] = [ParameterDescription.from_dict(**p) for p in _kwargs['parameters']]
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Emits the ``type`` discriminator, inverting :meth:`from_dict`.
+        """
+        return {
+            'version':    self.version,
+            'type':       self.type,
+            'parameters': [asdict(p) for p in self.parameters],
+        }
 
 
 class DynestyResults:
@@ -25,7 +79,8 @@ class DynestyResults:
 
     Wraps a :class:`dynesty.results.Results` object together with the descriptions of the varied
     parameters. Instances are created either by reading existing results from disk (passing their
-    ``path`` to the constructor) or by writing new results with :meth:`create`.
+    ``path`` to the constructor) or by writing new results with :meth:`create`. Reading requires the
+    optional dynesty module.
 
     :ivar type: The type identifier of the data object, always ``'DynestyResults'``.
     :ivar varied_parameters: The descriptions (name, min, max) of the varied parameters.
@@ -44,24 +99,17 @@ class DynestyResults:
         if not os.path.exists(path) or not os.path.isdir(path):
             raise RuntimeError(f'Path {path} does not exist or is not a directory')
 
-        f = os.path.join(path, 'description.yaml')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+        description = DynestyResultsDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
-
-        if not description['type'] == 'DynestyResults':
-            raise RuntimeError(f'Path {path} not pointing to a DynestyResults file')
-
-        self.type = 'DynestyResults'
-        self.varied_parameters = description['parameters']
-        self.lookup_table = { item['name']: idx for idx, item in enumerate(self.varied_parameters) }
+        self.type = description.type
+        self.varied_parameters = [asdict(p) for p in description.parameters]
+        self.lookup_table = { p.name: idx for idx, p in enumerate(description.parameters) }
 
         f = os.path.join(path, 'dynesty_results.npy')
         if not os.path.exists(f) or not os.path.isfile(f):
             raise RuntimeError(f'Dynesty results file {f} does not exist or is not a file')
 
+        import dynesty
         res_dict = _np.load(f, allow_pickle=True).item()
         if "blob" in res_dict:
             res_dict.pop('blob')
@@ -81,18 +129,13 @@ class DynestyResults:
         :param results: The results of a nested sampling run.
         :type results: dynesty.results.Results
         """
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'DynestyResults'
-        description['parameters'] = [{
-            'name': p.name(),
-            'min': p.min(),
-            'max': p.max()
-        } for p in parameters]
+        description = DynestyResultsDescription(
+            version    = eos.__version__,
+            parameters = [ParameterDescription(name=p.name(), min=p.min(), max=p.max()) for p in parameters],
+        )
 
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))
 
         res_dict = results.asdict()
         _np.save(os.path.join(path, 'dynesty_results.npy'), res_dict)

--- a/python/eos/data/dynesty_results_TEST.py
+++ b/python/eos/data/dynesty_results_TEST.py
@@ -17,7 +17,10 @@ import unittest
 
 import eos
 import eos.data
+import numpy as np
 import os
+import tempfile
+import yaml
 
 
 def dynesty_is_missing():
@@ -28,9 +31,39 @@ def dynesty_is_missing():
         return True
 
 
+class _Parameter:
+    "Minimal stand-in for eos.Parameter, exposing the name/min/max accessors that create() uses."
+
+    def __init__(self, name, minimum, maximum):
+        self._name = name
+        self._min  = minimum
+        self._max  = maximum
+
+    def name(self):
+        return self._name
+
+    def min(self):
+        return self._min
+
+    def max(self):
+        return self._max
+
+
 class DynestyResultsTests(unittest.TestCase):
 
     _path = os.path.join(os.environ['SOURCE_DIR'], 'eos/data/dynesty_results_TEST.d')
+
+    _parameters = [
+        _Parameter('CKM::abs(V_ub)',        3.0e-3, 4.5e-3),
+        _Parameter('B->pi::f_+(0)@BCL2008', 0.21,   0.32  ),
+    ]
+
+    @staticmethod
+    def _write(directory, description):
+        "Materialize a (possibly malformed) DynestyResults description in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
 
     @unittest.skipIf(dynesty_is_missing(), "Test requires the 'dynesty' module")
     def test_loading(self):
@@ -39,16 +72,73 @@ class DynestyResultsTests(unittest.TestCase):
 
         self.assertEqual(dr.type, 'DynestyResults')
         self.assertEqual(dr.lookup_table, {'CKM::abs(V_ub)': 0, 'B->pi::f_+(0)@BCL2008': 1})
+        self.assertEqual(dr.varied_parameters[0]['name'], 'CKM::abs(V_ub)')
         # the reconstructed samples have one column per varied parameter
         self.assertEqual(dr.samples.shape[1], 2)
         # there is exactly one weight per sample
         self.assertEqual(len(dr.weights), dr.samples.shape[0])
 
-    @unittest.skipIf(dynesty_is_missing(), "Test requires the 'dynesty' module")
     def test_invalid_path(self):
         "Loading from a non-existent path raises an error."
         with self.assertRaises(RuntimeError):
             eos.data.DynestyResults(os.path.join(self._path, 'does-not-exist'))
+
+    @unittest.skipIf(dynesty_is_missing(), "Test requires the 'dynesty' module")
+    def test_roundtrip(self):
+        "Results written by create() read back identically (write/read symmetry)."
+        src = eos.data.DynestyResults(self._path)
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'nested')
+            eos.data.DynestyResults.create(path, self._parameters, src.results)
+
+            dr = eos.data.DynestyResults(path)
+            self.assertEqual(dr.type, 'DynestyResults')
+            self.assertEqual(dr.lookup_table, {'CKM::abs(V_ub)': 0, 'B->pi::f_+(0)@BCL2008': 1})
+            np.testing.assert_allclose(dr.samples, src.samples)
+            np.testing.assert_allclose(dr.weights, src.weights)
+
+    def test_wrong_type(self):
+        "A description whose type is not 'DynestyResults' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'MarkovChain', 'parameters': []})
+            with self.assertRaises(ValueError):
+                eos.data.DynestyResults(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'DynestyResults',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}], 'bogus': 42,
+            })
+            with self.assertRaises(ValueError):
+                eos.data.DynestyResults(d)
+
+    def test_missing_parameters(self):
+        "A description missing the required 'parameters' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'DynestyResults'})
+            with self.assertRaises(ValueError):
+                eos.data.DynestyResults(d)
+
+    def test_missing_payload(self):
+        "A valid description without the results payload is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'DynestyResults',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
+            })
+            with self.assertRaises(RuntimeError):
+                eos.data.DynestyResults(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.DynestyResults(d)
 
 
 if __name__ == '__main__':

--- a/python/eos/data/importance_samples.py
+++ b/python/eos/data/importance_samples.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2022-2025 Danny van Dyk
-# Copyright (c) 2023 Méril Reboud
+# Copyright (c) 2022-2026 Danny van Dyk
+# Copyright (c) 2021-2024 Méril Reboud
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -14,10 +14,64 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field, asdict
+from eos.data._common import ParameterDescription, load_array
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
 import numpy as _np
-import yaml
+
+
+@dataclass(kw_only=True)
+class ImportanceSamplesDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for an :class:`ImportanceSamples` object.
+
+    This is the single source of truth for the metadata stored alongside a set of importance samples,
+    and it backs both the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`).
+    The ``type`` discriminator is validated on deserialization and is not part of the constructor.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param parameters: The descriptions of the varied parameters.
+    :type parameters: list[ParameterDescription]
+    """
+    version:str
+    parameters:list[ParameterDescription]
+    type:str = field(init=False, default='ImportanceSamples')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create an :class:`ImportanceSamplesDescription` from its on-disk keyword description.
+
+        Validates the ``type`` discriminator and deserializes each entry of ``parameters`` into a
+        :class:`ParameterDescription`.
+
+        :raises ValueError: If the description does not identify an importance-samples object.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type != 'ImportanceSamples':
+            raise ValueError(f'Expected a description of type \'ImportanceSamples\', got \'{_type}\'')
+
+        if 'parameters' in _kwargs:
+            _kwargs['parameters'] = [ParameterDescription.from_dict(**p) for p in _kwargs['parameters']]
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Emits the ``type`` discriminator, inverting :meth:`from_dict`.
+        """
+        return {
+            'version':    self.version,
+            'type':       self.type,
+            'parameters': [asdict(p) for p in self.parameters],
+        }
 
 
 class ImportanceSamples:
@@ -44,35 +98,21 @@ class ImportanceSamples:
         if not os.path.exists(path) or not os.path.isdir(path):
             raise RuntimeError(f'Path {path} does not exist or is not a directory')
 
-        f = os.path.join(path, 'description.yaml')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+        description = ImportanceSamplesDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
+        self.type = description.type
+        self.varied_parameters = [asdict(p) for p in description.parameters]
+        self.lookup_table = { p.name: idx for idx, p in enumerate(description.parameters) }
 
-        if not description['type'] == 'ImportanceSamples':
-            raise RuntimeError(f'Path {path} not pointing to an ImportanceSamples object')
+        ncols = len(description.parameters)
+        self.samples = load_array(path, 'samples.npy', ncols=ncols)
+        self.weights = load_array(path, 'weights.npy', nrows=self.samples.shape[0])
 
-        self.type = 'ImportanceSamples'
-        self.varied_parameters = description['parameters']
-        self.lookup_table = { item['name']: idx for idx, item in enumerate(self.varied_parameters) }
-
-        f = os.path.join(path, 'samples.npy')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Samples file {f} does not exist or is not a file')
-        self.samples = _np.load(f)
-
-        f = os.path.join(path, 'weights.npy')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Weights file {f} does not exist or is not a file')
-        self.weights = _np.load(f)
-
-        f = os.path.join(path, 'posterior_values.npy')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            self.posterior_values = None
+        # posterior_values are optional and detected by the presence of their file
+        if os.path.isfile(os.path.join(path, 'posterior_values.npy')):
+            self.posterior_values = load_array(path, 'posterior_values.npy', nrows=self.samples.shape[0])
         else:
-            self.posterior_values = _np.load(f)
+            self.posterior_values = None
 
 
     @staticmethod
@@ -88,15 +128,6 @@ class ImportanceSamples:
         :param weights: Weights on a linear scale as a 1D array of shape (N, ).
         :type weights: 1D numpy array, optional
         """
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'ImportanceSamples'
-        description['parameters'] = [{
-            'name': p.name(),
-            'min': p.min() if 'min' in dir(p) else -_np.inf,
-            'max': p.max() if 'max' in dir(p) else +_np.inf
-        } for p in parameters]
-
         if not samples.shape[1] == len(parameters):
             raise RuntimeError(f'Shape of samples {samples.shape} incompatible with number of parameters {len(parameters)}')
 
@@ -106,9 +137,17 @@ class ImportanceSamples:
         if not posterior_values is None and not samples.shape[0] == posterior_values.shape[0]:
             raise RuntimeError(f'Shape of posterior values {posterior_values.shape} incompatible with shape of samples {samples.shape}')
 
+        description = ImportanceSamplesDescription(
+            version    = eos.__version__,
+            parameters = [ParameterDescription(
+                name = p.name(),
+                min  = p.min() if 'min' in dir(p) else -_np.inf,
+                max  = p.max() if 'max' in dir(p) else +_np.inf,
+            ) for p in parameters],
+        )
+
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))
         _np.save(os.path.join(path, 'samples.npy'), samples)
         _np.save(os.path.join(path, 'weights.npy'), weights)
         if not posterior_values is None:

--- a/python/eos/data/importance_samples_TEST.py
+++ b/python/eos/data/importance_samples_TEST.py
@@ -1,15 +1,162 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
 import unittest
 
 import eos
+import eos.data
+import numpy as np
 import os
+import tempfile
+import yaml
+
+
+class _Parameter:
+    "Minimal stand-in for eos.Parameter, exposing the name/min/max accessors that create() uses."
+
+    def __init__(self, name, minimum, maximum):
+        self._name = name
+        self._min  = minimum
+        self._max  = maximum
+
+    def name(self):
+        return self._name
+
+    def min(self):
+        return self._min
+
+    def max(self):
+        return self._max
 
 
 class ImportanceSamplesTests(unittest.TestCase):
 
-    def test_importing_samples(self):
-        "Test the import of importance samples."
+    _path = os.path.join(os.environ['SOURCE_DIR'], 'eos/data/importance_samples_TEST.d/samples')
 
-        file = eos.data.ImportanceSamples(os.path.join(os.environ['SOURCE_DIR'], "eos/data/importance_samples_TEST.d/samples"))
+    _parameters = [
+        _Parameter('CKM::abs(V_ub)',        3.0e-3, 4.5e-3),
+        _Parameter('B->pi::f_+(0)@BCL2008', 0.21,   0.32  ),
+    ]
+
+    @staticmethod
+    def _write(directory, description, samples=None, weights=None, posterior_values=None):
+        "Materialize a (possibly malformed) ImportanceSamples fixture in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
+        if samples is not None:
+            np.save(os.path.join(directory, 'samples.npy'), samples)
+        if weights is not None:
+            np.save(os.path.join(directory, 'weights.npy'), weights)
+        if posterior_values is not None:
+            np.save(os.path.join(directory, 'posterior_values.npy'), posterior_values)
+
+    def test_loading(self):
+        "Load an ImportanceSamples object from a prepared fixture and check its contents."
+        f = eos.data.ImportanceSamples(self._path)
+
+        self.assertEqual(f.type, 'ImportanceSamples')
+        self.assertEqual(len(f.lookup_table), 6)
+        self.assertEqual(f.lookup_table['CKM::abs(V_ub)'], 0)
+        self.assertEqual(f.samples.shape[1], 6)
+        self.assertEqual(f.weights.shape[0], f.samples.shape[0])
+        self.assertIsNone(f.posterior_values)
+
+    def test_varied_parameters_are_dicts(self):
+        "The public varied_parameters remain subscriptable dicts for backward compatibility."
+        f = eos.data.ImportanceSamples(self._path)
+        self.assertEqual(f.varied_parameters[0]['name'], 'CKM::abs(V_ub)')
+        self.assertIn('min', f.varied_parameters[0])
+        self.assertIn('max', f.varied_parameters[0])
+
+    def test_invalid_path(self):
+        "Loading from a non-existent path raises an error."
+        with self.assertRaises(RuntimeError):
+            eos.data.ImportanceSamples(os.path.join(self._path, 'does-not-exist'))
+
+    def test_roundtrip(self):
+        "A data set written by create() reads back identically (write/read symmetry)."
+        samples          = np.array([[3.5e-3, 0.22], [3.7e-3, 0.27], [4.1e-3, 0.30]])
+        weights          = np.array([1.0, 2.0, 3.0])
+        posterior_values = np.array([-1.0, -2.0, -3.0])
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'samples')
+            eos.data.ImportanceSamples.create(path, self._parameters, samples, weights, posterior_values)
+
+            f = eos.data.ImportanceSamples(path)
+            self.assertEqual(f.type, 'ImportanceSamples')
+            self.assertEqual(f.lookup_table, {'CKM::abs(V_ub)': 0, 'B->pi::f_+(0)@BCL2008': 1})
+            self.assertEqual(f.varied_parameters[0]['min'], 3.0e-3)
+            np.testing.assert_allclose(f.samples,          samples)
+            np.testing.assert_allclose(f.weights,          weights)
+            np.testing.assert_allclose(f.posterior_values, posterior_values)
+
+    def test_roundtrip_without_posterior_values(self):
+        "A data set created without posterior_values reads back with the attribute set to None."
+        samples = np.array([[3.5e-3, 0.22], [3.7e-3, 0.27]])
+        weights = np.array([1.0, 2.0])
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'samples')
+            eos.data.ImportanceSamples.create(path, self._parameters, samples, weights)
+
+            f = eos.data.ImportanceSamples(path)
+            self.assertIsNone(f.posterior_values)
+
+    def test_wrong_type(self):
+        "A description whose type is not 'ImportanceSamples' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'MarkovChain', 'parameters': []})
+            with self.assertRaises(ValueError):
+                eos.data.ImportanceSamples(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'ImportanceSamples',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}], 'bogus': 42,
+            })
+            with self.assertRaises(ValueError):
+                eos.data.ImportanceSamples(d)
+
+    def test_missing_parameters(self):
+        "A description missing the required 'parameters' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'ImportanceSamples'})
+            with self.assertRaises(ValueError):
+                eos.data.ImportanceSamples(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.ImportanceSamples(d)
+
+    def test_shape_mismatch(self):
+        "Samples whose column count disagrees with the parameters are rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'ImportanceSamples',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}, {'name': 'b', 'min': 0.0, 'max': 1.0}],
+            }, samples=np.zeros((5, 3)), weights=np.zeros(5))
+            with self.assertRaises(RuntimeError):
+                eos.data.ImportanceSamples(d)
 
 
 if __name__ == '__main__':

--- a/python/eos/data/markov_chain.py
+++ b/python/eos/data/markov_chain.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Danny van Dyk
+# Copyright (c) 2020-2026 Danny van Dyk
 # Copyright (c) 2023 Stephan Kürten
 #
 # This file is part of the EOS project. EOS is free software;
@@ -14,10 +14,73 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field, asdict
+from eos.data._common import ParameterDescription, load_array
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
 import numpy as _np
-import yaml
+
+
+@dataclass(kw_only=True)
+class MarkovChainDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for a :class:`MarkovChain`.
+
+    This is the single source of truth for the metadata stored alongside a Markov chain, and it backs
+    both the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`). The
+    ``type`` discriminator is validated on deserialization and is not part of the constructor.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param parameters: The descriptions of the varied parameters.
+    :type parameters: list[ParameterDescription]
+    :param has_weights: Whether the chain stores importance weights (on-disk key ``has-weights``).
+    :type has_weights: bool
+    """
+    version:str
+    parameters:list[ParameterDescription]
+    has_weights:bool = field(default=False)
+    type:str = field(init=False, default='MarkovChain')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`MarkovChainDescription` from its on-disk keyword description.
+
+        Validates the ``type`` discriminator, normalizes the on-disk ``has-weights`` key to the
+        ``has_weights`` field, and deserializes each entry of ``parameters`` into a
+        :class:`ParameterDescription`.
+
+        :raises ValueError: If the description does not identify a Markov chain.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type != 'MarkovChain':
+            raise ValueError(f'Expected a description of type \'MarkovChain\', got \'{_type}\'')
+
+        if 'has-weights' in _kwargs:
+            _kwargs['has_weights'] = _kwargs.pop('has-weights')
+
+        if 'parameters' in _kwargs:
+            _kwargs['parameters'] = [ParameterDescription.from_dict(**p) for p in _kwargs['parameters']]
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Emits the on-disk ``has-weights`` key and the ``type`` discriminator, inverting
+        :meth:`from_dict`.
+        """
+        return {
+            'version':     self.version,
+            'type':        self.type,
+            'parameters':  [asdict(p) for p in self.parameters],
+            'has-weights': self.has_weights,
+        }
 
 
 class MarkovChain:
@@ -45,35 +108,18 @@ class MarkovChain:
         if not os.path.exists(path) or not os.path.isdir(path):
             raise RuntimeError(f'Path {path} does not exist or is not a directory')
 
-        f = os.path.join(path, 'description.yaml')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+        description = MarkovChainDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
+        self.type = description.type
+        self.varied_parameters = [asdict(p) for p in description.parameters]
+        self.lookup_table = { p.name: idx for idx, p in enumerate(description.parameters) }
 
-        if not description['type'] == 'MarkovChain':
-            raise RuntimeError(f'Path {path} not pointing to a MarkovChain')
+        ncols = len(description.parameters)
+        self.samples  = load_array(path, 'samples.npy',  ncols=ncols)
+        self.usamples = load_array(path, 'usamples.npy', ncols=ncols)
 
-        self.type = 'MarkovChain'
-        self.varied_parameters = description['parameters']
-        self.lookup_table = { item['name']: idx for idx, item in enumerate(self.varied_parameters) }
-
-        f = os.path.join(path, 'samples.npy')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Samples file {f} does not exist or is not a file')
-        self.samples = _np.load(f)
-
-        f = os.path.join(path, 'usamples.npy')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'U-space samples file {f} does not exist or is not a file')
-        self.usamples = _np.load(f)
-
-        if description['has-weights']:
-            f = os.path.join(path, 'weights.npy')
-            if not os.path.exists(f) or not os.path.isfile(f):
-                raise RuntimeError(f'Weights file {f} does not exist or is not a file')
-            self.weights = _np.load(f)
+        if description.has_weights:
+            self.weights = load_array(path, 'weights.npy', nrows=self.samples.shape[0])
         else:
             self.weights = None
 
@@ -93,16 +139,6 @@ class MarkovChain:
         :param weights: Weights on a linear scale as a 1D array of shape (N, ).
         :type weights: 1D numpy array, optional
         """
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'MarkovChain'
-        description['parameters'] = [{
-            'name': p.name(),
-            'min': p.min(),
-            'max': p.max()
-        } for p in parameters]
-        description['has-weights'] = (not weights is None)
-
         if not samples.shape[1] == len(parameters):
             raise RuntimeError(f'Shape of samples {samples.shape} incompatible with number of parameters {len(parameters)}')
 
@@ -112,9 +148,14 @@ class MarkovChain:
         if not weights is None and not samples.shape[0] == weights.shape[0]:
             raise RuntimeError(f'Shape of weights {weights.shape} incompatible with shape of samples {samples.shape}')
 
+        description = MarkovChainDescription(
+            version     = eos.__version__,
+            parameters  = [ParameterDescription(name=p.name(), min=p.min(), max=p.max()) for p in parameters],
+            has_weights = weights is not None,
+        )
+
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))
         _np.save(os.path.join(path, 'samples.npy'), samples)
         _np.save(os.path.join(path, 'usamples.npy'), usamples)
 

--- a/python/eos/data/markov_chain_TEST.py
+++ b/python/eos/data/markov_chain_TEST.py
@@ -17,12 +17,51 @@ import unittest
 
 import eos
 import eos.data
+import numpy as np
 import os
+import tempfile
+import yaml
+
+
+class _Parameter:
+    "Minimal stand-in for eos.Parameter, exposing the name/min/max accessors that create() uses."
+
+    def __init__(self, name, minimum, maximum):
+        self._name = name
+        self._min  = minimum
+        self._max  = maximum
+
+    def name(self):
+        return self._name
+
+    def min(self):
+        return self._min
+
+    def max(self):
+        return self._max
 
 
 class MarkovChainTests(unittest.TestCase):
 
     _path = os.path.join(os.environ['SOURCE_DIR'], 'eos/data/markov_chain_TEST.d')
+
+    _parameters = [
+        _Parameter('CKM::abs(V_ub)',        3.0e-3, 4.5e-3),
+        _Parameter('B->pi::f_+(0)@BCL2008', 0.21,   0.32  ),
+    ]
+
+    @staticmethod
+    def _write(directory, description, samples=None, usamples=None, weights=None):
+        "Materialize a (possibly malformed) MarkovChain fixture in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
+        if samples is not None:
+            np.save(os.path.join(directory, 'samples.npy'), samples)
+        if usamples is not None:
+            np.save(os.path.join(directory, 'usamples.npy'), usamples)
+        if weights is not None:
+            np.save(os.path.join(directory, 'weights.npy'), weights)
 
     def test_loading(self):
         "Load a MarkovChain from a prepared fixture and check its contents."
@@ -35,10 +74,92 @@ class MarkovChainTests(unittest.TestCase):
         self.assertIsNotNone(mc.weights)
         self.assertEqual(mc.weights.shape, (5,))
 
+    def test_varied_parameters_are_dicts(self):
+        "The public varied_parameters remain subscriptable dicts for backward compatibility."
+        mc = eos.data.MarkovChain(self._path)
+        self.assertEqual(mc.varied_parameters[0]['name'], 'CKM::abs(V_ub)')
+        self.assertIn('min', mc.varied_parameters[0])
+        self.assertIn('max', mc.varied_parameters[0])
+
     def test_invalid_path(self):
         "Loading from a non-existent path raises an error."
         with self.assertRaises(RuntimeError):
             eos.data.MarkovChain(os.path.join(self._path, 'does-not-exist'))
+
+    def test_roundtrip(self):
+        "A chain written by create() reads back identically (write/read symmetry)."
+        samples  = np.array([[3.5e-3, 0.22], [3.7e-3, 0.27], [4.1e-3, 0.30]])
+        usamples = np.array([[0.10, 0.20], [0.30, 0.40], [0.50, 0.60]])
+        weights  = np.array([1.0, 2.0, 3.0])
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'mcmc-0000')
+            eos.data.MarkovChain.create(path, self._parameters, samples, usamples, weights)
+
+            mc = eos.data.MarkovChain(path)
+            self.assertEqual(mc.type, 'MarkovChain')
+            self.assertEqual(mc.lookup_table, {'CKM::abs(V_ub)': 0, 'B->pi::f_+(0)@BCL2008': 1})
+            self.assertEqual(mc.varied_parameters[0]['min'], 3.0e-3)
+            self.assertEqual(mc.varied_parameters[1]['max'], 0.32)
+            np.testing.assert_allclose(mc.samples,  samples)
+            np.testing.assert_allclose(mc.usamples, usamples)
+            np.testing.assert_allclose(mc.weights,  weights)
+
+    def test_roundtrip_unweighted(self):
+        "A chain created without weights reads back with weights set to None."
+        samples  = np.array([[3.5e-3, 0.22], [3.7e-3, 0.27]])
+        usamples = np.array([[0.10, 0.20], [0.30, 0.40]])
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'mcmc-0000')
+            eos.data.MarkovChain.create(path, self._parameters, samples, usamples)
+
+            mc = eos.data.MarkovChain(path)
+            self.assertIsNone(mc.weights)
+
+    def test_wrong_type(self):
+        "A description whose type is not 'MarkovChain' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'Prediction', 'parameters': [], 'has-weights': False})
+            with self.assertRaises(ValueError):
+                eos.data.MarkovChain(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'MarkovChain',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
+                'has-weights': False, 'bogus': 42,
+            })
+            with self.assertRaises(ValueError):
+                eos.data.MarkovChain(d)
+
+    def test_missing_parameters(self):
+        "A description missing the required 'parameters' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'MarkovChain', 'has-weights': False})
+            with self.assertRaises(ValueError):
+                eos.data.MarkovChain(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.MarkovChain(d)
+
+    def test_shape_mismatch(self):
+        "Samples whose column count disagrees with the parameters are rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'MarkovChain',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}, {'name': 'b', 'min': 0.0, 'max': 1.0}],
+                'has-weights': False,
+            }, samples=np.zeros((5, 3)), usamples=np.zeros((5, 2)))
+            with self.assertRaises(RuntimeError):
+                eos.data.MarkovChain(d)
 
 
 if __name__ == '__main__':

--- a/python/eos/data/mixture_density.py
+++ b/python/eos/data/mixture_density.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Danny van Dyk
+# Copyright (c) 2020-2026 Danny van Dyk
 # Copyright (c) 2024 Méril Reboud
 #
 # This file is part of the EOS project. EOS is free software;
@@ -14,12 +14,88 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field
+from eos.data._common import GaussianComponentDescription
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
 import numpy as _np
-import yaml
 from scipy.special import erf
 from scipy.linalg import block_diag
+
+
+@dataclass(kw_only=True)
+class MixtureDensityDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for a :class:`MixtureDensity`.
+
+    This is the single source of truth for the metadata stored for a mixture density, and it backs both
+    the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`). The ``type``
+    discriminator is validated on deserialization and is not part of the constructor.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param components: The Gaussian components of the mixture.
+    :type components: list[GaussianComponentDescription]
+    :param weights: The component weights of the mixture.
+    :type weights: list
+    :param varied_parameters: The qualified names of the varied parameters, or ``None`` if not stored.
+    :type varied_parameters: list | None
+    :param test_statistics: The precomputed test statistics, or ``None`` if not stored.
+    :type test_statistics: dict | None
+    """
+    version:str
+    components:list[GaussianComponentDescription]
+    weights:list
+    varied_parameters:list|None = field(default=None)
+    test_statistics:dict|None = field(default=None)
+    type:str = field(init=False, default='MixtureDensity')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`MixtureDensityDescription` from its on-disk keyword description.
+
+        Validates the ``type`` discriminator and deserializes each Gaussian component (which carries a
+        ``type: 'gauss'`` marker on disk).
+
+        :raises ValueError: If the description does not identify a mixture density, or a component has
+            an unsupported type.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type != 'MixtureDensity':
+            raise ValueError(f'Expected a description of type \'MixtureDensity\', got \'{_type}\'')
+
+        if 'components' in _kwargs:
+            components = []
+            for c in _kwargs['components']:
+                _c = dict(c)
+                ctype = _c.pop('type', 'gauss')
+                if ctype != 'gauss':
+                    raise ValueError(f'Unsupported MixtureDensity component type \'{ctype}\'; only \'gauss\' is supported')
+                components.append(GaussianComponentDescription.from_dict(**_c))
+            _kwargs['components'] = components
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Re-emits the ``type: 'gauss'`` marker on each component, inverting :meth:`from_dict`.
+        """
+        result = {
+            'version':    self.version,
+            'type':       self.type,
+            'components': [{'type': 'gauss', 'mu': c.mu, 'sigma': c.sigma} for c in self.components],
+            'weights':    self.weights,
+        }
+        if self.varied_parameters is not None:
+            result['varied_parameters'] = self.varied_parameters
+        result['test_statistics'] = self.test_statistics if self.test_statistics is not None else {'sigma': [], 'densities': []}
+        return result
 
 
 class MixtureDensity:
@@ -54,20 +130,13 @@ class MixtureDensity:
         else:
             raise RuntimeError(f'Path {path} is neither a file nor a directory')
 
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+        description = MixtureDensityDescription.from_yaml_file(f)
 
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
-
-        if not description['type'] == 'MixtureDensity':
-            raise RuntimeError(f'Path {path} not pointing to a MixtureDensity')
-
-        self.type = 'MixtureDensity'
-        self.components = description['components']
-        self.weights    = description['weights']
-        self.varied_parameters = description['varied_parameters'] if 'varied_parameters' in description else None
-        self.test_statistics = description['test_statistics'] if 'test_statistics' in description else None
+        self.type = description.type
+        self.components = [{'type': 'gauss', 'mu': c.mu, 'sigma': c.sigma} for c in description.components]
+        self.weights    = description.weights
+        self.varied_parameters = description.varied_parameters
+        self.test_statistics = description.test_statistics
 
     def density(self):
         """Construct the corresponding PyPMC mixture density.
@@ -106,25 +175,18 @@ class MixtureDensity:
             import pypmc
         except ImportError as e:
             raise ImportError('eos.data.MixtureDensity.create requires the PyPMC python module, which can be installed from PyPI.') from e
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'MixtureDensity'
-        description['components'] = []
+
+        components = []
         for c in density.components:
             if type(c) is pypmc.density.gauss.Gauss:
-                description['components'].append({
-                    'type': 'gauss',
-                    'mu': c.mu.tolist(),
-                    'sigma': c.sigma.tolist()
-                })
+                components.append(GaussianComponentDescription(mu=c.mu.tolist(), sigma=c.sigma.tolist()))
             else:
                 raise RuntimeError(f'Unsupported type of MixtureDensity component: {type(c)}')
-        description['weights'] = density.weights.tolist()
-        if varied_parameters is not None:
-            description['varied_parameters'] = list(varied_parameters)
+
+        varied_parameters = list(varied_parameters) if varied_parameters is not None else None
 
         # The test statistics defaults to two empty lists
-        description['test_statistics'] = { "sigma": [], "densities": [] }
+        test_statistics = { "sigma": [], "densities": [] }
         if sigma_test_stat is not None and samples is not None and weights is not None:
             sigma_test_stat = _np.array(sigma_test_stat)
             samples_pdf = list(map(lambda x: -density.evaluate(x), samples))
@@ -135,14 +197,21 @@ class MixtureDensity:
             percents = erf(sigma_test_stat/_np.sqrt(2))
             weighted_percentile = _np.interp(percents, cumulant, samples_pdf_sorted)
 
-            description['test_statistics'] = {
+            test_statistics = {
                 "sigma": sigma_test_stat.tolist(),
                 "densities": weighted_percentile.tolist()
             }
 
+        description = MixtureDensityDescription(
+            version           = eos.__version__,
+            components        = components,
+            weights           = density.weights.tolist(),
+            varied_parameters = varied_parameters,
+            test_statistics   = test_statistics,
+        )
+
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))
 
     @staticmethod
     def _cartesian_product(densityA, densityB):

--- a/python/eos/data/mixture_density_TEST.py
+++ b/python/eos/data/mixture_density_TEST.py
@@ -17,7 +17,10 @@ import unittest
 
 import eos
 import eos.data
+import numpy as np
 import os
+import tempfile
+import yaml
 
 
 def pypmc_is_missing():
@@ -32,6 +35,13 @@ class MixtureDensityTests(unittest.TestCase):
 
     _path = os.path.join(os.environ['SOURCE_DIR'], 'eos/data/mixture_density_TEST.d')
 
+    @staticmethod
+    def _write(directory, description):
+        "Materialize a (possibly malformed) MixtureDensity description in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
+
     def test_loading(self):
         "Load a MixtureDensity from a prepared fixture and check its contents."
         md = eos.data.MixtureDensity(self._path)
@@ -44,6 +54,12 @@ class MixtureDensityTests(unittest.TestCase):
         self.assertEqual(md.weights, [0.4, 0.6])
         self.assertEqual(md.varied_parameters, ['CKM::abs(V_ub)', 'B->pi::f_+(0)@BCL2008'])
         self.assertEqual(md.test_statistics, {'sigma': [], 'densities': []})
+
+    def test_loading_from_file(self):
+        "The description.yaml file itself is also accepted as the path."
+        md = eos.data.MixtureDensity(os.path.join(self._path, 'description.yaml'))
+        self.assertEqual(md.type, 'MixtureDensity')
+        self.assertEqual(len(md.components), 2)
 
     @unittest.skipIf(pypmc_is_missing(), "Test requires the 'pypmc' module")
     def test_density(self):
@@ -59,6 +75,77 @@ class MixtureDensityTests(unittest.TestCase):
         "Loading from a non-existent path raises an error."
         with self.assertRaises(RuntimeError):
             eos.data.MixtureDensity(os.path.join(self._path, 'does-not-exist'))
+
+    @unittest.skipIf(pypmc_is_missing(), "Test requires the 'pypmc' module")
+    def test_roundtrip(self):
+        "A mixture written by create() reads back identically (write/read symmetry)."
+        import pypmc
+
+        means   = [np.array([3.7e-3, 0.27]), np.array([4.0e-3, 0.30])]
+        covs    = [np.array([[1.0e-7, 0.0], [0.0, 1.0e-3]]), np.array([[2.0e-7, 0.0], [0.0, 2.0e-3]])]
+        weights = np.array([0.4, 0.6])
+        density = pypmc.density.mixture.create_gaussian_mixture(means, covs, weights)
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'clusters')
+            eos.data.MixtureDensity.create(path, density, varied_parameters=['a', 'b'])
+
+            md = eos.data.MixtureDensity(path)
+            self.assertEqual(md.type, 'MixtureDensity')
+            self.assertEqual(len(md.components), 2)
+            self.assertEqual(md.components[0]['type'], 'gauss')
+            np.testing.assert_allclose(md.components[0]['mu'], means[0])
+            np.testing.assert_allclose(md.components[0]['sigma'], covs[0])
+            np.testing.assert_allclose(md.weights, [0.4, 0.6])
+            self.assertEqual(md.varied_parameters, ['a', 'b'])
+            self.assertEqual(md.test_statistics, {'sigma': [], 'densities': []})
+
+    def test_wrong_type(self):
+        "A description whose type is not 'MixtureDensity' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'PMCSampler', 'components': [], 'weights': []})
+            with self.assertRaises(ValueError):
+                eos.data.MixtureDensity(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'MixtureDensity',
+                'components': [{'type': 'gauss', 'mu': [0.0], 'sigma': [[1.0]]}],
+                'weights': [1.0], 'bogus': 42,
+            })
+            with self.assertRaises(ValueError):
+                eos.data.MixtureDensity(d)
+
+    def test_unsupported_component_type(self):
+        "A mixture component of an unsupported type is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'MixtureDensity',
+                'components': [{'type': 'student-t', 'mu': [0.0], 'sigma': [[1.0]]}],
+                'weights': [1.0],
+            })
+            with self.assertRaises(ValueError):
+                eos.data.MixtureDensity(d)
+
+    def test_missing_weights(self):
+        "A description missing the required 'weights' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'MixtureDensity',
+                'components': [{'type': 'gauss', 'mu': [0.0], 'sigma': [[1.0]]}],
+            })
+            with self.assertRaises(ValueError):
+                eos.data.MixtureDensity(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.MixtureDensity(d)
 
 
 if __name__ == '__main__':

--- a/python/eos/data/mode.py
+++ b/python/eos/data/mode.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2022-2024 Méril Reboud
-# Copyright (c) 2023 Danny van Dyk
+# Copyright (c) 2023-2026 Danny van Dyk
 # Copyright (c) 2023 Stephan Kürten
 # Copyright (c) 2024 Lorenz Gärtner
 #
@@ -16,9 +16,84 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field, asdict
+from eos.data._common import ParameterDescription
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
-import yaml
+
+
+@dataclass(kw_only=True)
+class ModeDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for a :class:`Mode`.
+
+    This is the single source of truth for the metadata stored for a (local) mode, and it backs both
+    the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`). The ``type``
+    discriminator is validated on deserialization and is not part of the constructor. The
+    ``global_chi2`` and ``dof`` keys are optional for backward compatibility with older files.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param parameters: The descriptions of the varied parameters.
+    :type parameters: list[ParameterDescription]
+    :param mode: The location of the mode in parameter space.
+    :type mode: list[float]
+    :param pvalue: The global p-value at the mode, or ``None``.
+    :type pvalue: float | None
+    :param local_pvalues: The local p-values at the mode.
+    :type local_pvalues: dict
+    :param global_chi2: The global :math:`\chi^2` value at the mode, or ``None`` if not stored.
+    :type global_chi2: float | None
+    :param dof: The number of degrees of freedom, or ``None`` if not stored.
+    :type dof: float | None
+    """
+    version:str
+    parameters:list[ParameterDescription]
+    mode:list[float]
+    pvalue:float|None
+    local_pvalues:dict
+    global_chi2:float|None = field(default=None)
+    dof:float|None = field(default=None)
+    type:str = field(init=False, default='Mode')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`ModeDescription` from its on-disk keyword description.
+
+        Validates the ``type`` discriminator and deserializes each entry of ``parameters`` into a
+        :class:`ParameterDescription`.
+
+        :raises ValueError: If the description does not identify a mode.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type != 'Mode':
+            raise ValueError(f'Expected a description of type \'Mode\', got \'{_type}\'')
+
+        if 'parameters' in _kwargs:
+            _kwargs['parameters'] = [ParameterDescription.from_dict(**p) for p in _kwargs['parameters']]
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Emits the ``type`` discriminator, inverting :meth:`from_dict`.
+        """
+        return {
+            'version':       self.version,
+            'type':          self.type,
+            'parameters':    [asdict(p) for p in self.parameters],
+            'mode':          self.mode,
+            'pvalue':        self.pvalue,
+            'local_pvalues': self.local_pvalues,
+            'global_chi2':   self.global_chi2,
+            'dof':           self.dof,
+        }
 
 
 class Mode:
@@ -46,27 +121,15 @@ class Mode:
         if not os.path.exists(path) or not os.path.isdir(path):
             raise RuntimeError(f'Path {path} does not exist or is not a directory')
 
-        f = os.path.join(path, 'description.yaml')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+        description = ModeDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
-
-        if not description['type'] == 'Mode':
-            raise RuntimeError(f'Path {path} not pointing to a Mode file')
-
-        self.type = 'Mode'
-        self.varied_parameters = description['parameters']
-        self.mode = description['mode']
-        self.pvalue = description['pvalue']
-        self.local_pvalues = description['local_pvalues']
-        self.global_chi2 = None
-        if 'global_chi2' in description:
-            self.global_chi2 = description['global_chi2']
-        self.dof = None
-        if 'dof' in description:
-            self.dof = description['dof']
+        self.type = description.type
+        self.varied_parameters = [asdict(p) for p in description.parameters]
+        self.mode = description.mode
+        self.pvalue = description.pvalue
+        self.local_pvalues = description.local_pvalues
+        self.global_chi2 = description.global_chi2
+        self.dof = description.dof
 
     @staticmethod
     def create(path, parameters, mode, pvalue, local_pvalues, global_chi2, dof):
@@ -87,20 +150,15 @@ class Mode:
         :param dof: The degrees of freedom of the mode.
         :type dof: float
         """
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'Mode'
-        description['parameters'] = [{
-            'name': p.name(),
-            'min': p.min(),
-            'max': p.max()
-        } for p in parameters]
-        description['mode'] = mode.tolist()
-        description['pvalue'] = float(pvalue) if pvalue is not None else None
-        description['local_pvalues'] = local_pvalues
-        description['global_chi2'] = global_chi2
-        description['dof'] = dof
+        description = ModeDescription(
+            version       = eos.__version__,
+            parameters    = [ParameterDescription(name=p.name(), min=p.min(), max=p.max()) for p in parameters],
+            mode          = mode.tolist(),
+            pvalue        = float(pvalue) if pvalue is not None else None,
+            local_pvalues = local_pvalues,
+            global_chi2   = global_chi2,
+            dof           = dof,
+        )
 
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))

--- a/python/eos/data/mode.py
+++ b/python/eos/data/mode.py
@@ -24,6 +24,32 @@ from eos.serializable import Serializable
 import copy as _copy
 import eos
 import os
+import numpy as _np
+
+
+# The current on-disk format version written by :meth:`Mode.create`. Files without an explicit
+# 'format_version' key predate this versioning and are treated as format v1.
+_MODE_FORMAT_VERSION = 2
+
+
+@dataclass(kw_only=True)
+class TestStatisticDescription(Serializable, Deserializable):
+    r"""Describes the test statistic of a single element of the likelihood evaluated at a mode.
+
+    :param name: The name of the likelihood element (e.g. the constraint name).
+    :type name: str
+    :param local_pvalue: The local p-value of the element at the mode.
+    :type local_pvalue: float
+    :param type: The type of the primary test statistic, typically ``'chi^2'``.
+    :type type: str
+    :param value: The value of the primary test statistic, or ``None`` if not recorded (e.g. read
+        from a format-v1 file, which stored only the local p-value).
+    :type value: float | None
+    """
+    name:str
+    local_pvalue:float
+    type:str = field(default='chi^2')
+    value:float|None = field(default=None)
 
 
 @dataclass(kw_only=True)
@@ -32,8 +58,12 @@ class ModeDescription(Serializable, Deserializable):
 
     This is the single source of truth for the metadata stored for a (local) mode, and it backs both
     the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`). The ``type``
-    discriminator is validated on deserialization and is not part of the constructor. The
-    ``global_chi2`` and ``dof`` keys are optional for backward compatibility with older files.
+    discriminator is validated on deserialization and is not part of the constructor.
+
+    The ``format_version`` key versions the on-disk layout. Files without it predate the versioning and are
+    read as format v1: their flat ``local_pvalues`` map is upgraded into :attr:`test_statistics`
+    entries (with ``type='chi^2'`` and no recorded statistic value). New files are always written as
+    format :data:`_MODE_FORMAT_VERSION`. The ``global_chi2`` and ``dof`` keys remain optional.
 
     :param version: The version of EOS that wrote the data object.
     :type version: str
@@ -43,8 +73,8 @@ class ModeDescription(Serializable, Deserializable):
     :type mode: list[float]
     :param pvalue: The global p-value at the mode, or ``None``.
     :type pvalue: float | None
-    :param local_pvalues: The local p-values at the mode.
-    :type local_pvalues: dict
+    :param test_statistics: The per-element test statistics at the mode.
+    :type test_statistics: list[TestStatisticDescription]
     :param global_chi2: The global :math:`\chi^2` value at the mode, or ``None`` if not stored.
     :type global_chi2: float | None
     :param dof: The number of degrees of freedom, or ``None`` if not stored.
@@ -54,19 +84,22 @@ class ModeDescription(Serializable, Deserializable):
     parameters:list[ParameterDescription]
     mode:list[float]
     pvalue:float|None
-    local_pvalues:dict
+    test_statistics:list[TestStatisticDescription]
     global_chi2:float|None = field(default=None)
     dof:float|None = field(default=None)
+    format_version:int = field(default=_MODE_FORMAT_VERSION)
     type:str = field(init=False, default='Mode')
 
     @classmethod
     def from_dict(cls, **kwargs):
         """Create a :class:`ModeDescription` from its on-disk keyword description.
 
-        Validates the ``type`` discriminator and deserializes each entry of ``parameters`` into a
-        :class:`ParameterDescription`.
+        Validates the ``type`` discriminator, deserializes each entry of ``parameters``, and reads the
+        per-element test statistics. Format-v1 files (those without a ``format_version`` key) are upgraded: the
+        flat ``local_pvalues`` map is converted into :class:`TestStatisticDescription` entries.
 
-        :raises ValueError: If the description does not identify a mode.
+        :raises ValueError: If the description does not identify a mode, or a format-v1 description is
+            missing its ``local_pvalues`` map.
         """
         _kwargs = _copy.deepcopy(kwargs)
 
@@ -74,25 +107,47 @@ class ModeDescription(Serializable, Deserializable):
         if _type != 'Mode':
             raise ValueError(f'Expected a description of type \'Mode\', got \'{_type}\'')
 
+        _format = _kwargs.pop('format_version', 1)
+
         if 'parameters' in _kwargs:
             _kwargs['parameters'] = [ParameterDescription.from_dict(**p) for p in _kwargs['parameters']]
+
+        if _format >= 2:
+            if 'test_statistics' in _kwargs:
+                _kwargs['test_statistics'] = [TestStatisticDescription.from_dict(**t) for t in _kwargs['test_statistics']]
+        else:
+            # Upgrade a format-v1 description: synthesize test statistics from the flat local_pvalues map.
+            local_pvalues = _kwargs.pop('local_pvalues', None)
+            if local_pvalues is None:
+                raise ValueError('A format-v1 Mode description must contain \'local_pvalues\'')
+            _kwargs['test_statistics'] = [
+                TestStatisticDescription.from_dict(name=name, local_pvalue=local_pvalue)
+                for name, local_pvalue in local_pvalues.items()
+            ]
+
+        # Record the format the description was read from (provenance); freshly created
+        # descriptions default to the current format.
+        _kwargs['format_version'] = _format
 
         return Deserializable.make(cls, **_kwargs)
 
     def to_dict(self):
         """Serialize this description into the on-disk mapping written to ``description.yaml``.
 
-        Emits the ``type`` discriminator, inverting :meth:`from_dict`.
+        Always emits the current on-disk format (:data:`_MODE_FORMAT_VERSION`), independent of
+        :attr:`format_version` (which records the provenance of a read description): the in-memory structure
+        is always the current one, so any file we write is a current-format file.
         """
         return {
-            'version':       self.version,
-            'type':          self.type,
-            'parameters':    [asdict(p) for p in self.parameters],
-            'mode':          self.mode,
-            'pvalue':        self.pvalue,
-            'local_pvalues': self.local_pvalues,
-            'global_chi2':   self.global_chi2,
-            'dof':           self.dof,
+            'version':         self.version,
+            'type':            self.type,
+            'format_version':  _MODE_FORMAT_VERSION,
+            'parameters':      [asdict(p) for p in self.parameters],
+            'mode':            self.mode,
+            'pvalue':          self.pvalue,
+            'global_chi2':     self.global_chi2,
+            'dof':             self.dof,
+            'test_statistics': [asdict(t) for t in self.test_statistics],
         }
 
 
@@ -101,13 +156,16 @@ class Mode:
 
     Stores the location of the mode in parameter space together with goodness-of-fit information.
     Instances are created either by reading an existing mode from disk (passing its ``path`` to the
-    constructor) or by writing a new mode with :meth:`create`.
+    constructor) or by writing a new mode with :meth:`create` (low-level) or :meth:`from_bfp_and_gof`
+    (from an optimization result).
 
     :ivar type: The type identifier of the data object, always ``'Mode'``.
+    :ivar format_version: The on-disk format version the mode was read from (1 for legacy files).
     :ivar varied_parameters: The descriptions (name, min, max) of the varied parameters.
     :ivar mode: The location of the mode in parameter space.
     :ivar pvalue: The global p-value at the mode.
-    :ivar local_pvalues: The local p-values at the mode.
+    :ivar test_statistics: The per-element test statistics at the mode (name, type, value, local p-value).
+    :ivar local_pvalues: A mapping from each element's name to its local p-value, derived from :attr:`test_statistics`.
     :ivar global_chi2: The global :math:`\chi^2` value at the mode, or ``None`` if not stored.
     :ivar dof: The number of degrees of freedom, or ``None`` if not stored.
     """
@@ -124,16 +182,22 @@ class Mode:
         description = ModeDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
         self.type = description.type
+        self.format_version = description.format_version
         self.varied_parameters = [asdict(p) for p in description.parameters]
         self.mode = description.mode
         self.pvalue = description.pvalue
-        self.local_pvalues = description.local_pvalues
         self.global_chi2 = description.global_chi2
         self.dof = description.dof
+        self.test_statistics = [asdict(t) for t in description.test_statistics]
+        self.local_pvalues = { t['name']: t['local_pvalue'] for t in self.test_statistics }
 
     @staticmethod
-    def create(path, parameters, mode, pvalue, local_pvalues, global_chi2, dof):
+    def create(path, parameters, mode, pvalue, test_statistics, global_chi2, dof):
         """ Write a new Mode object to disk.
+
+        This is the low-level serializer. To record a mode obtained from an optimization, prefer
+        :meth:`from_bfp_and_gof`, which derives the arguments below from the best-fit point and the
+        goodness-of-fit object.
 
         :param path: Path to the storage location, which will be created as a directory.
         :type path: str
@@ -141,24 +205,58 @@ class Mode:
         :type parameters: list or iterable of eos.Parameter
         :param mode: The mode to be stored.
         :type mode: numpy.ndarray
-        :param pvalue: The p-value of the mode.
+        :param pvalue: The global p-value of the mode.
         :type pvalue: float
-        :param local_pvalues: The local p-values of the mode.
-        :type local_pvalues: dict
+        :param test_statistics: The per-element test statistics, each a mapping with the keys
+            ``name``, ``local_pvalue`` and, optionally, ``type`` (default ``'chi^2'``) and ``value``.
+        :type test_statistics: list of dict
         :param global_chi2: The global chi2 value of the mode.
         :type global_chi2: float
         :param dof: The degrees of freedom of the mode.
         :type dof: float
         """
         description = ModeDescription(
-            version       = eos.__version__,
-            parameters    = [ParameterDescription(name=p.name(), min=p.min(), max=p.max()) for p in parameters],
-            mode          = mode.tolist(),
-            pvalue        = float(pvalue) if pvalue is not None else None,
-            local_pvalues = local_pvalues,
-            global_chi2   = global_chi2,
-            dof           = dof,
+            version         = eos.__version__,
+            parameters      = [ParameterDescription(name=p.name(), min=p.min(), max=p.max()) for p in parameters],
+            mode            = _np.asarray(mode).tolist(),
+            pvalue          = float(pvalue) if pvalue is not None else None,
+            test_statistics = [TestStatisticDescription.from_dict(**t) for t in test_statistics],
+            global_chi2     = global_chi2,
+            dof             = dof,
         )
 
         os.makedirs(path, exist_ok=True)
         description.to_yaml_file(os.path.join(path, 'description.yaml'))
+
+    @staticmethod
+    def from_bfp_and_gof(path, bfp, gof):
+        """ Write a new Mode object to disk from an optimization result.
+
+        Derives the varied parameters and the mode from the best-fit point ``bfp`` and the global and
+        per-element test statistics (chi^2 values, degrees of freedom, and p-values) from the
+        goodness-of-fit object ``gof``, then delegates to :meth:`create`.
+
+        :param path: Path to the storage location, which will be created as a directory.
+        :type path: str
+        :param bfp: The best-fit point, as returned by :meth:`eos.Analysis.optimize`.
+        :type bfp: eos.BestFitPoint
+        :param gof: The goodness-of-fit at the best-fit point.
+        :type gof: eos.GoodnessOfFit
+        """
+        import scipy.stats
+
+        total_chi2 = gof.total_chi_square()
+        dof        = gof.total_degrees_of_freedom()
+        pvalue     = float(1.0 - scipy.stats.chi2(dof).cdf(total_chi2))
+
+        test_statistics = []
+        for name, entry in gof:
+            local_pvalue = float(1.0 - scipy.stats.chi2(entry.dof).cdf(entry.chi2))
+            test_statistics.append({
+                'name':         str(name),
+                'type':         'chi^2',
+                'value':        float(entry.chi2),
+                'local_pvalue': local_pvalue,
+            })
+
+        Mode.create(path, bfp.analysis.varied_parameters, bfp.point, pvalue, test_statistics, total_chi2, dof)

--- a/python/eos/data/mode_TEST.py
+++ b/python/eos/data/mode_TEST.py
@@ -17,12 +17,45 @@ import unittest
 
 import eos
 import eos.data
+import numpy as np
 import os
+import tempfile
+import yaml
+
+
+class _Parameter:
+    "Minimal stand-in for eos.Parameter, exposing the name/min/max accessors that create() uses."
+
+    def __init__(self, name, minimum, maximum):
+        self._name = name
+        self._min  = minimum
+        self._max  = maximum
+
+    def name(self):
+        return self._name
+
+    def min(self):
+        return self._min
+
+    def max(self):
+        return self._max
 
 
 class ModeTests(unittest.TestCase):
 
     _path = os.path.join(os.environ['SOURCE_DIR'], 'eos/data/mode_TEST.d')
+
+    _parameters = [
+        _Parameter('CKM::abs(V_ub)',        3.0e-3, 4.5e-3),
+        _Parameter('B->pi::f_+(0)@BCL2008', 0.21,   0.32  ),
+    ]
+
+    @staticmethod
+    def _write(directory, description):
+        "Materialize a (possibly malformed) Mode fixture in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
 
     def test_loading(self):
         "Load a Mode from a prepared fixture and check its contents."
@@ -40,6 +73,87 @@ class ModeTests(unittest.TestCase):
         "Loading from a non-existent path raises an error."
         with self.assertRaises(RuntimeError):
             eos.data.Mode(os.path.join(self._path, 'does-not-exist'))
+
+    def test_roundtrip(self):
+        "A mode written by create() reads back identically (write/read symmetry)."
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'mode-default')
+            eos.data.Mode.create(
+                path, self._parameters, np.array([3.67e-3, 0.27]),
+                0.25, {'B->pilnu::BR': 0.5}, 12.0, 5.0
+            )
+
+            m = eos.data.Mode(path)
+            self.assertEqual(m.type, 'Mode')
+            self.assertEqual([p['name'] for p in m.varied_parameters], ['CKM::abs(V_ub)', 'B->pi::f_+(0)@BCL2008'])
+            self.assertEqual(m.mode, [3.67e-3, 0.27])
+            self.assertAlmostEqual(m.pvalue, 0.25)
+            self.assertEqual(m.local_pvalues, {'B->pilnu::BR': 0.5})
+            self.assertAlmostEqual(m.global_chi2, 12.0)
+            self.assertAlmostEqual(m.dof, 5.0)
+
+    def test_roundtrip_none_pvalue(self):
+        "A mode created with pvalue None reads back as None."
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'mode-default')
+            eos.data.Mode.create(path, self._parameters, np.array([3.67e-3, 0.27]), None, {}, None, None)
+
+            m = eos.data.Mode(path)
+            self.assertIsNone(m.pvalue)
+            self.assertIsNone(m.global_chi2)
+            self.assertIsNone(m.dof)
+
+    def test_optional_keys_absent(self):
+        "An older description without global_chi2/dof loads with those attributes set to None."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Mode',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
+                'mode': [0.5], 'pvalue': 0.25, 'local_pvalues': {},
+            })
+            m = eos.data.Mode(d)
+            self.assertIsNone(m.global_chi2)
+            self.assertIsNone(m.dof)
+
+    def test_wrong_type(self):
+        "A description whose type is not 'Mode' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Prediction',
+                'parameters': [], 'mode': [], 'pvalue': None, 'local_pvalues': {},
+            })
+            with self.assertRaises(ValueError):
+                eos.data.Mode(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Mode',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
+                'mode': [0.5], 'pvalue': 0.25, 'local_pvalues': {}, 'bogus': 42,
+            })
+            with self.assertRaises(ValueError):
+                eos.data.Mode(d)
+
+    def test_missing_mode(self):
+        "A description missing the required 'mode' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Mode',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
+                'pvalue': 0.25, 'local_pvalues': {},
+            })
+            with self.assertRaises(ValueError):
+                eos.data.Mode(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.Mode(d)
 
 
 if __name__ == '__main__':

--- a/python/eos/data/mode_TEST.py
+++ b/python/eos/data/mode_TEST.py
@@ -19,6 +19,7 @@ import eos
 import eos.data
 import numpy as np
 import os
+import scipy.stats
 import tempfile
 import yaml
 
@@ -41,6 +42,43 @@ class _Parameter:
         return self._max
 
 
+class _Entry:
+    "Minimal stand-in for a GoodnessOfFit test-statistic entry."
+
+    def __init__(self, chi2, dof):
+        self.chi2 = chi2
+        self.dof  = dof
+
+
+class _GoodnessOfFit:
+    "Minimal stand-in for eos.GoodnessOfFit, iterating as (name, entry) pairs."
+
+    def __init__(self, total_chi2, total_dof, entries):
+        self._total_chi2 = total_chi2
+        self._total_dof  = total_dof
+        self._entries    = entries
+
+    def total_chi_square(self):
+        return self._total_chi2
+
+    def total_degrees_of_freedom(self):
+        return self._total_dof
+
+    def __iter__(self):
+        return iter(self._entries)
+
+
+class _Analysis:
+    def __init__(self, varied_parameters):
+        self.varied_parameters = varied_parameters
+
+
+class _BestFitPoint:
+    def __init__(self, analysis, point):
+        self.analysis = analysis
+        self.point    = point
+
+
 class ModeTests(unittest.TestCase):
 
     _path = os.path.join(os.environ['SOURCE_DIR'], 'eos/data/mode_TEST.d')
@@ -57,17 +95,22 @@ class ModeTests(unittest.TestCase):
         with open(os.path.join(directory, 'description.yaml'), 'w') as f:
             yaml.safe_dump(description, f, default_flow_style=False)
 
-    def test_loading(self):
-        "Load a Mode from a prepared fixture and check its contents."
+    def test_loading_format1(self):
+        "Load a legacy (format-v1) Mode fixture and check that it is upgraded in memory."
         m = eos.data.Mode(self._path)
 
         self.assertEqual(m.type, 'Mode')
+        self.assertEqual(m.format_version, 1)
         self.assertEqual([p['name'] for p in m.varied_parameters], ['CKM::abs(V_ub)', 'B->pi::f_+(0)@BCL2008'])
         self.assertEqual(m.mode, [3.67e-3, 0.27])
         self.assertAlmostEqual(m.pvalue, 0.25)
-        self.assertEqual(m.local_pvalues, {'B->pilnu::BR': 0.5})
         self.assertAlmostEqual(m.global_chi2, 12.0)
         self.assertAlmostEqual(m.dof, 5.0)
+        # the flat local_pvalues map is upgraded into test statistics (with no recorded value)
+        self.assertEqual(m.local_pvalues, {'B->pilnu::BR': 0.5})
+        self.assertEqual(m.test_statistics, [
+            {'name': 'B->pilnu::BR', 'type': 'chi^2', 'value': None, 'local_pvalue': 0.5},
+        ])
 
     def test_invalid_path(self):
         "Loading from a non-existent path raises an error."
@@ -75,52 +118,71 @@ class ModeTests(unittest.TestCase):
             eos.data.Mode(os.path.join(self._path, 'does-not-exist'))
 
     def test_roundtrip(self):
-        "A mode written by create() reads back identically (write/read symmetry)."
+        "A mode written by create() reads back identically as format 2 (write/read symmetry)."
+        test_statistics = [
+            {'name': 'B->pilnu::BR',    'type': 'chi^2', 'value': 3.50, 'local_pvalue': 0.06},
+            {'name': 'B->Dlnu::R_D',    'type': 'chi^2', 'value': 1.20, 'local_pvalue': 0.27},
+        ]
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'mode-default')
-            eos.data.Mode.create(
-                path, self._parameters, np.array([3.67e-3, 0.27]),
-                0.25, {'B->pilnu::BR': 0.5}, 12.0, 5.0
-            )
+            eos.data.Mode.create(path, self._parameters, np.array([3.67e-3, 0.27]), 0.25, test_statistics, 12.0, 5.0)
 
             m = eos.data.Mode(path)
             self.assertEqual(m.type, 'Mode')
+            self.assertEqual(m.format_version, 2)
             self.assertEqual([p['name'] for p in m.varied_parameters], ['CKM::abs(V_ub)', 'B->pi::f_+(0)@BCL2008'])
             self.assertEqual(m.mode, [3.67e-3, 0.27])
             self.assertAlmostEqual(m.pvalue, 0.25)
-            self.assertEqual(m.local_pvalues, {'B->pilnu::BR': 0.5})
             self.assertAlmostEqual(m.global_chi2, 12.0)
             self.assertAlmostEqual(m.dof, 5.0)
+            self.assertEqual(m.test_statistics, test_statistics)
+            self.assertEqual(m.local_pvalues, {'B->pilnu::BR': 0.06, 'B->Dlnu::R_D': 0.27})
 
     def test_roundtrip_none_pvalue(self):
-        "A mode created with pvalue None reads back as None."
+        "A mode created with pvalue None and no test statistics reads back accordingly."
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'mode-default')
-            eos.data.Mode.create(path, self._parameters, np.array([3.67e-3, 0.27]), None, {}, None, None)
+            eos.data.Mode.create(path, self._parameters, np.array([3.67e-3, 0.27]), None, [], None, None)
 
             m = eos.data.Mode(path)
             self.assertIsNone(m.pvalue)
             self.assertIsNone(m.global_chi2)
             self.assertIsNone(m.dof)
+            self.assertEqual(m.test_statistics, [])
+            self.assertEqual(m.local_pvalues, {})
 
-    def test_optional_keys_absent(self):
-        "An older description without global_chi2/dof loads with those attributes set to None."
+    def test_from_bfp_and_gof(self):
+        "from_bfp_and_gof derives the mode, chi2/dof and p-values, then stores them."
+        bfp = _BestFitPoint(_Analysis(self._parameters), np.array([3.67e-3, 0.27]))
+        gof = _GoodnessOfFit(2.0, 3, [
+            ('B->pilnu::BR', _Entry(1.0, 2)),
+            ('B->Dlnu::R_D', _Entry(1.0, 1)),
+        ])
+
         with tempfile.TemporaryDirectory() as d:
-            self._write(d, {
-                'version': 'test', 'type': 'Mode',
-                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
-                'mode': [0.5], 'pvalue': 0.25, 'local_pvalues': {},
-            })
-            m = eos.data.Mode(d)
-            self.assertIsNone(m.global_chi2)
-            self.assertIsNone(m.dof)
+            path = os.path.join(d, 'mode-default')
+            eos.data.Mode.from_bfp_and_gof(path, bfp, gof)
+
+            m = eos.data.Mode(path)
+            self.assertEqual(m.format_version, 2)
+            self.assertEqual([p['name'] for p in m.varied_parameters], ['CKM::abs(V_ub)', 'B->pi::f_+(0)@BCL2008'])
+            self.assertEqual(m.mode, [3.67e-3, 0.27])
+            self.assertAlmostEqual(m.global_chi2, 2.0)
+            self.assertEqual(m.dof, 3)
+            self.assertAlmostEqual(m.pvalue, float(1.0 - scipy.stats.chi2(3).cdf(2.0)))
+
+            self.assertEqual([t['name']  for t in m.test_statistics], ['B->pilnu::BR', 'B->Dlnu::R_D'])
+            self.assertEqual([t['type']  for t in m.test_statistics], ['chi^2', 'chi^2'])
+            self.assertEqual([t['value'] for t in m.test_statistics], [1.0, 1.0])
+            self.assertAlmostEqual(m.local_pvalues['B->pilnu::BR'], float(1.0 - scipy.stats.chi2(2).cdf(1.0)))
+            self.assertAlmostEqual(m.local_pvalues['B->Dlnu::R_D'], float(1.0 - scipy.stats.chi2(1).cdf(1.0)))
 
     def test_wrong_type(self):
         "A description whose type is not 'Mode' is rejected."
         with tempfile.TemporaryDirectory() as d:
             self._write(d, {
-                'version': 'test', 'type': 'Prediction',
-                'parameters': [], 'mode': [], 'pvalue': None, 'local_pvalues': {},
+                'version': 'test', 'type': 'Prediction', 'format_version': 2,
+                'parameters': [], 'mode': [], 'pvalue': None, 'test_statistics': [],
             })
             with self.assertRaises(ValueError):
                 eos.data.Mode(d)
@@ -129,20 +191,31 @@ class ModeTests(unittest.TestCase):
         "An unexpected key in the description is rejected rather than silently ignored."
         with tempfile.TemporaryDirectory() as d:
             self._write(d, {
-                'version': 'test', 'type': 'Mode',
+                'version': 'test', 'type': 'Mode', 'format_version': 2,
                 'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
-                'mode': [0.5], 'pvalue': 0.25, 'local_pvalues': {}, 'bogus': 42,
+                'mode': [0.5], 'pvalue': 0.25, 'test_statistics': [], 'bogus': 42,
             })
             with self.assertRaises(ValueError):
                 eos.data.Mode(d)
 
     def test_missing_mode(self):
-        "A description missing the required 'mode' key is rejected."
+        "A format-2 description missing the required 'mode' key is rejected."
         with tempfile.TemporaryDirectory() as d:
             self._write(d, {
-                'version': 'test', 'type': 'Mode',
+                'version': 'test', 'type': 'Mode', 'format_version': 2,
                 'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
-                'pvalue': 0.25, 'local_pvalues': {},
+                'pvalue': 0.25, 'test_statistics': [],
+            })
+            with self.assertRaises(ValueError):
+                eos.data.Mode(d)
+
+    def test_format1_missing_local_pvalues(self):
+        "A format-1 description without the required 'local_pvalues' map is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Mode', 'format_version': 1,
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
+                'mode': [0.5], 'pvalue': 0.25,
             })
             with self.assertRaises(ValueError):
                 eos.data.Mode(d)

--- a/python/eos/data/nabu_likelihood.py
+++ b/python/eos/data/nabu_likelihood.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Danny van Dyk
+# Copyright (c) 2024-2026 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -13,9 +13,63 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field, asdict
+from eos.data._common import ParameterDescription
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
-import yaml
+
+
+@dataclass(kw_only=True)
+class NabuLikelihoodDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for a :class:`NabuLikelihood` object.
+
+    This is the single source of truth for the metadata stored alongside a nabu-serialized likelihood,
+    and it backs both the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`).
+    The ``type`` discriminator is validated on deserialization and is not part of the constructor.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param parameters: The descriptions of the varied parameters.
+    :type parameters: list[ParameterDescription]
+    """
+    version:str
+    parameters:list[ParameterDescription]
+    type:str = field(init=False, default='NabuLikelihood')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`NabuLikelihoodDescription` from its on-disk keyword description.
+
+        Validates the ``type`` discriminator and deserializes each entry of ``parameters`` into a
+        :class:`ParameterDescription`.
+
+        :raises ValueError: If the description does not identify a nabu-likelihood object.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type != 'NabuLikelihood':
+            raise ValueError(f'Expected a description of type \'NabuLikelihood\', got \'{_type}\'')
+
+        if 'parameters' in _kwargs:
+            _kwargs['parameters'] = [ParameterDescription.from_dict(**p) for p in _kwargs['parameters']]
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Emits the ``type`` discriminator, inverting :meth:`from_dict`.
+        """
+        return {
+            'version':    self.version,
+            'type':       self.type,
+            'parameters': [asdict(p) for p in self.parameters],
+        }
 
 
 class NabuLikelihood:
@@ -38,54 +92,40 @@ class NabuLikelihood:
         :param path: Path to the storage location.
         :type path: str
         """
-        import nabu
-
         if not os.path.exists(path) or not os.path.isdir(path):
             raise RuntimeError(f'Path {path} does not exist or is not a directory')
 
-        f = os.path.join(path, 'description.yaml')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+        description = NabuLikelihoodDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
-
-        if not description['type'] == 'NabuLikelihood':
-            raise RuntimeError(f'Path {path} not pointing to a NabuLikelihood file')
-
-        self.type = 'NabuLikelihood'
-        self.varied_parameters = description['parameters']
-        self.lookup_table = { item['name']: idx for idx, item in enumerate(self.varied_parameters) }
+        self.type = description.type
+        self.varied_parameters = [asdict(p) for p in description.parameters]
+        self.lookup_table = { p.name: idx for idx, p in enumerate(description.parameters) }
 
         f = os.path.join(path, 'likelihood.nabu')
         if not os.path.exists(f) or not os.path.isfile(f):
             raise RuntimeError(f'Nabu likelihood file {f} does not exist or is not a file')
 
+        import nabu
         self.likelihood = nabu.Likelihood.load(f)
 
 
     @staticmethod
     def create(path, parameters, likelihood):
-        """ Write a new Results object (in the dynesty.results module) to disk.
+        """ Write a new NabuLikelihood object to disk.
 
         :param path: Path to the storage location, which will be created as a directory.
         :type path: str
         :param parameters: Parameter descriptions as a 1D array of shape (N, ).
         :type parameters: list or iterable of eos.Parameter
         :param likelihood: The likelihood object created by nabu.
-        :type results: nabu.Likelihood or descendant
+        :type likelihood: nabu.Likelihood or descendant
         """
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'NabuLikelihood'
-        description['parameters'] = [{
-            'name': p.name(),
-            'min': p.min(),
-            'max': p.max()
-        } for p in parameters]
+        description = NabuLikelihoodDescription(
+            version    = eos.__version__,
+            parameters = [ParameterDescription(name=p.name(), min=p.min(), max=p.max()) for p in parameters],
+        )
 
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))
 
         likelihood.save(os.path.join(path, 'likelihood.nabu'))

--- a/python/eos/data/nabu_likelihood_TEST.py
+++ b/python/eos/data/nabu_likelihood_TEST.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import unittest
+
+import eos
+import eos.data
+import os
+import tempfile
+import yaml
+
+
+# These tests exercise the hardening of the description parsing, which happens before the (optional)
+# nabu payload is loaded, so they do not require the nabu module to be installed.
+class NabuLikelihoodTests(unittest.TestCase):
+
+    @staticmethod
+    def _write(directory, description):
+        "Materialize a (possibly malformed) NabuLikelihood description in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
+
+    def test_invalid_path(self):
+        "Loading from a non-existent path raises an error."
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(RuntimeError):
+                eos.data.NabuLikelihood(os.path.join(d, 'does-not-exist'))
+
+    def test_wrong_type(self):
+        "A description whose type is not 'NabuLikelihood' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'MarkovChain', 'parameters': []})
+            with self.assertRaises(ValueError):
+                eos.data.NabuLikelihood(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'NabuLikelihood',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}], 'bogus': 42,
+            })
+            with self.assertRaises(ValueError):
+                eos.data.NabuLikelihood(d)
+
+    def test_missing_parameters(self):
+        "A description missing the required 'parameters' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'NabuLikelihood'})
+            with self.assertRaises(ValueError):
+                eos.data.NabuLikelihood(d)
+
+    def test_missing_payload(self):
+        "A valid description without the likelihood payload is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'NabuLikelihood',
+                'parameters': [{'name': 'a', 'min': 0.0, 'max': 1.0}],
+            })
+            with self.assertRaises(RuntimeError):
+                eos.data.NabuLikelihood(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.NabuLikelihood(d)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)

--- a/python/eos/data/pmc_sampler.py
+++ b/python/eos/data/pmc_sampler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Danny van Dyk
+# Copyright (c) 2021-2026 Danny van Dyk
 # Copyright (c) 2021-2024 Méril Reboud
 #
 # This file is part of the EOS project. EOS is free software;
@@ -14,11 +14,107 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field, asdict
+from eos.data._common import GaussianComponentDescription, ParameterDescription
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
 import numpy as _np
-import yaml
 from scipy.special import erf
+
+
+@dataclass(kw_only=True)
+class ProposalDescription(Serializable, Deserializable):
+    r"""Describes the Gaussian-mixture proposal density of a :class:`PMCSampler`.
+
+    :param components: The Gaussian components of the proposal mixture.
+    :type components: list[GaussianComponentDescription]
+    :param weights: The component weights of the proposal mixture.
+    :type weights: list
+    """
+    components:list[GaussianComponentDescription]
+    weights:list
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`ProposalDescription`, deserializing its Gaussian components."""
+        _kwargs = _copy.deepcopy(kwargs)
+        if 'components' in _kwargs:
+            _kwargs['components'] = [GaussianComponentDescription.from_dict(**c) for c in _kwargs['components']]
+        return Deserializable.make(cls, **_kwargs)
+
+
+@dataclass(kw_only=True)
+class PMCSamplerDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for a :class:`PMCSampler`.
+
+    This is the single source of truth for the metadata stored alongside a PMC proposal, and it backs
+    both the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`). The ``type``
+    discriminator is validated on deserialization and is not part of the constructor.
+
+    The test statistics are written under the ``test_statistics`` key. For backward compatibility the
+    legacy misspelled key ``'test statistics'`` (with a space) is also accepted on deserialization
+    (with a warning), since older files were written with it.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param parameters: The descriptions of the varied parameters.
+    :type parameters: list[ParameterDescription]
+    :param proposal: The Gaussian-mixture proposal density.
+    :type proposal: ProposalDescription
+    :param test_statistics: The precomputed test statistics.
+    :type test_statistics: dict
+    """
+    version:str
+    parameters:list[ParameterDescription]
+    proposal:ProposalDescription
+    test_statistics:dict = field(default_factory=lambda: {'sigma': [], 'densities': []})
+    type:str = field(init=False, default='PMCSampler')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`PMCSamplerDescription` from its on-disk keyword description.
+
+        Validates the ``type`` discriminator, deserializes the parameters and the proposal, and
+        normalizes the legacy ``'test statistics'`` key to ``test_statistics``.
+
+        :raises ValueError: If the description does not identify a PMC sampler.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type != 'PMCSampler':
+            raise ValueError(f'Expected a description of type \'PMCSampler\', got \'{_type}\'')
+
+        if 'test statistics' in _kwargs:
+            eos.warn('The \'test statistics\' key is deprecated; it will be written as \'test_statistics\' when this data set is re-saved')
+            legacy = _kwargs.pop('test statistics')
+            _kwargs.setdefault('test_statistics', legacy)
+
+        if 'parameters' in _kwargs:
+            _kwargs['parameters'] = [ParameterDescription.from_dict(**p) for p in _kwargs['parameters']]
+
+        if 'proposal' in _kwargs:
+            _kwargs['proposal'] = ProposalDescription.from_dict(**_kwargs['proposal'])
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Emits the ``type`` discriminator and the (normalized) ``test_statistics`` key, inverting
+        :meth:`from_dict`.
+        """
+        return {
+            'version':         self.version,
+            'type':            self.type,
+            'parameters':      [asdict(p) for p in self.parameters],
+            'proposal':        self.proposal.to_dict(),
+            'test_statistics': self.test_statistics,
+        }
 
 
 class PMCSampler:
@@ -35,6 +131,7 @@ class PMCSampler:
     :ivar lookup_table: A mapping from each parameter name to its index in :attr:`varied_parameters`.
     :ivar components: The Gaussian components of the proposal mixture.
     :ivar component_weights: The weights of the proposal mixture components.
+    :ivar test_statistics: The precomputed test statistics.
     """
 
     def __init__(self, path):
@@ -46,25 +143,19 @@ class PMCSampler:
         if not os.path.exists(path) or not os.path.isdir(path):
             raise RuntimeError(f'Path {path} does not exist or is not a directory')
 
-        f = os.path.join(path, 'description.yaml')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
-
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
-
-        if not description['type'] == 'PMCSampler':
-            raise RuntimeError(f'Path {path} not pointing to a PMCSampler')
+        description = PMCSamplerDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
         try:
             import pypmc
         except ImportError as e:
             raise ImportError('eos.data.PMCSampler requires the PyPMC python module, which can be installed from PyPI.') from e
-        self.type = 'PMCSampler'
-        self.varied_parameters = description['parameters']
-        self.lookup_table = { item['name']: idx for idx, item in enumerate(self.varied_parameters) }
-        self.components        = _np.array([pypmc.density.gauss.Gauss(_np.array(c['mu']), _np.array(c['sigma'])) for c in description['proposal']['components']])
-        self.component_weights = _np.array(description['proposal']['weights'])
+
+        self.type = description.type
+        self.varied_parameters = [asdict(p) for p in description.parameters]
+        self.lookup_table = { p.name: idx for idx, p in enumerate(description.parameters) }
+        self.components        = _np.array([pypmc.density.gauss.Gauss(_np.array(c.mu), _np.array(c.sigma)) for c in description.proposal.components])
+        self.component_weights = _np.array(description.proposal.weights)
+        self.test_statistics   = description.test_statistics
 
 
     def density(self):
@@ -115,26 +206,17 @@ class PMCSampler:
         :param weights: Weights on a linear scale as a 1D array of shape (N, ). Needed to generate the test statistic.
         :type weights: 1D numpy array, optional
         """
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'PMCSampler'
-        description['parameters'] = [{
-            'name': p.name(),
-            'min': p.min(),
-            'max': p.max()
-        } for p in parameters]
-
         # Don't write components that have a 0 weight
         purged_components = []
         purged_weights = []
         for comp, w in zip(proposal.components, proposal.weights.tolist()):
             if w != 0:
-                purged_components.append({ 'mu': comp.mu.tolist(), 'sigma': comp.sigma.tolist() })
+                purged_components.append(GaussianComponentDescription(mu=comp.mu.tolist(), sigma=comp.sigma.tolist()))
                 purged_weights.append(w)
-        description['proposal'] = { 'components': purged_components, 'weights': purged_weights }
+        proposal_description = ProposalDescription(components=purged_components, weights=purged_weights)
 
-        # The test statistics defaults to two empty lists
-        description['test statistics'] = { "sigma": [], "densities": [] }
+        # The test statistics default to two empty lists
+        test_statistics = { "sigma": [], "densities": [] }
         if sigma_test_stat is not None and samples is not None and weights is not None:
             sigma_test_stat = _np.array(sigma_test_stat)
             samplesPDF = list(map(lambda x: -2.0 * _np.log(PMCSampler._evaluate_mixture_pdf(proposal, x)), samples))
@@ -145,11 +227,17 @@ class PMCSampler:
             percents = erf(sigma_test_stat/_np.sqrt(2))
             weighted_percentile = _np.interp(percents, cumulant, sorted_samplesPDF)
 
-            description['test statistics'] = {
+            test_statistics = {
                 "sigma": sigma_test_stat.tolist(),
                 "densities": weighted_percentile.tolist()
             }
 
+        description = PMCSamplerDescription(
+            version         = eos.__version__,
+            parameters      = [ParameterDescription(name=p.name(), min=p.min(), max=p.max()) for p in parameters],
+            proposal        = proposal_description,
+            test_statistics = test_statistics,
+        )
+
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))

--- a/python/eos/data/pmc_sampler_TEST.py
+++ b/python/eos/data/pmc_sampler_TEST.py
@@ -1,10 +1,75 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
 import unittest
 
 import eos
+import eos.data
 import numpy as np
+import os
+import tempfile
+import yaml
+
+
+def pypmc_is_missing():
+    try:
+        import pypmc
+        return False
+    except ImportError:
+        return True
+
+
+class _Parameter:
+    "Minimal stand-in for eos.Parameter, exposing the name/min/max accessors that create() uses."
+
+    def __init__(self, name, minimum, maximum):
+        self._name = name
+        self._min  = minimum
+        self._max  = maximum
+
+    def name(self):
+        return self._name
+
+    def min(self):
+        return self._min
+
+    def max(self):
+        return self._max
 
 
 class PMCSamplerTests(unittest.TestCase):
+
+    _parameters = [
+        _Parameter('CKM::abs(V_ub)',        3.0e-3, 4.5e-3),
+        _Parameter('B->pi::f_+(0)@BCL2008', 0.21,   0.32  ),
+    ]
+
+    @staticmethod
+    def _write(directory, description):
+        "Materialize a (possibly malformed) PMCSampler description in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
+
+    @staticmethod
+    def _proposal():
+        import pypmc
+        means   = [np.array([5.0, 0.01]), np.array([-4.0, 1.0])]
+        covs    = [np.array([[0.01, 0.003], [0.003, 0.0025]]), np.array([[0.1, 0.0], [0.0, 0.02]])]
+        weights = np.array([0.3, 0.7])
+        return pypmc.density.mixture.create_gaussian_mixture(means, covs, weights)
 
     def test_evaluate_mixture_pdf(self):
         "Test the evaluation of a mixture PDF, used in the computation of test statistics."
@@ -34,6 +99,88 @@ class PMCSamplerTests(unittest.TestCase):
             0.26256727,
             delta=1e-5
         )
+
+    @unittest.skipIf(pypmc_is_missing(), "Test requires the 'pypmc' module")
+    def test_roundtrip(self):
+        "A PMC sampler written by create() reads back identically and writes the modern key."
+        proposal = self._proposal()
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'pmc')
+            eos.data.PMCSampler.create(path, self._parameters, proposal)
+
+            # the modern key is written; the legacy misspelling is not
+            with open(os.path.join(path, 'description.yaml')) as f:
+                on_disk = yaml.safe_load(f)
+            self.assertIn('test_statistics', on_disk)
+            self.assertNotIn('test statistics', on_disk)
+
+            s = eos.data.PMCSampler(path)
+            self.assertEqual(s.type, 'PMCSampler')
+            self.assertEqual(s.lookup_table, {'CKM::abs(V_ub)': 0, 'B->pi::f_+(0)@BCL2008': 1})
+            self.assertEqual(len(s.components), 2)
+            np.testing.assert_allclose(s.component_weights, [0.3, 0.7])
+            self.assertEqual(s.test_statistics, {'sigma': [], 'densities': []})
+
+            density = s.density()
+            self.assertEqual(len(density.components), 2)
+
+    @unittest.skipIf(pypmc_is_missing(), "Test requires the 'pypmc' module")
+    def test_legacy_test_statistics_warns(self):
+        "A legacy 'test statistics' (space) key is accepted, warns, and is normalized."
+        proposal = self._proposal()
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'pmc')
+            eos.data.PMCSampler.create(path, self._parameters, proposal)
+
+            # rewrite the description with the legacy misspelled key
+            desc = os.path.join(path, 'description.yaml')
+            with open(desc) as f:
+                on_disk = yaml.safe_load(f)
+            on_disk['test statistics'] = on_disk.pop('test_statistics')
+            with open(desc, 'w') as f:
+                yaml.safe_dump(on_disk, f)
+
+            with self.assertLogs('EOS', level='WARNING'):
+                s = eos.data.PMCSampler(path)
+            self.assertEqual(s.test_statistics, {'sigma': [], 'densities': []})
+
+    def test_invalid_path(self):
+        "Loading from a non-existent path raises an error."
+        with self.assertRaises(RuntimeError):
+            eos.data.PMCSampler(os.path.join(tempfile.gettempdir(), 'eos-does-not-exist-pmc'))
+
+    def test_wrong_type(self):
+        "A description whose type is not 'PMCSampler' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'MixtureDensity',
+                            'parameters': [], 'proposal': {'components': [], 'weights': []}})
+            with self.assertRaises(ValueError):
+                eos.data.PMCSampler(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'PMCSampler',
+                            'parameters': [], 'proposal': {'components': [], 'weights': []}, 'bogus': 42})
+            with self.assertRaises(ValueError):
+                eos.data.PMCSampler(d)
+
+    def test_missing_proposal(self):
+        "A description missing the required 'proposal' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'PMCSampler', 'parameters': []})
+            with self.assertRaises(ValueError):
+                eos.data.PMCSampler(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.PMCSampler(d)
 
 
 if __name__ == '__main__':

--- a/python/eos/data/prediction.py
+++ b/python/eos/data/prediction.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Danny van Dyk
+# Copyright (c) 2020-2026 Danny van Dyk
 # Copyright (c) 2024-2025 Méril Reboud
 #
 # This file is part of the EOS project. EOS is free software;
@@ -14,10 +14,145 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field, asdict
+from eos.data._common import load_array
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
 import numpy as _np
-import yaml
+
+
+# The current on-disk format version written by :meth:`Prediction.create`. Files without an explicit
+# 'format' key predate this versioning and are treated as format 1 (no recorded column 'kind').
+_PREDICTION_FORMAT = 2
+
+
+def _classify_column(name, options, kinematics, parameters, observables):
+    r"""Classify a prediction column as an ``'observable'`` or a ``'parameter'``.
+
+    Mirrors the precedence of :cpp:func:`eos.Observable.make`: a column is a parameter (clothed as an
+    observable) only if it carries no options and no kinematics, its qualified name has an empty option
+    part, its name does **not** match a registered observable (a registered observable always shadows a
+    parameter of the same name), and its name **does** match a parameter.
+
+    :param name: The qualified name of the column.
+    :param options: The column's options as a mapping (empty for a parameter).
+    :param kinematics: The column's kinematics as a mapping (empty for a parameter).
+    :param parameters: The parameter set to test membership against.
+    :type parameters: eos.Parameters
+    :param observables: The observable registry to test the shadowing rule against.
+    :type observables: eos.Observables
+    :rtype: str
+    """
+    if options or kinematics:
+        return 'observable'
+    if list(eos.QualifiedName(name).options_part()):
+        return 'observable'
+    # a registered observable of the same name shadows any parameter
+    try:
+        observables[name]
+        return 'observable'
+    except RuntimeError:
+        pass
+    try:
+        parameters[name]
+        return 'parameter'
+    except RuntimeError:
+        return 'observable'
+
+
+@dataclass(kw_only=True)
+class ObservableDescription(Serializable, Deserializable):
+    r"""Describes a single column of a :class:`Prediction`.
+
+    A column is either a genuine observable (with its options and kinematics) or a parameter clothed as
+    an observable (with empty options and kinematics), as recorded by :attr:`kind`.
+
+    :param name: The qualified name of the observable (or parameter).
+    :type name: str
+    :param kind: Whether the column is an ``'observable'`` or a ``'parameter'``.
+    :type kind: str
+    :param kinematics: The kinematic variables and their values. Empty for a parameter.
+    :type kinematics: dict
+    :param options: The options and their values. Empty for a parameter.
+    :type options: dict
+    """
+    name:str
+    kind:str = field(default='observable')
+    kinematics:dict = field(default_factory=dict)
+    options:dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.kind not in ('observable', 'parameter'):
+            raise ValueError(f'Invalid column kind \'{self.kind}\'; must be \'observable\' or \'parameter\'')
+
+
+@dataclass(kw_only=True)
+class PredictionDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for a :class:`Prediction`.
+
+    This is the single source of truth for the metadata stored alongside a set of posterior-predictive
+    samples, and it backs both the read path (:meth:`from_yaml_file`) and the write path
+    (:meth:`to_yaml_file`). The ``type`` discriminator is validated on deserialization and is not part
+    of the constructor.
+
+    The ``format`` key versions the on-disk layout. Files without it predate the versioning and are
+    read as format 1, which does not record whether each column is an observable or a parameter; that
+    classification is then re-derived on read. New files are always written as format
+    :data:`_PREDICTION_FORMAT`, recording each column's :attr:`~ObservableDescription.kind`.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param observables: The descriptions of the predicted columns.
+    :type observables: list[ObservableDescription]
+    """
+    version:str
+    observables:list[ObservableDescription]
+    format:int = field(default=_PREDICTION_FORMAT)
+    type:str = field(init=False, default='Prediction')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`PredictionDescription` from its on-disk keyword description.
+
+        Validates the ``type`` discriminator and deserializes each entry of ``observables`` into an
+        :class:`ObservableDescription`.
+
+        :raises ValueError: If the description does not identify a prediction.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type != 'Prediction':
+            raise ValueError(f'Expected a description of type \'Prediction\', got \'{_type}\'')
+
+        _format = _kwargs.pop('format', 1)
+
+        if 'observables' in _kwargs:
+            _kwargs['observables'] = [ObservableDescription.from_dict(**o) for o in _kwargs['observables']]
+
+        # Record the format the description was read from (provenance); freshly created
+        # descriptions default to the current format.
+        _kwargs['format'] = _format
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Always emits the current on-disk format (:data:`_PREDICTION_FORMAT`), independent of
+        :attr:`format` (which records the provenance of a read description): the in-memory structure
+        is always the current one, so any file we write is a current-format file.
+        """
+        return {
+            'version':     self.version,
+            'type':        self.type,
+            'format':      _PREDICTION_FORMAT,
+            'observables': [o.to_dict() for o in self.observables],
+        }
 
 
 class Prediction:
@@ -27,9 +162,13 @@ class Prediction:
     created either by reading an existing data set from disk (passing its ``path`` to the constructor) or
     by writing a new data set with :meth:`create`.
 
+    Each column is either a genuine observable or a parameter clothed as an observable; the two are
+    distinguished by the ``kind`` key of the corresponding entry in :attr:`varied_parameters`.
+
     :ivar type: The type identifier of the data object, always ``'Prediction'``.
-    :ivar varied_parameters: The descriptions (name, kinematics, options) of the predicted observables.
-    :ivar lookup_table: A mapping from each observable's qualified name (including options and kinematics) to its column index in :attr:`samples`.
+    :ivar format: The on-disk format version the prediction was read from (1 for legacy files).
+    :ivar varied_parameters: The descriptions (name, kind, kinematics, options) of the predicted columns.
+    :ivar lookup_table: A mapping from each column's qualified name (including options and kinematics) to its column index in :attr:`samples`.
     :ivar samples: The predictive samples as a 2D array of shape (N, O).
     :ivar weights: The importance weights on a linear scale as a 1D array of shape (N, ).
     """
@@ -43,36 +182,32 @@ class Prediction:
         if not os.path.exists(path) or not os.path.isdir(path):
             raise RuntimeError(f'Path {path} does not exist or is not a directory')
 
-        f = os.path.join(path, 'description.yaml')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+        description = PredictionDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
+        self.type = description.type
+        self.format = description.format
+        observables = description.observables
 
-        if not description['type'] == 'Prediction':
-            raise RuntimeError(f'Path {path} not pointing to a Prediction')
+        # For legacy files (no recorded kind), re-derive each column's kind, mirroring
+        # eos.Observable.make (best-effort, against the default registries).
+        if description.format < 2:
+            registry   = eos.Observables()
+            parameters = eos.Parameters()
+            for o in observables:
+                o.kind = _classify_column(o.name, o.options, o.kinematics, parameters, registry)
 
-        self.type = 'Prediction'
-        self.varied_parameters = description['observables']
+        self.varied_parameters = [asdict(o) for o in observables]
+
         self.lookup_table = {}
-        for idx, item in enumerate(self.varied_parameters):
-            id = item['name']
-            if 'options' in item:
-                id += ';' + str(eos.Options(item['options'])).replace(" ", "")
-            if 'kinematics' in item:
-                id += '[' + str(eos.Kinematics(item['kinematics'])).replace(" ", "") + ']'
+        for idx, o in enumerate(observables):
+            id = o.name
+            id += ';' + str(eos.Options(o.options)).replace(" ", "")
+            id += '[' + str(eos.Kinematics(o.kinematics)).replace(" ", "") + ']'
             self.lookup_table[id] = idx
 
-        f = os.path.join(path, 'samples.npy')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Samples file {f} does not exist or is not a file')
-        self.samples = _np.load(f)
-
-        f = os.path.join(path, 'weights.npy')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Weights file {f} does not exist or is not a file')
-        self.weights = _np.load(f)
+        ncols = len(observables)
+        self.samples = load_array(path, 'samples.npy', ncols=ncols)
+        self.weights = load_array(path, 'weights.npy', nrows=self.samples.shape[0])
 
 
     @staticmethod
@@ -88,23 +223,25 @@ class Prediction:
         :param weights: Weights on a linear scale as a 1D array of shape (N, ).
         :type weights: 1D numpy array
         """
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'Prediction'
-        description['observables'] = [{
-            'name': o.name().full(),
-            'kinematics': { k.name(): float(k) for k in o.kinematics() },
-            'options': { str(k): str(v) for k, v in o.options() }
-        } for o in observables]
-
         if not samples.shape[1] == len(observables):
             raise RuntimeError(f'Shape of samples {samples.shape} incompatible with number of observables {len(observables)}')
 
         if not samples.shape[0] == weights.shape[0]:
             raise RuntimeError(f'Shape of weights {weights.shape} incompatible with shape of samples {samples.shape}')
 
+        registry = eos.Observables()
+        observable_descriptions = []
+        for o in observables:
+            name       = o.name().full()
+            kinematics = { k.name(): float(k) for k in o.kinematics() }
+            options    = { str(k): str(v) for k, v in o.options() }
+            kind       = _classify_column(name, options, kinematics, o.parameters(), registry)
+            observable_descriptions.append(ObservableDescription(
+                name=name, kind=kind, kinematics=kinematics, options=options))
+
+        description = PredictionDescription(version=eos.__version__, observables=observable_descriptions)
+
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))
         _np.save(os.path.join(path, 'samples.npy'), samples)
         _np.save(os.path.join(path, 'weights.npy'), weights)

--- a/python/eos/data/prediction_TEST.py
+++ b/python/eos/data/prediction_TEST.py
@@ -1,16 +1,176 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
 import unittest
 
 import eos
+import eos.data
+import numpy as np
 import os
+import tempfile
+import yaml
 
 
 class PredictionTests(unittest.TestCase):
 
-    def test_importing_predictions(self):
-        "Test the import of prediction samples."
+    _path = os.path.join(os.environ['SOURCE_DIR'], 'eos/data/prediction_TEST.d')
 
-        file = eos.data.Prediction(os.path.join(os.environ['SOURCE_DIR'], "eos/data/prediction_TEST.d/predictions-binned"))
-        file = eos.data.Prediction(os.path.join(os.environ['SOURCE_DIR'], "eos/data/prediction_TEST.d/predictions"))
+    @staticmethod
+    def _write(directory, description, samples=None, weights=None):
+        "Materialize a (possibly malformed) Prediction fixture in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
+        if samples is not None:
+            np.save(os.path.join(directory, 'samples.npy'), samples)
+        if weights is not None:
+            np.save(os.path.join(directory, 'weights.npy'), weights)
+
+    def test_loading(self):
+        "Load the prepared (legacy) fixtures and check their contents."
+        for name in ('predictions', 'predictions-binned'):
+            p = eos.data.Prediction(os.path.join(self._path, name))
+            self.assertEqual(p.type, 'Prediction')
+            self.assertEqual(p.format, 1)
+            self.assertEqual(p.samples.shape[0], p.weights.shape[0])
+            self.assertEqual(p.samples.shape[1], len(p.varied_parameters))
+            # the fixture columns are all genuine observables (they carry options and kinematics)
+            for vp in p.varied_parameters:
+                self.assertEqual(vp['kind'], 'observable')
+            # the lookup keys keep the qualified-name form 'name;options[kinematics]'
+            first = next(iter(p.lookup_table))
+            self.assertTrue(first.startswith('B->pilnu::'))
+            self.assertIn(';', first)
+            self.assertTrue(first.endswith(']'))
+
+    def test_invalid_path(self):
+        "Loading from a non-existent path raises an error."
+        with self.assertRaises(RuntimeError):
+            eos.data.Prediction(os.path.join(self._path, 'does-not-exist'))
+
+    def test_roundtrip(self):
+        "A prediction of a genuine observable and a parameter-clothed column round-trips with kinds."
+        params = eos.Parameters.Defaults()
+        obs = eos.Observable.make(
+            'B->pilnu::dBR/dq2', params,
+            eos.Kinematics({'q2': 1.0}),
+            eos.Options({'P': 'pi', 'form-factors': 'BCL2008', 'model': 'CKM'}),
+        )
+        par = eos.Observable.make('CKM::abs(V_ub)', params, eos.Kinematics({}), eos.Options({}))
+        self.assertIsNotNone(obs)
+        self.assertIsNotNone(par)
+
+        samples = np.array([[1.0e-6, 3.7e-3], [2.0e-6, 3.6e-3], [3.0e-6, 3.8e-3]])
+        weights = np.array([1.0, 2.0, 3.0])
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'pred-test')
+            eos.data.Prediction.create(path, [obs, par], samples, weights)
+
+            p = eos.data.Prediction(path)
+            self.assertEqual(p.type, 'Prediction')
+            self.assertEqual(p.format, 2)
+
+            # the genuine observable is classified as such, the parameter as a parameter
+            self.assertEqual(p.varied_parameters[0]['kind'], 'observable')
+            self.assertEqual(p.varied_parameters[1]['kind'], 'parameter')
+            self.assertEqual(p.varied_parameters[1]['name'], 'CKM::abs(V_ub)')
+            self.assertEqual(p.varied_parameters[1]['options'], {})
+            self.assertEqual(p.varied_parameters[1]['kinematics'], {})
+
+            # lookup keys: the parameter column has empty options/kinematics parts
+            self.assertEqual(p.lookup_table['CKM::abs(V_ub);[]'], 1)
+            obs_keys = [k for k in p.lookup_table if k != 'CKM::abs(V_ub);[]']
+            self.assertEqual(len(obs_keys), 1)
+            self.assertEqual(p.lookup_table[obs_keys[0]], 0)
+            self.assertTrue(obs_keys[0].startswith('B->pilnu::dBR/dq2;'))
+
+            np.testing.assert_allclose(p.samples, samples)
+            np.testing.assert_allclose(p.weights, weights)
+
+    def test_legacy_reclassification(self):
+        "A legacy (format-1) file without kinds is reclassified on read."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Prediction',
+                'observables': [
+                    {'name': 'B->pilnu::dBR/dq2', 'kinematics': {'q2': 1.0},
+                     'options': {'P': 'pi', 'form-factors': 'BCL2008', 'model': 'CKM'}},
+                    {'name': 'CKM::abs(V_ub)', 'kinematics': {}, 'options': {}},
+                ],
+            }, samples=np.zeros((3, 2)), weights=np.zeros(3))
+
+            p = eos.data.Prediction(d)
+            self.assertEqual(p.format, 1)
+            self.assertEqual(p.varied_parameters[0]['kind'], 'observable')
+            self.assertEqual(p.varied_parameters[1]['kind'], 'parameter')
+
+    def test_wrong_type(self):
+        "A description whose type is not 'Prediction' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'MarkovChain', 'observables': []})
+            with self.assertRaises(ValueError):
+                eos.data.Prediction(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Prediction', 'format': 2,
+                'observables': [], 'bogus': 42,
+            })
+            with self.assertRaises(ValueError):
+                eos.data.Prediction(d)
+
+    def test_missing_observables(self):
+        "A description missing the required 'observables' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'Prediction'})
+            with self.assertRaises(ValueError):
+                eos.data.Prediction(d)
+
+    def test_invalid_kind(self):
+        "A column with an unrecognized kind is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Prediction', 'format': 2,
+                'observables': [{'name': 'a', 'kind': 'nonsense', 'kinematics': {}, 'options': {}}],
+            })
+            with self.assertRaises(ValueError):
+                eos.data.Prediction(d)
+
+    def test_shape_mismatch(self):
+        "Samples whose column count disagrees with the observables are rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {
+                'version': 'test', 'type': 'Prediction', 'format': 2,
+                'observables': [
+                    {'name': 'a', 'kind': 'observable', 'kinematics': {}, 'options': {}},
+                    {'name': 'b', 'kind': 'observable', 'kinematics': {}, 'options': {}},
+                ],
+            }, samples=np.zeros((5, 3)), weights=np.zeros(5))
+            with self.assertRaises(RuntimeError):
+                eos.data.Prediction(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.Prediction(d)
 
 
 if __name__ == '__main__':

--- a/python/eos/data/sample_mask.py
+++ b/python/eos/data/sample_mask.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 Matthew Kirk
+# Copyright (c) 2026 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -13,10 +14,66 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from dataclasses import dataclass, field
+from eos.data._common import load_array
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable
+
+import copy as _copy
 import eos
 import os
 import numpy as _np
-import yaml
+
+
+@dataclass(kw_only=True)
+class SampleMaskDescription(Serializable, Deserializable):
+    r"""Schema of the ``description.yaml`` written for a :class:`SampleMask`.
+
+    This is the single source of truth for the metadata stored alongside a sample mask, and it backs
+    both the read path (:meth:`from_yaml_file`) and the write path (:meth:`to_yaml_file`).
+
+    The ``type`` discriminator is always written as ``'SampleMask'``. For backward compatibility the
+    legacy discriminator ``'Mask'`` is also accepted on deserialization (with a warning), since older
+    files were written with it.
+
+    :param version: The version of EOS that wrote the data object.
+    :type version: str
+    :param observables: The names of the observables to which the mask applies.
+    :type observables: list
+    """
+    version:str
+    observables:list
+    type:str = field(init=False, default='SampleMask')
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        """Create a :class:`SampleMaskDescription` from its on-disk keyword description.
+
+        Accepts either the current ``'SampleMask'`` discriminator or the legacy ``'Mask'`` one; the
+        latter is deprecated and triggers a warning.
+
+        :raises ValueError: If the description does not identify a sample mask.
+        """
+        _kwargs = _copy.deepcopy(kwargs)
+
+        _type = _kwargs.pop('type', None)
+        if _type == 'Mask':
+            eos.warn('The \'Mask\' data type is deprecated; it will be written as \'SampleMask\' when this data set is re-saved')
+        elif _type != 'SampleMask':
+            raise ValueError(f'Expected a description of type \'SampleMask\' (or the legacy \'Mask\'), got \'{_type}\'')
+
+        return Deserializable.make(cls, **_kwargs)
+
+    def to_dict(self):
+        """Serialize this description into the on-disk mapping written to ``description.yaml``.
+
+        Always emits the current ``'SampleMask'`` discriminator, inverting :meth:`from_dict`.
+        """
+        return {
+            'version':     self.version,
+            'type':        self.type,
+            'observables': self.observables,
+        }
 
 
 class SampleMask:
@@ -26,7 +83,7 @@ class SampleMask:
     applies to. Instances are created either by reading an existing mask from disk (passing its ``path``
     to the constructor) or by writing a new mask with :meth:`create`.
 
-    :ivar type: The type identifier of the data object, always ``'Mask'``.
+    :ivar type: The type identifier of the data object, always ``'SampleMask'``.
     :ivar observables: The observables to which the mask applies.
     :ivar mask: The boolean mask as a 1D array.
     """
@@ -40,27 +97,15 @@ class SampleMask:
         if not os.path.exists(path) or not os.path.isdir(path):
             raise RuntimeError(f'Path {path} does not exist or is not a directory')
 
-        f = os.path.join(path, 'description.yaml')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Description file {f} does not exist or is not a file')
+        description = SampleMaskDescription.from_yaml_file(os.path.join(path, 'description.yaml'))
 
-        with open(f) as df:
-            description = yaml.load(df, Loader=yaml.SafeLoader)
-
-        if not description['type'] == 'Mask':
-            raise RuntimeError(f'Path {path} not pointing to a Mask file')
-
-        self.type = 'Mask'
-        self.observables = description['observables']
-
-        f = os.path.join(path, 'mask.npy')
-        if not os.path.exists(f) or not os.path.isfile(f):
-            raise RuntimeError(f'Mask file {f} does not exist or is not a file')
-        self.mask = _np.load(f)
+        self.type = description.type
+        self.observables = description.observables
+        self.mask = load_array(path, 'mask.npy')
 
     @staticmethod
     def create(path, mask, observables):
-        """ Write a new Mask object to disk.
+        """ Write a new SampleMask object to disk.
 
         :param path: Path to the storage location, which will be created as a directory.
         :type path: str
@@ -68,12 +113,8 @@ class SampleMask:
         :type mask: list or iterable of bool
         :param observables: Observables as a 1D array
         """
-        description = {}
-        description['version'] = eos.__version__
-        description['type'] = 'Mask'
-        description['observables'] = observables
+        description = SampleMaskDescription(version=eos.__version__, observables=observables)
 
         os.makedirs(path, exist_ok=True)
-        with open(os.path.join(path, 'description.yaml'), 'w') as description_file:
-            yaml.dump(description, description_file, default_flow_style=False)
+        description.to_yaml_file(os.path.join(path, 'description.yaml'))
         _np.save(os.path.join(path, 'mask.npy'), mask)

--- a/python/eos/data/sample_mask_TEST.py
+++ b/python/eos/data/sample_mask_TEST.py
@@ -17,20 +17,34 @@ import unittest
 
 import eos
 import eos.data
+import numpy as np
 import os
+import tempfile
+import yaml
 
 
 class SampleMaskTests(unittest.TestCase):
 
     _path = os.path.join(os.environ['SOURCE_DIR'], 'eos/data/sample_mask_TEST.d')
 
-    def test_loading(self):
-        "Load a SampleMask from a prepared fixture and check its contents."
-        sm = eos.data.SampleMask(self._path)
+    _observables = ['B->Dlnu::BR', 'B->pilnu::BR', 'B->Dlnu::dBR/dq2', 'B->pilnu::dBR/dq2', 'B_u->lnu::BR']
 
-        self.assertEqual(sm.type, 'Mask')
-        self.assertEqual(sm.observables,
-            ['B->Dlnu::BR', 'B->pilnu::BR', 'B->Dlnu::dBR/dq2', 'B->pilnu::dBR/dq2', 'B_u->lnu::BR'])
+    @staticmethod
+    def _write(directory, description, mask=None):
+        "Materialize a (possibly malformed) SampleMask fixture in the given directory."
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, 'description.yaml'), 'w') as f:
+            yaml.safe_dump(description, f, default_flow_style=False)
+        if mask is not None:
+            np.save(os.path.join(directory, 'mask.npy'), mask)
+
+    def test_loading_legacy(self):
+        "Load a legacy (type 'Mask') fixture: it is accepted, warns, and normalizes the type."
+        with self.assertLogs('EOS', level='WARNING'):
+            sm = eos.data.SampleMask(self._path)
+
+        self.assertEqual(sm.type, 'SampleMask')
+        self.assertEqual(sm.observables, self._observables)
         self.assertEqual(sm.mask.dtype, bool)
         self.assertEqual(sm.mask.shape, (5,))
         self.assertEqual(list(sm.mask), [True, False, True, True, False])
@@ -39,6 +53,60 @@ class SampleMaskTests(unittest.TestCase):
         "Loading from a non-existent path raises an error."
         with self.assertRaises(RuntimeError):
             eos.data.SampleMask(os.path.join(self._path, 'does-not-exist'))
+
+    def test_roundtrip(self):
+        "A mask written by create() is stored as 'SampleMask' and reads back identically."
+        mask = np.array([True, False, True, True, False])
+
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'mask-default')
+            eos.data.SampleMask.create(path, mask, self._observables)
+
+            # the discriminator is written as the current 'SampleMask'
+            with open(os.path.join(path, 'description.yaml')) as f:
+                self.assertEqual(yaml.safe_load(f)['type'], 'SampleMask')
+
+            sm = eos.data.SampleMask(path)
+            self.assertEqual(sm.type, 'SampleMask')
+            self.assertEqual(sm.observables, self._observables)
+            np.testing.assert_array_equal(sm.mask, mask)
+
+    def test_wrong_type(self):
+        "A description whose type is neither 'SampleMask' nor 'Mask' is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'Prediction', 'observables': []}, mask=np.array([True]))
+            with self.assertRaises(ValueError):
+                eos.data.SampleMask(d)
+
+    def test_unknown_key(self):
+        "An unexpected key in the description is rejected rather than silently ignored."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'SampleMask', 'observables': [], 'bogus': 42},
+                        mask=np.array([True]))
+            with self.assertRaises(ValueError):
+                eos.data.SampleMask(d)
+
+    def test_missing_observables(self):
+        "A description missing the required 'observables' key is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'SampleMask'}, mask=np.array([True]))
+            with self.assertRaises(ValueError):
+                eos.data.SampleMask(d)
+
+    def test_missing_payload(self):
+        "A valid description without the mask payload is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {'version': 'test', 'type': 'SampleMask', 'observables': self._observables})
+            with self.assertRaises(RuntimeError):
+                eos.data.SampleMask(d)
+
+    def test_non_mapping_description(self):
+        "A description.yaml that is not a top-level mapping is rejected."
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'description.yaml'), 'w') as f:
+                yaml.safe_dump(['not', 'a', 'mapping'], f)
+            with self.assertRaises(RuntimeError):
+                eos.data.SampleMask(d)
 
 
 if __name__ == '__main__':

--- a/python/eos/deserializable.py
+++ b/python/eos/deserializable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Danny van Dyk
+# Copyright (c) 2024-2026 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -25,6 +25,8 @@ class Deserializable:
     @classmethod
     def from_yaml(cls, yaml_data:str):
         kwargs = _yaml.safe_load(yaml_data)
+        if not isinstance(kwargs, dict):
+            raise ValueError('The provided YAML data does not describe a mapping')
         return cls.from_dict(**kwargs)
 
     @staticmethod

--- a/python/eos/deserializable.py
+++ b/python/eos/deserializable.py
@@ -13,6 +13,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+import os as _os
 import yaml as _yaml
 
 class Deserializable:
@@ -28,6 +29,27 @@ class Deserializable:
         if not isinstance(kwargs, dict):
             raise ValueError('The provided YAML data does not describe a mapping')
         return cls.from_dict(**kwargs)
+
+    @classmethod
+    def from_yaml_file(cls, path:str):
+        """Load and parse a single YAML file, then deserialize it via :meth:`from_dict`.
+
+        Centralizes the checks and error handling shared by all on-disk descriptions: the file must
+        exist and contain a top-level YAML mapping. The parsed mapping is forwarded to :meth:`from_dict`,
+        so any per-class normalization and validation applies unchanged.
+
+        :param path: Path to the YAML file to load.
+        :type path: str
+        :returns: The deserialized instance.
+        :raises RuntimeError: If the file does not exist, is not a file, or does not contain a mapping.
+        """
+        if not _os.path.exists(path) or not _os.path.isfile(path):
+            raise RuntimeError(f'Description file {path} does not exist or is not a file')
+        with open(path) as f:
+            data = _yaml.safe_load(f)
+        if not isinstance(data, dict):
+            raise RuntimeError(f'Description file {path} does not contain a YAML mapping')
+        return cls.from_dict(**data)
 
     @staticmethod
     def make(cls, **kwargs):

--- a/python/eos/serializable.py
+++ b/python/eos/serializable.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import dataclasses as _dc
+import yaml as _yaml
+
+
+# Top-level packages whose objects must never be serialized. On-disk descriptions must hold only
+# native Python types; a value from one of these packages (e.g. a numpy array or scalar) is rejected
+# rather than being silently coerced or emitted with a library-specific YAML tag. Extend this list to
+# exclude further libraries.
+_EXCLUDED_MODULES = ['numpy']
+
+
+class _SimpleDumper(_yaml.SafeDumper):
+    """A :class:`yaml.SafeDumper` restricted to simple, native Python types.
+
+    Any object whose defining top-level module is listed in :data:`_EXCLUDED_MODULES` is rejected with a
+    clear error instead of being serialized. The check is by module name, so it needs no import of the
+    excluded libraries and catches values at any depth of the structure.
+    """
+    def represent_data(self, data):
+        top_module = type(data).__module__.split('.', 1)[0]
+        if top_module in _EXCLUDED_MODULES:
+            raise TypeError(
+                f'refusing to serialize the object of type \'{type(data).__module__}.{type(data).__name__}\' '
+                f'from the excluded module \'{top_module}\'; convert it to a native Python type '
+                f'(e.g. via float(), int(), or .tolist()) first'
+            )
+        return super().represent_data(data)
+
+
+class Serializable:
+    """
+    Utility mixin to serialize instances of classes to YAML data.
+
+    This is the inverse of :class:`eos.deserializable.Deserializable`. Classes that participate in
+    write/read symmetry inherit from both; classes that are only ever read from disk inherit
+    :class:`Deserializable` alone.
+    """
+    def to_dict(self):
+        """Serialize this instance into a dictionary suitable for YAML output.
+
+        The default implementation requires the instance to be a :func:`dataclasses.dataclass` and
+        returns :func:`dataclasses.asdict`. Classes whose on-disk representation differs from their
+        field layout (e.g. keys that are not valid Python identifiers) override this method to emit
+        the canonical on-disk keys. It is the inverse of :meth:`Deserializable.from_dict`.
+
+        :returns: The dictionary representation of this instance.
+        :rtype: dict
+        """
+        if not _dc.is_dataclass(self):
+            raise TypeError(f'{type(self).__name__} is not a dataclass and must override to_dict()')
+        return _dc.asdict(self)
+
+    def to_yaml_file(self, path:str):
+        """Serialize this instance via :meth:`to_dict` and write it to a YAML file.
+
+        :param path: Path to the YAML file to write.
+        :type path: str
+        """
+        with open(path, 'w') as f:
+            _yaml.dump(self.to_dict(), f, Dumper=_SimpleDumper, default_flow_style=False)

--- a/python/eos/serializable_TEST.py
+++ b/python/eos/serializable_TEST.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import unittest
+
+import numpy as np
+import os
+import tempfile
+import yaml
+
+from dataclasses import dataclass
+from eos.deserializable import Deserializable
+from eos.serializable import Serializable, _SimpleDumper, _EXCLUDED_MODULES
+
+
+@dataclass
+class _Holder(Serializable, Deserializable):
+    "Minimal dataclass used to exercise Serializable.to_yaml_file."
+    value:object
+
+
+class SerializableTests(unittest.TestCase):
+
+    @staticmethod
+    def _dump(obj):
+        return yaml.dump(obj, Dumper=_SimpleDumper, default_flow_style=False)
+
+    def test_numpy_is_excluded(self):
+        "numpy is on the list of modules that must not be serialized."
+        self.assertIn('numpy', _EXCLUDED_MODULES)
+
+    def test_native_types_serialize(self):
+        "Native Python structures serialize (and round-trip) unchanged."
+        obj = {'a': [1.0, 2, 'x'], 'b': None, 'c': {'d': True}}
+        self.assertEqual(yaml.safe_load(self._dump(obj)), obj)
+
+    def test_rejects_numpy_array(self):
+        "A numpy array is rejected with a TypeError."
+        with self.assertRaises(TypeError):
+            self._dump({'x': np.array([1.0, 2.0])})
+
+    def test_rejects_numpy_scalars(self):
+        "numpy scalar types are rejected, even those subclassing Python builtins."
+        for scalar in (np.float64(1.5), np.int64(3), np.bool_(True), np.str_('abc')):
+            with self.assertRaises(TypeError):
+                self._dump({'x': scalar})
+
+    def test_rejects_numpy_when_nested(self):
+        "A numpy value nested at any depth is rejected."
+        with self.assertRaises(TypeError):
+            self._dump({'a': {'b': [1.0, np.float64(2.0)]}})
+
+    def test_to_yaml_file_native(self):
+        "Serializable.to_yaml_file writes a description of native types."
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'x.yaml')
+            _Holder(value=[1.0, 2.0]).to_yaml_file(path)
+            with open(path) as f:
+                self.assertEqual(yaml.safe_load(f), {'value': [1.0, 2.0]})
+
+    def test_to_yaml_file_rejects_numpy(self):
+        "Serializable.to_yaml_file refuses to serialize a numpy value."
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'x.yaml')
+            with self.assertRaises(TypeError):
+                _Holder(value=np.arange(3)).to_yaml_file(path)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -290,20 +290,14 @@ def find_mode(analysis_file:str, posterior:str, base_directory:str='./', optimiz
     pvalue = (1.0 - scipy.stats.chi2(gof.total_degrees_of_freedom()).cdf(gof.total_chi_square()))
     eos.info(f'p value     = {100 * pvalue:.2f}%')
     eos.info('individual test statistics:')
-    local_pvalues = {}
     for n, e in gof:
         local_pvalue = (1.0 - scipy.stats.chi2(e.dof).cdf(e.chi2))
-        local_pvalues[f'{n}'] = float(local_pvalue)
         eos.info(f'  - {n}: chi^2 / dof = {e.chi2:.2f} / {e.dof}, local_pvalue = {100 * local_pvalue:.2f}%')
 
-    eos.data.Mode.create(
+    eos.data.Mode.from_bfp_and_gof(
         os.path.join(base_directory, 'data', posterior, f'mode-{label}'),
-        analysis.varied_parameters,
-        bfp.point,
-        pvalue,
-        local_pvalues,
-        min_chi2,
-        gof.total_degrees_of_freedom()
+        bfp,
+        gof
         )
     if (pvalue < 0.03):
         eos.warn(f'Final p value is {100 * pvalue:.2f}%, which is below the a-priori threshold 3%')


### PR DESCRIPTION
- 8a476e64 [python] Add a type check to ``eos.Deserializable.from_yaml``.
- 917dafa6 [python] Add helper ``eos.Deserializable.from_yaml_file()`` as a convenience and to reduce code duplication.
- 0672711c [python] Add class ``eos.Serializable``. This class is the inverse of ``eos.Deserializable`` and based on Python's ``@dataclass`` decorator.
- 50f72111 [python] Add helpers to be used in multiple class within ``eos.data``. Reduces code duplication.
- 47c3edc9 [python] Convert ``eos.data.MarkovChain`` to ``eos.Serializable``/``eos.Deserializable``.
- bde00a7e [python] Convert ``eos.data.Mode`` to ``eos.Serializable``/``eos.Deserializable``.
- c6cb253c [python] Bump the on-disk format for ``eos.data.Mode``. Replaces the list ``local_pvalues`` with a list of test statistics (see ``TestStatisticDescription``). New files are always written in the new format. Files conforming to the old format are converted on the fly with minimal assumption.
- 3b349512 [python] Convert ``eos.data.ImportanceSamples`` to ``eos.Serializable``/``eos.Deserializable``.
- a672634e [python] Convert ``eos.data.DynestyResults`` to ``eos.Serializable``/``eos.Deserializable``.
- a672634e [python] Convert ``eos.data.NabuLikelihood`` to ``eos.Serializable``/``eos.Deserializable``.
- e0d52161 [python] Convert ``eos.data.Prediction`` to ``eos.Serializable``/``eos.Deserializable``.
- e0d52161 [python] Convert ``eos.data.SampleMask`` to ``eos.Serializable``/``eos.Deserializable``.
- 01987d98 [python] Convert ``eos.data.PMCSampler`` to ``eos.Serializable``/``eos.Deserializable``.
- 095a9aef [python] Convert ``eos.data.MixtureDensity`` to ``eos.Serializable``/``eos.Deserializable``.
- 45eb6092 [eos] Update changelog for PR #1198.

Resolves issue #1188.