### PR TITLE
Fix scalar contributions differential rate of 2-body tau decays and add double-differential rate

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,11 +6,15 @@
 
 ### Added
 
+- Add double-differential rates ``tau->K_Spinu::d^2Gamma/dq^2/dcos(theta_K)`` and similar based on [EPPRR:2026A] (D. van Dyk)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Fix bug in scalar contributions to ``tau->K_spinu::dBR/dq2`` and ``tau->K^-pinu::dBR/dq2`` (issue #1203) (D. van Dyk)
 
 
 ## [v1.0.21] - 2026-08-05

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -1420,6 +1420,15 @@ EHMRR:2010A:
     id: oai:arXiv.org:1005.0571
   inspire-id: Egede:2010zc
   title: New physics reach of the decay mode $\bar{B} \to \bar{K}^{*0}\ell^+\ell^-$
+EPPRR:2026A:
+  authors: Estrada, E. and Passemar, E. and Paz, S. and Rodríguez-Sánchez, A. and Roig,
+    P.
+  eprint:
+    archive: arXiv
+    id: oai:arXiv.org:2606.13139
+  inspire-id: Estrada:2026nww
+  title: Electroweak precision physics via angular distributions in hadronic $\tau$
+    decays
 ETM:2017A:
   authors: Lubicz, V. and Melis, A. and Simula, S.
   collaboration: ETM

--- a/eos/tau-decays/observables.cc
+++ b/eos/tau-decays/observables.cc
@@ -1,8 +1,8 @@
 /* vim: set sw=4 sts=4 et tw=150 foldmethod=marker : */
 
 /*
- * Copyright (c) 2024 Danny van Dyk
- * Copyright (c) 2025 Matthew Kirk
+ * Copyright (c) 2024-2026 Danny van Dyk
+ * Copyright (c) 2025      Matthew Kirk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -93,6 +93,20 @@ namespace eos
                                                                            Unit::None(),
                                                                            &TauToKPiNeutrino::total_branching_ratio,
                                                                            std::make_tuple(),
+                                                                           Options{ { "K"_ok, "K_u"_ov } }
+                                                                           ),
+                                                           make_observable("tau->K_Spinu::d2Gamma/dq2/dcos(theta_K)",
+                                                                           R"(d^2\Gamma(\tau^- \to K_S \pi^- \nu_\tau)/dq^2/d\cos\theta_K)",
+                                                                           Unit::InverseGeV(),
+                                                                           &TauToKPiNeutrino::double_differential_decay_width,
+                                                                           std::make_tuple("q2", "cos(theta_K)"),
+                                                                           Options{ { "K"_ok, "K_S"_ov } }
+                                                                           ),
+                                                           make_observable("tau->K^-pinu::d2Gamma/dq2/dcos(theta_K)",
+                                                                           R"(d^2\Gamma(\tau^- \to K^- \pi^0 \nu_\tau)/dq^2/d\cos\theta_K)",
+                                                                           Unit::InverseGeV(),
+                                                                           &TauToKPiNeutrino::double_differential_decay_width,
+                                                                           std::make_tuple("q2", "cos(theta_K)"),
                                                                            Options{ { "K"_ok, "K_u"_ov } }
                                                                            ),
         });

--- a/eos/tau-decays/tau-to-k-pi-nu.cc
+++ b/eos/tau-decays/tau-to-k-pi-nu.cc
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2025-2026 Danny van Dyk
- * Copyright (c) 2025 Matthew Kirk
+ * Copyright (c) 2025      Matthew Kirk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -69,6 +69,9 @@ namespace eos
 
             GSL::QAGS::Config int_config;
 
+            SpecifiedOption debug_tensor;
+            float           tensor_form_factor;
+
             static const std::vector<OptionSpecification> options;
 
             Implementation(const Parameters & p, const Options & o, ParameterUser & u) :
@@ -86,34 +89,55 @@ namespace eos
                 tau_tau(p["life_time::tau"], u),
                 isospin_factor(opt_K.value() == "K_L" ? +1.0 : -1.0), // K_L -> pi+ vs K_S -> pi+ and K- -> pi^0
                 mu(p["ustaunutau::mu"], u),
-                int_config(GSL::QAGS::Config().epsrel(0.5e-3))
+                int_config(GSL::QAGS::Config().epsrel(0.5e-3)),
+                debug_tensor(o, options, "debug-tensor"_ok),
+                tensor_form_factor(0.0)
             {
                 Context ctx("When constructing tau^+ -> [K pi]^+ nubar observable");
 
                 u.uses(*model);
                 u.uses(*form_factors);
+
+                if ("1"_ov == debug_tensor.value())
+                {
+                    tensor_form_factor = 1.0;
+                }
             }
 
-            double
-            differential_decay_width(const double & k2) const
+            // Angular coefficients of the two-fold differential rate
+            //     d^2 Gamma / (dq^2 d cos(theta_K)) = a + b cos(theta_K) + c cos^2(theta_K),
+            // where theta_K is the Kpi helicity angle between the kaon momentum and the extension
+            // of the Kpi line of flight, both evaluated in the Kpi rest frame. See [EPPRR:2026A],
+            // where theta_K is denotated as beta, eq. (2.31) on page 6.
+            //
+            // Both the single- and double-differential rates are expressed in terms of these coefficients:
+            //     dGamma/dq^2                  = 2 a + 2 c / 3    (b-term integrates to zero),
+            //     d^2 Gamma / (dq^2 dz)        = a + b z + c z^2  (z = cos(theta_K)).
+            //
+            // The coefficients follow the second-order squared amplitude of [EPPRR:2026A]; integrating
+            // over cos(theta_K) reproduces dGamma/dq^2 of [CCH:2017A], page 2, eqs. (12-14), whose
+            // phase convention for the tensor form factor we also follow. The absence of
+            // right-handed neutrinos fixes c_A = -c_V and i c_P = +c_S (issue #1203), hence
+            // A = -V and P = -S.
+            struct AngularCoefficients
+            {
+                    double a, b, c;
+            };
+
+            AngularCoefficients
+            angular_coefficients(const double & k2) const
             {
                 // Return zero outside of physical phase space
                 if (k2 < power_of<2>(m_K + m_pi) || k2 > power_of<2>(m_tau))
                 {
-                    return 0.0;
+                    return { 0.0, 0.0, 0.0 };
                 }
 
-                // Expression taken from [CCH:2017A], page 2, eqs. (12-14)
-                // Except the missing factor of S_EW, as this is a RG evolution for the vector coefficient
-                // alone, and is taken care of by our RG
-
                 // Compare EOS basis with [CCH:2017A], page 2, eq. (9)
-                const WilsonCoefficients<ChargedCurrent> wc  = model->wet_uslnu(LeptonFlavor::tauon, false);
-                const complex<double>                    cV  = std::conj(wc.cvl() + wc.cvr());
-                const complex<double>                    cA  = -std::conj(wc.cvl() + wc.cvr());
-                const complex<double>                    cS  = std::conj(wc.csl() + wc.csr());
-                const complex<double>                    icP = -std::conj(wc.csl() + wc.csr());
-                const complex<double>                    cT  = 2.0 * std::conj(wc.ct());
+                const WilsonCoefficients<ChargedCurrent> wc = model->wet_uslnu(LeptonFlavor::tauon, false);
+                const complex<double>                    cV = std::conj(wc.cvl() + wc.cvr());
+                const complex<double>                    cS = std::conj(wc.csl() + wc.csr());
+                const complex<double>                    cT = 2.0 * std::conj(wc.ct());
 
                 const auto m_tau2 = power_of<2>(m_tau);
                 const auto m_K2   = power_of<2>(m_K);
@@ -122,26 +146,56 @@ namespace eos
                 const auto fp = form_factors->f_p(k2);
                 const auto f0 = form_factors->f_0(k2);
                 // const auto BT = ( (-2.0 * m_K) / (m_K + m_pi) ) *  form_factors->f_t(k2);
-                const auto BT = 0.0; // neglect tensor form factor as not implemented yet!
+                const auto BT = complex<double>(tensor_form_factor); // use the option-provided debug value; defaults to zero
 
                 const double lambda_piK = lambda(k2, m_pi2, m_K2);
-                const auto   xi         = (m_tau2 + 2.0 * k2) * lambda_piK / (3.0 * m_tau2 * power_of<2>(m_K2 - m_pi2));
+                const double Delta      = m_K2 - m_pi2;
 
-                const auto T = 3.0 * k2 * m_tau * cT * BT / ((m_tau2 + 2.0 * k2) * m_K);
-                const auto V = fp * cV - T;
-                const auto A = fp * cA + T;
-                const auto S = f0 * (cV + k2 * cS / (m_tau * (m_s - m_u)));
-                const auto P = f0 * (cA - k2 * icP / (m_tau * (m_s - m_u)));
+                const auto T   = 3.0 * k2 * m_tau * cT * BT / ((m_tau2 + 2.0 * k2) * m_K);
+                const auto V   = fp * cV;
+                const auto S_V = f0 * cV;
+                const auto S   = f0 * (cV + k2 * cS / (m_tau * (m_s - m_u)));
 
-                return power_of<2>(g_fermi * std::abs(model->ckm_us())) * sqrt(lambda_piK) * power_of<2>((m_tau2 - k2) * (m_K2 - m_pi2))
-                       / (1024.0 * pow(M_PI, 3.0) * m_tau * pow(k2, 3.0))
-                       * (xi * (std::norm(V) + std::norm(A) + 4.0 * power_of<2>(m_tau2 - k2) * std::norm(T) / (9.0 * k2 * m_tau2)) + std::norm(S) + std::norm(P));
+                const double pref =
+                        power_of<2>(g_fermi * std::abs(model->ckm_us())) * sqrt(lambda_piK) * power_of<2>((m_tau2 - k2) * Delta) / (1024.0 * pow(M_PI, 3.0) * m_tau * pow(k2, 3.0));
+
+                const double lam_over_D2 = lambda_piK / power_of<2>(Delta);
+                const double eta_T       = (m_tau2 + 2.0 * k2) / (3.0 * m_tau2);
+                const double tensor_norm = power_of<2>(eta_T) * m_tau2 / k2;
+
+                const double a = pref * (lam_over_D2 * (k2 / m_tau2 * std::norm(V) + tensor_norm * std::norm(T) - 2.0 * eta_T * std::real(V * std::conj(T))) + std::norm(S));
+                const double b = pref * 2.0 * sqrt(lambda_piK) / Delta * (std::real(V * std::conj(S)) - eta_T * std::real(S_V * std::conj(T)));
+                const double c = pref * lam_over_D2 * (1.0 - k2 / m_tau2) * (std::norm(V) - tensor_norm * std::norm(T));
+
+                return { a, b, c };
+            }
+
+            double
+            differential_decay_width(const double & k2) const
+            {
+                const AngularCoefficients ac = angular_coefficients(k2);
+
+                return 2.0 * ac.a + 2.0 / 3.0 * ac.c;
             }
 
             double
             differential_branching_ratio(const double & k2) const
             {
                 return differential_decay_width(k2) * tau_tau / hbar;
+            }
+
+            double
+            double_differential_decay_width(const double & k2, const double & z) const
+            {
+                const AngularCoefficients ac = angular_coefficients(k2);
+
+                return ac.a + ac.b * z + ac.c * power_of<2>(z);
+            }
+
+            double
+            double_differential_branching_ratio(const double & k2, const double & z) const
+            {
+                return double_differential_decay_width(k2, z) * tau_tau / hbar;
             }
 
             double
@@ -173,7 +227,8 @@ namespace eos
 
     const std::vector<OptionSpecification> Implementation<TauToKPiNeutrino>::options{
         Model::option_specification(),
-        { "K"_ok, { "K_u"_ov, "K_S"_ov, "K_L"_ov }, "K_u"_ov },
+        {            "K"_ok, { "K_u"_ov, "K_S"_ov, "K_L"_ov }, "K_u"_ov },
+        { "debug-tensor"_ok,               { "0"_ov, "1"_ov },   "0"_ov }
     };
 
     TauToKPiNeutrino::TauToKPiNeutrino(const Parameters & parameters, const Options & options) :
@@ -193,6 +248,18 @@ namespace eos
     TauToKPiNeutrino::differential_decay_width(const double & k2) const
     {
         return _imp->differential_decay_width(k2);
+    }
+
+    double
+    TauToKPiNeutrino::double_differential_decay_width(const double & k2, const double & z) const
+    {
+        return _imp->double_differential_decay_width(k2, z);
+    }
+
+    double
+    TauToKPiNeutrino::double_differential_branching_ratio(const double & k2, const double & z) const
+    {
+        return _imp->double_differential_branching_ratio(k2, z);
     }
 
     double
@@ -228,7 +295,7 @@ namespace eos
         return _imp->integrated_pdf_q2(q2_min, q2_max);
     }
 
-    const std::set<ReferenceName> TauToKPiNeutrino::references{ "CCH:2017A"_rn };
+    const std::set<ReferenceName> TauToKPiNeutrino::references{ "CCH:2017A"_rn, "EPPRR:2026A"_rn };
 
     std::vector<OptionSpecification>::const_iterator
     TauToKPiNeutrino::begin_options()

--- a/eos/tau-decays/tau-to-k-pi-nu.hh
+++ b/eos/tau-decays/tau-to-k-pi-nu.hh
@@ -1,8 +1,8 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2025 Danny van Dyk
- * Copyright (c) 2025 Matthew Kirk
+ * Copyright (c) 2025-2026 Danny van Dyk
+ * Copyright (c) 2025      Matthew Kirk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -38,6 +38,10 @@ namespace eos
             // Differential Observables
             double differential_branching_ratio(const double & k2) const;
             double differential_decay_width(const double & k2) const;
+
+            // Two-fold differential observables in q^2 and the Kpi helicity angle theta_K
+            double double_differential_decay_width(const double & k2, const double & cos_theta_k) const;
+            double double_differential_branching_ratio(const double & k2, const double & cos_theta_k) const;
 
             // Integrated Observables
             double total_branching_ratio() const;

--- a/eos/tau-decays/tau-to-k-pi-nu_TEST.cc
+++ b/eos/tau-decays/tau-to-k-pi-nu_TEST.cc
@@ -1,8 +1,8 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2025 Danny van Dyk
- * Copyright (c) 2025 Matthew Kirk
+ * Copyright (c) 2025-2026 Danny van Dyk
+ * Copyright (c) 2025      Matthew Kirk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -98,6 +98,164 @@ class TauToKPiNeutrinoTest : public TestCase
                                          { "n-resonances-0m"_ok,   "1"_ov }
                 });
                 TEST_CHECK_NEARLY_EQUAL(d.total_branching_ratio(), 4.25288e-3, eps);
+
+                // Regression test for the sign of the pseudoscalar amplitude, cf. gh#1203.
+                // A non-zero scalar NP coefficient must produce a *linear* shift in the rate; with the
+                // former sign bug the |S|^2 + |P|^2 combination cancelled the linear term, so that
+                // the rate was identical under Re{cSL} -> -Re{cSL}. Requires the WET model, as the SM
+                // model ignores the ustaunutau Wilson coefficients.
+                const Options wet_opts{
+                    {           "model"_ok, "WET"_ov },
+                    { "n-resonances-1m"_ok,   "2"_ov },
+                    { "n-resonances-0m"_ok,   "1"_ov }
+                };
+                p["ustaunutau::Re{cSL}"] = +0.1;
+                TauToKPiNeutrino d_cSL_plus(p, wet_opts);
+                TEST_CHECK_NEARLY_EQUAL(d_cSL_plus.total_branching_ratio(), 0.0046365212390183843, eps);
+                p["ustaunutau::Re{cSL}"] = -0.1;
+                TauToKPiNeutrino d_cSL_minus(p, wet_opts);
+                TEST_CHECK_NEARLY_EQUAL(d_cSL_minus.total_branching_ratio(), 0.0042855354180517651, eps);
+                p["ustaunutau::Re{cSL}"] = 0.0;
+
+                // Two-fold differential rate d^2Gamma/dq2/dcos(theta_K) (here for tau -> K_L pi- nu,
+                // the last instance constructed above). The distribution is a quadratic in
+                // z = cos(theta_K); Simpson's rule is exact for a quadratic, so
+                //     (f(-1) + 4 f(0) + f(+1)) / 3 == dBR/dq2 .
+                const double f_m1 = d.double_differential_branching_ratio(1.0, -1.0);
+                const double f_0  = d.double_differential_branching_ratio(1.0, 0.0);
+                const double f_p1 = d.double_differential_branching_ratio(1.0, +1.0);
+                TEST_CHECK_NEARLY_EQUAL((f_m1 + 4.0 * f_0 + f_p1) / 3.0, d.differential_branching_ratio(1.0), eps);
+                TEST_CHECK_NEARLY_EQUAL(f_m1, 0.0013654922519557517, eps);
+                TEST_CHECK_NEARLY_EQUAL(f_0, 0.00051133788806815986, eps);
+                TEST_CHECK_NEARLY_EQUAL(f_p1, 0.0018269935336002955, eps);
+                // the S-P interference (linear in cos(theta_K)) makes the distribution forward-backward
+                // asymmetric: f(+1) != f(-1).
+                TEST_CHECK(std::abs(f_p1 - f_m1) > 1.0e-2 * f_0);
+            }
+
+            // Single- and double-differential rates (channel tau -> K_S pi- nu) evaluated at the
+            // mode of the FF_2_2_3_3 posterior of PR #1204 (prs/1204/{mode,analysis}.yaml), for two
+            // Wilson-coefficient sets and cos(theta_K) in {-0.5, +0.1, +0.8}. The reference values
+            // were produced from the f_+ and f_0 form factors of the mode and fed into an independent
+            // Mathematica transcription of the rate.
+            {
+                const double eps = 1e-8;
+
+                Parameters pm                      = Parameters::Defaults();
+                // FF_2_2_3_3 fixed parameters
+                pm["CKM::abs(V_us)"]               = 0.22515;
+                pm["0->Kpi::t_0@KSvD2025"]         = -4.0;
+                pm["0->Kpi::M_(+,1)@KSvD2025"]     = 1.368;
+                pm["0->Kpi::Gamma_(+,1)@KSvD2025"] = 0.212;
+                pm["0->Kpi::M_(0,0)@KSvD2025"]     = 0.680;
+                pm["0->Kpi::Gamma_(0,0)@KSvD2025"] = 0.600;
+                pm["0->Kpi::M_(0,1)@KSvD2025"]     = 1.431;
+                pm["0->Kpi::Gamma_(0,1)@KSvD2025"] = 0.220;
+                // FF_2_2_3_3 posterior mode
+                pm["0->Kpi::b_+^1@KSvD2025"]       = 0.0661020107264485;
+                pm["0->Kpi::b_+^2@KSvD2025"]       = 0.07227068199414584;
+                pm["0->Kpi::b_+^3@KSvD2025"]       = 0.01799556162000065;
+                pm["0->Kpi::b_0^1@KSvD2025"]       = 0.31182977560257646;
+                pm["0->Kpi::b_0^2@KSvD2025"]       = 0.2718566992904784;
+                pm["0->Kpi::b_0^3@KSvD2025"]       = -0.012034090375745321;
+                pm["0->Kpi::M_(+,0)@KSvD2025"]     = 0.8917120142957791;
+                pm["0->Kpi::Gamma_(+,0)@KSvD2025"] = 0.04513720400819739;
+                pm["decay-constant::K_u"]          = 0.15569999791603167;
+                pm["decay-constant::pi"]           = 0.12969354237876146;
+
+                const Options mode_opts{
+                    {           "model"_ok, "WET"_ov },
+                    {               "K"_ok, "K_S"_ov },
+                    { "n-resonances-1m"_ok,   "2"_ov },
+                    { "n-resonances-0p"_ok,   "2"_ov }
+                };
+
+                // WC set 1: Standard Model (Re{cVL} = 1.009653 encodes the electroweak correction)
+                pm["ustaunutau::Re{cVL}"] = 1.009653;
+                pm["ustaunutau::Re{cVR}"] = 0.0;
+                pm["ustaunutau::Im{cVR}"] = 0.0;
+                pm["ustaunutau::Re{cSL}"] = 0.0;
+                pm["ustaunutau::Im{cSL}"] = 0.0;
+                pm["ustaunutau::Re{cSR}"] = 0.0;
+                pm["ustaunutau::Im{cSR}"] = 0.0;
+                {
+                    TauToKPiNeutrino d(pm, mode_opts);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(0.5), 0.00038675505491877913, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, -0.5), 6.4551233505561254e-05, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, +0.1), 0.00018221129092269793, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, +0.8), 0.00041832741893284617, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(1.0), 0.0017914256796805357, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, -0.5), 0.00075821001062914735, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, +0.1), 0.00054835709578110253, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, +0.8), 0.0013068205833905338, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(1.8), 0.00012653597457715373, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, -0.5), 3.8954451930347461e-05, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, +0.1), 5.6589353783935947e-05, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, +0.8), 0.00010805346454769402, eps);
+                }
+
+                // WC set 2: complex vector and scalar new physics
+                pm["ustaunutau::Re{cVL}"] = 1.0;
+                pm["ustaunutau::Re{cVR}"] = 0.10;
+                pm["ustaunutau::Im{cVR}"] = 0.05;
+                pm["ustaunutau::Re{cSL}"] = 0.20;
+                pm["ustaunutau::Im{cSL}"] = 0.10;
+                pm["ustaunutau::Re{cSR}"] = -0.08;
+                pm["ustaunutau::Im{cSR}"] = 0.03;
+                {
+                    TauToKPiNeutrino d(pm, mode_opts);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(0.5), 0.00076669281338883515, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, -0.5), 0.00015656563956361816, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, +0.1), 0.00038477527535802172, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, +0.8), 0.0007685899361395093, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(1.0), 0.0022271696505980986, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, -0.5), 0.0010436006454148028, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, +0.1), 0.00068171777940277776, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, +0.8), 0.0014528626685785728, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(1.8), 0.00024388025527597514, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, -0.5), 7.4529812209619498e-05, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, +0.1), 0.00011769461891696896, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, +0.8), 0.00020479500226404309, eps);
+                }
+
+                // WC set 3: the couplings of WC set 2 plus a complex tensor coefficient. Since no
+                // form factor implementation provides f_T yet, this requires debug-tensor = 1, which
+                // substitutes B_T = 1. The vector and scalar couplings are unchanged with respect to
+                // WC set 2, so that the difference between the two isolates the tensor sector: the
+                // tensor-tensor term, the vector-tensor interference in a and c, and the
+                // scalar-tensor interference in b.
+                const Options mode_opts_tensor{
+                    {           "model"_ok, "WET"_ov },
+                    {               "K"_ok, "K_S"_ov },
+                    { "n-resonances-1m"_ok,   "2"_ov },
+                    { "n-resonances-0p"_ok,   "2"_ov },
+                    {    "debug-tensor"_ok,   "1"_ov }
+                };
+
+                pm["ustaunutau::Re{cVL}"] = 1.0;
+                pm["ustaunutau::Re{cVR}"] = 0.10;
+                pm["ustaunutau::Im{cVR}"] = 0.05;
+                pm["ustaunutau::Re{cSL}"] = 0.20;
+                pm["ustaunutau::Im{cSL}"] = 0.10;
+                pm["ustaunutau::Re{cSR}"] = -0.08;
+                pm["ustaunutau::Im{cSR}"] = 0.03;
+                pm["ustaunutau::Re{cT}"]  = 0.15;
+                pm["ustaunutau::Im{cT}"]  = -0.06;
+                {
+                    TauToKPiNeutrino d(pm, mode_opts_tensor);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(0.5), 0.00073574631204537380, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, -0.5), 0.00015177467973205986, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, +0.1), 0.00036836581045930140, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(0.5, +0.8), 0.00073541313105551930, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(1.0), 0.0027900709232341150, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, -0.5), 0.0013327140281895065, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, +0.1), 0.00097079255254210580, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.0, +0.8), 0.0017173847960770617, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.differential_branching_ratio(1.8), 0.00030612793006224910, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, -0.5), 0.00010263108846277380, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, +0.1), 0.00015614154875673390, eps);
+                    TEST_CHECK_NEARLY_EQUAL(d.double_differential_branching_ratio(1.8, +0.8), 0.00023732977893832068, eps);
+                }
             }
         }
 } tau_to_k_pi_nu_test;


### PR DESCRIPTION
- de2af2b1 [eos] Add EPPRR:2026A reference.
- 8136e6d7 [tau-decays] Fix sign error in scalar contributions to tau->Kpinu. The sign error cause the linear interference term between scalar and SM contributions to vanish. Regression test is included to avoid this happening again.
- 65f0b52c [tau-decays] Implement double-differential rates for tau->Kpinu following EPPRR:2026A; specifically, v2 of the EPPRR:2026A preprint.
- a6ef3b93 [eos] Update changelog for PR #1204.