### PR TITLE
Update/fix the physics documentation, deprecate ``eos.plot`` and ``corner-plot``

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -63,6 +63,7 @@
 - Add an output stream operator for ``qnp::OptionValue`` (D. van Dyk)
 - Document the user-facing classes and methods of the ``eos`` Python modules, and auto-generate the analysis file format reference from the ``eos.analysis_file_description`` classes (D. van Dyk)
 - Complete the reference documentation of the ``eos`` Python bindings: fix several incorrect docstrings, name all arguments and add docstrings across the documented C++-bound classes, and document the previously undocumented ``Model``, ``LogLikelihoodBlock``, ``Constraint``, ``ConstraintEntry``, ``ObservableEntry``, ``Reference``, ``References``, and ``SignalPDFEntry`` classes; the list of documented classes now lives in ``eos._api``, shared by the API reference template and by a new unit test that guards argument naming and docstring coverage against regressions (D. van Dyk)
+- Add a top-level ``Physics`` section to the documentation, split off from the reference, covering the physics conventions, the definitions and parametrisations of the hadronic matrix elements of local operators (decay constants and semileptonic form factors, including the ``1/2^+ -> 1/2^+`` baryon form factors), and the observables predicted for semileptonic decays to a pseudoscalar meson, to a vector meson, and to a ``1/2^+`` baryon (D. van Dyk)
 - Add a ``vertical`` plot item that draws a vertical line at a fixed position on the x axis, e.g. to mark a kinematic threshold (D. van Dyk)
 - Add an optional ``size`` field to ``grid`` figures to set the figure size explicitly (D. van Dyk)
 - Add an optional ``watermark_plot`` field to ``grid`` figures to stamp the watermark on a single panel, addressed either by a flattened index or by a ``(row, col)`` pair (D. van Dyk)
@@ -92,6 +93,8 @@
 
 - Deprecate the curtailed Gaussian prior description, i.e. a ``gauss``/``gaussian`` prior with ``min``/``max`` keys; use ``type: gaussian`` without ``min``/``max`` instead (D. van Dyk)
 - Deprecate constraint-based prior descriptions without a ``type`` key; use ``type: constraint`` instead (D. van Dyk)
+- Deprecate the ``eos.plot`` subpackage for removal in version 1.1; use the ``eos.figure`` subpackage instead (D. van Dyk)
+- Deprecate the ``corner-plot`` task for removal in version 1.1; use the ``corner`` figure type (``eos.figure.CornerFigure``) instead (D. van Dyk)
 
 ### Removed
 
@@ -109,6 +112,7 @@
 
 ### Fixed
 
+- Fix typos and errors in the documentation of the semileptonic form factors (D. van Dyk)
 - Fix some linewidth and linestyles arguments in figure framework (D. Suelmann)
 - Fix undefined name errors in Python code (D. van Dyk)
 - Fix usage of mutable default arguments in Python code (D. van Dyk)

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -21,7 +21,7 @@ reference/figure-format.rst
 reference/observables.rst
 reference/parameters.rst
 reference/python.rst
-reference/physics-conventions.rst
 reference/signal-pdfs.rst
+physics/conventions.rst
 user-guide/CKM-pi/*
 installation.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,5 +30,6 @@ their power to organise one or more analyses is demonstrated in the `analysis fi
 
    installation
    user-guide/index
+   physics/index
    faq
    reference/index

--- a/doc/physics/conventions.rst.jinja
+++ b/doc/physics/conventions.rst.jinja
@@ -1,0 +1,58 @@
+===========
+Conventions
+===========
+
+EOS implicitly uses the following conventions in the predictions of flavour physics observables.
+
+Units
+-----
+
+EOS uses natural units :math:`(\hbar = c =1)`.
+Most quantities are expressed in powers of GeV.
+Exceptions include lifetimes, which are expressed in seconds.
+Units are specified in the definition of observables and parameters (which can be found in this documentation (`here <../reference/constraints.html>`_ and `here <../reference/parameters.html>`_, respectively),
+or directly from python, as described in the `basic examples <../user-guide/basics.html>`_).
+EOS currently implements the following units:
+
+{% for unit, latex in units %}
+* ``{{ unit }}``: {{ latex }}
+{% endfor %}
+
+
+Weak Effective Theory
+---------------------
+
+We follow the conventions of the WCxf format for the Wilson coefficients of the effective Hamiltonian at mass dimension six.
+Each sector of the effective Hamiltonian is defined by a unique name, corresponding to the flavour quantum numbers
+of the fermion fields.
+
+Semileptonic Charged-Current Operators
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We use the Bern class-III notation for the semileptonic charged-current operators.
+For down-type (:math:`D`) to up-type (:math:`U`) semileptonic decays, the sector of the effective theory is described by the Lagrangian:
+
+.. math::
+   :nowrap:
+
+   \begin{align*}
+      \mathcal{L}^{UD\ell\nu}
+        = -\frac{4 G_\text{F}}{\sqrt{2}} V_{UD} \sum_{i} \mathcal{C}_i^{UD\ell\nu}(\mu) \, \mathcal{O}_i + \text{h.c.}\,,
+   \end{align*}
+
+
+where :math:`V_{UD}` is the CKM matrix element, :math:`G_\text{F}` is the Fermi constant. The operator basis :math:`\mathcal{O}_i` reads:
+
+.. math::
+   :nowrap:
+
+   \begin{align*}
+      \mathcal{O}_{VL}^{UD\ell\nu} & = [\bar{U} \gamma_\mu      P_L D] [\bar{\ell} \gamma^\mu      P_L \nu]\,, &
+      \mathcal{O}_{VR}^{UD\ell\nu} & = [\bar{U} \gamma_\mu      P_R D] [\bar{\ell} \gamma^\mu      P_L \nu]\,, \\
+      \mathcal{O}_{SL}^{UD\ell\nu} & = [\bar{U}                 P_L D] [\bar{\ell}                 P_L \nu]\,, &
+      \mathcal{O}_{SR}^{UD\ell\nu} & = [\bar{U}                 P_R D] [\bar{\ell}                 P_L \nu]\,, \\
+      \mathcal{O}_{T}^{UD\ell\nu}  & = [\bar{U} \sigma_{\mu\nu}     D] [\bar{\ell} \sigma^{\mu\nu} P_L \nu]\,.
+   \end{align*}
+
+The Wilson coefficients :math:`\mathcal{C}_i^{UD\ell\nu}(\mu)` are defined at the sector-specific scale :math:`\mu^{UD\ell\nu}` and are dimensionless.
+Their parameters use the prefix ``UDlnul``, where ``U``, ``D``, and ``l`` are understood as metavariables.

--- a/doc/physics/conventions.rst.py
+++ b/doc/physics/conventions.rst.py
@@ -1,5 +1,5 @@
 import eos
-from jinja_util import print_template, qn_to_link_map
+from jinja_util import print_template
 
 def get_units():
    unit_names = {m if m[0].isupper() else 'Undefined' for m in dir(eos.Unit)}

--- a/doc/physics/hadronic-matrix-elements.rst
+++ b/doc/physics/hadronic-matrix-elements.rst
@@ -83,10 +83,12 @@ For a generic form factor :math:`F(q^2)`, it reads:
    :nowrap:
 
    \begin{equation*}
-      F(q^2) = \frac{1}{q^2 - M_R^2} \left[\sum_{i=0}^N \alpha^{(F)}_{i} z^i(q^2) \right]\,.
+      F(q^2) = \frac{1}{1 - q^2 / M_R^2} \left[\sum_{i=0}^N \alpha^{(F)}_{i} \left(z(q^2) - z(0)\right)^i \right]\,.
    \end{equation*}
 
 Here :math:`M_R` correspond to the mass of the first resonance seen by that form factor and :math:`\alpha_i^{(F)}` are free parameters.
+The coefficients :math:`\alpha_i^{(F)}` are treated as unconstrained free parameters:
+there is no expectation for the magnitude of any individual coefficient, nor is there an expectation that the series of coefficients converges.
 We use the conformal mapping :math:`q^2 \mapsto z(q^2) = z(q^2; t_+, t_0)`, which reads
 
 .. math::

--- a/doc/physics/hadronic-matrix-elements.rst
+++ b/doc/physics/hadronic-matrix-elements.rst
@@ -72,6 +72,53 @@ where we abbreviate:
 
 Here, :math:`\eta` is the polarization vector of the vector meson, and again :math:`q = p - k` is the momentum transfer.
 
+In the case of the decay of a spin-parity :math:`J^P = 1/2^+` baryon (:math:`\mathcal{B}_1`) to another :math:`1/2^+` baryon (:math:`\mathcal{B}_2`),
+EOS uses the following helicity-based definitions.
+Abbreviating :math:`s_\pm \equiv (M_{\mathcal{B}_1} \pm M_{\mathcal{B}_2})^2 - q^2`,
+the vector and axialvector matrix elements are defined as:
+
+.. math::
+   :nowrap:
+
+   \begin{align*}
+      \braket{\mathcal{B}_2(k, s') | \bar{q}_1 \gamma^\mu q_2 | \mathcal{B}_1(p, s)}
+         & = \bar{u}(k, s') \bigg[
+              f_t^V(q^2)\, (M_{\mathcal{B}_1} - M_{\mathcal{B}_2}) \frac{q^\mu}{q^2}
+            + f_0^V(q^2)\, \frac{M_{\mathcal{B}_1} + M_{\mathcal{B}_2}}{s_+} \left( (p + k)^\mu - \frac{M_{\mathcal{B}_1}^2 - M_{\mathcal{B}_2}^2}{q^2} q^\mu \right) \\
+         & \qquad\qquad + f_\perp^V(q^2) \left( \gamma^\mu - \frac{2 M_{\mathcal{B}_2}}{s_+} p^\mu - \frac{2 M_{\mathcal{B}_1}}{s_+} k^\mu \right)
+              \bigg] u(p, s)\,, \\
+      \braket{\mathcal{B}_2(k, s') | \bar{q}_1 \gamma^\mu \gamma_5 q_2 | \mathcal{B}_1(p, s)}
+         & = -\bar{u}(k, s')\, \gamma_5 \bigg[
+              f_t^A(q^2)\, (M_{\mathcal{B}_1} + M_{\mathcal{B}_2}) \frac{q^\mu}{q^2}
+            + f_0^A(q^2)\, \frac{M_{\mathcal{B}_1} - M_{\mathcal{B}_2}}{s_-} \left( (p + k)^\mu - \frac{M_{\mathcal{B}_1}^2 - M_{\mathcal{B}_2}^2}{q^2} q^\mu \right) \\
+         & \qquad\qquad + f_\perp^A(q^2) \left( \gamma^\mu + \frac{2 M_{\mathcal{B}_2}}{s_-} p^\mu - \frac{2 M_{\mathcal{B}_1}}{s_-} k^\mu \right)
+              \bigg] u(p, s)\,,
+   \end{align*}
+
+while the tensor and axialtensor matrix elements are defined as:
+
+.. math::
+   :nowrap:
+
+   \begin{align*}
+      \braket{\mathcal{B}_2(k, s') | \bar{q}_1\, i \sigma^{\mu\nu} q_\nu q_2 | \mathcal{B}_1(p, s)}
+         & = -\bar{u}(k, s') \bigg[
+              f_0^T(q^2)\, \frac{q^2}{s_+} \left( (p + k)^\mu - \frac{M_{\mathcal{B}_1}^2 - M_{\mathcal{B}_2}^2}{q^2} q^\mu \right) \\
+         & \qquad\qquad + f_\perp^T(q^2)\, (M_{\mathcal{B}_1} + M_{\mathcal{B}_2}) \left( \gamma^\mu - \frac{2 M_{\mathcal{B}_2}}{s_+} p^\mu - \frac{2 M_{\mathcal{B}_1}}{s_+} k^\mu \right)
+              \bigg] u(p, s)\,, \\
+      \braket{\mathcal{B}_2(k, s') | \bar{q}_1\, i \sigma^{\mu\nu} q_\nu \gamma_5 q_2 | \mathcal{B}_1(p, s)}
+         & = -\bar{u}(k, s')\, \gamma_5 \bigg[
+              f_0^{T5}(q^2)\, \frac{q^2}{s_-} \left( (p + k)^\mu - \frac{M_{\mathcal{B}_1}^2 - M_{\mathcal{B}_2}^2}{q^2} q^\mu \right) \\
+         & \qquad\qquad + f_\perp^{T5}(q^2)\, (M_{\mathcal{B}_1} - M_{\mathcal{B}_2}) \left( \gamma^\mu + \frac{2 M_{\mathcal{B}_2}}{s_-} p^\mu - \frac{2 M_{\mathcal{B}_1}}{s_-} k^\mu \right)
+              \bigg] u(p, s)\,.
+   \end{align*}
+
+Here, :math:`u(p, s)` and :math:`u(k, s')` are the Dirac spinors of the initial- and final-state baryon,
+and again :math:`q = p - k` is the momentum transfer.
+The ten form factors are labelled by the current (:math:`V`, :math:`A`, :math:`T`, :math:`T5`) and by their helicity:
+:math:`t` (timelike), :math:`0` (longitudinal), and :math:`\perp` (transverse); the tensor currents have no timelike component.
+Within EOS the corresponding parameters carry the labels ``time``, ``long``, and ``perp``.
+
 
 Parametrisation of Semileptonic Form Factors
 --------------------------------------------

--- a/doc/physics/hadronic-matrix-elements.rst
+++ b/doc/physics/hadronic-matrix-elements.rst
@@ -1,68 +1,12 @@
-==================================
-Summary of the Physics Conventions
-==================================
+===========================================
+Hadronic Matrix Elements of Local Operators
+===========================================
 
-EOS implicitly uses the following conventions in the predictions of flavour physics observables.
-
-Units
------
-
-EOS uses natural units :math:`(\hbar = c =1)`.
-Most quantities are expressed in powers of GeV.
-Exceptions include lifetimes, which are expressed in seconds.
-Units are specified in the definition of observables and parameters (which can be found in this documentation (`here <constraints.html>`_ and `here <parameters.html>`_, respectively),
-or directly from python, as described in the `basic examples <../user-guide/basics.html>`_).
-EOS currently implements the following units:
-
-{% for unit, latex in units %}
-* ``{{ unit }}``: {{ latex }}
-{% endfor %}
-
-
-Weak Effective Theory
----------------------
-
-We follow the conventions of the WCxf format for the Wilson coefficients of the effective Hamiltonian at mass dimension six.
-Each sector of the effective Hamiltonian is defined by a unique name, corresponding to the flavour quantum numbers
-of the fermion fields.
-
-Semileptonic Charged-Current Operators
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-We use the Bern class-III notation for the semileptonic charged-current operators.
-For down-type (:math:`D`) to up-type (:math:`U`) semileptonic decays, the sector of the effective theory is described by the Lagrangian:
-
-.. math::
-   :nowrap:
-
-   \begin{align*}
-      \mathcal{L}^{UD\ell\nu}
-        = -\frac{4 G_\text{F}}{\sqrt{2}} V_{UD} \sum_{i} \mathcal{C}_i^{UD\ell\nu}(\mu) \, \mathcal{O}_i + \text{h.c.}\,,
-   \end{align*}
-
-
-where :math:`V_{UD}` is the CKM matrix element, :math:`G_\text{F}` is the Fermi constant. The operator basis :math:`\mathcal{O}_i` reads:
-
-.. math::
-   :nowrap:
-
-   \begin{align*}
-      \mathcal{O}_{VL}^{UD\ell\nu} & = [\bar{U} \gamma_\mu      P_L D] [\bar{\ell} \gamma^\mu      P_L \nu]\,, &
-      \mathcal{O}_{VR}^{UD\ell\nu} & = [\bar{U} \gamma_\mu      P_R D] [\bar{\ell} \gamma^\mu      P_L \nu]\,, \\
-      \mathcal{O}_{SL}^{UD\ell\nu} & = [\bar{U}                 P_L D] [\bar{\ell}                 P_L \nu]\,, &
-      \mathcal{O}_{SR}^{UD\ell\nu} & = [\bar{U}                 P_R D] [\bar{\ell}                 P_L \nu]\,, \\
-      \mathcal{O}_{T}^{UD\ell\nu}  & = [\bar{U} \sigma_{\mu\nu}     D] [\bar{\ell} \sigma^{\mu\nu} P_L \nu]\,.
-   \end{align*}
-
-The Wilson coefficients :math:`\mathcal{C}_i^{UD\ell\nu}(\mu)` are defined at the sector-specific scale :math:`\mu^{UD\ell\nu}` and are dimensionless.
-Their parameters use the prefix ``UDlnul``, where ``U``, ``D``, and ``l`` are understood as metavariables.
-
-
-Hadronic Matrix Elements
-------------------------
+EOS uses the following conventions for the hadronic matrix elements of local operators,
+i.e. the decay constants and the semileptonic form factors.
 
 Definition of Decay Constants
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------
 
 EOS uses meson to vacuum elements for the decay of both pseudoscalar (:math:`P`) and vector (:math:`V`) mesons.
 The decay constants are defined as:
@@ -82,7 +26,7 @@ and :math:`\epsilon` is the polarization vector of the vector meson.
 The parameters describing these decay constants use the prefix ``decay-constant``.
 
 Definition of Semileptonic Form Factors
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 EOS uses the following definitions for semileptonic form factors.
 
@@ -130,7 +74,7 @@ Here, :math:`\eta` is the polarization vector of the vector meson, and again :ma
 
 
 Parametrisation of Semileptonic Form Factors
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------------
 
 EOS provides one general-purpose parametrisation of all semileptonic form factors. It is referred to as the ``BSZ2015`` parametrisation.
 For a generic form factor :math:`F(q^2)`, it reads:

--- a/doc/physics/hadronic-matrix-elements.rst
+++ b/doc/physics/hadronic-matrix-elements.rst
@@ -54,7 +54,7 @@ In the case of the decay of a pseudoscalar meson (:math:`P`) to a vector meson (
       \braket{V(k, \eta) | \bar{q}_1 \gamma^\mu q_2 | P(p)}
          & = \frac{2 V^{P \to V}(q^2)}{M_P + M_V} \varepsilon^{\mu\nu\alpha\beta} \eta^*_\nu p_\alpha k_\beta\,, \\
       \braket{V(k, \eta) | \bar{q}_1 \gamma^\mu \gamma_5 q_2 | P(p)}
-         & = i \eta_\nu^* \left[ A_1^{P \to V}(q^2) (M_B + M_V) g^{\mu\nu} - A_2^{P \to V}(q^2) \frac{(p + k)^\mu q_\nu}{M_B + M_V} - (A_3 - A_0) \frac{2 M_V q^\mu q^\nu}{q^2}\right]\,, \\
+         & = i \eta_\nu^* \left[ A_1^{P \to V}(q^2) (M_P + M_V) g^{\mu\nu} - A_2^{P \to V}(q^2) \frac{(p + k)^\mu q_\nu}{M_P + M_V} - (A_3 - A_0) \frac{2 M_V q^\mu q^\nu}{q^2}\right]\,, \\
       \braket{V(k, \eta) | \bar{q}_1 \sigma^{\mu\nu} q_2 | P(p)}
          & = 2 T_1^{P \to V} \varepsilon^{\mu\nu\alpha\beta} \eta^*_\nu p_\alpha k_\beta\,, \\
       \braket{V(k, \eta) | \bar{q}_1 \sigma^{\mu\nu} \gamma_5 q_2 | P(p)}
@@ -67,7 +67,7 @@ where we abbreviate:
    :nowrap:
 
    \begin{equation*}
-      A_3^{P \to V}(q^2) = A_1^{P \to V}(q^2) \frac{M_B + M_V}{2 M_V} - A_2^{P \to V}(q^2) \frac{M_B - M_V}{2 M_V}\,.
+      A_3^{P \to V}(q^2) = A_1^{P \to V}(q^2) \frac{M_P + M_V}{2 M_V} - A_2^{P \to V}(q^2) \frac{M_P - M_V}{2 M_V}\,.
    \end{equation*}
 
 Here, :math:`\eta` is the polarization vector of the vector meson, and again :math:`q = p - k` is the momentum transfer.
@@ -83,7 +83,7 @@ For a generic form factor :math:`F(q^2)`, it reads:
    :nowrap:
 
    \begin{equation*}
-      F(q^2) = \frac{1}{q^2 - M_F^2} \left[\sum_{i=0}^N \alpha^{(F)}_{i} z^i(q^2) \right]\,.
+      F(q^2) = \frac{1}{q^2 - M_R^2} \left[\sum_{i=0}^N \alpha^{(F)}_{i} z^i(q^2) \right]\,.
    \end{equation*}
 
 Here :math:`M_R` correspond to the mass of the first resonance seen by that form factor and :math:`\alpha_i^{(F)}` are free parameters.
@@ -93,7 +93,7 @@ We use the conformal mapping :math:`q^2 \mapsto z(q^2) = z(q^2; t_+, t_0)`, whic
    :nowrap:
 
    \begin{equation*}
-      z(q^2; t_+, t_0) = \frac{\sqrt{t_+ - q^2} - \sqrt{t_+ - t_0}}{\sqrt{t_+ - q^2} - \sqrt{t_+ - t_0}}\,.
+      z(q^2; t_+, t_0) = \frac{\sqrt{t_+ - q^2} - \sqrt{t_+ - t_0}}{\sqrt{t_+ - q^2} + \sqrt{t_+ - t_0}}\,.
    \end{equation*}
 
 In the above, :math:`t_+ \equiv (M_1 + M_2)^2` represents the two-body threshold for the respective form factor for a reaction with hadron masses :math:`M_{1,2}`,
@@ -107,5 +107,5 @@ Examples for accessing the parameters :math:`\alpha_i^{(F)}` are:
 +-------------------+--------------+------------------------------+
 | :math:`D\to K`    | :math:`f_0`  | ``D->K::alpha^f0_2@BSZ2015`` |
 +-------------------+--------------+------------------------------+
-| :math:`B\to K^*`  | :math:`V`    | ``B->K^*::alpha^V_1@BZS2015``|
+| :math:`B\to K^*`  | :math:`V`    | ``B->K^*::alpha^V_1@BSZ2015``|
 +-------------------+--------------+------------------------------+

--- a/doc/physics/index.rst
+++ b/doc/physics/index.rst
@@ -1,0 +1,15 @@
+#######
+Physics
+#######
+
+This section documents the physics conventions that EOS uses implicitly in the
+predictions of flavour physics observables.
+It collects the choices of units, the effective field theories and their operator
+bases, and the definitions of the hadronic matrix elements of local operators
+together with their parametrisations.
+
+.. toctree::
+   :maxdepth: 3
+
+   conventions
+   hadronic-matrix-elements

--- a/doc/physics/index.rst
+++ b/doc/physics/index.rst
@@ -5,11 +5,13 @@ Physics
 This section documents the physics conventions that EOS uses implicitly in the
 predictions of flavour physics observables.
 It collects the choices of units, the effective field theories and their operator
-bases, and the definitions of the hadronic matrix elements of local operators
-together with their parametrisations.
+bases, the definitions of the hadronic matrix elements of local operators
+together with their parametrisations, and the observables that EOS predicts for
+semileptonic decays.
 
 .. toctree::
    :maxdepth: 3
 
    conventions
    hadronic-matrix-elements
+   semileptonic-observables

--- a/doc/physics/semileptonic-observables.rst
+++ b/doc/physics/semileptonic-observables.rst
@@ -1,0 +1,117 @@
+===================================
+Observables in Semileptonic Decays
+===================================
+
+EOS predicts a large number of observables for exclusive semileptonic decays,
+i.e. decays that proceed through a charged-current transition of the type described by the
+`semileptonic charged-current operators <conventions.html#semileptonic-charged-current-operators>`_.
+The available observables depend on the spin of the final-state hadron.
+This section summarises the observables that EOS provides for the two most common cases:
+the decay to a pseudoscalar meson (:math:`P`) and the decay to a vector meson (:math:`V`).
+Both cases are built from the corresponding
+`semileptonic form factors <hadronic-matrix-elements.html#definition-of-semileptonic-form-factors>`_.
+
+Throughout, :math:`q^2` denotes the invariant mass squared of the lepton-neutrino pair,
+and the physical :math:`q^2` range extends from :math:`m_\ell^2` to :math:`(M_1 - M_2)^2`,
+where :math:`M_1` and :math:`M_2` are the masses of the initial- and final-state hadron.
+For each decay, EOS provides observables that are
+
+* *fully differential* in :math:`q^2` and the decay angles;
+* *single differential* in :math:`q^2`, obtained by integrating over the angles; and
+* *integrated* over a :math:`q^2` interval :math:`[q^2_\text{min}, q^2_\text{max}]`.
+
+In addition, EOS provides a set of *normalised* observables, in which the dependence on the CKM matrix
+element :math:`|V_{UD}|` is removed (i.e. :math:`|V_{UD}| = 1`), and a set of *lepton-flavour-universality (LFU) ratios*.
+
+Decays to a Pseudoscalar Meson
+------------------------------
+
+For a decay :math:`P_1 \to P_2\, \ell\, \bar\nu` to a pseudoscalar meson, the kinematics are
+described by :math:`q^2` and a single angle: the helicity angle :math:`\theta_\ell` of the charged lepton,
+defined in the rest frame of the lepton-neutrino pair.
+The fully differential decay rate is a second-order polynomial in :math:`\cos\theta_\ell`:
+
+.. math::
+   :nowrap:
+
+   \begin{equation*}
+      \frac{d^2\Gamma}{dq^2\, d\cos\theta_\ell}
+        = a_\ell(q^2) + b_\ell(q^2) \cos\theta_\ell + c_\ell(q^2) \cos^2\theta_\ell\,.
+   \end{equation*}
+
+From this distribution EOS derives, as functions of :math:`q^2` and as quantities integrated over a :math:`q^2` bin:
+
+* the differential decay width :math:`d\Gamma/dq^2` and branching ratio :math:`d\mathcal{B}/dq^2`
+  (e.g. ``B->pilnu::dBR/dq2``), and the integrated branching ratio (``B->pilnu::BR``);
+* the leptonic forward-backward asymmetry :math:`A_\text{FB}(q^2)`
+  (``B->pilnu::A_FB(q2)``), which is sensitive to :math:`b_\ell(q^2)`;
+* the flat term :math:`F_H` (``B->pilnu::F_H``), which quantifies the angular-independent contribution
+  to the distribution and vanishes in the massless-lepton limit; and
+* the longitudinal lepton-polarisation asymmetry :math:`A_\lambda^\ell` (``B->pilnu::A_l``).
+
+LFU ratios compare the rates into different lepton flavours, for example
+
+.. math::
+   :nowrap:
+
+   \begin{equation*}
+      R_{P} = \frac{\mathcal{B}(P_1 \to P_2\, \tau\, \bar\nu)}{\mathcal{B}(P_1 \to P_2\, \ell\, \bar\nu)}\,,
+      \qquad \ell = e, \mu\,,
+   \end{equation*}
+
+which EOS exposes both integrated (``B->pilnu::R_pi``) and differential in :math:`q^2` (``B->pilnu::R_pi(q2)``).
+
+Decays to a Vector Meson
+------------------------
+
+For a decay :math:`P \to V(\to P_1 P_2)\, \ell\, \bar\nu` to a vector meson, the subsequent decay of the
+vector meson makes the full angular distribution accessible.
+The kinematics are described by :math:`q^2` and three angles: the helicity angle :math:`\theta_\ell` of the
+charged lepton, the helicity angle :math:`\theta_V` of the vector meson (defined through its decay products),
+and the azimuthal angle :math:`\phi` between the two decay planes.
+The fully differential decay rate reads
+
+.. math::
+   :nowrap:
+
+   \begin{align*}
+      \frac{d^4\Gamma}{dq^2\, d\cos\theta_\ell\, d\cos\theta_V\, d\phi}
+        = \frac{9}{32\pi} \Big[
+        & \left(J_{1s} \sin^2\theta_V + J_{1c} \cos^2\theta_V\right)
+          + \left(J_{2s} \sin^2\theta_V + J_{2c} \cos^2\theta_V\right) \cos 2\theta_\ell \\
+        & + J_3 \sin^2\theta_V \sin^2\theta_\ell \cos 2\phi
+          + J_4 \sin 2\theta_V \sin 2\theta_\ell \cos\phi
+          + J_5 \sin 2\theta_V \sin\theta_\ell \cos\phi \\
+        & + \left(J_{6s} \sin^2\theta_V + J_{6c} \cos^2\theta_V\right) \cos\theta_\ell
+          + J_7 \sin 2\theta_V \sin\theta_\ell \sin\phi \\
+        & + J_8 \sin 2\theta_V \sin 2\theta_\ell \sin\phi
+          + J_9 \sin^2\theta_V \sin^2\theta_\ell \sin 2\phi
+        \Big]\,,
+   \end{align*}
+
+where the twelve angular coefficient functions :math:`J_i \equiv J_i(q^2)` encode the full information
+of the decay.
+EOS provides each of the :math:`J_i` both differentially in :math:`q^2` (e.g. ``B->D^*lnu::J_1c(q2)``)
+and integrated over a :math:`q^2` bin (e.g. ``B->D^*lnu::J_1c``).
+
+From the angular coefficients EOS derives further observables, as functions of :math:`q^2` and integrated
+over a :math:`q^2` bin, including:
+
+* the differential decay width :math:`d\Gamma/dq^2` and branching ratio :math:`d\mathcal{B}/dq^2`
+  (e.g. ``B->D^*lnu::dBR/dq2``), and the integrated branching ratio (``B->D^*lnu::BR``);
+* the leptonic forward-backward asymmetry :math:`A_\text{FB}(q^2)` (``B->D^*lnu::A_FB(q2)``);
+* the longitudinal polarisation fraction :math:`F_\text{L}` of the vector meson (``B->D^*lnu::F_L``); and
+* a set of angular and CP asymmetries :math:`A_\text{C}^{1,2,3}` and :math:`A_\text{T}^{1,2,3}`
+  (e.g. ``B->D^*lnu::A_C^1``, ``B->D^*lnu::A_T^1``).
+
+As in the pseudoscalar case, EOS provides LFU ratios, for example
+
+.. math::
+   :nowrap:
+
+   \begin{equation*}
+      R_{V} = \frac{\mathcal{B}(P \to V\, \tau\, \bar\nu)}{\mathcal{B}(P \to V\, \ell\, \bar\nu)}\,,
+      \qquad \ell = e, \mu\,,
+   \end{equation*}
+
+available both integrated (``B->D^*lnu::R_D^*``) and differential in :math:`q^2` (``B->D^*lnu::R_{D^*}^{tau/mu}(q2)``).

--- a/doc/physics/semileptonic-observables.rst
+++ b/doc/physics/semileptonic-observables.rst
@@ -5,10 +5,12 @@ Observables in Semileptonic Decays
 EOS predicts a large number of observables for exclusive semileptonic decays,
 i.e. decays that proceed through a charged-current transition of the type described by the
 `semileptonic charged-current operators <conventions.html#semileptonic-charged-current-operators>`_.
-The available observables depend on the spin of the final-state hadron.
-This section summarises the observables that EOS provides for the two most common cases:
-the decay to a pseudoscalar meson (:math:`P`) and the decay to a vector meson (:math:`V`).
-Both cases are built from the corresponding
+The available observables depend on the spin of the initial- and final-state hadrons.
+This section summarises the observables that EOS provides for three common cases:
+the decay of a pseudoscalar meson to a pseudoscalar meson (:math:`P`),
+the decay of a pseudoscalar meson to a vector meson (:math:`V`), and
+the decay of a spin-:math:`1/2` baryon to a spin-:math:`1/2` baryon.
+All three cases are built from the corresponding
 `semileptonic form factors <hadronic-matrix-elements.html#definition-of-semileptonic-form-factors>`_.
 
 Throughout, :math:`q^2` denotes the invariant mass squared of the lepton-neutrino pair,
@@ -115,3 +117,61 @@ As in the pseudoscalar case, EOS provides LFU ratios, for example
    \end{equation*}
 
 available both integrated (``B->D^*lnu::R_D^*``) and differential in :math:`q^2` (``B->D^*lnu::R_{D^*}^{tau/mu}(q2)``).
+
+Decays to a Spin-1/2 Baryon
+---------------------------
+
+For the decay of a spin-parity :math:`J^P = 1/2^+` baryon to another :math:`1/2^+` baryon,
+:math:`\mathcal{B}_1 \to \mathcal{B}_2\, \ell\, \bar\nu`
+(e.g. :math:`\Lambda_b \to \Lambda_c\, \ell\, \bar\nu`), the final-state baryon is itself unstable.
+Its subsequent decay :math:`\mathcal{B}_2 \to \mathcal{B}_3\, \pi` (e.g. :math:`\Lambda_c \to \Lambda\, \pi`)
+acts as a polarisation analyser and thereby makes the full angular distribution accessible.
+The kinematics are described by :math:`q^2` and three angles: the helicity angle :math:`\theta_\ell`
+of the charged lepton (in the lepton-neutrino rest frame), the helicity angle :math:`\theta_\mathcal{B}`
+of the daughter baryon (defined through :math:`\mathcal{B}_2 \to \mathcal{B}_3\, \pi`), and the azimuthal
+angle :math:`\phi` between the two decay planes.
+Assuming the initial-state baryon :math:`\mathcal{B}_1` to be **unpolarised**, the fully differential decay rate reads
+
+.. math::
+   :nowrap:
+
+   \begin{align*}
+      \frac{d^4\Gamma}{dq^2\, d\cos\theta_\ell\, d\cos\theta_\mathcal{B}\, d\phi}
+        = \frac{3}{8\pi} \Big[
+        & \left(K_{1ss} \sin^2\theta_\ell + K_{1cc} \cos^2\theta_\ell + K_{1c} \cos\theta_\ell\right) \\
+        & + \left(K_{2ss} \sin^2\theta_\ell + K_{2cc} \cos^2\theta_\ell + K_{2c} \cos\theta_\ell\right) \cos\theta_\mathcal{B} \\
+        & + \left(K_{3sc} \sin\theta_\ell \cos\theta_\ell + K_{3s} \sin\theta_\ell\right) \sin\theta_\mathcal{B} \sin\phi \\
+        & + \left(K_{4sc} \sin\theta_\ell \cos\theta_\ell + K_{4s} \sin\theta_\ell\right) \sin\theta_\mathcal{B} \cos\phi
+        \Big]\,,
+   \end{align*}
+
+where the ten angular coefficient functions :math:`K_i \equiv K_i(q^2)` encode the full information
+of the decay.
+A non-zero polarisation of the initial-state baryon would introduce additional angular structures,
+and hence further angular coefficients, beyond these ten.
+EOS provides the :math:`K_i` integrated over a :math:`q^2` bin and normalised to the decay width
+(e.g. ``Lambda_b->Lambda_clnu::K_1ss``).
+
+From the angular coefficients EOS derives further observables, as functions of :math:`q^2` and integrated
+over a :math:`q^2` bin, including:
+
+* the differential decay width and branching ratio :math:`d\mathcal{B}/dq^2`
+  (``Lambda_b->Lambda_clnu::dBR/dq2``), and the integrated branching ratio (``Lambda_b->Lambda_clnu::BR``);
+* the leptonic forward-backward asymmetry :math:`A_\text{FB}^\ell` (``Lambda_b->Lambda_clnu::A_FB^l(q2)``);
+* the hadronic forward-backward asymmetry :math:`A_\text{FB}^h` (``Lambda_b->Lambda_clnu::A_FB^h(q2)``),
+  which arises from the polarisation of the daughter baryon;
+* the combined lepton-hadron forward-backward asymmetry :math:`A_\text{FB}^{h\ell}`
+  (``Lambda_b->Lambda_clnu::A_FB^c(q2)``); and
+* the fraction :math:`F_0` (``Lambda_b->Lambda_clnu::F_0(q2)``).
+
+As in the meson cases, EOS provides LFU ratios, for example
+
+.. math::
+   :nowrap:
+
+   \begin{equation*}
+      R_{\mathcal{B}_2} = \frac{\mathcal{B}(\mathcal{B}_1 \to \mathcal{B}_2\, \tau\, \bar\nu)}{\mathcal{B}(\mathcal{B}_1 \to \mathcal{B}_2\, \ell\, \bar\nu)}\,,
+      \qquad \ell = e, \mu\,,
+   \end{equation*}
+
+available as an integrated observable (``Lambda_b->Lambda_clnu::R(Lambda_c)``).

--- a/doc/reference/defining-observables.rst
+++ b/doc/reference/defining-observables.rst
@@ -91,7 +91,7 @@ This can be done using the :meth:`eos.Observables.insert` method.
     eos.Observables().insert(name, latex, unit, options, expression)
 
 Here the arguments ``name``, ``latex`` and ``unit`` are the qualified name, the latex representation, and the unit of the new observable, respectively.
-For the list of valid units, see `here <physics-conventions.html#units>`_.
+For the list of valid units, see `here <../physics/conventions.html#units>`_.
 
 The argument ``options`` takes an :class:`eos.Options` object and allows to specify *global* options (i.e. applied to all observables in the expression),
 for the newly defined observable.

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -7,7 +7,6 @@ This section
 .. toctree::
    :maxdepth: 3
 
-   physics-conventions
    python
    command-line-interface
    defining-observables

--- a/doc/reference/python.rst.jinja
+++ b/doc/reference/python.rst.jinja
@@ -102,6 +102,10 @@ EOS provides access to save and load the various (intermediate) results of analy
 Plotting
 ********
 
+.. deprecated:: 1.0.21
+   The ``eos.plot`` subpackage will be removed in version 1.1.
+   Use the ``eos.figure`` subpackage instead.
+
 EOS provides a plotting framework based on `Matplotlib <https://matplotlib.org/>`_.
 Plots can readily be created from a Python script, from within a Jupyter notebook,
 or in the command line using the ``eos-plot`` script.

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -861,6 +861,10 @@ def corner_plot(analysis_file:str, posterior:str, base_directory:str='./', forma
     """
     Generates a corner plot of the 1-D and 2-D marginalized posteriors.
 
+    .. deprecated:: 1.0.21
+       The ``corner-plot`` task will be removed in version 1.1.
+       Use the ``corner`` figure type (:class:`eos.figure.CornerFigure`) from the ``eos.figure`` subpackage instead.
+
     The input files are expected in EOS_BASE_DIRECTORY/data/POSTERIOR/samples.
     The output files will be stored in EOS_BASE_DIRECTORY/data/POSTERIOR/plots.
 


### PR DESCRIPTION
- b56f916d [doc] Deprecate ``eos.plot`` for removal in version 1.1.
- f8dae0ef [doc] Deprecate the ``corner-plot`` task for removal in version 1.1.
- cee51bb3 [doc] Split the physics documentation into its own top-level section.
- dade10c0 [doc] Fix typos in the documentation of the semileptonic form factors.
- d309c58c [doc] Fix errors in the BSZ2015 documentation and add cautionary note on coefficient size.
- 0fd87205 [doc] Add rudimentary documentation for semileptonic decays.
- f677b262 [doc] Document the 1/2^+->1/2^+ form factors.
- 30ded7b8 [doc] Document the 1/2^+->1/2^+ l nu observables.
- 8a171d73 [eos] Update changelog for PR #1209.