### PR TITLE
Fix all compiler warnings and add workflow to report newly-added compiler warnings

### DIFF
--- a/.github/scripts/collect-warnings.py
+++ b/.github/scripts/collect-warnings.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# vim: set sw=4 sts=4 et tw=120 :
+
+"""Collect the compiler diagnostics emitted by ``g++ -fdiagnostics-format=sarif-file``.
+
+During the build, GCC writes one ``<source>.sarif`` file per translation unit
+into the directory in which the compiler was invoked. In an out-of-tree (VPATH)
+build that directory lives under the build tree, and the source ``uri`` recorded
+inside each SARIF file is relative to it -- neither of which GitHub can map back
+to files in the repository.
+
+This script serves two purposes, controlled by the arguments:
+
+* ``--sarif-out``/``--list-out``: walk the build tree, rewrite every diagnostic
+  location to a repository-root-relative path, merge all runs into a single
+  SARIF document (suitable for ``github/codeql-action/upload-sarif``), and emit a
+  normalised, sorted, de-duplicated plain-text list of warnings.
+
+* ``--baseline``: compare a previously generated list against a committed
+  baseline, print any *new* warning as a GitHub ``::warning`` workflow command,
+  and exit non-zero if the set of warnings has grown.
+
+A warning is keyed on ``path<TAB>ruleId<TAB>message`` -- deliberately excluding
+the line number, so that unrelated edits which merely shift line numbers do not
+register as new warnings.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+SEP = '\t'
+
+
+def _iter_results(sarif):
+    """Yield ``(run, result)`` pairs for every result in a SARIF document."""
+    for run in sarif.get('runs', []):
+        for result in run.get('results', []):
+            yield run, result
+
+
+def _primary_location(result):
+    """Return the first physicalLocation of a result, or ``None``."""
+    for location in result.get('locations', []):
+        physical = location.get('physicalLocation')
+        if physical is not None:
+            return physical
+    return None
+
+
+def _resolve_uri(sarif_path, uri):
+    """Resolve a SARIF ``uri`` to an absolute filesystem path.
+
+    GCC records the ``uri`` relative to the directory in which it ran the
+    compiler, which is precisely the directory that holds the ``.sarif`` file.
+    """
+    if os.path.isabs(uri):
+        return os.path.normpath(uri)
+    return os.path.normpath(os.path.join(os.path.dirname(sarif_path), uri))
+
+
+def collect(build_dir, src_dir):
+    """Return ``(merged_sarif, warnings)`` gathered from ``build_dir``.
+
+    ``merged_sarif`` is a single SARIF document whose locations are rewritten to
+    be relative to ``src_dir`` (the repository root). ``warnings`` is the sorted,
+    de-duplicated list of ``path<TAB>rule<TAB>message`` keys. Diagnostics whose
+    source lies outside ``src_dir`` (e.g. system headers) are dropped, since they
+    cannot be annotated in the repository and are not the project's warnings.
+    """
+    src_root = os.path.abspath(src_dir)
+    merged_runs = []
+    warnings = set()
+
+    sarif_paths = []
+    for root, _, files in os.walk(build_dir):
+        for name in files:
+            if name.endswith('.sarif'):
+                sarif_paths.append(os.path.join(root, name))
+    sarif_paths.sort()
+
+    for sarif_path in sarif_paths:
+        with open(sarif_path, encoding='utf-8') as f:
+            sarif = json.load(f)
+
+        for run in sarif.get('runs', []):
+            kept_results = []
+            for result in run.get('results', []):
+                # Track compiler *warnings* only. GCC SARIF can also carry
+                # ``error`` and ``note`` results; including them would pollute
+                # the baseline and let non-warning diagnostics fail the check.
+                # A missing ``level`` defaults to "warning" per SARIF 2.1.0, so
+                # keep it and drop only explicitly non-warning results.
+                if result.get('level') not in (None, 'warning'):
+                    continue
+                physical = _primary_location(result)
+                if physical is None:
+                    continue
+                artifact = physical.get('artifactLocation', {})
+                uri = artifact.get('uri')
+                if uri is None:
+                    continue
+
+                abs_path = _resolve_uri(sarif_path, uri)
+                rel_path = os.path.relpath(abs_path, src_root)
+                # Drop diagnostics outside the repository (system headers, etc.).
+                if rel_path.startswith(os.pardir):
+                    continue
+
+                # Rewrite every artifactLocation in this result to be
+                # repository-root-relative and strip the build-tree base id.
+                for location in result.get('locations', []):
+                    phys = location.get('physicalLocation')
+                    if phys is None:
+                        continue
+                    loc_artifact = phys.get('artifactLocation')
+                    if loc_artifact is None:
+                        continue
+                    loc_uri = loc_artifact.get('uri')
+                    if loc_uri is None:
+                        continue
+                    loc_abs = _resolve_uri(sarif_path, loc_uri)
+                    loc_artifact['uri'] = os.path.relpath(loc_abs, src_root)
+                    loc_artifact.pop('uriBaseId', None)
+
+                kept_results.append(result)
+
+                rule = result.get('ruleId', '')
+                message = result.get('message', {}).get('text', '')
+                warnings.add(SEP.join((rel_path, rule, message)))
+
+            if kept_results:
+                run['results'] = kept_results
+                # The rewritten uris are relative to the repository root, so the
+                # build-tree base directory no longer applies.
+                run.pop('originalUriBaseIds', None)
+                merged_runs.append(run)
+
+    merged_sarif = {
+        '$schema': 'https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json',
+        'version': '2.1.0',
+        'runs': merged_runs,
+    }
+    return merged_sarif, sorted(warnings)
+
+
+def read_list(path):
+    """Read a warnings list file into a sorted list, ignoring blank lines."""
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding='utf-8') as f:
+        return sorted(line.rstrip('\n') for line in f
+                      if line.strip() and not line.startswith('#'))
+
+
+BASELINE_HEADER = (
+    '# Baseline of accepted g++ compiler warnings, one "path<TAB>rule<TAB>message"\n'
+    '# entry per line. Regenerate from a build tree with:\n'
+    '#   python3 .github/scripts/collect-warnings.py \\\n'
+    '#     --build-dir <build> --src-dir <src> --write-baseline .github/warnings-baseline.txt\n'
+)
+
+
+def write_list(path, warnings, header=None):
+    with open(path, 'w', encoding='utf-8') as f:
+        if header:
+            f.write(header)
+        for warning in warnings:
+            f.write(warning + '\n')
+
+
+def _escape_data(value):
+    """Escape the message portion of a GitHub workflow command."""
+    return value.replace('%', '%25').replace('\r', '%0D').replace('\n', '%0A')
+
+
+def _escape_property(value):
+    """Escape a property value (e.g. ``file=``) of a GitHub workflow command.
+
+    In addition to the data escapes, ``:`` and ``,`` are reserved because they
+    separate and terminate the property list.
+    """
+    return _escape_data(value).replace(':', '%3A').replace(',', '%2C')
+
+
+def check_baseline(warnings, baseline_path):
+    """Emit ``::warning`` commands for new warnings and return the exit code.
+
+    New warnings (present now, absent from the baseline) fail the build.
+    Warnings present in the baseline but no longer emitted are reported as
+    notices so that the baseline can be pruned, but do not fail the build.
+    """
+    baseline = set(read_list(baseline_path))
+    current = set(warnings)
+
+    new_warnings = sorted(current - baseline)
+    resolved_warnings = sorted(baseline - current)
+
+    for warning in new_warnings:
+        path, _, rest = warning.partition(SEP)
+        rule, _, message = rest.partition(SEP)
+        # GitHub renders this as an inline annotation even without SARIF upload.
+        # Values must be escaped so reserved characters (``%``, newlines, and --
+        # for properties -- ``:`` and ``,``) cannot malform the command.
+        print(f'::warning file={_escape_property(path)}::'
+              f'[{_escape_data(rule)}] {_escape_data(message)}')
+
+    if resolved_warnings:
+        print(f'::notice::{len(resolved_warnings)} baselined warning(s) are no longer '
+              'emitted; consider regenerating .github/warnings-baseline.txt', file=sys.stderr)
+
+    if new_warnings:
+        print(f'\n{len(new_warnings)} new compiler warning(s) introduced:', file=sys.stderr)
+        for warning in new_warnings:
+            print('  ' + warning.replace(SEP, '  |  '), file=sys.stderr)
+        return 1
+
+    print(f'No new compiler warnings ({len(current)} known, baseline has {len(baseline)}).',
+          file=sys.stderr)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--build-dir', help='build tree to scan for *.sarif files')
+    parser.add_argument('--src-dir', help='repository root the source uris are made relative to')
+    parser.add_argument('--sarif-out', help='write the merged SARIF document here')
+    parser.add_argument('--list-out', help='write the normalised warnings list here')
+    parser.add_argument('--list-in', help='read a previously generated warnings list from here')
+    parser.add_argument('--baseline', help='baseline list to compare against; fail on new warnings')
+    parser.add_argument('--write-baseline', help='(re)generate the baseline list at this path')
+    args = parser.parse_args()
+
+    # Collection mode: scan the build tree and emit the merged SARIF and list.
+    if args.build_dir or args.sarif_out or args.list_out:
+        if not (args.build_dir and args.src_dir):
+            parser.error('--build-dir and --src-dir are required to collect warnings')
+        merged_sarif, warnings = collect(args.build_dir, args.src_dir)
+        if args.sarif_out:
+            with open(args.sarif_out, 'w', encoding='utf-8') as f:
+                json.dump(merged_sarif, f, ensure_ascii=False, indent=1)
+        if args.list_out:
+            write_list(args.list_out, warnings)
+        if args.write_baseline:
+            write_list(args.write_baseline, warnings, header=BASELINE_HEADER)
+        print(f'Collected {len(warnings)} distinct warning(s) from {args.build_dir}.',
+              file=sys.stderr)
+    elif args.list_in:
+        warnings = read_list(args.list_in)
+        if args.write_baseline:
+            write_list(args.write_baseline, warnings, header=BASELINE_HEADER)
+    else:
+        parser.error('nothing to do: pass --build-dir (collect) or --list-in (check)')
+
+    if args.baseline:
+        return check_baseline(warnings, args.baseline)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/warnings-baseline.txt
+++ b/.github/warnings-baseline.txt
@@ -1,0 +1,4 @@
+# Baseline of accepted g++ compiler warnings, one "path<TAB>rule<TAB>message"
+# entry per line. Regenerate from a build tree with:
+#   python3 .github/scripts/collect-warnings.py \
+#     --build-dir <build> --src-dir <src> --write-baseline .github/warnings-baseline.txt

--- a/.github/workflows/ubuntu-build+check+deploy.yaml
+++ b/.github/workflows/ubuntu-build+check+deploy.yaml
@@ -65,9 +65,49 @@ jobs:
               shell: bash
               run: |
                 pushd _build
-                make -j4 all
+                # For g++, emit one SARIF file per translation unit alongside
+                # each object file. Appending the flag to CXX leaves the
+                # configured CXXFLAGS/AM_CXXFLAGS (and thus the set of warnings)
+                # untouched. clang's SARIF output is experimental and is skipped.
+                DIAG=""
+                [[ "${{ matrix.cfg.cxx }}" == g++* ]] && DIAG="-fdiagnostics-format=sarif-file"
+                make -j4 all CXX="${{ matrix.cfg.cxx }} ${DIAG}"
                 popd
                 tar caf _build.tar _build
+
+            - name: Collect compiler warnings (merge SARIF)
+              if: always() && startsWith(matrix.cfg.cxx, 'g++')
+              shell: bash
+              run: |
+                python3 _src/.github/scripts/collect-warnings.py \
+                  --build-dir _build --src-dir _src \
+                  --sarif-out eos.sarif --list-out warnings.txt
+                # Record the ref/sha the SARIF was produced for, so the companion
+                # ``workflow_run`` workflow can attribute the code-scanning results
+                # to the correct commit/PR -- including pull requests from forks,
+                # whose read-only token cannot upload SARIF from this job.
+                {
+                  echo "ref=${{ github.ref }}"
+                  echo "sha=${{ github.sha }}"
+                } > sarif-metadata.txt
+
+            - name: Upload warnings list as artifact
+              if: always() && startsWith(matrix.cfg.cxx, 'g++')
+              uses: actions/upload-artifact@v4
+              with:
+                name: eos-warnings-${{ matrix.cfg.os }}-${{ matrix.cfg.cxx }}-${{ github.sha }}
+                path: |
+                  eos.sarif
+                  warnings.txt
+                  sarif-metadata.txt
+
+            - name: Fail on new compiler warnings
+              if: always() && startsWith(matrix.cfg.cxx, 'g++')
+              shell: bash
+              run: |
+                python3 _src/.github/scripts/collect-warnings.py \
+                  --list-in warnings.txt \
+                  --baseline _src/.github/warnings-baseline.txt
 
             - name: Upload configured source as artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/upload-warnings-sarif.yaml
+++ b/.github/workflows/upload-warnings-sarif.yaml
@@ -1,0 +1,58 @@
+on:
+    workflow_run:
+        workflows: [ "Build/Check/Deploy on Ubuntu" ]
+        types: [ completed ]
+
+name: Upload compiler-warning SARIF
+
+concurrency:
+  group: warnings-sarif, ${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+    contents: read
+    actions: read            # download artifacts from the triggering run
+    security-events: write   # upload to the code-scanning API
+
+jobs:
+    upload-sarif:
+        name: Upload compiler-warning SARIF to code scanning
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
+        steps:
+            # The build job (which runs untrusted fork code) holds no
+            # write-scoped token. It records the ref/sha and uploads the merged
+            # SARIF as an artifact instead; this ``workflow_run`` companion runs
+            # in the base-repository context with ``security-events: write`` and
+            # performs the upload, so pull requests from forks receive native
+            # code-scanning annotations too.
+            - name: Download warnings artifact from the triggering run
+              uses: actions/download-artifact@v4
+              continue-on-error: true   # tolerate runs that produced no artifact
+              with:
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                run-id: ${{ github.event.workflow_run.id }}
+                pattern: eos-warnings-*
+                merge-multiple: true
+
+            - name: Read SARIF metadata
+              id: meta
+              shell: bash
+              run: |
+                if [[ ! -f sarif-metadata.txt || ! -f eos.sarif ]]; then
+                    echo "No warnings artifact from this run; nothing to upload."
+                    echo "found=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                fi
+                # sarif-metadata.txt carries the ``ref=`` and ``sha=`` lines.
+                cat sarif-metadata.txt >> "$GITHUB_OUTPUT"
+                echo "found=true" >> "$GITHUB_OUTPUT"
+
+            - name: Upload SARIF to code scanning
+              if: steps.meta.outputs.found == 'true'
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                sarif_file: eos.sarif
+                category: gcc-warnings
+                ref: ${{ steps.meta.outputs.ref }}
+                sha: ${{ steps.meta.outputs.sha }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -82,6 +82,7 @@
 - Add further test cases to cover the worst offenders in terms of code coverage (D. van Dyk)
 - Add a ``format_version`` field to the analysis file format, so that EOS rejects files declaring a newer schema version than it supports (issue #1196) (D. van Dyk)
 - Complete the documentation of the figure description format (D. van Dyk)
+- Detect newly introduced C++ compiler warnings in the CI/CD workflows using ``g++``'s SARIF diagnostics output, providing native code-scanning annotations on pull requests and failing the build on any warning not present in a committed baseline (D. van Dyk)
 
 ### Deprecated
 
@@ -136,6 +137,8 @@
 - Fix ``eos.figure.GridFigure`` to forward the analysis file context to each of its plots, so that items resolve relative data and parameter paths against the analysis file's base directory (D. van Dyk)
 - Defer loading of a figure item's ``fixed_parameters_from_file`` from construction to draw time, so that loading an analysis file no longer requires the parameter file (which may be the output of an earlier task such as ``find-mode``) to already exist (issue #1181) (D. van Dyk)
 - Fix the ``B->D^*lnu`` azimuthal (``phi``) 1D distribution, which contained a spurious ``cos(phi)`` term, and the phase-space normalization of the 1D PDFs, previously computed by ``BToDPiLeptonNeutrino`` (D. van Dyk)
+- Fix a latent initialization-order bug in the [GP:2004A] B->K^*ll amplitudes, where the ``lambda_*`` and ``sl_phase_*`` subleading parameters read the ``use_simple_sl`` flag before it was initialized (D. van Dyk)
+- Fix various C++ compiler warnings (``-Wreorder``, ``-Wunused-parameter``, ``-Wignored-qualifiers``, ``-Wunused-variable``, ``-Woverloaded-virtual``) (D. van Dyk)
 
 
 ## [v1.0.20] - 2026-04-28

--- a/eos/b-decays/b-to-l-nu.cc
+++ b/eos/b-decays/b-to-l-nu.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2015-2025 Danny van Dyk
+ * Copyright (c) 2015-2026 Danny van Dyk
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2018 Christoph Bobeth
  *
@@ -85,7 +85,6 @@ namespace eos
             Context ctx("When constructing B_q->lnu observable");
 
             using std::placeholders::_1;
-            using std::placeholders::_2;
             switch (opt_q.value())
             {
                 case QuarkFlavor::up:

--- a/eos/b-decays/b-to-psd-psd-l-nu.cc
+++ b/eos/b-decays/b-to-psd-psd-l-nu.cc
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2025 Florian Herren
- * Copyright (c) 2025 Danny van Dyk
+ * Copyright (c) 2025-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -222,9 +222,6 @@ namespace eos
             form_factors(FormFactorFactory<PToPP>::create(_process() + "::" + o.get("form-factors"_ok, "HKvT2025"_ov).str(), p, o))
         {
             Context ctx("When constructing B->PPlnu observable");
-
-            using std::placeholders::_1;
-            using std::placeholders::_2;
 
             switch (opt_U.value())
             {

--- a/eos/c-decays/lambdac-to-onehalfplus-l-nu.cc
+++ b/eos/c-decays/lambdac-to-onehalfplus-l-nu.cc
@@ -342,8 +342,8 @@ namespace eos
             m_B(p["mass::" + _B()], u),
             alpha(p[_B()+ "::alpha"], u),
             mu(p[stringify(_Q()) + "cnu" + opt_l.str() + opt_l.str() + "::mu"], u),
-            opt_cp_conjugate(o, options, "cp-conjugate"_ok),
-            form_factors(FormFactorFactory<OneHalfPlusToOneHalfPlus>::create(_process() + "::" + o.get("form-factors"_ok, "BMRvD2022"_ov).str(), p, o))
+            form_factors(FormFactorFactory<OneHalfPlusToOneHalfPlus>::create(_process() + "::" + o.get("form-factors"_ok, "BMRvD2022"_ov).str(), p, o)),
+            opt_cp_conjugate(o, options, "cp-conjugate"_ok)
         {
             Context ctx("When constructing Lambda_c->Baryon(1/2+)lnu observable");
 

--- a/eos/constraint.cc
+++ b/eos/constraint.cc
@@ -160,12 +160,6 @@ namespace eos
                 out << YAML::Value << "unimplemented";
                 out << YAML::EndMap;
             }
-
-            virtual ConstraintEntry *
-            deserialize(const YAML::Node &) const
-            {
-                return nullptr;
-            }
     };
 
     /// }}}

--- a/eos/form-factors/k-star-lcdas.cc
+++ b/eos/form-factors/k-star-lcdas.cc
@@ -1,7 +1,9 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2023 Stefan Meiser
+ * Copyright (c) 2023-2025 Stefan Meiser
+ * Copyright (c) 2025      Matthew Kirk
+ * Copyright (c) 2026      Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -376,7 +378,7 @@ namespace eos
                 (1.0 - 3.0 * a1perp(mu) + 6.0 * a2perp(mu)) * log(u))) / (2.0 * fpara * M_V);
         }
         // definition of chiral even parameters appearing in three-particle twist 4 LCDAs, [BBL:2007A], eq. 3.22 (renormalon model)
-        inline double psi0para(const double & mu) const
+        inline double psi0para(const double & /*mu*/) const
         {
             return 0.0;
         }
@@ -412,7 +414,7 @@ namespace eos
         {
             return -7.0 / 9.0 * zeta4para(mu);
         }
-        inline double theta0para(const double & mu) const
+        inline double theta0para(const double & /*mu*/) const
         {
             return 0.0;
         }
@@ -499,11 +501,11 @@ namespace eos
         }
 
         // definition of chiral odd G violating parameters appearing in three-particle twist 4 LCDAs, [BBL:2007A], eq. 4.20 (renormalon model)
-        inline double phi0perp(const double & mu) const
+        inline double phi0perp(const double & /*mu*/) const
         {
             return 0.0;
         }
-        inline double phi0perptilde(const double & mu) const
+        inline double phi0perptilde(const double & /*mu*/) const
         {
             return 0.0;
         }
@@ -515,11 +517,11 @@ namespace eos
         {
             return -21.0 / 20.0 * zeta4perp(mu) * a1perp(mu);
         }
-        inline double theta0perp(const double & mu) const
+        inline double theta0perp(const double & /*mu*/) const
         {
             return 0.0;
         }
-        inline double theta0perptilde(const double & mu) const
+        inline double theta0perptilde(const double & /*mu*/) const
         {
             return 0.0;
         }
@@ -1375,7 +1377,7 @@ namespace eos
                 (1.0 - 3.0 * a1perp(mu) + 6.0 * a2perp(mu)) * log(u))) / (2.0 * fpara * M_V);
         }
         // definition of chiral even parameters appearing in three-particle twist 4 LCDAs, [BBL:2007A], eq. 3.22 (renormalon model)
-        inline double psi0para(const double & mu) const
+        inline double psi0para(const double & /*mu*/) const
         {
             return 0.0;
         }
@@ -1411,7 +1413,7 @@ namespace eos
         {
             return -7.0 / 9.0 * zeta4para(mu);
         }
-        inline double theta0para(const double & mu) const
+        inline double theta0para(const double & /*mu*/) const
         {
             return 0.0;
         }
@@ -1498,11 +1500,11 @@ namespace eos
         }
 
         // definition of chiral odd G violating parameters appearing in three-particle twist 4 LCDAs, [BBL:2007A], eq. 4.20 (renormalon model)
-        inline double phi0perp(const double & mu) const
+        inline double phi0perp(const double & /*mu*/) const
         {
             return 0.0;
         }
-        inline double phi0perptilde(const double & mu) const
+        inline double phi0perptilde(const double & /*mu*/) const
         {
             return 0.0;
         }
@@ -1514,11 +1516,11 @@ namespace eos
         {
             return -21.0 / 20.0 * zeta4perp(mu) * a1perp(mu);
         }
-        inline double theta0perp(const double & mu) const
+        inline double theta0perp(const double & /*mu*/) const
         {
             return 0.0;
         }
-        inline double theta0perptilde(const double & mu) const
+        inline double theta0perptilde(const double & /*mu*/) const
         {
             return 0.0;
         }

--- a/eos/form-factors/parametric-bgjvd2019.cc
+++ b/eos/form-factors/parametric-bgjvd2019.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 tw=120 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2022-2025 Danny van Dyk
+ * Copyright (c) 2022-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -82,8 +82,6 @@ namespace eos
         _l6pone(p[_sslp_prefix(prefix) + "::l_6'(1)@HQET"], *this),
         _l6ppone(p[_sslp_prefix(prefix) + "::l_6''(1)@HQET"], *this)
     {
-        using std::placeholders::_1;
-
         if (_opt_lp_model.value() == "exponential")
         {
             _xi = [=, this](const double & q2) -> double

--- a/eos/form-factors/parametric-kkvdz2022.cc
+++ b/eos/form-factors/parametric-kkvdz2022.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2022-2025 Danny van Dyk
+ * Copyright (c) 2022-2026 Danny van Dyk
  * Copyright (c) 2022      Stephan Kürten
  *
  * This file is part of the EOS project. EOS is free software;
@@ -28,6 +28,7 @@ namespace eos
     KKvDZ2022FormFactors::KKvDZ2022FormFactors(const Parameters & p, const Options & o) :
         opt_subtracted(o, options, "subtracted"_ok),
         switch_subtracted(0.0),
+        _s_0(p[_par_name("s_0")],  *this),
         _a_omega{{{ UsedParameter(p[_par_name("N^omega_1_0")],  *this),
                    UsedParameter(p[_par_name("N^omega_1_1")],  *this),
                    UsedParameter(p[_par_name("N^omega_1_2")],  *this) },
@@ -63,8 +64,7 @@ namespace eos
                          UsedParameter(p[_par_name("c_3_2")],  *this) },
                        { UsedParameter(p[_par_name("c_4_0")],  *this),
                          UsedParameter(p[_par_name("c_4_1")],  *this),
-                         UsedParameter(p[_par_name("c_4_2")],  *this) }}},
-        _s_0(p[_par_name("s_0")],  *this)
+                         UsedParameter(p[_par_name("c_4_2")],  *this) }}}
     {
         if (opt_subtracted.value())
         {

--- a/eos/rare-b-decays/b-to-kstar-ll-gp2004.hh
+++ b/eos/rare-b-decays/b-to-kstar-ll-gp2004.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2012, 2013, 2014, 2015, 2016 Danny van Dyk
+ * Copyright (c) 2010-2026 Danny van Dyk
  * Copyright (c) 2010, 2011 Christian Wacker
  * Copyright (c) 2014 Frederik Beaujean
  * Copyright (c) 2014 Christoph Bobeth
@@ -39,6 +39,12 @@ namespace eos
             UsedParameter m_c_MSbar;
             UsedParameter m_s;
 
+            // ``use_simple_sl`` is read by the ``lambda_*`` and ``sl_phase_*``
+            // initializers below, so it (and its option) must be declared -- and
+            // therefore initialized -- first.
+            BooleanOption opt_use_simple_sl;
+            bool use_simple_sl;
+
             UsedParameter lambda_long;
             UsedParameter lambda_par;
             UsedParameter lambda_perp;
@@ -49,11 +55,9 @@ namespace eos
 
             BooleanOption opt_ccbar_resonance;
             BooleanOption opt_use_nlo;
-            BooleanOption opt_use_simple_sl;
 
             bool ccbar_resonance;
             bool use_nlo;
-            bool use_simple_sl;
 
             static const std::vector<OptionSpecification> options;
 

--- a/eos/rare-c-decays/lambda-c-to-proton-l-l.cc
+++ b/eos/rare-c-decays/lambda-c-to-proton-l-l.cc
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2019 Ahmet Kokulu
- * Copyright (c) 2019,2021 Danny van Dyk
+ * Copyright (c) 2019-2026 Danny van Dyk
  * Copyright (c) 2023 Méril Reboud
  * Copyright (c) 2026 Dominik Suelmann
  *
@@ -229,7 +229,7 @@ namespace eos
                 u.uses(*model);
             }
 
-            const double
+            double
             normalization(const double & q2) const
             {
                 double lam = lambda(m_Lambda_c * m_Lambda_c, m_proton * m_proton, q2);

--- a/eos/tau-decays/tau-to-k-pi-nu.cc
+++ b/eos/tau-decays/tau-to-k-pi-nu.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2025 Danny van Dyk
+ * Copyright (c) 2025-2026 Danny van Dyk
  * Copyright (c) 2025 Matthew Kirk
  *
  * This file is part of the EOS project. EOS is free software;
@@ -74,11 +74,11 @@ namespace eos
             Implementation(const Parameters & p, const Options & o, ParameterUser & u) :
                 form_factors(FormFactorFactory<VacuumToPP>::create("0->Kpi::KSvD2025", p, o)),
                 opt_model(o, options, "model"_ok),
-                opt_K(o, options, "K"_ok),
                 model(Model::make(opt_model.value(), p, o)),
                 hbar(p["QM::hbar"], u),
                 g_fermi(p["WET::G_Fermi"], u),
                 m_tau(p["mass::tau"], u),
+                opt_K(o, options, "K"_ok),
                 m_K(p["mass::" + opt_K.value()], u),
                 m_pi(p["mass::pi^" + std::string(opt_K.value() == "K_u" ? "0" : "-")], u),
                 m_s(p["mass::s(2GeV)"], u),


### PR DESCRIPTION
- c2ef710d [rare-b-decays] Fix latent bug in subleading terms for [GP:2004A] B->K*ll predictions. Caused by an out-of-order "initialization vs use" of an option.
- a64c55d2 [c-decays] Fix warnings (``-Wreorder``).
- 43b6d912 [form-factors] Fix warnings (``-Wreorder``, ``-Wunused-parameter``).
- 0dffd178 [rare-c-decays] Fix warning (``-Wignored-qualifiers``).
- 907a9f46 [tau-decays] Fix warning (``-Wreorder``).
- d83095ec [github] Detect g++ compiler warnings via SARIF. Reports them via ``github/codeql-action/upload-sarif@v3`` action.
- 949537ba [eos] Update changelog for PR #1208.