### PR TITLE
Fix two long-standing bugs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -148,6 +148,8 @@
 - Fix a latent initialization-order bug in the [GP:2004A] B->K^*ll amplitudes, where the ``lambda_*`` and ``sl_phase_*`` subleading parameters read the ``use_simple_sl`` flag before it was initialized (D. van Dyk)
 - Fix various C++ compiler warnings (``-Wreorder``, ``-Wunused-parameter``, ``-Wignored-qualifiers``, ``-Wunused-variable``, ``-Woverloaded-virtual``) (D. van Dyk)
 - Fix the workflow that uploads compiler-warning SARIF to code scanning, which failed on warning-free builds because the merged SARIF contained an empty set of runs (D. van Dyk)
+- Fix inconsistency in the expected values for options related to SSLP Isgur-Wise functions in the unitarity bounds (D. van Dyk)
+- Fix a long-standing memory leak in ``ThreadPool`` (D. van Dyk)
 
 
 ## [v1.0.20] - 2026-04-28

--- a/eos/form-factors/unitarity-bounds.cc
+++ b/eos/form-factors/unitarity-bounds.cc
@@ -64,7 +64,7 @@ namespace eos
 
         //B^_s(*)->D_s^(*)
         // option to determine if we use the SU3_F-symmetry limit for the subsubleading-power IW functions
-        SwitchOption opt_sslp_limit;
+        BooleanOption opt_sslp_limit;
 
         // parameters for the leading Isgur-Wise function xi
         UsedParameter xispone, xisppone, xispppone;
@@ -94,7 +94,7 @@ namespace eos
 
         std::string _sslp_prefix()
         {
-            if ("1" == opt_sslp_limit.value())
+            if (opt_sslp_limit.value())
                 return "B(*)->D(*)";
 
             return "B_s(*)->D_s(*)";
@@ -130,7 +130,7 @@ namespace eos
             l6one(p["B(*)->D(*)::l_6(1)@HQET"], u),
             l6pone(p["B(*)->D(*)::l_6'(1)@HQET"], u),
             l6ppone(p["B(*)->D(*)::l_6''(1)@HQET"], u),
-            opt_sslp_limit(o, "SU3F-limit-sslp"_ok, { "0"_ov, "1"_ov }, "0"_ov),
+            opt_sslp_limit(o, options, "SU3F-limit-sslp"_ok),
             xispone(p["B_s(*)->D_s(*)::xi'(1)@HQET"], u),
             xisppone(p["B_s(*)->D_s(*)::xi''(1)@HQET"], u),
             xispppone(p["B_s(*)->D_s(*)::xi'''(1)@HQET"], u),
@@ -2223,7 +2223,7 @@ namespace eos
     const std::vector<OptionSpecification>
     Implementation<BGLCoefficients>::options
     {
-        { "SU3F-limit-sslp"_ok, { "0"_ov, "1"_ov }, "0"_ov }
+        { "SU3F-limit-sslp"_ok, { "true"_ov, "false"_ov }, "false"_ov }
     };
 
     BGLCoefficients::BGLCoefficients(const Parameters & p, const Options & o) :
@@ -2871,7 +2871,7 @@ namespace eos
     const std::vector<OptionSpecification>
     Implementation<HQETUnitarityBounds>::options
     {
-        { "SU3F-limit-sslp"_ok, { "0"_ov, "1"_ov }, "0"_ov },
+        { "SU3F-limit-sslp"_ok, { "true"_ov, "false"_ov }, "false"_ov },
         { "z-order-bound"_ok,   { "1"_ov, "2"_ov }, "2"_ov }
     };
 

--- a/eos/utils/thread_pool.cc
+++ b/eos/utils/thread_pool.cc
@@ -50,19 +50,20 @@ namespace eos
             unsigned long waiting_for_jobs;
             unsigned long pending_jobs;
 
-            std::list<std::pair<Ticket, std::function<void(void)> *>> queue;
+            std::list<std::pair<Ticket, std::function<void(void)>>> queue;
 
             std::list<Thread *> threads;
 
             void
             thread_function()
             {
-                std::function<void(void)> * job;
-                Ticket                      ticket;
+                std::function<void(void)> job;
+                Ticket                    ticket;
+                bool                      have_job;
 
                 do
                 {
-                    job = 0;
+                    have_job = false;
 
                     {
                         Lock l(*job_mutex);
@@ -91,16 +92,20 @@ namespace eos
                             continue;
                         }
 
-                        ticket = queue.front().first;
-                        job    = queue.front().second;
+                        ticket   = queue.front().first;
+                        job      = std::move(queue.front().second);
+                        have_job = true;
                         queue.pop_front();
                     }
 
                     // Execute the job outside the critical section
-                    if (job)
+                    if (have_job)
                     {
-                        (*job)();
+                        job();
                         ticket.mark();
+
+                        // Release the job (and any state it captured) promptly.
+                        job = nullptr;
                     }
 
                     {
@@ -177,11 +182,11 @@ namespace eos
     Ticket
     ThreadPool::enqueue(const std::function<void(void)> & job)
     {
-        std::pair<Ticket, std::function<void(void)> *> item(Ticket(), new std::function<void(void)>(job));
+        Ticket ticket;
 
         {
             Lock l(*_imp->job_mutex);
-            _imp->queue.push_back(item);
+            _imp->queue.push_back(std::make_pair(ticket, job));
             _imp->pending_jobs += 1;
 
             if (_imp->waiting_for_jobs > 0)
@@ -190,7 +195,7 @@ namespace eos
             }
         }
 
-        return item.first;
+        return ticket;
     }
 
     ThreadPool *


### PR DESCRIPTION
- 7bc3209e [form-factors] Make option behaviour consistent for HQE unitarity bounds. The form factor option had previously been converted to ``BooleanOption``, although the unitarity bound option was not modified. The former now exected ``true``/``false`` literals, while the latter one only accepted ``1``/``0`` literals.
- a2c8912d [utils] Fix memory leak in ``ThreadPool``. Accidentally, jobs had been allocated with ``new`` but never de-allocated. The fix rectifies things by not allocating the jobs at all; rather, it emplaces the existing jobs into the queue. Reduces memory pressure for large analyses with low sampling efficiency.
- ac85e482 [eos] Update changelog for PR #1211.