### PR TITLE
Fix incorrect cloning of cached ``ExpressionObservable`` instances

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -126,6 +126,7 @@
 - Fix the detection of option conflicts in ``eos.AnalysisFile``, which silently failed to warn when an observable's option-part contradicted a global or local option (D. van Dyk)
 - Fix a crash when loading an analysis file that has no ``likelihoods`` section (D. van Dyk)
 - Report all unknown observable names in an analysis file prediction, rather than only the first (D. van Dyk)
+- Fix incorrect cloning of cached ``ExpressionObservable`` instances that fix the same kinematic variable to different values (issue #1077) (D. van Dyk)
 
 
 ## [v1.0.20] - 2026-04-28

--- a/eos/utils/expression-parser_TEST.cc
+++ b/eos/utils/expression-parser_TEST.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021      Méril Reboud
- * Copyright (c) 2023-2025 Danny van Dyk
+ * Copyright (c) 2023-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -491,6 +491,48 @@ class ExpressionParserTest : public TestCase
                 c.update();
                 ExpressionEvaluator evaluator;
                 TEST_CHECK_NEARLY_EQUAL(std::visit(evaluator, cached_e), 5.0, 1e-10);
+            }
+
+            // testing that cloning a *cached* expression preserves distinct fixed
+            // kinematic values (regression test for GitHub issue #1077)
+            {
+                // test::obs1 returns p[mass::c] * multiplier * (q2_max - q2_min).
+                // Both sub-observables fix the SAME kinematic variable (q2_min) to
+                // different values. Cloning the cached form must not let them collide
+                // on a single shared kinematic variable.
+                ExpressionTest test("<<test::obs1>>[q2_min=1.0] + <<test::obs1>>[q2_min=0.0]");
+
+                Parameters p = Parameters::Defaults();
+                p.set("mass::c", 1.0);
+                Kinematics k = Kinematics({
+                    { "q2_max", 3 },
+                });
+
+                ExpressionMaker maker(p, k, Options());
+                Expression      e;
+                TEST_CHECK_NO_THROW(e = std::visit(maker, *test.e));
+
+                // Cache the expression: ObservableExpression nodes become
+                // CachedObservableExpression nodes.
+                ObservableCache  c(p);
+                ExpressionCacher cacher(c);
+                Expression       cached_e;
+                TEST_CHECK_NO_THROW(cached_e = std::visit(cacher, e));
+                c.update();
+
+                ExpressionEvaluator evaluator;
+                TEST_CHECK_NEARLY_EQUAL(std::visit(evaluator, cached_e), 5.0, 1e-10);
+
+                // Clone the *cached* expression and evaluate. The result must remain
+                // 5.0 (= 2.0 + 3.0); a collision on q2_min would yield 4.0 (= 2 * 2.0)
+                // or 6.0 (= 2 * 3.0).
+                Parameters p2 = Parameters::Defaults();
+                p2.set("mass::c", 1.0);
+                Kinematics       k2 = k.clone();
+                ExpressionCloner cloner(p2, k2, Options());
+                Expression       cloned_cached_e;
+                TEST_CHECK_NO_THROW(cloned_cached_e = std::visit(cloner, cached_e));
+                TEST_CHECK_NEARLY_EQUAL(std::visit(evaluator, cloned_cached_e), 5.0, 1e-10);
             }
         }
 } expression_parser_test;

--- a/eos/utils/expression-visitors.cc
+++ b/eos/utils/expression-visitors.cc
@@ -336,12 +336,18 @@ namespace eos::exp
     ExpressionCloner::operator() (const CachedObservableExpression & e)
     {
         const auto & kinematics_values  = e.kinematics_specification.values;
-        const auto & kinematics_aliases = e.kinematics_specification.aliases;
+        auto         kinematics_aliases = e.kinematics_specification.aliases;
 
         // Set or alias kinematic specifications
         for (const auto & value : kinematics_values)
         {
-            _kinematics.declare(value.first, value.second);
+            // Set variables are aliased before being set, using a hidden alias
+            // that is unique per sub-observable. Declaring under the original
+            // name would let two sub-observables that fix the same variable
+            // (e.g. 'q2') collide on a single shared kinematic variable.
+            std::string hidden_alias = this->next_hidden_alias();
+            _kinematics.declare(hidden_alias, value.second);
+            kinematics_aliases.insert(std::make_pair(value.first, hidden_alias));
         }
         for (const auto & alias : kinematics_aliases)
         {


### PR DESCRIPTION
This PR resolves issue #1077.