### PR TITLE
Improve the documentation of the public Python API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -56,6 +56,7 @@
 - Add comparison operators for ``qnp::OptionValue`` (D. van Dyk)
 - Add an output stream operator for ``qnp::OptionValue`` (D. van Dyk)
 - Document the user-facing classes and methods of the ``eos`` Python modules, and auto-generate the analysis file format reference from the ``eos.analysis_file_description`` classes (D. van Dyk)
+- Complete the reference documentation of the ``eos`` Python bindings: fix several incorrect docstrings, name all arguments and add docstrings across the documented C++-bound classes, and document the previously undocumented ``Model``, ``LogLikelihoodBlock``, ``Constraint``, ``ConstraintEntry``, ``ObservableEntry``, ``Reference``, ``References``, and ``SignalPDFEntry`` classes; the list of documented classes now lives in ``eos._api``, shared by the API reference template and by a new unit test that guards argument naming and docstring coverage against regressions (D. van Dyk)
 - Add a ``vertical`` plot item that draws a vertical line at a fixed position on the x axis, e.g. to mark a kinematic threshold (D. van Dyk)
 - Add an optional ``size`` field to ``grid`` figures to set the figure size explicitly (D. van Dyk)
 - Add an optional ``watermark_plot`` field to ``grid`` figures to stamp the watermark on a single panel, addressed either by a flattened index or by a ``(row, col)`` pair (D. van Dyk)

--- a/doc/reference/python.rst.jinja
+++ b/doc/reference/python.rst.jinja
@@ -9,6 +9,12 @@ Basic Classes
 EOS provides its basic functionality via the main ``eos`` module.
 
 
+.. autoclass:: eos.Constraint
+   :members:
+
+.. autoclass:: eos.ConstraintEntry
+   :members:
+
 .. autoclass:: eos.Constraints
    :inherited-members:
    :members:
@@ -20,13 +26,22 @@ EOS provides its basic functionality via the main ``eos`` module.
 .. autoclass:: eos.LogLikelihood
    :members:
 
+.. autoclass:: eos.LogLikelihoodBlock
+   :members:
+
 .. autoclass:: eos.LogPrior
    :members:
 
 .. autoclass:: eos.LogPosterior
    :members:
 
+.. autoclass:: eos.Model
+   :members:
+
 .. autoclass:: eos.Observable
+   :members:
+
+.. autoclass:: eos.ObservableEntry
    :members:
 
 .. autoclass:: eos.Observables
@@ -46,8 +61,18 @@ EOS provides its basic functionality via the main ``eos`` module.
 .. autoclass:: eos.QualifiedName
    :members:
 
+.. autoclass:: eos.Reference
+   :members:
+
+.. autoclass:: eos.References
+   :inherited-members:
+   :members:
+
 .. autoclass:: eos.SignalPDF
    :inherited-members:
+   :members:
+
+.. autoclass:: eos.SignalPDFEntry
    :members:
 
 .. autoclass:: eos.SignalPDFs

--- a/doc/reference/python.rst.jinja
+++ b/doc/reference/python.rst.jinja
@@ -1,3 +1,10 @@
+{% macro autoclass(name, inherited) -%}
+.. autoclass:: eos.{{ name }}
+{% if inherited %}
+   :inherited-members:
+{% endif %}
+   :members:
+{%- endmacro %}
 ##########
 Python API
 ##########
@@ -8,79 +15,10 @@ Basic Classes
 
 EOS provides its basic functionality via the main ``eos`` module.
 
+{% for name, inherited in api_basic_classes.items() %}
 
-.. autoclass:: eos.Constraint
-   :members:
-
-.. autoclass:: eos.ConstraintEntry
-   :members:
-
-.. autoclass:: eos.Constraints
-   :inherited-members:
-   :members:
-
-.. autoclass:: eos.Kinematics
-   :inherited-members:
-   :members:
-
-.. autoclass:: eos.LogLikelihood
-   :members:
-
-.. autoclass:: eos.LogLikelihoodBlock
-   :members:
-
-.. autoclass:: eos.LogPrior
-   :members:
-
-.. autoclass:: eos.LogPosterior
-   :members:
-
-.. autoclass:: eos.Model
-   :members:
-
-.. autoclass:: eos.Observable
-   :members:
-
-.. autoclass:: eos.ObservableEntry
-   :members:
-
-.. autoclass:: eos.Observables
-   :inherited-members:
-   :members:
-
-.. autoclass:: eos.Options
-   :members:
-
-.. autoclass:: eos.Parameter
-   :members:
-
-.. autoclass:: eos.Parameters
-   :inherited-members:
-   :members:
-
-.. autoclass:: eos.QualifiedName
-   :members:
-
-.. autoclass:: eos.Reference
-   :members:
-
-.. autoclass:: eos.References
-   :inherited-members:
-   :members:
-
-.. autoclass:: eos.SignalPDF
-   :inherited-members:
-   :members:
-
-.. autoclass:: eos.SignalPDFEntry
-   :members:
-
-.. autoclass:: eos.SignalPDFs
-   :inherited-members:
-   :members:
-
-.. autoclass:: eos.Unit
-   :members:
+{{ autoclass(name, inherited) }}
+{% endfor %}
 
 
 **************
@@ -89,9 +27,10 @@ Common Classes
 
 EOS provides common classes for use in statistical analyses via the main ``eos`` module.
 
+{% for name, inherited in api_common_classes.items() %}
 
-.. autoclass:: eos.Analysis
-   :members:
+{{ autoclass(name, inherited) }}
+{% if name == 'Analysis' %}
 
    .. _eos-Analysis-prior-descriptions:
 
@@ -109,18 +48,8 @@ EOS provides common classes for use in statistical analyses via the main ``eos``
    * **sigma** (*float*, or *list*, *tuple* of *float*) -- The width of the 68% probability interval. If a list or tuple
      of two numbers is provided, the prior will by a asymmetric but continuous. The two values are then taken to be the
      distance to the lower and upper end of the 68% probability interval.
-
-.. autoclass:: eos.AnalysisFile
-   :members:
-
-.. autoclass:: eos.BestFitPoint
-   :members:
-
-.. autoclass:: eos.GoodnessOfFit
-   :members:
-
-.. autoclass:: eos.ObservableCache
-   :members:
+{% endif %}
+{% endfor %}
 
 
 .. _api_eos_tasks:

--- a/doc/reference/python.rst.py
+++ b/doc/reference/python.rst.py
@@ -1,5 +1,6 @@
 import eos
 import eos.figure
+from eos._api import API_BASIC_CLASSES, API_COMMON_CLASSES
 from jinja_util import print_template
 
 
@@ -46,6 +47,8 @@ task_names = [task.__name__ for task in eos.tasks._tasks.values() if task.__name
 task_names = sorted(task_names)
 
 print_template(__file__,
+    api_basic_classes = API_BASIC_CLASSES,
+    api_common_classes = API_COMMON_CLASSES,
     plot_types = plot_types,
     figure_figure_types = figure_figure_types,
     figure_item_types = figure_item_types,

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -3,6 +3,7 @@ CLEANFILES = *~
 EXTRA_DIST = \
 	setup.py.in \
 	eos/__init__.py \
+	eos/_api.py \
 	eos/analysis.py \
 	eos/analysis_TEST.d \
 	eos/analysis_TEST.py \
@@ -84,6 +85,7 @@ eosdir = $(pkgpythondir)
 eos_PYTHON =
 eos_SCRIPTS = \
 	eos/__init__.py \
+	eos/_api.py \
 	eos/analysis.py \
 	eos/analysis_file.py \
 	eos/analysis_file_description.py \
@@ -165,6 +167,7 @@ TESTS = \
 	eos/data/sample_mask_TEST.py \
 	eos/data/pmc_sampler_TEST.py \
 	eos/data/prediction_TEST.py \
+	eos/_api_TEST.py \
 	eos/observable_TEST.py \
 	eos/parameter_TEST.py \
 	eos/reporting_TEST.py \

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1398,7 +1398,10 @@ BOOST_PYTHON_MODULE(_eos)
                  args("self"))
             .def("kinematics", &Observable::kinematics, R"(
             Returns the set of kinematic variables bound to this observable.
-        )")
+
+            :rtype: eos.Kinematics
+        )",
+                 args("self"))
             .def("options", &Observable::options, R"(
             Returns the set of options used when creating the observable.
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -260,20 +260,25 @@ BOOST_PYTHON_MODULE(_eos)
             .def("__lt__", &QualifiedName::operator<)
             .def("prefix_part", &QualifiedName::prefix_part, return_value_policy<copy_const_reference>(), R"(
             Returns the prefix part of the name, i.e., the part preceeding the '::'.
-        )")
+        )",
+                 args("self"))
             .def("name_part", &QualifiedName::name_part, return_value_policy<copy_const_reference>(), R"(
             Returns the name part of the name, i.e., the part following the '::' and preceeding any
             optional '@'.
-        )")
+        )",
+                 args("self"))
             .def("suffix_part", &QualifiedName::suffix_part, return_value_policy<copy_const_reference>(), R"(
             Returns the optional suffix part of the name, i.e., the part following the optional '@'.
-        )")
+        )",
+                 args("self"))
             .def("options_part", &QualifiedName::options, return_value_policy<copy_const_reference>(), R"(
             Returns the optional options part of the name, i.e., the part following the optional ';'.
-        )")
+        )",
+                 args("self"))
             .def("full", &QualifiedName::full, return_value_policy<copy_const_reference>(), R"(
             Returns the full name, i.e., the concatenation of all parts.
-        )");
+        )",
+                 args("self"));
     implicitly_convertible<std::string, QualifiedName>();
 
 
@@ -1344,7 +1349,10 @@ BOOST_PYTHON_MODULE(_eos)
                  args("self"))
             .def("name", &Observable::name, return_value_policy<copy_const_reference>(), R"(
             Returns the name of the observable.
-        )")
+
+            :rtype: eos.QualifiedName
+        )",
+                 args("self"))
             .def("parameters", &Observable::parameters, R"(
             Returns the set of parameters bound to this observable.
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -629,7 +629,8 @@ BOOST_PYTHON_MODULE(_eos)
             .staticmethod("Femtometer2")
             .def("latex", &Unit::latex, return_value_policy<copy_const_reference>(), R"(
             Returns the LaTeX representation of the unit.
-        )")
+        )",
+                 args("self"))
             .def("__str__", &Unit::string, return_value_policy<copy_const_reference>())
             .def("__eq__", &Unit::operator==);
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1268,12 +1268,38 @@ BOOST_PYTHON_MODULE(_eos)
 
     // ObservableEntry
     register_ptr_to_python<std::shared_ptr<const ObservableEntry>>();
-    class_<ObservableEntry, boost::noncopyable>("ObservableEntry", no_init)
-            .def("name", &ObservableEntry::name, return_value_policy<copy_const_reference>())
-            .def("latex", &ObservableEntry::latex, return_value_policy<copy_const_reference>())
-            .def("unit", &ObservableEntry::unit, return_internal_reference<>())
-            .def("kinematic_variables", range(&ObservableEntry::begin_kinematic_variables, &ObservableEntry::end_kinematic_variables))
-            .def("options", range(&ObservableEntry::begin_options, &ObservableEntry::end_options));
+    class_<ObservableEntry, boost::noncopyable>("ObservableEntry", R"(
+            Describes a single observable known to EOS.
+
+            An observable entry records an observable's name, its LaTeX representation, its unit, and the
+            kinematic variables and options it accepts. Entries are obtained by iterating or indexing
+            :class:`eos.Observables`.
+        )",
+                                                no_init)
+            .def("name", &ObservableEntry::name, return_value_policy<copy_const_reference>(), R"(
+            Returns the name of the observable.
+
+            :rtype: eos.QualifiedName
+        )",
+                 args("self"))
+            .def("latex", &ObservableEntry::latex, return_value_policy<copy_const_reference>(), R"(
+            Returns the LaTeX representation of the observable.
+
+            :rtype: str
+        )",
+                 args("self"))
+            .def("unit", &ObservableEntry::unit, return_internal_reference<>(), R"(
+            Returns the unit of the observable.
+
+            :rtype: eos.Unit
+        )",
+                 args("self"))
+            .def("kinematic_variables", range(&ObservableEntry::begin_kinematic_variables, &ObservableEntry::end_kinematic_variables), R"(
+            Returns an iterator over the names of the kinematic variables accepted by the observable.
+        )")
+            .def("options", range(&ObservableEntry::begin_options, &ObservableEntry::end_options), R"(
+            Returns an iterator over the options accepted by the observable.
+        )");
 
     def("make_wilson_polynomial_observable", &make_wilson_polynomial_observable, args("name", "reference_observable", "coefficients"),
         R"(
@@ -1348,17 +1374,19 @@ BOOST_PYTHON_MODULE(_eos)
             :param name: The name of the new observable.
             :type name: eos.QualifiedName
             :param latex: The latex representation of the new observable.
-            :type latex: std::string
+            :type latex: str
             :param unit: The unit of the new observable.
             :type unit: eos.Unit
             :param options: The set of options relevant to this new observable. These options apply to **all** the observables in the expression.
             :type options: eos.Options
             :param expression: The expression to be parsed.
-            :type expression: std::string
+            :type expression: str
         )",
-                 args("name", "latex", "unit", "options", "expression"))
+                 args("self", "name", "latex", "unit", "options", "expression"))
             .def("__contains__", &Observables::has)
-            .def("sections", range(&Observables::begin_sections, &Observables::end_sections));
+            .def("sections", range(&Observables::begin_sections, &Observables::end_sections), R"(
+            Returns an iterator over the sections into which the known observables are grouped.
+        )");
 
 
     // SignalPDF

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1584,9 +1584,25 @@ BOOST_PYTHON_MODULE(_eos)
 
     // SignalPDFEntry
     register_ptr_to_python<std::shared_ptr<const SignalPDFEntry>>();
-    class_<SignalPDFEntry, boost::noncopyable>("SignalPDFEntry", no_init)
-            .def("name", &SignalPDFEntry::name, return_value_policy<copy_const_reference>())
-            .def("description", &SignalPDFEntry::description, return_value_policy<copy_const_reference>());
+    class_<SignalPDFEntry, boost::noncopyable>("SignalPDFEntry", R"(
+            Describes a single signal PDF known to EOS.
+
+            A signal-PDF entry records the PDF's name and a human-readable description. Entries are
+            obtained by iterating or indexing :class:`eos.SignalPDFs`.
+        )",
+                                               no_init)
+            .def("name", &SignalPDFEntry::name, return_value_policy<copy_const_reference>(), R"(
+            Returns the name of the signal PDF.
+
+            :rtype: eos.QualifiedName
+        )",
+                 args("self"))
+            .def("description", &SignalPDFEntry::description, return_value_policy<copy_const_reference>(), R"(
+            Returns the human-readable description of the signal PDF.
+
+            :rtype: str
+        )",
+                 args("self"));
 
     // SignalPDFGroup
     register_ptr_to_python<std::shared_ptr<SignalPDFGroup>>();
@@ -1614,7 +1630,7 @@ BOOST_PYTHON_MODULE(_eos)
             :param name: The name of the new signal PDF.
             :type name: eos.QualifiedName
             :param description: A human-readable description of the new signal PDF.
-            :type description: std::string
+            :type description: str
             :param options: The set of options relevant to this new signal PDF. These options apply to **both** backing observables.
             :type options: eos.Options
             :param numerator: The name of the observable that provides the unnormalized PDF.
@@ -1626,8 +1642,10 @@ BOOST_PYTHON_MODULE(_eos)
             :param normalization_kinematic_variables: The kinematic variables of the normalization; for each sampling variable ``v`` this should contain the bounds ``v_min`` and ``v_max``.
             :type normalization_kinematic_variables: list of str
         )",
-                 args("name", "description", "options", "numerator", "numerator_kinematic_variables", "normalization", "normalization_kinematic_variables"))
-            .def("sections", range(&SignalPDFs::begin_sections, &SignalPDFs::end_sections));
+                 args("self", "name", "description", "options", "numerator", "numerator_kinematic_variables", "normalization", "normalization_kinematic_variables"))
+            .def("sections", range(&SignalPDFs::begin_sections, &SignalPDFs::end_sections), R"(
+            Returns an iterator over the sections into which the known signal PDFs are grouped.
+        )");
 
     // Analytic Charm Loops
     def("delta_c7", &agv_2019a::delta_c7);

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -814,7 +814,7 @@ BOOST_PYTHON_MODULE(_eos)
             :type name: str
             :param shift: The shift vector to the original set of parameters
             :type shift: vector
-            :param transform; The matrix that transforms the original set of parameters
+            :param transform: The matrix that transforms the original set of parameters
             :type transform: matrix
             :param min: The vector of minimum values that the parameters are allowed to take.
             :type min: vector

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -622,14 +622,29 @@ BOOST_PYTHON_MODULE(_eos)
     // {{{ eos/statistics
     // LogLikelihoodBlock
     register_ptr_to_python<std::shared_ptr<LogLikelihoodBlock>>();
-    class_<LogLikelihoodBlock, boost::noncopyable>("LogLikelihoodBlock", no_init)
+    class_<LogLikelihoodBlock, boost::noncopyable>("LogLikelihoodBlock", R"(
+            Represents a single block (term) of a :class:`LogLikelihood <eos.LogLikelihood>`.
+
+            A block encapsulates the likelihood contribution of one or more observables, such as a
+            (multivariate) Gaussian constraint or a user-provided external likelihood. New blocks are
+            created using the static factory methods, e.g. :meth:`External <eos.LogLikelihoodBlock.External>`
+            and :meth:`Unbinned1D <eos.LogLikelihoodBlock.Unbinned1D>`, and added to a likelihood via
+            :meth:`LogLikelihood.add <eos.LogLikelihood.add>`.
+        )",
+                                                   no_init)
             .def("__str__", &LogLikelihoodBlock::as_string)
             .def("evaluate", &LogLikelihoodBlock::evaluate, R"(
             Evaluate the log-likelihood block at the current parameter point.
-        )")
+
+            :rtype: float
+        )",
+                 args("self"))
             .def("number_of_observations", &LogLikelihoodBlock::number_of_observations, R"(
             Retrieve the number of observations in this block.
-        )")
+
+            :rtype: int
+        )",
+                 args("self"))
             .def("External", &ExternalLogLikelihoodBlock::make, R"(
             Create a new external log-likelihood block.
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -703,7 +703,9 @@ BOOST_PYTHON_MODULE(_eos)
             Represents a Bayesian prior on the log scale.
 
             New LogPrior objects can only be created using the capitalized static methods:
-            :meth:`LogPrior.Uniform`, :meth:`LogPrior.Gaussian`, and :meth:`LogPrior.Scale`.
+            :meth:`LogPrior.Uniform`, :meth:`LogPrior.Flat`, :meth:`LogPrior.Gaussian`,
+            :meth:`LogPrior.CurtailedGauss`, :meth:`LogPrior.Poisson`, :meth:`LogPrior.Scale`,
+            and :meth:`LogPrior.Transform`.
         )",
                                          no_init)
             .def("Uniform", &LogPrior::Flat, return_value_policy<return_by_value>(), R"(

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -746,7 +746,7 @@ BOOST_PYTHON_MODULE(_eos)
             :param upper: The upper boundary of the 68% probability interval.
             :type upper: float
         )",
-                 args("parameters", "name", "range", "lower", "central", "upper"))
+                 args("parameters", "name", "min", "max", "lower", "central", "upper"))
             .staticmethod("CurtailedGauss")
             .def("Scale", &LogPrior::Scale, return_value_policy<return_by_value>(), R"(
             Returns a new Scale prior as a LogPrior.

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -473,7 +473,15 @@ BOOST_PYTHON_MODULE(_eos)
             .def("__init__", raw_function(&::impl::Options_ctor))
             .def("__iter__", range(&Options::begin, &Options::end))
             .def(init<>())
-            .def("declare", &Options::declare)
+            .def("declare", &Options::declare, R"(
+            Declares an option as a (key, value) pair.
+
+            :param key: The name of the option.
+            :type key: str
+            :param value: The value assigned to the option.
+            :type value: str
+        )",
+                 args("self", "key", "value"))
             .def("__str__", &Options::as_string)
             .def("__eq__", &Options::operator==)
             .def("__getitem__", &Options::operator[], return_value_policy<copy_const_reference>());
@@ -1264,7 +1272,10 @@ BOOST_PYTHON_MODULE(_eos)
         )")
             .def("options", &Observable::options, R"(
             Returns the set of options used when creating the observable.
-        )");
+
+            :rtype: eos.Options
+        )",
+                 args("self"));
 
     // ObservableEntry
     register_ptr_to_python<std::shared_ptr<const ObservableEntry>>();

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -291,10 +291,21 @@ BOOST_PYTHON_MODULE(_eos)
 
     // Parameters
     class_<Parameters>("_Parameters", no_init)
-            .def("Defaults", &Parameters::Defaults)
+            .def("Defaults", &Parameters::Defaults, R"(
+            Returns an independent instance of the default set of parameters known to EOS.
+
+            :rtype: eos.Parameters
+        )")
             .staticmethod("Defaults")
             .def("__getitem__", (Parameter(Parameters::*)(const QualifiedName &) const) &Parameters::operator[])
-            .def("by_id", (Parameter(Parameters::*)(const Parameter::Id &) const) &Parameters::operator[])
+            .def("by_id", (Parameter(Parameters::*)(const Parameter::Id &) const) &Parameters::operator[], R"(
+            Returns the parameter with the given internal id.
+
+            :param id: The internal id of the parameter.
+            :type id: int
+            :rtype: eos.Parameter
+        )",
+                 args("self", "id"))
             .def("__iter__", range(&Parameters::begin, &Parameters::end))
             .def("declare", &Parameters::declare,
                  R"(
@@ -335,7 +346,7 @@ BOOST_PYTHON_MODULE(_eos)
             :return: The newly inserted parameter.
             :rtype: eos.Parameter
             )",
-                 args("name", "latex", "unit", "value", "min", "max"))
+                 args("self", "name", "latex", "unit", "value", "min", "max"))
             .def("redirect", &Parameters::redirect,
                  R"(
             Redirect a parameter name to a different parameter id in the default set of parameters.
@@ -345,13 +356,15 @@ BOOST_PYTHON_MODULE(_eos)
             This is useful for example to alias a parameter name to a different parameter object.
 
             :param name: The name of the parameter to be redirected.
-            :type name:
+            :type name: eos.QualifiedName
             :param id: The id of the parameter to which the name shall be redirected.
             :type id: eos.Parameter::Id
             )",
                  args("name", "id"))
             .staticmethod("redirect")
-            .def("sections", range(&Parameters::begin_sections, &Parameters::end_sections))
+            .def("sections", range(&Parameters::begin_sections, &Parameters::end_sections), R"(
+            Returns an iterator over the sections into which the known parameters are grouped.
+        )")
             .def("set", &Parameters::set,
                  R"(
             Set the value of a parameter.
@@ -360,9 +373,25 @@ BOOST_PYTHON_MODULE(_eos)
             :type name: str
             :param value: The value to set the parameter to.
             :type value: float
-            )")
-            .def("has", &Parameters::has)
-            .def("override_from_file", &Parameters::override_from_file);
+            )",
+                 args("self", "name", "value"))
+            .def("has", &Parameters::has,
+                 R"(
+            Returns whether a parameter of the given name is part of this set.
+
+            :param name: The name of the parameter to look up.
+            :type name: eos.QualifiedName
+            :rtype: bool
+            )",
+                 args("self", "name"))
+            .def("override_from_file", &Parameters::override_from_file,
+                 R"(
+            Overrides parameter values from a YAML file.
+
+            :param file: The path to the YAML file with the parameter values.
+            :type file: str
+            )",
+                 args("self", "file"));
 
     // Mutable
     register_ptr_to_python<std::shared_ptr<Mutable>>();
@@ -1318,7 +1347,10 @@ BOOST_PYTHON_MODULE(_eos)
         )")
             .def("parameters", &Observable::parameters, R"(
             Returns the set of parameters bound to this observable.
-        )")
+
+            :rtype: eos.Parameters
+        )",
+                 args("self"))
             .def("kinematics", &Observable::kinematics, R"(
             Returns the set of kinematic variables bound to this observable.
         )")

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1298,13 +1298,50 @@ BOOST_PYTHON_MODULE(_eos)
     // {{{ eos/
     // Reference
     register_ptr_to_python<ReferencePtr>();
-    class_<Reference>("Reference", no_init)
-            .def("name", &Reference::name, return_value_policy<copy_const_reference>())
-            .def("authors", &Reference::authors, return_value_policy<copy_const_reference>())
-            .def("eprint_archive", &Reference::eprint_archive, return_value_policy<copy_const_reference>())
-            .def("eprint_id", &Reference::eprint_id, return_value_policy<copy_const_reference>())
-            .def("title", &Reference::title, return_value_policy<copy_const_reference>())
-            .def("inspire_id", &Reference::inspire_id, return_value_policy<copy_const_reference>());
+    class_<Reference>("Reference", R"(
+            Represents a single bibliographic reference known to EOS.
+
+            A reference records the bibliographic details (authors, title, e-print, and INSPIRE
+            identifier) of a publication underlying part of EOS, be it an experimental constraint or
+            a theoretical work such as the implementation of an observable, a form factor
+            parametrization, or a theory prediction. References are obtained by iterating or indexing
+            :class:`eos.References`.
+        )",
+                      no_init)
+            .def("name", &Reference::name, return_value_policy<copy_const_reference>(), R"(
+            Returns the name (handle) of the reference.
+        )",
+                 args("self"))
+            .def("authors", &Reference::authors, return_value_policy<copy_const_reference>(), R"(
+            Returns the authors of the reference.
+
+            :rtype: str
+        )",
+                 args("self"))
+            .def("eprint_archive", &Reference::eprint_archive, return_value_policy<copy_const_reference>(), R"(
+            Returns the e-print archive of the reference, e.g. ``arXiv``.
+
+            :rtype: str
+        )",
+                 args("self"))
+            .def("eprint_id", &Reference::eprint_id, return_value_policy<copy_const_reference>(), R"(
+            Returns the e-print identifier of the reference, e.g. the arXiv number.
+
+            :rtype: str
+        )",
+                 args("self"))
+            .def("title", &Reference::title, return_value_policy<copy_const_reference>(), R"(
+            Returns the title of the reference.
+
+            :rtype: str
+        )",
+                 args("self"))
+            .def("inspire_id", &Reference::inspire_id, return_value_policy<copy_const_reference>(), R"(
+            Returns the INSPIRE identifier of the reference.
+
+            :rtype: str
+        )",
+                 args("self"));
 
     // References
     ::impl::std_pair_to_python_converter<const ReferenceName, ReferencePtr> converter_references_iter;

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -493,7 +493,7 @@ BOOST_PYTHON_MODULE(_eos)
 
             Thirteen possible entries are currently implemented in EOS:
               - Undefined
-              - None
+              - Unity
               - GeV
               - GeV2
               - GeV3
@@ -533,7 +533,9 @@ BOOST_PYTHON_MODULE(_eos)
             .staticmethod("GeVSecond")
             .def("Femtometer2", &Unit::Femtometer2)
             .staticmethod("Femtometer2")
-            .def("latex", &Unit::latex, return_value_policy<copy_const_reference>())
+            .def("latex", &Unit::latex, return_value_policy<copy_const_reference>(), R"(
+            Returns the LaTeX representation of the unit.
+        )")
             .def("__str__", &Unit::string, return_value_policy<copy_const_reference>())
             .def("__eq__", &Unit::operator==);
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -666,12 +666,39 @@ BOOST_PYTHON_MODULE(_eos)
             .def("evaluate", &LogLikelihood::operator());
 
     // Constraint
-    class_<Constraint>("Constraint", no_init)
-            .def("make", &Constraint::make, return_value_policy<return_by_value>())
+    class_<Constraint>("Constraint", R"(
+            Represents a named experimental or theoretical constraint known to EOS.
+
+            A constraint bundles one or more observables with the log-likelihood blocks that
+            constrain them. New objects are created using the :meth:`make <eos.Constraint.make>`
+            static method. See also `the complete list of constraints <../reference/constraints.html>`_.
+        )",
+                       no_init)
+            .def("make", &Constraint::make, return_value_policy<return_by_value>(), R"(
+            Makes a new :class:`Constraint` object from the internal database of constraints.
+
+            :param name: The name of the constraint. See `the complete list of constraints <../reference/constraints.html>`_.
+            :type name: eos.QualifiedName
+            :param options: The set of options passed to the observables entering the constraint.
+            :type options: eos.Options
+
+            :return: The new constraint object.
+            :rtype: eos.Constraint
+        )",
+                 args("name", "options"))
             .staticmethod("make")
-            .def("name", &Constraint::name, return_value_policy<copy_const_reference>())
-            .def("blocks", range(&Constraint::begin_blocks, &Constraint::end_blocks))
-            .def("observables", range(&Constraint::begin_observables, &Constraint::end_observables));
+            .def("name", &Constraint::name, return_value_policy<copy_const_reference>(), R"(
+            Returns the name of the constraint.
+
+            :rtype: eos.QualifiedName
+        )",
+                 args("self"))
+            .def("blocks", range(&Constraint::begin_blocks, &Constraint::end_blocks), R"(
+            Returns an iterator over the log-likelihood blocks that make up the constraint.
+        )")
+            .def("observables", range(&Constraint::begin_observables, &Constraint::end_observables), R"(
+            Returns an iterator over the observables entering the constraint.
+        )");
 
     // ConstraintEntry
     register_ptr_to_python<std::shared_ptr<const ConstraintEntry>>();

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -544,35 +544,187 @@ BOOST_PYTHON_MODULE(_eos)
 
     // Model
     register_ptr_to_python<std::shared_ptr<Model>>();
-    class_<Model, boost::noncopyable>("Model", no_init)
-            .def("make", &::impl::Model_make, return_value_policy<return_by_value>())
+    class_<Model, boost::noncopyable>("Model", R"(
+            Represents a physics model, providing access to the CKM matrix elements, quark masses in
+            various renormalization schemes, the strong coupling, and Wilson coefficients.
+
+            New objects are created using the :meth:`make <eos.Model.make>` static method.
+        )",
+                                      no_init)
+            .def("make", &::impl::Model_make, return_value_policy<return_by_value>(), R"(
+            Makes a new :class:`Model` object.
+
+            :param name: The name of the model, e.g. ``SM`` or ``WET``.
+            :type name: str
+            :param parameters: The set of parameters to which the model is bound.
+            :type parameters: eos.Parameters
+            :param options: The set of options relevant to the model.
+            :type options: eos.Options
+
+            :return: The new model object.
+            :rtype: eos.Model
+        )",
+                 args("name", "parameters", "options"))
             .staticmethod("make")
             // CKM component
-            .def("ckm_cd", &Model::ckm_cd)
-            .def("ckm_cs", &Model::ckm_cs)
-            .def("ckm_cb", &Model::ckm_cb)
-            .def("ckm_ud", &Model::ckm_ud)
-            .def("ckm_us", &Model::ckm_us)
-            .def("ckm_ub", &Model::ckm_ub)
-            .def("ckm_td", &Model::ckm_td)
-            .def("ckm_ts", &Model::ckm_ts)
-            .def("ckm_tb", &Model::ckm_tb)
+            .def("ckm_cd", &Model::ckm_cd, R"(
+            Returns the CKM matrix element :math:`V_{cd}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
+            .def("ckm_cs", &Model::ckm_cs, R"(
+            Returns the CKM matrix element :math:`V_{cs}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
+            .def("ckm_cb", &Model::ckm_cb, R"(
+            Returns the CKM matrix element :math:`V_{cb}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
+            .def("ckm_ud", &Model::ckm_ud, R"(
+            Returns the CKM matrix element :math:`V_{ud}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
+            .def("ckm_us", &Model::ckm_us, R"(
+            Returns the CKM matrix element :math:`V_{us}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
+            .def("ckm_ub", &Model::ckm_ub, R"(
+            Returns the CKM matrix element :math:`V_{ub}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
+            .def("ckm_td", &Model::ckm_td, R"(
+            Returns the CKM matrix element :math:`V_{td}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
+            .def("ckm_ts", &Model::ckm_ts, R"(
+            Returns the CKM matrix element :math:`V_{ts}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
+            .def("ckm_tb", &Model::ckm_tb, R"(
+            Returns the CKM matrix element :math:`V_{tb}`.
+
+            :rtype: complex
+        )",
+                 args("self"))
             // QCD component
-            .def("m_t_msbar", &Model::m_t_msbar)
-            .def("m_t_pole", &Model::m_t_pole)
-            .def("m_b_kin", &Model::m_b_kin)
-            .def("m_b_msbar", &Model::m_b_msbar)
-            .def("m_b_pole", &Model::m_b_pole)
-            .def("m_b_pole", &::impl::m_b_pole_wrapper_noargs)
-            .def("m_c_kin", &Model::m_c_kin)
-            .def("m_c_msbar", &Model::m_c_msbar)
-            .def("m_c_pole", &Model::m_c_pole)
-            .def("m_s_msbar", &Model::m_s_msbar)
-            .def("m_ud_msbar", &Model::m_ud_msbar)
+            .def("m_t_msbar", &Model::m_t_msbar, R"(
+            Returns the top-quark :math:`\overline{\text{MS}}` mass :math:`\overline{m}_t(\mu)` in GeV.
+
+            :param mu: The renormalization scale in GeV.
+            :type mu: float
+            :rtype: float
+        )",
+                 args("self", "mu"))
+            .def("m_t_pole", &Model::m_t_pole, R"(
+            Returns the top-quark pole mass in GeV.
+
+            :rtype: float
+        )",
+                 args("self"))
+            .def("m_b_kin", &Model::m_b_kin, R"(
+            Returns the bottom-quark kinetic mass :math:`m_b^{\text{kin}}(\mu_{\text{kin}})` in GeV.
+
+            :param mu_kin: The kinetic cutoff scale in GeV.
+            :type mu_kin: float
+            :rtype: float
+        )",
+                 args("self", "mu_kin"))
+            .def("m_b_msbar", &Model::m_b_msbar, R"(
+            Returns the bottom-quark :math:`\overline{\text{MS}}` mass :math:`\overline{m}_b(\mu)` in GeV.
+
+            :param mu: The renormalization scale in GeV.
+            :type mu: float
+            :rtype: float
+        )",
+                 args("self", "mu"))
+            .def("m_b_pole", &Model::m_b_pole, R"(
+            Returns the bottom-quark pole mass in GeV.
+
+            :param loop_order: The loop order of the conversion from the :math:`\overline{\text{MS}}` mass. Defaults to 3.
+            :type loop_order: int
+            :rtype: float
+        )",
+                 args("self", "loop_order"))
+            .def("m_b_pole", &::impl::m_b_pole_wrapper_noargs, R"(
+            Returns the bottom-quark pole mass in GeV at the default loop order.
+
+            :rtype: float
+        )",
+                 args("self"))
+            .def("m_c_kin", &Model::m_c_kin, R"(
+            Returns the charm-quark kinetic mass :math:`m_c^{\text{kin}}(\mu_{\text{kin}})` in GeV.
+
+            :param mu_kin: The kinetic cutoff scale in GeV.
+            :type mu_kin: float
+            :rtype: float
+        )",
+                 args("self", "mu_kin"))
+            .def("m_c_msbar", &Model::m_c_msbar, R"(
+            Returns the charm-quark :math:`\overline{\text{MS}}` mass :math:`\overline{m}_c(\mu)` in GeV.
+
+            :param mu: The renormalization scale in GeV.
+            :type mu: float
+            :rtype: float
+        )",
+                 args("self", "mu"))
+            .def("m_c_pole", &Model::m_c_pole, R"(
+            Returns the charm-quark pole mass in GeV.
+
+            :rtype: float
+        )",
+                 args("self"))
+            .def("m_s_msbar", &Model::m_s_msbar, R"(
+            Returns the strange-quark :math:`\overline{\text{MS}}` mass :math:`\overline{m}_s(\mu)` in GeV.
+
+            :param mu: The renormalization scale in GeV.
+            :type mu: float
+            :rtype: float
+        )",
+                 args("self", "mu"))
+            .def("m_ud_msbar", &Model::m_ud_msbar, R"(
+            Returns the averaged up-/down-quark :math:`\overline{\text{MS}}` mass :math:`\overline{m}_{ud}(\mu)` in GeV.
+
+            :param mu: The renormalization scale in GeV.
+            :type mu: float
+            :rtype: float
+        )",
+                 args("self", "mu"))
             // WilsonCoefficients
-            .def("wilson_coefficients_b_to_s", &Model::wilson_coefficients_b_to_s)
+            .def("wilson_coefficients_b_to_s", &Model::wilson_coefficients_b_to_s, R"(
+            Returns the Wilson coefficients of the :math:`b \to s` effective Hamiltonian.
+
+            :param mu: The renormalization scale in GeV.
+            :type mu: float
+            :param lepton_flavor: The lepton flavor, one of ``e``, ``mu``, or ``tau``.
+            :type lepton_flavor: str
+            :param cp_conjugate: Whether to return the CP-conjugated Wilson coefficients. Defaults to False.
+            :type cp_conjugate: bool
+        )",
+                 args("self", "mu", "lepton_flavor", "cp_conjugate"))
             // alpha_s
-            .def("alpha_s", &Model::alpha_s);
+            .def("alpha_s", &Model::alpha_s, R"(
+            Returns the strong coupling :math:`\alpha_s(\mu)` at the renormalization scale ``mu``.
+
+            :param mu: The renormalization scale in GeV.
+            :type mu: float
+            :rtype: float
+        )",
+                 args("self", "mu"));
 
     class_<ObservableCache::ObservableId>("ObservableId", R"(
     )",
@@ -591,7 +743,7 @@ BOOST_PYTHON_MODULE(_eos)
             :param handle: The handle of the observable.
             :type handle: int
         )",
-                 args("handle"))
+                 args("self", "handle"))
             .def("add", &ObservableCache::add, R"(
             Add an existing observable to the cache.
 
@@ -601,13 +753,17 @@ BOOST_PYTHON_MODULE(_eos)
             :returns: An internal handle to the cached observable. The observable's value can be retrieved using ``cache[handle]``.
             :rtype: int
         )",
-                 args("observable"))
+                 args("self", "observable"))
             .def("update", &ObservableCache::update, R"(
             Update the cache for the current parameter point.
-        )")
+        )",
+                 args("self"))
             .def("parameters", &ObservableCache::parameters, R"(
             Retrieve the set of parameters bound to this cache.
-        )");
+
+            :rtype: eos.Parameters
+        )",
+                 args("self"));
 
     // ReferenceName
     class_<ReferenceName>("ReferenceName", init<std::string>())

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -1553,19 +1553,34 @@ BOOST_PYTHON_MODULE(_eos)
             To speed up sampling from the PDF, the :meth:`evaluate <eos.SignalPDF.evaluate>` returns values of an
             unnormalized function proportional to the actual PDF. To ensure that the integral over the PDF is
             normalized to 1, the values returned by evaluate need to be divided by the return value of this method.
-        )")
+
+            :rtype: float
+        )",
+                 args("self"))
             .def("name", &SignalPDF::name, return_value_policy<copy_const_reference>(), R"(
             Returns the name of the PDF.
-        )")
+
+            :rtype: eos.QualifiedName
+        )",
+                 args("self"))
             .def("parameters", &SignalPDF::parameters, R"(
             Returns the set of parameters bound to this PDF.
-        )")
+
+            :rtype: eos.Parameters
+        )",
+                 args("self"))
             .def("options", &SignalPDF::options, R"(
             Returns the set of options used when creating the PDF.
-        )")
+
+            :rtype: eos.Options
+        )",
+                 args("self"))
             .def("kinematics", &SignalPDF::kinematics, R"(
             Returns the set of kinematic variables bound to this PDF.
-        )");
+
+            :rtype: eos.Kinematics
+        )",
+                 args("self"));
 
     // SignalPDFEntry
     register_ptr_to_python<std::shared_ptr<const SignalPDFEntry>>();

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -702,15 +702,76 @@ BOOST_PYTHON_MODULE(_eos)
 
     // ConstraintEntry
     register_ptr_to_python<std::shared_ptr<const ConstraintEntry>>();
-    class_<eos::ConstraintEntry, boost::noncopyable>("ConstraintEntry", no_init)
-            .def("make", &ConstraintEntry::make, return_value_policy<return_by_value>())
-            .def("make_prior", &ConstraintEntry::make_prior, return_value_policy<return_by_value>())
-            .def("name", &ConstraintEntry::name, return_value_policy<copy_const_reference>())
-            .def("type", &ConstraintEntry::type, return_value_policy<copy_const_reference>())
-            .def("observables", range(&ConstraintEntry::begin_observable_names, &ConstraintEntry::end_observable_names))
-            .def("references", range(&ConstraintEntry::begin_references, &ConstraintEntry::end_references))
-            .def("serialize", (std::string(ConstraintEntry::*)(void) const) &ConstraintEntry::serialize, return_value_policy<return_by_value>())
-            .def("deserialize", (ConstraintEntry * (*) (const QualifiedName &, const std::string &) ) & ConstraintEntry::FromYAML, return_value_policy<manage_new_object>())
+    class_<eos::ConstraintEntry, boost::noncopyable>("ConstraintEntry", R"(
+            Describes a single constraint known to EOS and acts as its factory.
+
+            A constraint entry records a constraint's name, type, the observables it constrains, and
+            the references it originates from. Entries are obtained by iterating or indexing
+            :class:`eos.Constraints`, and can create the corresponding :class:`eos.Constraint` (via
+            :meth:`make <eos.ConstraintEntry.make>`) or an equivalent :class:`eos.LogPrior` (via
+            :meth:`make_prior <eos.ConstraintEntry.make_prior>`).
+        )",
+                                                     no_init)
+            .def("make", &ConstraintEntry::make, return_value_policy<return_by_value>(), R"(
+            Makes a new :class:`Constraint` object from this entry.
+
+            :param name: The name of the constraint.
+            :type name: eos.QualifiedName
+            :param options: The set of options passed to the observables entering the constraint.
+            :type options: eos.Options
+
+            :return: The new constraint object.
+            :rtype: eos.Constraint
+        )",
+                 args("self", "name", "options"))
+            .def("make_prior", &ConstraintEntry::make_prior, return_value_policy<return_by_value>(), R"(
+            Makes a new :class:`LogPrior` object from this entry.
+
+            :param parameters: The set of parameters to which the prior is bound.
+            :type parameters: eos.Parameters
+            :param options: The set of options passed to the observables entering the constraint.
+            :type options: eos.Options
+
+            :return: The new log(prior) object.
+            :rtype: eos.LogPrior
+        )",
+                 args("self", "parameters", "options"))
+            .def("name", &ConstraintEntry::name, return_value_policy<copy_const_reference>(), R"(
+            Returns the name of the constraint.
+
+            :rtype: eos.QualifiedName
+        )",
+                 args("self"))
+            .def("type", &ConstraintEntry::type, return_value_policy<copy_const_reference>(), R"(
+            Returns the type description of the constraint, e.g. ``Gaussian`` or ``MultivariateGaussian``.
+
+            :rtype: str
+        )",
+                 args("self"))
+            .def("observables", range(&ConstraintEntry::begin_observable_names, &ConstraintEntry::end_observable_names), R"(
+            Returns an iterator over the names of the observables entering the constraint.
+        )")
+            .def("references", range(&ConstraintEntry::begin_references, &ConstraintEntry::end_references), R"(
+            Returns an iterator over the names of the references from which the constraint originates.
+        )")
+            .def("serialize", (std::string(ConstraintEntry::*)(void) const) &ConstraintEntry::serialize, return_value_policy<return_by_value>(), R"(
+            Returns the YAML representation of the constraint entry as a string.
+
+            :rtype: str
+        )",
+                 args("self"))
+            .def("deserialize", (ConstraintEntry * (*) (const QualifiedName &, const std::string &) ) & ConstraintEntry::FromYAML, return_value_policy<manage_new_object>(), R"(
+            Creates a new :class:`ConstraintEntry` by deserializing its YAML representation.
+
+            :param name: The name of the constraint.
+            :type name: eos.QualifiedName
+            :param yaml: The YAML representation of the constraint entry.
+            :type yaml: str
+
+            :return: The new constraint entry object.
+            :rtype: eos.ConstraintEntry
+        )",
+                 args("name", "yaml"))
             .staticmethod("deserialize");
 
     // Constraints

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -377,42 +377,94 @@ BOOST_PYTHON_MODULE(_eos)
         )",
                       no_init)
             .def(float_(self))
-            .def("central", &Parameter::central, return_value_policy<copy_const_reference>())
-            .def("max", &Parameter::max, return_value_policy<copy_const_reference>())
-            .def("min", &Parameter::min, return_value_policy<copy_const_reference>())
+            .def("central", &Parameter::central, return_value_policy<copy_const_reference>(),
+                 R"(
+            Returns the default central value of the parameter.
+
+            :rtype: float
+            )",
+                 args("self"))
+            .def("max", &Parameter::max, return_value_policy<copy_const_reference>(),
+                 R"(
+            Returns the maximum value that the parameter is allowed to take.
+
+            :rtype: float
+            )",
+                 args("self"))
+            .def("min", &Parameter::min, return_value_policy<copy_const_reference>(),
+                 R"(
+            Returns the minimum value that the parameter is allowed to take.
+
+            :rtype: float
+            )",
+                 args("self"))
             .def("name", &Parameter::name, return_value_policy<copy_const_reference>(),
                  R"(
             Returns the name of the parameter.
-            )")
+
+            :rtype: str
+            )",
+                 args("self"))
             .def("latex", &Parameter::latex, return_value_policy<copy_const_reference>(),
                  R"(
             Returns the LaTeX representation of the parameter.
-            )")
-            .def("unit", &Parameter::unit)
+
+            :rtype: str
+            )",
+                 args("self"))
+            .def("unit", &Parameter::unit,
+                 R"(
+            Returns the unit of the parameter.
+
+            :rtype: eos.Unit
+            )",
+                 args("self"))
             .def("set", &Parameter::set,
                  R"(
             Set the value of a parameter.
 
             :param value: The value to set the parameter to.
             :type value: float
-            )")
+            )",
+                 args("self", "value"))
             .def("set_generator", &Parameter::set_generator,
                  R"(
             Set the generator value of a parameter.
 
             :param value: The value to set the parameter's generator to.
             :type value: float
-            )")
-            .def("set_max", &Parameter::set_max)
-            .def("set_min", &Parameter::set_min)
+            )",
+                 args("self", "value"))
+            .def("set_max", &Parameter::set_max,
+                 R"(
+            Set the maximum value that the parameter is allowed to take.
+
+            :param value: The maximum value to set.
+            :type value: float
+            )",
+                 args("self", "value"))
+            .def("set_min", &Parameter::set_min,
+                 R"(
+            Set the minimum value that the parameter is allowed to take.
+
+            :param value: The minimum value to set.
+            :type value: float
+            )",
+                 args("self", "value"))
             .def("evaluate", &Parameter::evaluate,
                  R"(
             Return the current value of a parameter.
-            )")
+
+            :rtype: float
+            )",
+                 args("self"))
             .def("evaluate_generator", &Parameter::evaluate_generator,
                  R"(
             Return the current generator value of a parameter.
-            )");
+
+            :rtype: float
+            )",
+                 args("self"));
 
     // ParameterUser
     class_<ParameterUser>("ParameterUser", no_init).def("used_parameter_ids", range(&ParameterUser::begin, &ParameterUser::end));

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -779,7 +779,18 @@ BOOST_PYTHON_MODULE(_eos)
     class_<Constraints>("_Constraints")
             .def("__getitem__", (std::shared_ptr<const ConstraintEntry>(Constraints::*)(const QualifiedName &) const) & Constraints::operator[])
             .def("__iter__", range(&Constraints::begin, &Constraints::end))
-            .def("insert", &Constraints::insert);
+            .def("insert", &Constraints::insert, R"(
+            Inserts a new constraint into EOS at run time by parsing its YAML representation.
+
+            :param name: The name of the new constraint.
+            :type name: eos.QualifiedName
+            :param entry: The YAML representation of the constraint entry.
+            :type entry: str
+
+            :return: The newly inserted constraint entry.
+            :rtype: eos.ConstraintEntry
+        )",
+                 args("self", "name", "entry"));
 
     class_<ParameterDescription>("ParameterDescription").def_readonly("parameter", &ParameterDescription::parameter);
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -965,16 +965,23 @@ BOOST_PYTHON_MODULE(_eos)
             .staticmethod("Transform")
             .def("evaluate", &LogPrior::operator(), R"(
             Returns the logarithm of the prior's probability density at the current parameter values.
-        )")
+
+            :rtype: float
+        )",
+                 args("self"))
             .def("sample", &LogPrior::sample, R"(
             Sets its parameters' values corresponding to the cumulative propability :math:`p` assigned to
             each parameter via its :meth:`Parameter.set_generator` method.
-        )")
+        )",
+                 args("self"))
             .def("compute_cdf", &LogPrior::compute_cdf, R"(
             Returns the cumulative probabilities :math:`p` assigned to each parameter via its
             :meth:`Parameter.evaluate_generator` method.
-        )")
-            .def("varied_parameters", range(&LogPrior::begin, &LogPrior::end));
+        )",
+                 args("self"))
+            .def("varied_parameters", range(&LogPrior::begin, &LogPrior::end), R"(
+            Returns an iterator over the :class:`Parameter <eos.Parameter>` objects varied by this prior.
+        )");
 
     // LogPosterior
     class_<LogPosterior>("LogPosterior", R"(

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -983,16 +983,31 @@ BOOST_PYTHON_MODULE(_eos)
                          init<LogLikelihood>())
             .def("add", &LogPosterior::add, R"(
             Adds a new prior object to the posterior.
-        )")
+
+            :param prior: The prior to add to the posterior.
+            :type prior: eos.LogPrior
+            :param nuisance: Whether the prior's parameters shall be treated as nuisance parameters.
+            :type nuisance: bool
+
+            :return: Whether the prior was added successfully.
+            :rtype: bool
+        )",
+                 args("self", "prior", "nuisance"))
             .def("log_likelihood", &LogPosterior::log_likelihood, R"(
             Returns the likelihood object used as part of the posterior.
-        )")
+
+            :rtype: eos.LogLikelihood
+        )",
+                 args("self"))
             .def("log_priors", range(&LogPosterior::begin_priors, &LogPosterior::end_priors), R"(
             Returns a range of :class:`LogPrior` objects used as part of the posterior.
         )")
             .def("evaluate", &LogPosterior::evaluate, R"(
             Returns the posterior probability density.
-        )");
+
+            :rtype: float
+        )",
+                 args("self"));
 
     // test_statistics::ChiSquare
     class_<test_statistics::ChiSquare>("test_statisticsChiSquare", no_init)

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -973,10 +973,16 @@ BOOST_PYTHON_MODULE(_eos)
             .def("total_chi_square", &GoodnessOfFit::total_chi_square, R"(
             Returns the total :math:`\chi^2` value of the log(likelihood). Only (multivariate) gaussian
             likelihoods are considered for this result.
-        )")
+
+            :rtype: float
+        )",
+                 args("self"))
             .def("total_degrees_of_freedom", &GoodnessOfFit::total_degrees_of_freedom, R"(
             Returns the total number of degrees of freedom in the log(posterior).
-        )");
+
+            :rtype: int
+        )",
+                 args("self"));
 
     // }}}
 

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -659,11 +659,33 @@ BOOST_PYTHON_MODULE(_eos)
             Represents the log(likelihood) of a Bayesian analysis undertaken with the :class:`Analysis <eos.Analysis>` class.
         )",
                           init<Parameters>())
-            .def("add", (void(LogLikelihood::*)(const Constraint &)) & LogLikelihood::add)
-            .def("add", (void(LogLikelihood::*)(const LogLikelihoodBlockPtr &)) & LogLikelihood::add)
+            .def("add", (void(LogLikelihood::*)(const Constraint &)) & LogLikelihood::add, R"(
+            Adds a constraint from the internal database to the likelihood.
+
+            :param constraint: The constraint to add.
+            :type constraint: eos.Constraint
+        )",
+                 args("self", "constraint"))
+            .def("add", (void(LogLikelihood::*)(const LogLikelihoodBlockPtr &)) & LogLikelihood::add, R"(
+            Adds a single log-likelihood block to the likelihood.
+
+            :param block: The log-likelihood block to add.
+            :type block: eos.LogLikelihoodBlock
+        )",
+                 args("self", "block"))
             .def("__iter__", range(&LogLikelihood::begin, &LogLikelihood::end))
-            .def("observable_cache", &LogLikelihood::observable_cache)
-            .def("evaluate", &LogLikelihood::operator());
+            .def("observable_cache", &LogLikelihood::observable_cache, R"(
+            Returns the observable cache shared by the likelihood's blocks.
+
+            :rtype: eos.ObservableCache
+        )",
+                 args("self"))
+            .def("evaluate", &LogLikelihood::operator(), R"(
+            Evaluates the log(likelihood) for the current parameter point.
+
+            :rtype: float
+        )",
+                 args("self"));
 
     // Constraint
     class_<Constraint>("Constraint", R"(

--- a/python/eos/_api.py
+++ b/python/eos/_api.py
@@ -1,0 +1,71 @@
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""
+Single source of truth for the public, C++ (boost::python) binding classes of EOS that are
+part of the documented Python API.
+
+This module intentionally has no dependencies (in particular it does not import ``eos``), so that
+it can be imported cheaply by both:
+
+  * ``eos/_api_TEST.py``, which asserts that every method bound on these classes names its
+    arguments (no ``argN`` placeholder) and carries a docstring; and
+  * ``doc/reference/python.rst.py``, which generates the ``.. autoclass::`` directives for the
+    Python API reference.
+
+The classes are grouped exactly as in the Python API reference: ``API_BASIC_CLASSES`` are the
+"Basic Classes" and ``API_COMMON_CLASSES`` are the "Common Classes". Each dict maps the attribute
+name of a class in the ``eos`` module to whether its ``.. autoclass::`` directive uses
+``:inherited-members:``. The flag is ``True`` for the thin Python wrapper classes (e.g.
+``eos.Parameters``) whose bound methods are inherited from an underscore-prefixed C++ base (e.g.
+``_eos._Parameters``) and must therefore be documented through inheritance; it is ``False`` for
+classes that are documented with ``:members:`` only. The insertion order is the order in which the
+classes are documented.
+"""
+
+API_BASIC_CLASSES = {
+    'Constraint':         False,
+    'ConstraintEntry':    False,
+    'Constraints':        True,
+    'Kinematics':         True,
+    'LogLikelihood':      False,
+    'LogLikelihoodBlock': False,
+    'LogPrior':           False,
+    'LogPosterior':       False,
+    'Model':              False,
+    'Observable':         False,
+    'ObservableEntry':    False,
+    'Observables':        True,
+    'Options':            False,
+    'Parameter':          False,
+    'Parameters':         True,
+    'QualifiedName':      False,
+    'Reference':          False,
+    'References':         True,
+    'SignalPDF':          True,
+    'SignalPDFEntry':     False,
+    'SignalPDFs':         True,
+    'Unit':               False,
+}
+
+API_COMMON_CLASSES = {
+    'Analysis':        False,
+    'AnalysisFile':    False,
+    'BestFitPoint':    False,
+    'GoodnessOfFit':   False,
+    'ObservableCache': False,
+}

--- a/python/eos/_api_TEST.py
+++ b/python/eos/_api_TEST.py
@@ -1,0 +1,157 @@
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import re
+import unittest
+
+import eos
+from eos._api import API_BASIC_CLASSES, API_COMMON_CLASSES
+
+# The set of documented classes, mapping each class' attribute name in the ``eos`` module to whether
+# its ``.. autoclass::`` directive uses ``:inherited-members:`` (see eos._api).
+_DOCUMENTED_CLASSES = {**API_BASIC_CLASSES, **API_COMMON_CLASSES}
+
+# For each documented class, every method that boost::python binds must:
+#
+#   (a) name all of its arguments (including the receiver ``self``) via boost::python::args,
+#       so that no ``argN`` placeholder leaks into the rendered signature; and
+#   (b) carry a user-provided docstring.
+#
+# This test introspects the live bindings rather than the rendered HTML, so it is
+# independent of the documentation theme or Sphinx version. The set of classes and the
+# ``:inherited-members:`` flag are shared with the documentation via eos._api.
+
+# Matches an unnamed boost::python argument placeholder in a signature, e.g. ``(Parameter)arg1``.
+_ARGN = re.compile(r'\)arg\d')
+
+# Matches the signature of a boost::python iterator method bound via ``range(...)``, e.g.
+# ``sections( (_Parameters)arg1) -> object``. Such methods take only the receiver and return a
+# Python iterator; boost::python does not accept ``args(...)`` for them, so their receiver
+# unavoidably renders as ``arg1``. They expose no user-facing arguments and are therefore exempt
+# from the unnamed-argument check. (The trailing `` :`` appears when the method has a docstring.)
+_ITERATOR_SIG = re.compile(r'\w+\(\s*\(\w+\)arg1\s*\)\s*->\s*object\b')
+
+
+def _is_iterator_method(doc):
+    """Return whether ``doc``'s signature is that of a ``range(...)``-bound iterator method."""
+    first = doc.strip().split('\n', 1)[0]
+    return bool(_ITERATOR_SIG.match(first))
+
+
+def _is_boost_function(obj):
+    """Return whether ``obj`` is a live boost::python binding (as opposed to a Python wrapper)."""
+    t = type(obj)
+    return t.__module__ == 'Boost.Python' and t.__name__ == 'function'
+
+
+def _bound_methods(cls, include_inherited):
+    """
+    Yield ``(name, doc)`` for every boost::python method rendered for ``cls``.
+
+    When ``include_inherited`` is set, the class' full MRO is walked so that C++ methods
+    inherited by a Python wrapper class (e.g. ``eos.Parameters`` deriving from
+    ``_eos._Parameters``) are covered; this mirrors the ``:inherited-members:`` autodoc option.
+    Otherwise only the class' own methods are considered.
+
+    Methods that a Python wrapper overrides (e.g. ``eos.SignalPDF.make``) resolve to the Python
+    function and are therefore skipped: they are documented on the Python side, not in the
+    bindings. Dunder methods are excluded.
+    """
+    bases = cls.__mro__ if include_inherited else [cls]
+    seen = set()
+    for base in bases:
+        if base is object:
+            continue
+        for name in vars(base):
+            if name.startswith('__') or name in seen:
+                continue
+            seen.add(name)
+            try:
+                attr = getattr(cls, name)
+            except Exception:
+                continue
+            if not _is_boost_function(attr):
+                continue
+            yield name, (attr.__doc__ or '')
+
+
+def _signature_only(name, doc):
+    """Return whether ``doc`` contains only boost's auto-generated signature line(s), i.e. no
+    user-provided description follows."""
+    for line in doc.split('\n'):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # boost renders one signature line per overload, each starting with ``name(``.
+        if stripped.startswith(name + '('):
+            continue
+        return False
+    return True
+
+
+def _is_zero_argument_static(name, doc):
+    """Return whether ``doc`` describes a receiver-less, argument-less binding, e.g. ``GeV() -> Unit``."""
+    return bool(re.match(r'\s*' + re.escape(name) + r'\(\s*\)\s*->', doc.strip()))
+
+
+class BindingDocstringTests(unittest.TestCase):
+
+    def test_no_unnamed_arguments(self):
+        "every documented binding names all of its arguments (no ``argN`` placeholder leaks)"
+
+        offenders = []
+        for clsname, include_inherited in _DOCUMENTED_CLASSES.items():
+            cls = getattr(eos, clsname)
+            for name, doc in _bound_methods(cls, include_inherited):
+                # iterator methods bound via boost::python::range cannot carry args(...); their
+                # receiver necessarily renders as ``arg1`` and they take no user arguments.
+                if _is_iterator_method(doc):
+                    continue
+                if _ARGN.search(doc):
+                    offenders.append(f'{clsname}.{name}')
+
+        self.assertEqual(
+            offenders, [],
+            "the following bindings leak an unnamed 'argN' placeholder into their signature "
+            "(add boost::python::args(\"self\", ...) to their .def in python/_eos.cc):\n  "
+            + '\n  '.join(offenders)
+        )
+
+    def test_methods_have_docstrings(self):
+        "every documented binding carries a user-provided docstring"
+
+        offenders = []
+        for clsname, include_inherited in _DOCUMENTED_CLASSES.items():
+            cls = getattr(eos, clsname)
+            for name, doc in _bound_methods(cls, include_inherited):
+                # eos.Unit's zero-argument static factory methods (GeV(), GeV2(), ...) are
+                # self-explanatory and intentionally left un-docstringed; the eos.Unit class
+                # docstring enumerates them. See the Group B documentation decision.
+                if clsname == 'Unit' and _is_zero_argument_static(name, doc):
+                    continue
+                if _signature_only(name, doc):
+                    offenders.append(f'{clsname}.{name}')
+
+        self.assertEqual(
+            offenders, [],
+            "the following bindings lack a docstring (add one to their .def in python/_eos.cc):\n  "
+            + '\n  '.join(offenders)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -793,6 +793,8 @@ class Analysis:
         :type maxiter: int, optional
         :param miniter: The minimum number of iterations. Defaults to 0. Samples will be added until miniter is reached, even if the termination condition is reached earlier.
         :type miniter: int, optional
+        :param print_progress: Whether to print progress messages during sampling. Defaults to True.
+        :type print_progress: bool, optional
         :param print_function: The function used to print progress messages. Defaults to using a dynesty-based function.
         :type print_function: callable, optional
         :param seed: The seed used to initialize the Mersenne Twister pseudo-random number generator.

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -376,7 +376,7 @@ class Analysis:
         return eos.GoodnessOfFit(self._log_posterior)
 
 
-    def optimize(self, start_point=None, rng=np.random.mtrand, **kwargs):
+    def optimize(self, start_point=None, rng=None, **kwargs):
         r"""
         Optimize the log(posterior) and returns a best-fit-point summary.
         Optimization is performed using the scipy SLSQP method by default since the varied parameters are usually bounded.
@@ -392,6 +392,9 @@ class Analysis:
         :param \**kwargs: Are passed to `scipy.optimize.minimize`
 
         """
+        if rng is None:
+            rng = np.random.mtrand
+
         if str(start_point) == "random":
             # generate random uniform probabilities and store them in the generator values
             for param in self.varied_parameters:
@@ -472,7 +475,7 @@ class Analysis:
         return -self.log_pdf(u, *args)
 
 
-    def sample_prior(self, N=1000, rng=np.random.mtrand):
+    def sample_prior(self, N=1000, rng=None):
         """
         Return prior samples of the parameters.
 
@@ -484,6 +487,9 @@ class Analysis:
 
         :return: An iterable of the parameter samples of size N.
         """
+        if rng is None:
+            rng = np.random.mtrand
+
         samples = []
         for _ in range(N):
             u_samples = rng.uniform(0.0, 1.0, len(self.varied_parameters))
@@ -491,7 +497,7 @@ class Analysis:
         return np.array(samples)
 
 
-    def sample(self, N=1000, stride=5, pre_N=150, preruns=3, cov_scale=0.1, observables=None, start_point=None, rng=np.random.mtrand,
+    def sample(self, N=1000, stride=5, pre_N=150, preruns=3, cov_scale=0.1, observables=None, start_point=None, rng=None,
                return_uspace=False):
         """
         Return samples of the parameters, log(weights), and optionally posterior-predictive samples for a sequence of observables.
@@ -515,6 +521,9 @@ class Analysis:
         .. note::
            This method requiries the PyPMC python module, which can be installed from PyPI.
         """
+        if rng is None:
+            rng = np.random.mtrand
+
         try:
             import pypmc
         except ImportError as e:
@@ -588,7 +597,7 @@ class Analysis:
             return(parameter_samples, weights, np.array(observable_samples))
 
 
-    def sample_pmc(self, log_proposal, step_N=1000, steps=10, final_N=5000, rng=np.random.mtrand,
+    def sample_pmc(self, log_proposal, step_N=1000, steps=10, final_N=5000, rng=None,
                     return_final_only=True, final_perplexity_threshold=1.0, weight_threshold=1e-10,
                     pmc_iterations=1, pmc_rel_tol=1e-10, pmc_abs_tol=1e-05, pmc_lookback=1):
         """
@@ -642,6 +651,9 @@ class Analysis:
         .. note::
            This method requires the PyPMC python module, which can be installed from PyPI.
         """
+        if rng is None:
+            rng = np.random.mtrand
+
         try:
             import pypmc
         except ImportError as e:

--- a/python/eos/constraint.py
+++ b/python/eos/constraint.py
@@ -18,6 +18,21 @@
 from _eos import _Constraints, _References
 
 class Constraints(_Constraints):
+    """
+    Represents the complete list of constraints known to EOS.
+
+    Objects of this class are visualized as tables in Jupyter notebooks for easy
+    overview. Filters can be applied through keyword arguments to the initialization.
+
+    :param prefix: Only show constraints whose qualified names contain the provided ``prefix`` in their prefix part.
+    :type prefix: str
+    :param name: Only show constraints whose qualified names contain the provided ``name`` in their name part.
+    :type name: str
+    :param suffix: Only show constraints whose qualified names contain the provided ``suffix`` in their suffix part.
+    :type suffix: str
+
+    See also `the complete list of constraints <../reference/constraints.html>`_ in this documentation.
+    """
     def __init__(self, prefix=None, name=None, suffix=None):
         super().__init__()
         self.prefix=prefix

--- a/python/eos/reference.py
+++ b/python/eos/reference.py
@@ -18,6 +18,19 @@
 from _eos import _References
 
 class References(_References):
+    """
+    Represents the complete list of references known to EOS.
+
+    Objects of this class are visualized as tables in Jupyter notebooks for easy
+    overview. Filters can be applied through keyword arguments to the initialization.
+
+    :param year: Only show references whose names contain the provided ``year`` in their year part.
+    :type year: str
+    :param index: Only show references whose names contain the provided ``index`` in their index part.
+    :type index: str
+
+    See also `the complete list of references <../reference/bibliography.html>`_ in this documentation.
+    """
     def __init__(self, year=None, index=None):
         super().__init__()
         self.year  = year

--- a/python/eos/signal_pdf.py
+++ b/python/eos/signal_pdf.py
@@ -32,7 +32,7 @@ class SignalPDF(_SignalPDF):
 
         return self.evaluate()
 
-    def sample_mcmc(self, N, stride, pre_N, preruns, cov_scale=0.1, start_point=None, rng=np.random.mtrand):
+    def sample_mcmc(self, N, stride, pre_N, preruns, cov_scale=0.1, start_point=None, rng=None):
         """
         Return samples of the kinematic variables and the log(PDF).
 
@@ -53,6 +53,9 @@ class SignalPDF(_SignalPDF):
         .. note::
            This method requires the PyPMC python module, which can be installed from PyPI.
         """
+        if rng is None:
+            rng = np.random.mtrand
+
         import pypmc
         try:
             from tqdm.auto import tqdm

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -736,8 +736,8 @@ def report(analysis_file:str, template_file:str, base_directory:str='./', genera
     :type template_file: str
     :param base_directory: The base directory for the storage of data files. Can also be set via the EOS_BASE_DIRECTORY environment variable.
     :type base_directory: str, optional
-    :param convert_to_pdf: The flag that enables the conversion of the intermediate file to PDF. Defaults to `True`.
-    :type convert_to_pdf: bool, optional
+    :param generate_pdf: The flag that enables the conversion of the intermediate file to PDF. Defaults to `True`.
+    :type generate_pdf: bool, optional
     """
     import jinja2
 

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -678,7 +678,7 @@ def sample_nested(analysis_file:str, posterior:str, base_directory:str='./', bou
     :type bound: str, optional
     :param nlive: The number of live points.
     :type nlive: int, optional
-    :param dlogz: Relative tolerance for the remaining evidence. Defaults to 5%.
+    :param dlogz: The relative tolerance for the remaining evidence. Defaults to 1.0.
     :type dlogz: float, optional
     :param maxiter: The maximum number of iterations. Iterations may stop earlier if the termination condition is reached.
     :type maxiter: int, optional


### PR DESCRIPTION
- 9a9af21f [python] Fix docstring for ``eos.tasks.report``.
- 607d7338 [python] Fix docstring for ``eos.LogPrior.Transform``.
- 53131c28 [python] Fix argument names for ``eos.LogPrior.CurtailedGauss``.
- 8f5a8270 [python] Fix docstring for ``eos.LogPrior``.
- 2a66fe1a [python] Hide ``np.random.mtrand`` from default arguments.
- e073f39a [python] Fix docstring for ``eos.Analysis.sample_nested``.
- ba8e7f95 [python] Fix docstring for ``eos.tasks.sample_nested``.
- 24f301aa [python] Fix docstring for ``eos.Unit`` and ``eos.Unit.latex``.
- e2ca5efc [doc] Expand Python API.
- 2cdcf54c [python] Add docstrings for ``eos.Constraint``.
- 7ec16103 [python] Add docstrings for ``eos.ConstraintEntry``.
- b9a225b6 [python] Add docstrings for ``eos.Constraints``.
- 2b7f60d4 [python] Add argument names for ``eos.GoodnessOfFit``.
- 01721af6 [python] Add docstrings for ``eos.LogLikelihood``.
- bbf741c5 [python] Add docstrings for ``eos.LogLikelihoodBlock``.
- 8c9aa718 [python] Add docstrings for ``eos.LogPosterior``.
- 6d88cd61 [python] Add docstrings for ``eos.LogPrior``.
- f24ce7d1 [python] Fix docstrings for ``eos.ObservableCache``.
- 575896e8 [python] Add docstrings for ``eos.Observables``.
- 50b334e5 [python] Add docstrings for ``eos.Options``.
- a8d2bef0 [python] Add docstrings for ``eos.Parameter``.
- c083b321 [python] Add docstrings for ``eos.Parameters``.
- fd2c834c [python] Add argument names for ``eos.QualifiedName``.
- f9e6d269 [python] Add docstrings for ``eos.Reference``.
- b255112f [python] Add docstrings for ``eos.References``.
- ecd323a6 [python] Fix docstrings for ``eos.SignalPDF``.
- eff370d7 [python] Add docstrings for ``eos.SignalPDFs``.
- b08be370 [python] Add argument names for ``eos.Kinematics``.
- 1b35c320 [python] Add test case to ensure correct docstrings for the public API.
- 1973aec5 [doc] Use templating to generate most of the Python API document.