### PR TITLE
Improve user experience when using analysis files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,8 @@
 - Use ``std::filesystem`` in lieu of ``boost::filesystem`` (D. van Dyk)
 - Use ``std::format`` in lieu of ``boost::format`` when templating parameters (D. van Dyk)
 - Change the interface for generating reports: report templates now access the recorded results through a single, lazily-loaded ``eos.reporting.AnalysisData`` object (iterating over the posteriors and, on demand, their importance samples, modes and goodness of fit, and predictions) together with a ``corner_figure`` helper, in lieu of the previous ``analyses``, ``modes``, ``len``, and ``zip`` template variables (D. van Dyk)
+- Move ``AnalysisFileContext`` into its own module, ``eos.analysis_file_context`` (D. van Dyk)
+- Deserialize analysis files through a new ``eos.AnalysisFileDescription`` class, which maps the YAML structure to description objects and rejects unknown top-level keys (issue #1197) (D. van Dyk)
 
 ### Added
 
@@ -76,6 +78,7 @@
 - Add the ``eos.reporting`` module with the ``AnalysisData``, ``PosteriorData``, and ``GoodnessOfFit`` classes, providing lazy, disk-driven access to the recorded results of an analysis for use in report templates (D. van Dyk)
 - Extend the ``inference`` example to find the best-fit point via a ``find-mode`` step and to report the goodness of fit (as a per-constraint table) and a corner figure for each posterior (D. van Dyk)
 - Add further test cases to cover the worst offenders in terms of code coverage (D. van Dyk)
+- Add a ``format_version`` field to the analysis file format, so that EOS rejects files declaring a newer schema version than it supports (issue #1196) (D. van Dyk)
 
 ### Deprecated
 
@@ -127,6 +130,8 @@
 - Fix a crash when loading an analysis file that has no ``likelihoods`` section (D. van Dyk)
 - Report all unknown observable names in an analysis file prediction, rather than only the first (D. van Dyk)
 - Fix incorrect cloning of cached ``ExpressionObservable`` instances that fix the same kinematic variable to different values (issue #1077) (D. van Dyk)
+- Fix ``eos.figure.GridFigure`` to forward the analysis file context to each of its plots, so that items resolve relative data and parameter paths against the analysis file's base directory (D. van Dyk)
+- Defer loading of a figure item's ``fixed_parameters_from_file`` from construction to draw time, so that loading an analysis file no longer requires the parameter file (which may be the output of an earlier task such as ``find-mode``) to already exist (issue #1181) (D. van Dyk)
 
 
 ## [v1.0.20] - 2026-04-28

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -11,6 +11,8 @@ EXTRA_DIST = \
 	eos/analysis_file_TEST.d \
 	eos/analysis_file_TEST.d/invalid \
 	eos/analysis_file_TEST.py \
+	eos/analysis_file_context.py \
+	eos/analysis_file_context_TEST.py \
 	eos/analysis_file_description.py \
 	eos/config.py \
 	eos/constraint.py \
@@ -88,6 +90,7 @@ eos_SCRIPTS = \
 	eos/_api.py \
 	eos/analysis.py \
 	eos/analysis_file.py \
+	eos/analysis_file_context.py \
 	eos/analysis_file_description.py \
 	eos/config.py \
 	eos/constraint.py \
@@ -153,6 +156,7 @@ TESTS = \
 	eos_TEST.py \
 	eos/analysis_TEST.py \
 	eos/analysis_file_TEST.py \
+	eos/analysis_file_context_TEST.py \
 	eos/analysis_file_description_TEST.py \
 	eos/datasets_TEST.py \
 	eos/datasets_file_description_TEST.py \

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -24,11 +24,8 @@ import yaml
 import inspect
 from collections import Counter
 from dataclasses import asdict
-from eos.analysis_file_description import PriorComponent, LikelihoodComponent, PosteriorDescription, \
-                                       PredictionDescription, ObservableComponent, ParameterComponent, \
-                                       StepComponent, PriorDescription, MaskComponent, MaskExpressionComponent, MaskNamedComponent, \
-                                       MetadataDescription
-from eos.figure import FigureFactory
+from eos.analysis_file_description import AnalysisFileDescription, PriorDescription, \
+                                       MaskExpressionComponent, MaskNamedComponent
 
 # The highest analysis file format version understood by this version of EOS. Increment this
 # whenever a change to the schema alters how existing files are interpreted. Files that omit the
@@ -76,26 +73,26 @@ class AnalysisFile:
                                f'{self.format_version}, but this version of EOS supports at most '
                                f'{SUPPORTED_FORMAT_VERSION}; please update EOS')
 
-        if 'metadata' in self.input_data:
-            self._metadata = MetadataDescription.from_dict(**self.input_data['metadata'])
-        else:
-            self._metadata = MetadataDescription()
+        # Deserialize the file's structure. AnalysisFileDescription performs the pure YAML->object
+        # mapping and rejects unknown top-level keys; the mandatory-section checks, cross-reference
+        # validation, uniqueness checks, and EOS-runtime side effects below remain here.
+        self._description = AnalysisFileDescription.from_dict(**self.input_data)
+
+        self._metadata = self._description.metadata
 
         if 'priors' not in self.input_data:
             raise RuntimeError('Cannot load analysis file: need at least one prior component')
 
-        self._priors = { p["name"]: PriorComponent.from_dict(**p) for p in self.input_data['priors'] }
+        self._priors = { p.name: p for p in self._description.priors }
 
         if 'likelihoods' not in self.input_data:
             eos.warn('No likelihood components found in analysis file')
-            self._likelihoods = {}
-        else:
-            self._likelihoods = { ll["name"]: LikelihoodComponent.from_dict(**ll) for ll in self.input_data['likelihoods'] }
+        self._likelihoods = { ll.name: ll for ll in self._description.likelihoods }
 
         if 'posteriors' not in self.input_data:
             raise RuntimeError('Cannot load analysis file: need at least one posterior')
 
-        self._posteriors = { p["name"]: PosteriorDescription.from_dict(**p) for p in self.input_data['posteriors'] }
+        self._posteriors = { p.name: p for p in self._description.posteriors }
         # Check that the priors and likelihoods referenced by the posteriors are defined
         for pc in self._posteriors.values():
             for p in pc.prior:
@@ -105,34 +102,25 @@ class AnalysisFile:
                 if l not in self._likelihoods:
                     raise RuntimeError(f'Posterior \'{pc.name}\' references likelihood \'{l}\' which is not defined')
 
-        # Optional: provide a list of figures
-        if 'figures' not in self.input_data:
-            self._figures = {}
-        else:
-            self._figures = { f['name']: FigureFactory.from_dict(**f) for f in self.input_data['figures'] }
+        # Optional: figures
+        self._figures = { f.name: f for f in self._description.figures }
 
-        # Optional: provide a list of observables for posterior prediction
-        if 'predictions' not in self.input_data:
-            self._predictions = {}
-        else:
-            self._predictions = { p["name"]: PredictionDescription.from_dict(**p) for p in self.input_data['predictions'] }
+        # Optional: observables for posterior prediction
+        self._predictions = { p.name: p for p in self._description.predictions }
 
         # Optional: insert custom observables using the expression parser
-        if 'observables' not in self.input_data:
-            self._obs = []
-        else:
+        self._obs = self._description.observables
+        if self._obs:
             eos.inprogress('Inserting custom observables ...')
-            self._obs = [ObservableComponent.from_dict(name=n, **d) for n,d in self.input_data['observables'].items()]
             for o in self._obs:
                 eos.Observables().insert(o.name, o.latex, eos.Unit(o.unit), eos.Options(**o.options), o.expression)
                 eos.info(f'Inserted observable: { o.name }')
             eos.completed(f'... finished inserting {len(self._obs)} custom observables')
 
-        if 'parameters' not in self.input_data:
-            self._params = []
-        else:
+        # Optional: declare custom parameters
+        self._params = self._description.parameters
+        if self._params:
             eos.inprogress('Declaring custom parameters ...')
-            self._params = [ParameterComponent.from_dict(name=n, **d) for n, d in self.input_data["parameters"].items()]
             for p in self._params:
                 try:
                     qn = eos.QualifiedName(p.name)
@@ -146,19 +134,14 @@ class AnalysisFile:
                     raise ValueError(f'Unexpected value encountered in description of parameter \'{p.name}\': {e}')
             eos.completed(f'... finished declaring {len(self._params)} custom parameters')
 
-        if 'steps' not in self.input_data:
-            self._steps = {}
-        else:
-            if len(self.input_data['steps']) != len({s['id'] for s in self.input_data['steps']}):
-                raise ValueError("All steps must have a unique id")
-            self._steps = { s["id"]: StepComponent.from_dict(**s) for s in self.input_data['steps'] }
+        if len(self._description.steps) != len({s.id for s in self._description.steps}):
+            raise ValueError("All steps must have a unique id")
+        self._steps = { s.id: s for s in self._description.steps }
 
-        if 'masks' not in self.input_data:
-            self._masks = {}
-        else:
-            if len(self.input_data['masks']) != len({m['name'] for m in self.input_data['masks']}):
-                raise ValueError("All masks must have a unique name")
-            self._masks = { m["name"]: MaskComponent.from_dict(**m) for m in self.input_data['masks'] }
+        if len(self._description.masks) != len({m.name for m in self._description.masks}):
+            raise ValueError("All masks must have a unique name")
+        self._masks = { m.name: m for m in self._description.masks }
+        if self._masks:
             # Insert custom observables using the expression parser
             eos.inprogress('Inserting custom observables for sample masks ...')
             for mc in self._masks.values():

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -30,6 +30,11 @@ from eos.analysis_file_description import PriorComponent, LikelihoodComponent, P
                                        MetadataDescription
 from eos.figure import FigureFactory
 
+# The highest analysis file format version understood by this version of EOS. Increment this
+# whenever a change to the schema alters how existing files are interpreted. Files that omit the
+# top-level 'format_version' key predate format versioning and are treated as version 1.
+SUPPORTED_FORMAT_VERSION = 1
+
 class AnalysisFile:
     """Represents a collection of statistical analyses and their building blocks.
 
@@ -50,6 +55,26 @@ class AnalysisFile:
 
         with open(analysis_file) as input_file:
             self.input_data = yaml.safe_load(input_file)
+
+        # A well-formed analysis file is a top-level YAML mapping. safe_load returns None for an empty
+        # file and other types (e.g. a bare scalar or list) for malformed input; reject these with a
+        # clear message rather than letting the .get()/** below raise an opaque AttributeError.
+        if not isinstance(self.input_data, dict):
+            raise RuntimeError(f'Cannot load analysis file: \'{analysis_file}\' is not a YAML mapping')
+
+        # The top-level 'format_version' records the schema version of the analysis file. Files that
+        # omit it predate format versioning and are treated as version 1. Reject files that declare a
+        # newer version than this EOS understands, rather than silently misinterpreting them.
+        self.format_version = self.input_data.get('format_version', 1)
+        # bool is a subclass of int; reject it (e.g. 'format_version: true') so that it is not
+        # silently treated as version 1, and reject non-integers before the numeric comparison below.
+        if not isinstance(self.format_version, int) or isinstance(self.format_version, bool):
+            raise RuntimeError(f'Cannot load analysis file: \'format_version\' must be an integer, '
+                               f'but is {self.format_version!r}')
+        if self.format_version > SUPPORTED_FORMAT_VERSION:
+            raise RuntimeError(f'Cannot load analysis file: it declares format version '
+                               f'{self.format_version}, but this version of EOS supports at most '
+                               f'{SUPPORTED_FORMAT_VERSION}; please update EOS')
 
         if 'metadata' in self.input_data:
             self._metadata = MetadataDescription.from_dict(**self.input_data['metadata'])

--- a/python/eos/analysis_file_TEST.d/invalid/empty-file.yaml
+++ b/python/eos/analysis_file_TEST.d/invalid/empty-file.yaml
@@ -1,0 +1,1 @@
+# an empty file: yaml.safe_load returns None, which is not a top-level mapping; loading must be refused

--- a/python/eos/analysis_file_TEST.d/invalid/future-format-version.yaml
+++ b/python/eos/analysis_file_TEST.d/invalid/future-format-version.yaml
@@ -1,0 +1,13 @@
+# declares a format version newer than any EOS understands; loading must be refused
+format_version: 999
+
+priors:
+  - name: DC-Bu
+    descriptions:
+      - { 'parameter': 'decay-constant::B_u', 'central': 0.1894, 'sigma':  0.0014, 'type': 'gaussian' }
+
+posteriors:
+  - name: CKM-all
+    prior:
+      - DC-Bu
+    likelihood: []

--- a/python/eos/analysis_file_TEST.d/invalid/string-format-version.yaml
+++ b/python/eos/analysis_file_TEST.d/invalid/string-format-version.yaml
@@ -1,0 +1,13 @@
+# 'format_version' is a string rather than an integer; loading must be refused with a clear error
+format_version: '1'
+
+priors:
+  - name: DC-Bu
+    descriptions:
+      - { 'parameter': 'decay-constant::B_u', 'central': 0.1894, 'sigma':  0.0014, 'type': 'gaussian' }
+
+posteriors:
+  - name: CKM-all
+    prior:
+      - DC-Bu
+    likelihood: []

--- a/python/eos/analysis_file_TEST.d/valid-analysis-file.yaml
+++ b/python/eos/analysis_file_TEST.d/valid-analysis-file.yaml
@@ -1,3 +1,5 @@
+format_version: 1
+
 parameters:
   'ublnul::Re{cVL}' :
       alias_of: [ 'ubenue::Re{cVL}', 'ubmunumu::Re{cVL}', 'ubtaunutau::Re{cVL}' ]

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -1,3 +1,22 @@
+#!/usr/bin/python
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2024-2026 Danny van Dyk
+# Copyright (c) 2025 Matthew Kirk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
 import unittest
 
 import contextlib
@@ -30,6 +49,18 @@ class TestAnalysisFile(unittest.TestCase):
         self.assertEqual(dict(af.likelihoods), {})
         af.validate()
 
+    def test_format_version(self):
+
+        # the fixture declares 'format_version: 1' explicitly
+        af = eos.AnalysisFile(_TESTD / 'valid-analysis-file.yaml')
+        self.assertEqual(af.format_version, 1)
+
+    def test_format_version_defaults_to_one(self):
+
+        # a file without a 'format_version' key predates format versioning and is treated as v1
+        af = eos.AnalysisFile(_TESTD / 'minimal-analysis-file.yaml')
+        self.assertEqual(af.format_version, 1)
+
 
 class TestAnalysisFileConstructionErrors(unittest.TestCase):
     """The mandatory-structure and uniqueness checks in ``__init__`` must raise."""
@@ -42,6 +73,24 @@ class TestAnalysisFileConstructionErrors(unittest.TestCase):
         # a directory is not a valid analysis file
         with self.assertRaises(RuntimeError):
             eos.AnalysisFile(_TESTD)
+
+    def test_future_format_version(self):
+        # a file declaring a newer format version than this EOS supports must be refused rather
+        # than silently misinterpreted
+        with self.assertRaises(RuntimeError):
+            eos.AnalysisFile(_TESTD / 'invalid' / 'future-format-version.yaml')
+
+    def test_empty_file(self):
+        # an empty file parses to None, which is not a top-level mapping; loading must raise a clear
+        # RuntimeError rather than an opaque AttributeError from the subsequent .get()/** access
+        with self.assertRaises(RuntimeError):
+            eos.AnalysisFile(_TESTD / 'invalid' / 'empty-file.yaml')
+
+    def test_non_integer_format_version(self):
+        # a 'format_version' that is not an integer (e.g. a quoted string) must be refused rather
+        # than raising an opaque TypeError from the numeric comparison
+        with self.assertRaises(RuntimeError):
+            eos.AnalysisFile(_TESTD / 'invalid' / 'string-format-version.yaml')
 
     def test_missing_priors(self):
         with self.assertRaises(RuntimeError):

--- a/python/eos/analysis_file_context.py
+++ b/python/eos/analysis_file_context.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2024-2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from dataclasses import dataclass
+import os
+
+@dataclass(kw_only=True)
+class AnalysisFileContext:
+    """
+    Auxiliary class used to resolve paths relative to an analysis file's base directory.
+
+    Instances are passed to consumers of an analysis file (e.g. figures and tasks) so that relative data
+    paths can be resolved against a common base directory.
+
+    :param base_directory: The base directory against which relative paths are resolved. Defaults to the current working directory.
+    :type base_directory: str
+    """
+    base_directory:str='./'
+
+    def __post_init__(self):
+        if not os.path.exists(self.base_directory):
+            raise ValueError(f'Base directory \'{self.base_directory}\' does not exist')
+
+        if not os.path.isdir(self.base_directory):
+            raise ValueError(f'Base directory \'{self.base_directory}\' is not a directory')
+
+    def data_path(self, relative_path:str):
+        """Resolve a path relative to :attr:`base_directory` into an absolute path.
+
+        :param relative_path: A path relative to the base directory.
+        :type relative_path: str
+        :returns: The corresponding absolute path.
+        :rtype: str
+        """
+        return os.path.abspath(os.path.join(self.base_directory, relative_path))

--- a/python/eos/analysis_file_context_TEST.py
+++ b/python/eos/analysis_file_context_TEST.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import unittest
+import os
+
+from eos.analysis_file_context import AnalysisFileContext
+
+
+class AnalysisFileContextTests(unittest.TestCase):
+
+    def test_data_path(self):
+        "Check that data_path resolves a relative path against the base directory."
+        ctx = AnalysisFileContext()
+        path = ctx.data_path('some/relative/path')
+        self.assertTrue(os.path.isabs(path))
+        self.assertTrue(path.endswith(os.path.join('some', 'relative', 'path')))
+
+    def test_invalid_base_directory(self):
+        "Check that a non-existent or non-directory base directory is rejected."
+        with self.assertRaises(ValueError):
+            AnalysisFileContext(base_directory='/this/does/not/exist/at/all')
+        # a path that exists but is a file, not a directory
+        with self.assertRaises(ValueError):
+            AnalysisFileContext(base_directory=__file__)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -4,38 +4,6 @@ from collections import defaultdict
 import copy as _copy
 import eos
 import inspect
-import os
-
-@dataclass(kw_only=True)
-class AnalysisFileContext:
-    """
-    Auxiliary class used to resolve paths relative to an analysis file's base directory.
-
-    Instances are passed to consumers of an analysis file (e.g. figures and tasks) so that relative data
-    paths can be resolved against a common base directory.
-
-    :param base_directory: The base directory against which relative paths are resolved. Defaults to the current working directory.
-    :type base_directory: str
-    """
-    base_directory:str='./'
-
-    def __post_init__(self):
-        if not os.path.exists(self.base_directory):
-            raise ValueError(f'Base directory \'{self.base_directory}\' does not exist')
-
-        if not os.path.isdir(self.base_directory):
-            raise ValueError(f'Base directory \'{self.base_directory}\' is not a directory')
-
-    def data_path(self, relative_path:str):
-        """Resolve a path relative to :attr:`base_directory` into an absolute path.
-
-        :param relative_path: A path relative to the base directory.
-        :type relative_path: str
-        :returns: The corresponding absolute path.
-        :rtype: str
-        """
-        return os.path.abspath(os.path.join(self.base_directory, relative_path))
-
 
 @dataclass
 class MetadataAuthorDescription(Deserializable):

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -786,6 +786,9 @@ MaskDescription.registry = {
 # AnalysisFile schema
 
 # dict with keys:
+#   format_version (optional): int, the schema version of the file; defaults to 1 (the version
+#       predating format versioning). EOS refuses to load a file declaring a newer version than
+#       it supports.
 #   metadata (optional)
 #   priors (mandatory)
 #   likelihoods (mandatory)

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -1,4 +1,26 @@
+#!/usr/bin/python
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2024-2026 Danny van Dyk
+# Copyright (c) 2024-2025 Matthew Kirk
+# Copyright (c) 2024      Carolina Bolognani
+# Copyright (c) 2024      Méril Reboud
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
 from .deserializable import Deserializable
+from eos.figure import FigureFactory
 from dataclasses import dataclass, field
 from collections import defaultdict
 import copy as _copy
@@ -750,6 +772,91 @@ MaskDescription.registry = {
     'expression': MaskExpressionComponent,
     'mask_name':  MaskNamedComponent,
 }
+
+
+@dataclass
+class AnalysisFileDescription(Deserializable):
+    r"""Structured, deserialized representation of a complete analysis file.
+
+    This is the in-memory counterpart of an analysis file's top-level YAML mapping: each field mirrors
+    one top-level section, and :meth:`from_dict` deserializes every section into the corresponding
+    description objects. It performs only the pure structural deserialization; the mandatory-section
+    and cross-reference checks (e.g. that a posterior refers only to defined priors and likelihoods),
+    the enforcement of unique step ids and mask names, and the EOS-runtime side effects (declaring
+    custom parameters, inserting custom observables) remain the responsibility of :class:`eos.AnalysisFile`.
+
+    Unknown top-level keys are rejected: adding a new section requires adding a field here (and, for a
+    backwards-incompatible change, bumping the analysis file format version).
+
+    :param format_version: The schema version of the analysis file. Defaults to 1, the version predating format versioning.
+    :type format_version: int
+    :param metadata: The analysis file's metadata.
+    :type metadata: MetadataDescription
+    :param priors: The named priors.
+    :type priors: list[PriorComponent]
+    :param likelihoods: The named likelihoods.
+    :type likelihoods: list[LikelihoodComponent]
+    :param posteriors: The named posteriors.
+    :type posteriors: list[PosteriorDescription]
+    :param predictions: The named predictions.
+    :type predictions: list[PredictionDescription]
+    :param figures: The figures.
+    :type figures: list
+    :param observables: The custom observables (from the YAML mapping keyed by observable name).
+    :type observables: list[ObservableComponent]
+    :param parameters: The custom parameters (from the YAML mapping keyed by parameter name).
+    :type parameters: list[ParameterComponent]
+    :param steps: The reproducible-analysis steps.
+    :type steps: list[StepComponent]
+    :param masks: The named sample masks.
+    :type masks: list[MaskComponent]
+    """
+    format_version:int           = 1
+    metadata:MetadataDescription = field(default_factory=MetadataDescription)
+    priors:list                  = field(default_factory=list)
+    likelihoods:list             = field(default_factory=list)
+    posteriors:list              = field(default_factory=list)
+    predictions:list             = field(default_factory=list)
+    figures:list                 = field(default_factory=list)
+    observables:list             = field(default_factory=list)
+    parameters:list              = field(default_factory=list)
+    steps:list                   = field(default_factory=list)
+    masks:list                   = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, **kwargs):
+        r"""Create an :class:`AnalysisFileDescription` from the top-level mapping of an analysis file.
+
+        Each recognized section is deserialized into its corresponding description objects via that
+        type's own ``from_dict``. The ``observables`` and ``parameters`` sections are YAML mappings
+        keyed by name; the name is injected into each entry so the resulting objects match those built
+        elsewhere. Unknown top-level keys are rejected by the dataclass constructor.
+
+        :returns: The deserialized analysis file description.
+        :rtype: AnalysisFileDescription
+        """
+        _kwargs = dict(kwargs) # shallow copy: only the top-level keys are reassigned below
+        if 'metadata' in kwargs:
+            _kwargs['metadata'] = MetadataDescription.from_dict(**kwargs['metadata'])
+        if 'priors' in kwargs:
+            _kwargs['priors'] = [PriorComponent.from_dict(**p) for p in kwargs['priors']]
+        if 'likelihoods' in kwargs:
+            _kwargs['likelihoods'] = [LikelihoodComponent.from_dict(**ll) for ll in kwargs['likelihoods']]
+        if 'posteriors' in kwargs:
+            _kwargs['posteriors'] = [PosteriorDescription.from_dict(**p) for p in kwargs['posteriors']]
+        if 'predictions' in kwargs:
+            _kwargs['predictions'] = [PredictionDescription.from_dict(**p) for p in kwargs['predictions']]
+        if 'figures' in kwargs:
+            _kwargs['figures'] = [FigureFactory.from_dict(**f) for f in kwargs['figures']]
+        if 'observables' in kwargs:
+            _kwargs['observables'] = [ObservableComponent.from_dict(name=n, **d) for n, d in kwargs['observables'].items()]
+        if 'parameters' in kwargs:
+            _kwargs['parameters'] = [ParameterComponent.from_dict(name=n, **d) for n, d in kwargs['parameters'].items()]
+        if 'steps' in kwargs:
+            _kwargs['steps'] = [StepComponent.from_dict(**s) for s in kwargs['steps']]
+        if 'masks' in kwargs:
+            _kwargs['masks'] = [MaskComponent.from_dict(**m) for m in kwargs['masks']]
+        return Deserializable.make(cls, **_kwargs)
 
 # AnalysisFile schema
 

--- a/python/eos/analysis_file_description_TEST.py
+++ b/python/eos/analysis_file_description_TEST.py
@@ -45,6 +45,7 @@ from eos.analysis_file_description import (
     MaskObservableComponent,
     MaskNamedComponent,
     MaskComponent,
+    AnalysisFileDescription,
 )
 
 
@@ -506,6 +507,66 @@ class MaskComponentTests(unittest.TestCase):
                 description=[{'name': 'B->pilnu::BR'}],
                 logical_combination='xor',
             )
+
+
+class AnalysisFileDescriptionTests(unittest.TestCase):
+
+    def test_defaults(self):
+        "An empty mapping yields the format-version baseline and empty sections."
+        desc = AnalysisFileDescription.from_dict()
+        self.assertEqual(desc.format_version, 1)
+        self.assertIsInstance(desc.metadata, MetadataDescription)
+        for section in (desc.priors, desc.likelihoods, desc.posteriors, desc.predictions,
+                        desc.figures, desc.observables, desc.parameters, desc.steps, desc.masks):
+            self.assertEqual(section, [])
+
+    def test_from_dict(self):
+        "Every recognized section is deserialized into its corresponding description objects."
+        desc = AnalysisFileDescription.from_dict(
+            format_version=1,
+            metadata={'title': 'My Analysis', 'authors': [{'name': 'Jane Doe'}]},
+            priors=[{'name': 'CKM', 'descriptions': [
+                {'parameter': 'CKM::abs(V_ub)', 'min': 3.0e-3, 'max': 4.5e-3, 'type': 'uniform'}]}],
+            likelihoods=[{'name': 'TH-pi', 'constraints': ['B->pi::f_++f_0@RBC+UKQCD:2015A']}],
+            posteriors=[{'name': 'CKM-all', 'prior': ['CKM'], 'likelihood': ['TH-pi']}],
+            predictions=[{'name': 'leptonic', 'observables': [{'name': 'B_u->lnu::BR;l=e'}]}],
+            figures=[{'name': 'fig-A', 'type': 'single', 'plot': {'items': []}}],
+            observables={'B->pilnu::R_pi': {'latex': '$R_\\pi$', 'unit': '1',
+                                            'expression': '<<B->pilnu::BR;l=tau>> / <<B->pilnu::BR;l=e>>'}},
+            parameters={'my::parameter': {'latex': 'x', 'unit': '1', 'central': 0.0, 'min': -1.0, 'max': 1.0}},
+            steps=[{'title': 'Corner', 'id': 'ckm.corner', 'tasks': [
+                {'task': 'corner-plot', 'arguments': {'posterior': 'CKM-all', 'format': ['pdf']}}]}],
+            masks=[{'name': 'mask-A', 'description': [{'name': 'B->pilnu::BR'}]}],
+        )
+        self.assertEqual(desc.format_version, 1)
+        self.assertEqual(desc.metadata.title, 'My Analysis')
+        self.assertIsInstance(desc.metadata.authors[0], MetadataAuthorDescription)
+        self.assertIsInstance(desc.priors[0], PriorComponent)
+        self.assertIsInstance(desc.likelihoods[0], LikelihoodComponent)
+        self.assertIsInstance(desc.posteriors[0], PosteriorDescription)
+        self.assertIsInstance(desc.predictions[0], PredictionDescription)
+        # figures are deserialized through the FigureFactory and carry their name
+        self.assertEqual(desc.figures[0].name, 'fig-A')
+        self.assertIsInstance(desc.steps[0], StepComponent)
+        self.assertIsInstance(desc.masks[0], MaskComponent)
+
+    def test_mapping_sections_inject_name(self):
+        "The observables/parameters mappings become lists with the name injected into each entry."
+        desc = AnalysisFileDescription.from_dict(
+            observables={'B->pilnu::R_pi': {'latex': '$R_\\pi$', 'unit': '1', 'expression': '1'}},
+            parameters={'my::parameter': {'latex': 'x', 'unit': '1', 'central': 0.0, 'min': -1.0, 'max': 1.0}},
+        )
+        self.assertEqual(len(desc.observables), 1)
+        self.assertIsInstance(desc.observables[0], ObservableComponent)
+        self.assertEqual(desc.observables[0].name, 'B->pilnu::R_pi')
+        self.assertEqual(len(desc.parameters), 1)
+        self.assertIsInstance(desc.parameters[0], ParameterComponent)
+        self.assertEqual(desc.parameters[0].name, 'my::parameter')
+
+    def test_unknown_top_level_key_is_rejected(self):
+        "An unrecognized top-level key is rejected rather than silently ignored."
+        with self.assertRaises(ValueError):
+            AnalysisFileDescription.from_dict(not_a_section=42)
 
 
 if __name__ == '__main__':

--- a/python/eos/analysis_file_description_TEST.py
+++ b/python/eos/analysis_file_description_TEST.py
@@ -14,12 +14,10 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 import unittest
-import os
 
 import eos
 
 from eos.analysis_file_description import (
-    AnalysisFileContext,
     MetadataAuthorDescription,
     MetadataDescription,
     PriorDescription,
@@ -48,24 +46,6 @@ from eos.analysis_file_description import (
     MaskNamedComponent,
     MaskComponent,
 )
-
-
-class AnalysisFileContextTests(unittest.TestCase):
-
-    def test_data_path(self):
-        "Check that data_path resolves a relative path against the base directory."
-        ctx = AnalysisFileContext()
-        path = ctx.data_path('some/relative/path')
-        self.assertTrue(os.path.isabs(path))
-        self.assertTrue(path.endswith(os.path.join('some', 'relative', 'path')))
-
-    def test_invalid_base_directory(self):
-        "Check that a non-existent or non-directory base directory is rejected."
-        with self.assertRaises(ValueError):
-            AnalysisFileContext(base_directory='/this/does/not/exist/at/all')
-        # a path that exists but is a file, not a directory
-        with self.assertRaises(ValueError):
-            AnalysisFileContext(base_directory=__file__)
 
 
 class MetadataAuthorDescriptionTests(unittest.TestCase):

--- a/python/eos/figure/data.py
+++ b/python/eos/figure/data.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025 Danny van Dyk
+# Copyright (c) 2024-2026 Danny van Dyk
 # Copyright (c) 2024      Méril Reboud
 #
 # This file is part of the EOS project. EOS is free software;
@@ -15,7 +15,7 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 from dataclasses import dataclass
-from eos.analysis_file_description import AnalysisFileContext
+from eos.analysis_file_context import AnalysisFileContext
 from eos.deserializable import Deserializable
 from eos.figure.item import ItemColorCycler
 

--- a/python/eos/figure/data_TEST.py
+++ b/python/eos/figure/data_TEST.py
@@ -19,7 +19,7 @@ import eos
 import eos.figure
 import os
 
-from eos.analysis_file_description import AnalysisFileContext
+from eos.analysis_file_context import AnalysisFileContext
 
 class DataFileTests(unittest.TestCase):
 

--- a/python/eos/figure/figure.py
+++ b/python/eos/figure/figure.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Danny van Dyk
+# Copyright (c) 2023-2026 Danny van Dyk
 # Copyright (c) 2023      Philip Lueghausen
 #
 # This file is part of the EOS project. EOS is free software;
@@ -16,7 +16,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from eos.analysis_file_description import AnalysisFileContext
+from eos.analysis_file_context import AnalysisFileContext
 from eos.deserializable import Deserializable
 
 from .plot import Plot, PlotFactory
@@ -39,7 +39,7 @@ class Figure(ABC, Deserializable):
         """Draw the figure.
 
         :param context: The analysis file context, which contains the paths to the data files and other relevant information.
-        :type context: :class:`AnalysisFileContext <eos.analysis_file_description.AnalysisFileContext>`
+        :type context: :class:`AnalysisFileContext <eos.analysis_file_context.AnalysisFileContext>`
         :param output: The path(s) to the output file(s) where the figure should be saved. If None, the figure is not saved.
         :type output: str | list[str] | None
         """
@@ -93,7 +93,7 @@ class SingleFigure(Figure):
         one or more output files.
 
         :param context: The analysis file context, which contains the paths to the data files and other relevant information.
-        :type context: :class:`AnalysisFileContext <eos.analysis_file_description.AnalysisFileContext>`
+        :type context: :class:`AnalysisFileContext <eos.analysis_file_context.AnalysisFileContext>`
         :param output: The path(s) to the output file(s) where the figure should be saved. If None, the figure is not saved.
         :type output: str | list[str] | None
         """
@@ -230,7 +230,7 @@ class InsetFigure(Figure):
         """Draw the inset figure.
 
         :param context: The analysis file context, which contains the paths to the data files and other relevant information.
-        :type context: :class:`AnalysisFileContext <eos.analysis_file_description.AnalysisFileContext>`
+        :type context: :class:`AnalysisFileContext <eos.analysis_file_context.AnalysisFileContext>`
         :param output: The path(s) to the output file(s) where the figure should be saved. If None, the figure is not saved.
         :type output: str | list[str] | None
         """
@@ -374,7 +374,7 @@ class GridFigure(Figure):
         """Draw the grid figure.
 
         :param context: The analysis file context, which contains the paths to the data files and other relevant information.
-        :type context: :class:`AnalysisFileContext <eos.analysis_file_description.AnalysisFileContext>`
+        :type context: :class:`AnalysisFileContext <eos.analysis_file_context.AnalysisFileContext>`
         :param output: The path(s) to the output file(s) where the figure should be saved. If None, the figure is not saved.
         :type output: str | list[str] | None
         """
@@ -453,7 +453,7 @@ class CornerFigure(Figure):
         """Prepare the corner figure for drawing.
 
         :param context: The analysis file context, which contains the paths to the data files and other relevant information.
-        :type context: :class:`AnalysisFileContext <eos.analysis_file_description.AnalysisFileContext>`
+        :type context: :class:`AnalysisFileContext <eos.analysis_file_context.AnalysisFileContext>`
         :param output: The path to the output file where the figure should be saved. If None, the figure is not saved.
         :type output: str | None
         """
@@ -579,7 +579,7 @@ class CornerFigure(Figure):
         """Draw the corner figure.
 
         :param context: The analysis file context, which contains the paths to the data files and other relevant information.
-        :type context: :class:`AnalysisFileContext <eos.analysis_file_description.AnalysisFileContext>`
+        :type context: :class:`AnalysisFileContext <eos.analysis_file_context.AnalysisFileContext>`
         :param output: The path(s) to the output file(s) where the figure should be saved. If None, the figure is not saved.
         :type output: str | list[str] | None
         """

--- a/python/eos/figure/figure.py
+++ b/python/eos/figure/figure.py
@@ -380,7 +380,7 @@ class GridFigure(Figure):
         """
         context = AnalysisFileContext() if context is None else context
         for idx, plot in enumerate(self.plots):
-            plot.prepare()
+            plot.prepare(context)
             plot.draw(self._axes[idx])
             if self._watermark_idx is None or self._watermark_idx == idx:
                 plot.draw_watermark(self._axes[idx], self.watermark)

--- a/python/eos/figure/figure_TEST.py
+++ b/python/eos/figure/figure_TEST.py
@@ -335,6 +335,30 @@ class GridFigureTests(unittest.TestCase):
         with self.assertRaises(Exception):
             eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 2]', 2, extra="shared_axes: 'diagonal'"))
 
+    def test_draw_forwards_context(self):
+
+        # Regression: GridFigure.draw must forward its context to each plot's prepare(), so that
+        # items resolve relative paths against the analysis file's base directory. Previously the
+        # context was dropped and every plot fell back to a fresh CWD-rooted context.
+        from eos.analysis_file_context import AnalysisFileContext
+
+        figure = eos.figure.FigureFactory.from_yaml(self._grid_yaml('[1, 2]', 2))
+        context = AnalysisFileContext()
+
+        seen = []
+        for plot in figure.plots:
+            original = plot.prepare
+            def spy(ctx=None, _original=original):
+                seen.append(ctx)
+                return _original(ctx)
+            plot.prepare = spy
+
+        figure.draw(context=context)
+
+        self.assertEqual(len(seen), len(figure.plots))
+        for ctx in seen:
+            self.assertIs(ctx, context)
+
 
 class CornerFigureTests(unittest.TestCase):
 

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -269,18 +269,10 @@ class ObservableItem(Item):
                     raise ValueError(f"Kinematic variable '{k}' does not match any of the declared kinematic variables '{self.observable}': {valid_kinematic_variables.__repr__()}")
                 self._kinematics.declare(k, v)
 
-        # Create parameters
+        # Create parameters. Values overridden from a file and explicit fixed parameters are applied
+        # in prepare() rather than here, so that loading a figure does not require the parameter file
+        # to exist yet; it may be the output of an earlier task (e.g. find-mode). See issue #1181.
         self._parameters = eos.Parameters.Defaults()
-        if self.fixed_parameters_from_file:
-            eos.warn('Overriding parameters from file')
-            self._parameters.override_from_file(self.fixed_parameters_from_file)
-
-        if self.fixed_parameters:
-            if self.fixed_parameters_from_file:
-                eos.warn('Overriding values read from \'parameters-from-file\' with explicit values in \'parameters\'')
-
-            for key, value in self.fixed_parameters.items():
-                self._parameters.set(key, value)
 
         # Declare variable that is either parameter or kinematic
         self._variable = None
@@ -320,6 +312,20 @@ class ObservableItem(Item):
         :type context: AnalysisFileContext | None
         """
         context = AnalysisFileContext() if context is None else context
+
+        # Override parameters from a file (resolved relative to the analysis file's base directory)
+        # and/or from explicit values, with explicit values taking precedence. Done here rather than
+        # in __post_init__ so that the parameter file need not exist at load time; see issue #1181.
+        if self.fixed_parameters_from_file:
+            eos.warn('Overriding parameters from file')
+            self._parameters.override_from_file(context.data_path(self.fixed_parameters_from_file))
+
+        if self.fixed_parameters:
+            if self.fixed_parameters_from_file:
+                eos.warn('Overriding values read from \'parameters-from-file\' with explicit values in \'parameters\'')
+            for key, value in self.fixed_parameters.items():
+                self._parameters.set(key, value)
+
         self._yvalues = _np.empty((len(self._xvalues),))
         for i, x in enumerate(self._xvalues):
             self._variable.set(x)
@@ -2783,18 +2789,10 @@ class ComplexPlaneItem(Item):
                     raise ValueError(f"Kinematic variable '{k}' does not match any of the declared kinematic variables '{self.observable}': {valid_kinematic_variables.__repr__()}")
                 self._kinematics.declare(k, v)
 
-        # Create parameters
+        # Create parameters. Values overridden from a file and explicit fixed parameters are applied
+        # in prepare() rather than here, so that loading a figure does not require the parameter file
+        # to exist yet; it may be the output of an earlier task (e.g. find-mode). See issue #1181.
         self._parameters = eos.Parameters.Defaults()
-        if self.fixed_parameters_from_file:
-            eos.warn('Overriding parameters from file')
-            self._parameters.override_from_file(self.fixed_parameters_from_file)
-
-        if self.fixed_parameters:
-            if self.fixed_parameters_from_file:
-                eos.warn('Overriding values read from \'parameters-from-file\' with explicit values in \'parameters\'')
-
-            for key, value in self.fixed_parameters.items():
-                self._parameters.set(key, value)
 
         # Declare variables
         if self.variables[0] not in valid_kinematic_variables:
@@ -2852,9 +2850,26 @@ class ComplexPlaneItem(Item):
         Evaluates the observable on a regular ``resolution`` x ``resolution`` grid of complex values
         spanning the two ranges given by ``ranges`` and caches the results for :meth:`draw`.
 
-        :param context: The analysis file context. Accepted for interface consistency and unused.
+        :param context: The analysis file context used to resolve the relative path to
+            ``fixed_parameters_from_file``. If ``None``, a default context rooted at the current
+            working directory is used.
         :type context: AnalysisFileContext | None
         """
+        context = AnalysisFileContext() if context is None else context
+
+        # Override parameters from a file (resolved relative to the analysis file's base directory)
+        # and/or from explicit values, with explicit values taking precedence. Done here rather than
+        # in __post_init__ so that the parameter file need not exist at load time; see issue #1181.
+        if self.fixed_parameters_from_file:
+            eos.warn('Overriding parameters from file')
+            self._parameters.override_from_file(context.data_path(self.fixed_parameters_from_file))
+
+        if self.fixed_parameters:
+            if self.fixed_parameters_from_file:
+                eos.warn('Overriding values read from \'parameters-from-file\' with explicit values in \'parameters\'')
+            for key, value in self.fixed_parameters.items():
+                self._parameters.set(key, value)
+
         self._ovalues = _np.reshape(list(map(self.evaluate, self._cvalues)), (self.resolution, self.resolution)).T
 
     def draw(self, ax):

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -16,7 +16,7 @@
 
 from abc import abstractmethod
 from dataclasses import dataclass, field
-from eos.analysis_file_description import AnalysisFileContext
+from eos.analysis_file_context import AnalysisFileContext
 from eos.deserializable import Deserializable
 
 import inspect

--- a/python/eos/figure/item_TEST.py
+++ b/python/eos/figure/item_TEST.py
@@ -19,7 +19,7 @@ import eos
 import eos.figure
 import os
 
-from eos.analysis_file_description import AnalysisFileContext
+from eos.analysis_file_context import AnalysisFileContext
 from matplotlib import pyplot as plt
 from matplotlib.container import ErrorbarContainer
 from matplotlib.lines import Line2D

--- a/python/eos/figure/item_TEST.py
+++ b/python/eos/figure/item_TEST.py
@@ -18,6 +18,7 @@ import unittest
 import eos
 import eos.figure
 import os
+import tempfile
 
 from eos.analysis_file_context import AnalysisFileContext
 from matplotlib import pyplot as plt
@@ -1078,6 +1079,42 @@ class ObservableItemValidationTests(unittest.TestCase):
             range: [0.1, 1.0]
             """)
 
+    def test_missing_fixed_parameters_from_file(self):
+
+        # Regression (issue #1181): an item referencing a fixed_parameters_from_file that does not
+        # exist must still load, because the file is read only when the item is prepared for drawing
+        # (it may be the output of an earlier task, e.g. find-mode). A file that is genuinely missing
+        # at prepare() then raises.
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: observable
+        observable: 'B->Dlnu::dBR/dq2'
+        variable: q2
+        range: [0.1, 1.0]
+        resolution: 3
+        fixed_parameters_from_file: 'does-not-exist.yaml'
+        """)
+        with self.assertRaises(RuntimeError):
+            item.prepare()
+
+    def test_fixed_parameters_from_file(self):
+
+        # The parameter file is resolved relative to the context's base directory and applied in
+        # prepare(), not at construction.
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(os.path.join(tmp, 'params.yaml'), 'w') as f:
+                f.write("'mass::mu':\n  central: 0.10566\n")
+            item = eos.figure.ItemFactory.from_yaml("""
+            type: observable
+            observable: 'B->Dlnu::dBR/dq2'
+            variable: q2
+            range: [0.1, 1.0]
+            resolution: 3
+            fixed_parameters_from_file: 'params.yaml'
+            """)
+            item.prepare(context=AnalysisFileContext(base_directory=tmp))
+            _, ax = plt.subplots()
+            item.draw(ax)
+
 class ExpressionItemValidationTests(unittest.TestCase):
 
     def test_invalid(self):
@@ -1490,6 +1527,21 @@ class ComplexPlaneItemValidationTests(unittest.TestCase):
         # a non-positive resolution is rejected
         with self.assertRaises(ValueError):
             eos.figure.ItemFactory.from_yaml(base + "variables: ['Re{q2}', 'Im{q2}']\nranges: [[-1, 1], [-1, 1]]\nresolution: 0")
+
+    def test_missing_fixed_parameters_from_file(self):
+
+        # Regression (issue #1181): loading must not require the parameter file to exist; it is read
+        # only in prepare(), which raises if the file is genuinely missing at draw time.
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: complex-plane
+        observable: 'b->s::Re{F17}(Re{q2},Im{q2})'
+        variables: ['Re{q2}', 'Im{q2}']
+        ranges: [[-1.0, 1.0], [-1.0, 1.0]]
+        resolution: 5
+        fixed_parameters_from_file: 'does-not-exist.yaml'
+        """)
+        with self.assertRaises(RuntimeError):
+            item.prepare()
 
 class ErrorBarsItemValidationTests(unittest.TestCase):
 

--- a/python/eos/figure/plot.py
+++ b/python/eos/figure/plot.py
@@ -16,7 +16,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from eos.analysis_file_description import AnalysisFileContext
+from eos.analysis_file_context import AnalysisFileContext
 from eos.deserializable import Deserializable
 
 from .item import Item, ItemFactory, ItemColorCycler

--- a/python/eos/reporting.py
+++ b/python/eos/reporting.py
@@ -182,7 +182,7 @@ class PosteriorData:
         if self.samples is None:
             raise RuntimeError(f'No importance samples recorded for posterior \'{self.name}\'; cannot draw a corner figure')
 
-        from eos.analysis_file_description import AnalysisFileContext
+        from eos.analysis_file_context import AnalysisFileContext
 
         _os.makedirs(output_directory, exist_ok=True)
 

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -22,7 +22,7 @@ import functools
 import glob
 import inspect
 import logging
-import eos.analysis_file_description
+import eos.analysis_file_context
 import numpy as _np
 import os
 import scipy
@@ -844,7 +844,7 @@ def draw_figure(analysis_file:str, figure_name:str, base_directory:str='./', for
             raise ValueError(f'Figure format \'{fmt}\' not supported. Supported formats are: {",".join(SUPPORTED_FORMATS)}')
 
     eos.inprogress(f'Drawing figure {figure_name}')
-    context = eos.analysis_file_description.AnalysisFileContext(base_directory=base_directory)
+    context = eos.analysis_file_context.AnalysisFileContext(base_directory=base_directory)
     figure = analysis_file._figures[figure_name]
     for fmt in format:
         eos.info(f'Drawing figure {figure_name} in \'{fmt}\' format')


### PR DESCRIPTION
- 772445ad [python] Add a ``format_version`` field to the analysis file format. The default format is now ``1``.
- 610195fc [python] Move ``AnalysisFileContext`` into its own module. This breaks the potential for circular dependencies.
- 6bcb66ff [python] Add ``AnalysisFileDescription`` and make use of it in ``AnalysisFile.__init__``. Unknown top-level keys now raise an exception.
- 5b8e9d9b [python] Fix ``GridFigure.draw`` to forward context to each plot. The previous behaviour deviated from other figures and prohibited the easy solution to #1181 in the next commit.
- 15b2294f [python] Defer figure parameter-file loading to draw time. Resolves #1181.
- e13a26d8 [eos] Update changelog for PR #1201.