### PR TITLE
Rewrite analysis file validation framework

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,12 @@
 
 ### Changed
 
+- Report problems in an analysis file as located ``eos.diagnostic.Diagnostic`` objects in lieu of raising on the first one: loading now enforces a structural validation phase, while a separate and side-effect-free semantic phase resolves the file's own custom parameters, observables and constraints through a per-file validation context, checks expressions through the C++ expression parser without registering them, reports unused priors, likelihoods, masks, and custom entities, and reports parameters that a posterior fixes while one of its own priors varies them or that neither its likelihood nor any of its predictions uses (D. van Dyk)
+- Restrict file-local names in analysis files to exclude `/` and whitespace (D. van Dyk)
+
 ### Added
+
+- Add the function ``eos.analyze_expression``, which reports whether an EOS expression is well-formed and which observables and parameters it references, without registering anything (D. van Dyk)
 
 ### Deprecated
 

--- a/eos/observable.cc
+++ b/eos/observable.cc
@@ -38,7 +38,7 @@
 #include <eos/utils/concrete_observable.hh>
 #include <eos/utils/expression-fwd.hh>
 #include <eos/utils/expression-observable.hh>
-#include <eos/utils/expression-parser-impl.hh>
+#include <eos/utils/expression-parser.hh>
 #include <eos/utils/instantiation_policy-impl.hh>
 #include <eos/utils/log.hh>
 #include <eos/utils/observable_stub.hh>
@@ -374,18 +374,7 @@ namespace eos
     void
     Observables::insert(const QualifiedName & name, const std::string & latex, const Unit & unit, const Options & forced_options, const std::string & input) const
     {
-        eos::exp::ExpressionPtr expression(nullptr);
-
-        using It = std::string::const_iterator;
-        ExpressionParser<It> parser;
-
-        It   first(input.begin()), last(input.end());
-        bool completed = qi::phrase_parse(first, last, parser, ascii::space, expression) && (first == last);
-
-        if ((! completed) || (! expression))
-        {
-            throw ParsingError("Could not parse expression '" + input + "'");
-        }
+        eos::exp::ExpressionPtr expression = eos::exp::parse_expression(input);
 
         ExpressionObservableEntry * expression_observable_entry = new ExpressionObservableEntry(name, latex, unit, expression, forced_options);
 
@@ -419,22 +408,7 @@ namespace eos
 
         const QualifiedName qn(name);
         const std::string   input(_expression);
-        ExpressionPtr       expression(nullptr);
-
-        {
-            bool completed;
-
-            using It = std::string::const_iterator;
-            ExpressionParser<It> parser;
-
-            It first(input.begin()), last(input.end());
-            completed = qi::phrase_parse(first, last, parser, ascii::space, expression) && (first == last);
-
-            if ((! completed) || (! expression))
-            {
-                throw InternalError("Error when parsing expression " + std::string(name) + " in make_expression_observable");
-            }
-        }
+        ExpressionPtr       expression = parse_expression(input);
 
         auto result = std::make_pair(qn, ObservableEntryPtr(new ExpressionObservableEntry(qn, std::string(latex), unit, expression, Options{})));
 

--- a/eos/observable.cc
+++ b/eos/observable.cc
@@ -39,6 +39,7 @@
 #include <eos/utils/expression-fwd.hh>
 #include <eos/utils/expression-observable.hh>
 #include <eos/utils/expression-parser.hh>
+#include <eos/utils/expression-referenced-names-reader.hh>
 #include <eos/utils/instantiation_policy-impl.hh>
 #include <eos/utils/log.hh>
 #include <eos/utils/observable_stub.hh>
@@ -415,5 +416,18 @@ namespace eos
         impl::observable_entries.insert(result);
 
         return result;
+    }
+
+    ExpressionReferences
+    analyze_expression(const std::string & input)
+    {
+        const auto                           expression = exp::parse_expression(input);
+        exp::ExpressionReferencedNamesReader reader;
+        std::visit(reader, *expression);
+
+        return {
+            { reader.observable_names.begin(), reader.observable_names.end() },
+            {  reader.parameter_names.begin(),  reader.parameter_names.end() }
+        };
     }
 } // namespace eos

--- a/eos/observable.hh
+++ b/eos/observable.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et tw=150 foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2016-2019, 2022 Danny van Dyk
+ * Copyright (c) 2010-2026 Danny van Dyk
  * Copyright (c) 2024 Lorenz Gärtner
  *
  * This file is part of the EOS project. EOS is free software;
@@ -33,9 +33,18 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 namespace eos
 {
+    struct ExpressionReferences
+    {
+            std::vector<QualifiedName> observables;
+            std::vector<QualifiedName> parameters;
+    };
+
+    ExpressionReferences analyze_expression(const std::string & input);
+
     /**
      * Observable is internally used to handle the creation,
      * evaluation and cloning of any (pseudo)observable quantities.

--- a/eos/utils/Makefile.am
+++ b/eos/utils/Makefile.am
@@ -25,6 +25,7 @@ libeosutils_la_SOURCES = \
 	expression-observable.cc expression-observable.hh \
 	expression-parser.cc expression-parser.hh expression-parser-impl.hh \
 	expression-printer.hh \
+	expression-referenced-names-reader.hh \
 	expression-used-kinematics-reader.hh expression-used-parameter-reader.hh \
 	expression-visitors.cc \
 	gsl-hacks.cc \

--- a/eos/utils/expression-parser.cc
+++ b/eos/utils/expression-parser.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Danny van Dyk
+ * Copyright (c) 2021-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -15,6 +15,7 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <eos/utils/exception.hh>
 #include <eos/utils/expression-parser-impl.hh>
 
 #include <string>
@@ -22,4 +23,23 @@
 namespace eos
 {
     template struct ExpressionParser<std::string::const_iterator>;
-}
+
+    exp::ExpressionPtr
+    exp::parse_expression(const std::string & input)
+    {
+        ExpressionPtr expression(nullptr);
+
+        using It = std::string::const_iterator;
+        ExpressionParser<It> parser;
+
+        It         first(input.begin()), last(input.end());
+        const bool completed = qi::phrase_parse(first, last, parser, ascii::space, expression) && (first == last);
+
+        if ((! completed) || (! expression))
+        {
+            throw ParsingError("Could not parse expression '" + input + "'");
+        }
+
+        return expression;
+    }
+} // namespace eos

--- a/eos/utils/expression-parser.hh
+++ b/eos/utils/expression-parser.hh
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021      Méril Reboud
- * Copyright (c) 2023-2025 Danny van Dyk
+ * Copyright (c) 2023-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -60,6 +60,11 @@ namespace eos
     };
 
     extern template struct ExpressionParser<std::string::const_iterator>;
+
+    namespace exp
+    {
+        ExpressionPtr parse_expression(const std::string & input);
+    }
 } // namespace eos
 
 #endif

--- a/eos/utils/expression-parser_TEST.cc
+++ b/eos/utils/expression-parser_TEST.cc
@@ -16,6 +16,7 @@
  * Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
+#include <eos/observable.hh>
 #include <eos/utils/expression-cacher.hh>
 #include <eos/utils/expression-cloner.hh>
 #include <eos/utils/expression-evaluator.hh>
@@ -69,6 +70,30 @@ class ExpressionParserTest : public TestCase
         virtual void
         run() const
         {
+            // Analyze directly referenced names without resolving them.
+            {
+                auto references = analyze_expression("<<A::b>>");
+                TEST_CHECK_EQUAL(std::vector<QualifiedName>({ QualifiedName("A::b") }), references.observables);
+                TEST_CHECK(references.parameters.empty());
+
+                references = analyze_expression("[[A::c]]");
+                TEST_CHECK(references.observables.empty());
+                TEST_CHECK_EQUAL(std::vector<QualifiedName>({ QualifiedName("A::c") }), references.parameters);
+
+                references = analyze_expression("<<A::b;l=tau>>[q2_min=>x] + [[A::c]]");
+                TEST_CHECK_EQUAL(std::vector<QualifiedName>({ QualifiedName("A::b;l=tau") }), references.observables);
+                TEST_CHECK_EQUAL(std::vector<QualifiedName>({ QualifiedName("A::c") }), references.parameters);
+
+                references = analyze_expression("<<B_c->J/psi::FormFactors@HPQCD:2025A>>");
+                TEST_CHECK_EQUAL(std::vector<QualifiedName>({ QualifiedName("B_c->J/psi::FormFactors@HPQCD:2025A") }), references.observables);
+
+                // These names are deliberately unregistered; analysis must not perform a lookup.
+                TEST_CHECK_NO_THROW(analyze_expression("<<Unregistered::observable>> + [[Unregistered::parameter]]"));
+
+                TEST_CHECK_THROWS(ParsingError, analyze_expression("1 /* 2"));
+                TEST_CHECK_THROWS(QualifiedNameSyntaxError, analyze_expression("<<not-a-name>>"));
+            }
+
             // testing parser failure
             {
                 ExpressionTest test("1 /* 2");

--- a/eos/utils/expression-referenced-names-reader.hh
+++ b/eos/utils/expression-referenced-names-reader.hh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#ifndef EOS_GUARD_EOS_UTILS_EXPRESSION_REFERENCED_NAMES_READER_HH
+#define EOS_GUARD_EOS_UTILS_EXPRESSION_REFERENCED_NAMES_READER_HH 1
+
+#include <eos/utils/expression-fwd.hh>
+#include <eos/utils/qualified-name.hh>
+
+#include <set>
+
+namespace eos::exp
+{
+    class ExpressionReferencedNamesReader
+    {
+        public:
+            std::set<QualifiedName> observable_names;
+            std::set<QualifiedName> parameter_names;
+
+            ExpressionReferencedNamesReader()  = default;
+            ~ExpressionReferencedNamesReader() = default;
+
+            void operator() (const BinaryExpression & e);
+            void operator() (const FunctionExpression & e);
+            void operator() (const ConstantExpression &);
+            void operator() (const ObservableNameExpression & e);
+            void operator() (const ObservableExpression & e);
+            void operator() (const ParameterNameExpression & e);
+            void operator() (const ParameterExpression & e);
+            void operator() (const KinematicVariableNameExpression &);
+            void operator() (const KinematicVariableExpression &);
+            void operator() (const CachedObservableExpression &);
+    };
+} // namespace eos::exp
+
+#endif

--- a/eos/utils/expression-visitors.cc
+++ b/eos/utils/expression-visitors.cc
@@ -25,6 +25,7 @@
 #include <eos/utils/expression-kinematic-reader.hh>
 #include <eos/utils/expression-maker.hh>
 #include <eos/utils/expression-printer.hh>
+#include <eos/utils/expression-referenced-names-reader.hh>
 #include <eos/utils/expression-used-kinematics-reader.hh>
 #include <eos/utils/expression-used-parameter-reader.hh>
 #include <eos/utils/expression.hh>
@@ -39,6 +40,66 @@
 
 namespace eos::exp
 {
+    /*
+     * ExpressionReferencedNamesReader
+     */
+    void
+    ExpressionReferencedNamesReader::operator() (const BinaryExpression & e)
+    {
+        std::visit(*this, *e.lhs);
+        std::visit(*this, *e.rhs);
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const FunctionExpression & e)
+    {
+        std::visit(*this, *e.arg);
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const ConstantExpression &)
+    {
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const ObservableNameExpression & e)
+    {
+        observable_names.insert(e.observable_name);
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const ObservableExpression & e)
+    {
+        observable_names.insert(e.observable->name());
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const ParameterNameExpression & e)
+    {
+        parameter_names.insert(e.parameter_name);
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const ParameterExpression & e)
+    {
+        parameter_names.insert(QualifiedName(e.parameter.name()));
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const KinematicVariableNameExpression &)
+    {
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const KinematicVariableExpression &)
+    {
+    }
+
+    void
+    ExpressionReferencedNamesReader::operator() (const CachedObservableExpression &)
+    {
+    }
+
     /*
      * ExpressionPrinter
      */

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -163,6 +163,7 @@ TESTS = \
 	eos/analysis_file_description_TEST.py \
 	eos/datasets_TEST.py \
 	eos/datasets_file_description_TEST.py \
+	eos/deserializable_TEST.py \
 	eos/diagnostic_TEST.py \
 	eos/serializable_TEST.py \
 	eos/tasks_TEST.py \

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -19,6 +19,7 @@ EXTRA_DIST = \
 	eos/datasets.py \
 	eos/datasets_TEST.d \
 	eos/datasets_file_description.py \
+	eos/diagnostic.py \
 	eos/deserializable.py \
 	eos/serializable.py \
 	eos/ipython.py \
@@ -97,6 +98,7 @@ eos_SCRIPTS = \
 	eos/datasets.py \
 	eos/datasets_file_description.py \
 	eos/deserializable.py \
+	eos/diagnostic.py \
 	eos/serializable.py \
 	eos/ipython.py \
 	eos/log_likelihood.py \
@@ -161,6 +163,7 @@ TESTS = \
 	eos/analysis_file_description_TEST.py \
 	eos/datasets_TEST.py \
 	eos/datasets_file_description_TEST.py \
+	eos/diagnostic_TEST.py \
 	eos/serializable_TEST.py \
 	eos/tasks_TEST.py \
 	eos/data/dynesty_results_TEST.py \

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -14,6 +14,7 @@ EXTRA_DIST = \
 	eos/analysis_file_context.py \
 	eos/analysis_file_context_TEST.py \
 	eos/analysis_file_description.py \
+	eos/validation_context.py \
 	eos/config.py \
 	eos/constraint.py \
 	eos/datasets.py \
@@ -93,6 +94,7 @@ eos_SCRIPTS = \
 	eos/analysis_file.py \
 	eos/analysis_file_context.py \
 	eos/analysis_file_description.py \
+	eos/validation_context.py \
 	eos/config.py \
 	eos/constraint.py \
 	eos/datasets.py \
@@ -161,6 +163,7 @@ TESTS = \
 	eos/analysis_file_TEST.py \
 	eos/analysis_file_context_TEST.py \
 	eos/analysis_file_description_TEST.py \
+	eos/validation_context_TEST.py \
 	eos/datasets_TEST.py \
 	eos/datasets_file_description_TEST.py \
 	eos/deserializable_TEST.py \

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -281,6 +281,13 @@ BOOST_PYTHON_MODULE(_eos)
         )",
                  args("self"));
     implicitly_convertible<std::string, QualifiedName>();
+    ::impl::std_vector_to_python_converter<QualifiedName> converter_vector_qualified_name;
+
+    class_<ExpressionReferences>("ExpressionReferences", no_init)
+            .add_property("observables", make_getter(&ExpressionReferences::observables, return_value_policy<return_by_value>()))
+            .add_property("parameters", make_getter(&ExpressionReferences::parameters, return_value_policy<return_by_value>()));
+
+    def("analyze_expression", &analyze_expression, args("input"));
 
 
     // ParameterSection

--- a/python/eos/analysis.py
+++ b/python/eos/analysis.py
@@ -270,6 +270,12 @@ class Analysis:
             for i in observable.used_parameter_ids():
                 used_parameter_names.add(self.parameters.by_id(i).name())
 
+        # the names of the parameters the likelihood registers as used; consumers (e.g.
+        # eos.AnalysisFile.validate) rely on this rather than recomputing it. Note that an
+        # implementation may register a parameter that its options exclude from the calculation,
+        # so this set is an upper bound on the actual dependence.
+        self.used_parameter_names = frozenset(used_parameter_names)
+
         used_but_unvaried = used_parameter_names - varied_parameter_names - fixed_parameter_names
         if (len(used_but_unvaried) > 0):
             eos.info(f'likelihood probably depends on {len(used_but_unvaried)} parameter(s) that do not appear in the prior; check prior?')

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -318,17 +318,38 @@ class AnalysisFile:
         if deep:
             for posterior in self._posteriors:
                 try:
-                    self.analysis(posterior)
+                    analysis = self.analysis(posterior)
                     eos.info(f'Successfully created analysis for posterior \'{posterior}\'')
+                    used_parameters = set(analysis.used_parameter_names)
 
                     for prediction in self._predictions:
                         try:
-                            self.observables(posterior, prediction, eos.Parameters())
+                            observables = self.observables(posterior, prediction, eos.Parameters())
                             eos.info(f'Successfully created prediction \'{prediction}\' set for posterior \'{posterior}\'')
+                            # a posterior's fixed parameters are merged into those of each of its
+                            # predictions, so a parameter the likelihood ignores may still matter here
+                            used_parameters.update(
+                                analysis.parameters.by_id(id).name()
+                                for observable in observables
+                                for id in observable.used_parameter_ids()
+                            )
                         except Exception as e:
                             diagnostics.append(Diagnostic(
                                 ('predictions', prediction), Severity.ERROR,
                                 f'cannot create observables for posterior \'{posterior}\': {e}'
+                            ))
+
+                    # A fixed parameter that neither the likelihood nor any prediction uses has no
+                    # effect. Note that the used-parameter set is an upper bound: an implementation
+                    # may register a parameter that its options exclude from the calculation, so a
+                    # fix that is inert for that reason is not reported here.
+                    for parameter in self._posteriors[posterior].fixed_parameters:
+                        if str(parameter) not in used_parameters:
+                            diagnostics.append(Diagnostic(
+                                ('posteriors', posterior, 'fixed_parameters', str(parameter)),
+                                Severity.WARNING,
+                                f'Parameter \'{parameter}\' is fixed but used by neither the '
+                                f'likelihood nor any prediction of posterior \'{posterior}\''
                             ))
 
                 except Exception as e:

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -26,6 +26,7 @@ from collections import Counter
 from dataclasses import asdict
 from eos.analysis_file_description import AnalysisFileDescription, PriorDescription, \
                                        MaskExpressionComponent, MaskNamedComponent
+from eos.diagnostic import Severity
 
 # The highest analysis file format version understood by this version of EOS. Increment this
 # whenever a change to the schema alters how existing files are interpreted. Files that omit the
@@ -74,33 +75,24 @@ class AnalysisFile:
                                f'{SUPPORTED_FORMAT_VERSION}; please update EOS')
 
         # Deserialize the file's structure. AnalysisFileDescription performs the pure YAML->object
-        # mapping and rejects unknown top-level keys; the mandatory-section checks, cross-reference
-        # validation, uniqueness checks, and EOS-runtime side effects below remain here.
+        # mapping and rejects unknown top-level keys. Structural validation is performed by the
+        # description before EOS-runtime side effects are applied.
         self._description = AnalysisFileDescription.from_dict(**self.input_data)
+        if isinstance(self._description, AnalysisFileDescription):
+            structural_diagnostics = list(self._description.validate_structure())
+        else:
+            structural_diagnostics = list(self._description.validate())
+        if any(diagnostic.severity is Severity.ERROR for diagnostic in structural_diagnostics):
+            rendered_diagnostics = '\n'.join(str(diagnostic) for diagnostic in structural_diagnostics)
+            raise RuntimeError(f'Cannot load analysis file:\n{rendered_diagnostics}')
 
         self._metadata = self._description.metadata
 
-        if 'priors' not in self.input_data:
-            raise RuntimeError('Cannot load analysis file: need at least one prior component')
-
         self._priors = { p.name: p for p in self._description.priors }
 
-        if 'likelihoods' not in self.input_data:
-            eos.warn('No likelihood components found in analysis file')
         self._likelihoods = { ll.name: ll for ll in self._description.likelihoods }
 
-        if 'posteriors' not in self.input_data:
-            raise RuntimeError('Cannot load analysis file: need at least one posterior')
-
         self._posteriors = { p.name: p for p in self._description.posteriors }
-        # Check that the priors and likelihoods referenced by the posteriors are defined
-        for pc in self._posteriors.values():
-            for p in pc.prior:
-                if p not in self._priors:
-                    raise RuntimeError(f'Posterior \'{pc.name}\' references prior \'{p}\' which is not defined')
-            for l in pc.likelihood:
-                if l not in self._likelihoods:
-                    raise RuntimeError(f'Posterior \'{pc.name}\' references likelihood \'{l}\' which is not defined')
 
         # Optional: figures
         self._figures = { f.name: f for f in self._description.figures }
@@ -134,12 +126,8 @@ class AnalysisFile:
                     raise ValueError(f'Unexpected value encountered in description of parameter \'{p.name}\': {e}')
             eos.completed(f'... finished declaring {len(self._params)} custom parameters')
 
-        if len(self._description.steps) != len({s.id for s in self._description.steps}):
-            raise ValueError("All steps must have a unique id")
         self._steps = { s.id: s for s in self._description.steps }
 
-        if len(self._description.masks) != len({m.name for m in self._description.masks}):
-            raise ValueError("All masks must have a unique name")
         self._masks = { m.name: m for m in self._description.masks }
         if self._masks:
             # Insert custom observables using the expression parser
@@ -149,9 +137,6 @@ class AnalysisFile:
                     if isinstance(d, MaskExpressionComponent):
                         eos.Observables().insert(d.name, "", eos.Unit("1"), eos.Options(), d.expression)
                         eos.info(f'Inserted observable: {d.name}')
-                    if isinstance(d, MaskNamedComponent):
-                        if d.mask_name not in self._masks:
-                            raise ValueError(f"Mask {mc.name} references unknown mask {d.mask_name}")
 
 
     def analysis(self, _posterior):

--- a/python/eos/analysis_file.py
+++ b/python/eos/analysis_file.py
@@ -21,12 +21,11 @@ import eos
 import os
 import sys
 import yaml
-import inspect
-from collections import Counter
 from dataclasses import asdict
 from eos.analysis_file_description import AnalysisFileDescription, PriorDescription, \
                                        MaskExpressionComponent, MaskNamedComponent
-from eos.diagnostic import Severity
+from eos.diagnostic import Diagnostic, Severity
+from eos.validation_context import ValidationContext
 
 # The highest analysis file format version understood by this version of EOS. Increment this
 # whenever a change to the schema alters how existing files are interpreted. Files that omit the
@@ -77,11 +76,10 @@ class AnalysisFile:
         # Deserialize the file's structure. AnalysisFileDescription performs the pure YAML->object
         # mapping and rejects unknown top-level keys. Structural validation is performed by the
         # description before EOS-runtime side effects are applied.
+        # from_dict returns an InvalidComponent when the top-level mapping has unknown or missing
+        # keys; it exposes the same validate_structure(), so no special case is needed here.
         self._description = AnalysisFileDescription.from_dict(**self.input_data)
-        if isinstance(self._description, AnalysisFileDescription):
-            structural_diagnostics = list(self._description.validate_structure())
-        else:
-            structural_diagnostics = list(self._description.validate())
+        structural_diagnostics = list(self._description.validate_structure())
         if any(diagnostic.severity is Severity.ERROR for diagnostic in structural_diagnostics):
             rendered_diagnostics = '\n'.join(str(diagnostic) for diagnostic in structural_diagnostics)
             raise RuntimeError(f'Cannot load analysis file:\n{rendered_diagnostics}')
@@ -300,99 +298,47 @@ class AnalysisFile:
         return observable
 
 
-    def validate(self):
-        """Validates the analysis file."""
-        messages = []
-        # Check that all priors are known to EOS
-        known_params = eos.Parameters()
-        for p_name, pc in self._priors.items():
-            for description in pc.descriptions:
-                try:
-                    known_params[description.parameter]
-                except RuntimeError:
-                    messages.append(f"Error in prior {p_name}: Parameter '{description.parameter}' not known to EOS")
-        # Check that all likelihoods contain valid constraints and manual constraints
-        known_constraints = eos.Constraints()
-        for l_name, lc in self._likelihoods.items():
-            for description in lc.constraints:
-                try:
-                    known_constraints[description.constraint]
-                except RuntimeError:
-                    messages.append(f"Error in likelihood {l_name}: Constraint '{description.constraint}'  not known to EOS")
-            for manual in lc.manual_constraints:
-                try:
-                    known_constraints[manual.name]
-                    messages.append(f"Error in likelihood {l_name}: The manual constraint named '{manual.name}' matches an already defined constraint name")
-                except RuntimeError:
-                    pass
-        # Check that all observables in a prediction are known to EOS
-        known_observables = eos.Observables()
-        for pred_name, pd in self._predictions.items():
-            for o in pd.observables:
-                try:
-                    known_observables[o.name]
-                except RuntimeError:
-                    messages.append(f"Error in prediction {pred_name}: Observable '{o.name}' not known to EOS")
-        # Check that any parameters that are fixed (in posteriors or predictions) are known to EOS
-        for p_name, posterior in self._posteriors.items():
-            for param in posterior.fixed_parameters:
-                try:
-                    known_params[param]
-                except RuntimeError:
-                    messages.append(f"Error in posterior {p_name}: Fixed parameter '{param}' not known to EOS")
-        for p_name, prediction in self._predictions.items():
-            for param in prediction.fixed_parameters:
-                try:
-                    known_params[param]
-                except RuntimeError:
-                    messages.append(f"Error in prediction {p_name}: Fixed parameter '{param}' not known to EOS")
-        for step_id, step in self._steps.items():
-            # Check that all the dependencies of a step exist
-            if (unknown_dependencies := step.depends_on - self._steps.keys()):
-                messages.append(f'Step \'{step_id}\' depends on unknown steps: {unknown_dependencies}')
-            # Check that the default arguments correspond to real tasks
-            if (unknown_tasks := step.default_arguments.keys() - eos.tasks._tasks.keys()):
-                messages.append(f'Step \'{step_id}\' has default arguments for unknown tasks: {unknown_tasks}')
-            for tc in step.tasks:
-                # Check all posteriors named in steps exist
-                if 'posterior' in tc.arguments:
-                    if tc.arguments['posterior'] not in self._posteriors:
-                        messages.append(f"Error in step {step_id}: Posterior '{tc.arguments['posterior']}' not known to EOS")
-                # Check that default arguments in steps can be applied to all specified tasks
-                task_func = eos.tasks._tasks[tc.task]
-                provided_arguments = step.default_arguments[tc.task].keys() | tc.arguments.keys()
-                known_arguments = set(inspect.signature(task_func).parameters.keys())
-                for arg in provided_arguments - known_arguments:
-                    messages.append(f'Task \'{tc.task}\' does not recognize argument \'{arg}\'')
-        # Check that any expression observables defined in masks have unique names
-        counts = Counter()
-        for mc in self._masks.values():
-            for d in mc.description:
-                if isinstance(d, MaskExpressionComponent):
-                    counts[d.name] += 1
-        repeated = {name for name, count in counts.items() if count > 1}
-        for name in repeated:
-            messages.append(f"Error in masks: Name '{name}' is used repeatedly")
+    def validate(self, deep:bool=True):
+        """Validates the analysis file semantically and, by default, deeply.
+
+        The deep phase instantiates every posterior and every prediction set, which catches errors
+        that the semantic phase cannot see: invalid options, malformed manual-constraint bodies,
+        inconsistent prior ranges, and unreadable pyhf workspaces. It is enabled by default.
+
+        :param deep: If True, additionally instantiate all posteriors and prediction sets. Defaults to True.
+        :type deep: bool
+        :returns: The diagnostics found, most-structural first.
+        :rtype: list[eos.diagnostic.Diagnostic]
+        """
+        context = ValidationContext(self._description)
+        diagnostics = list(self._description.validate_semantics(context))
 
         # Check all the posteriors can be initialised, and used for the predictions specified in the analysis file
         # This will (hopefully) act as a catch all for any errors not spotted above
-        for posterior in self._posteriors:
-            try:
-                self.analysis(posterior)
-                eos.info(f'Successfully created analysis for posterior \'{posterior}\'')
+        if deep:
+            for posterior in self._posteriors:
+                try:
+                    self.analysis(posterior)
+                    eos.info(f'Successfully created analysis for posterior \'{posterior}\'')
 
-                for prediction in self._predictions:
-                    try:
-                        self.observables(posterior, prediction, eos.Parameters())
-                        eos.info(f'Successfully created prediction \'{prediction}\' set for posterior \'{posterior}\'')
-                    except Exception as e:
-                        messages.append(f'Error encountered when creating observables for prediction \'{prediction}\' of posterior \'{posterior}\': {e}')
+                    for prediction in self._predictions:
+                        try:
+                            self.observables(posterior, prediction, eos.Parameters())
+                            eos.info(f'Successfully created prediction \'{prediction}\' set for posterior \'{posterior}\'')
+                        except Exception as e:
+                            diagnostics.append(Diagnostic(
+                                ('predictions', prediction), Severity.ERROR,
+                                f'cannot create observables for posterior \'{posterior}\': {e}'
+                            ))
 
-            except Exception as e:
-                messages.append(f'Error encountered when creating posterior \'{posterior}\': {e}')
-        for m in messages:
-            print(m)
-        return messages
+                except Exception as e:
+                    diagnostics.append(Diagnostic(
+                        ('posteriors', posterior), Severity.ERROR,
+                        f'cannot be created: {e}'
+                    ))
+        for diagnostic in diagnostics:
+            print(diagnostic)
+        return diagnostics
 
 
     @property

--- a/python/eos/analysis_file_TEST.d/fixed-but-unused-parameter.yaml
+++ b/python/eos/analysis_file_TEST.d/fixed-but-unused-parameter.yaml
@@ -1,0 +1,24 @@
+# The posterior 'unused-fix' fixes two parameters: one that its likelihood genuinely uses, and one
+# from an unrelated decay (0 -> K pi) that no observable of this analysis can touch. Deep validation
+# must report only the latter.
+likelihoods:
+  - name: TH-pi
+    constraints:
+      - 'B->pi::f_++f_0@RBC+UKQCD:2015A;form-factors=BCL2008-4'
+
+priors:
+  - name: FF-pi
+    descriptions:
+      - { 'parameter': 'B->pi::f_+(0)@BCL2008', 'min': 0.21, 'max': 0.32, 'type': 'uniform' }
+
+posteriors:
+  - name: unused-fix
+    prior:
+      - FF-pi
+    likelihood:
+      - TH-pi
+    global_options:
+      form-factors: 'BCL2008-4'
+    fixed_parameters:
+      'B->pi::b_+^1@BCL2008':      -2.1
+      '0->Kpi::M_(+,0)@KSvD2025':   0.892

--- a/python/eos/analysis_file_TEST.d/invalid/bad-component-name.yaml
+++ b/python/eos/analysis_file_TEST.d/invalid/bad-component-name.yaml
@@ -1,0 +1,17 @@
+priors:
+  - name: prior
+    descriptions:
+      - { parameter: 'CKM::abs(V_ub)', min: 3.0e-3, max: 4.5e-3, type: uniform }
+
+likelihoods:
+  - name: likelihood
+    constraints:
+      - 'B^+->tau^+nu::BR@Belle:2014A;form-factors=BCL2008-4'
+  - name: a/b
+    constraints:
+      - 'B^+->tau^+nu::BR@Belle:2014A;form-factors=BCL2008-4'
+
+posteriors:
+  - name: posterior
+    prior: [ prior ]
+    likelihood: [ likelihood ]

--- a/python/eos/analysis_file_TEST.d/invalid/multiple-structural-errors.yaml
+++ b/python/eos/analysis_file_TEST.d/invalid/multiple-structural-errors.yaml
@@ -1,0 +1,28 @@
+priors:
+  - name: incomplete-prior
+    descriptions:
+      - type: uniform
+        parameter: CKM::abs(V_ub)
+        min: 0.0
+
+likelihoods:
+  - name: empty-likelihood
+
+posteriors:
+  - name: broken-posterior
+    prior:
+      - missing-prior
+    likelihood:
+      - missing-likelihood
+
+steps:
+  - title: Broken step
+    id: broken/step
+    tasks:
+      - task: not-a-real-task
+
+masks:
+  - name: broken-mask
+    logical_combination: xor
+    description:
+      - mask_name: missing-mask

--- a/python/eos/analysis_file_TEST.d/unused-entities.yaml
+++ b/python/eos/analysis_file_TEST.d/unused-entities.yaml
@@ -1,0 +1,51 @@
+format_version: 1
+
+priors:
+  - name: used-prior
+    descriptions:
+      - { parameter: 'mass::e', type: uniform, min: 0.0, max: 1.0 }
+  - name: unused-prior
+    descriptions:
+      - { parameter: 'mass::mu', type: uniform, min: 0.0, max: 1.0 }
+
+likelihoods:
+  - name: used-likelihood
+    constraints:
+      - 'B->D::f_++f_0@HPQCD:2015A'
+  - name: unused-likelihood
+    constraints:
+      - 'B->D::f_++f_0@HPQCD:2015A'
+
+posteriors:
+  - name: posterior
+    prior:
+      - used-prior
+    likelihood:
+      - used-likelihood
+
+masks:
+  - name: mask-used-by-mask
+    description:
+      - { name: 'B->Dlnu::BR' }
+  - name: mask-composite
+    description:
+      - { mask_name: mask-used-by-mask }
+  - name: mask-used-by-task
+    description:
+      - { name: 'B->Dlnu::BR' }
+  - name: unused-mask
+    description:
+      - { name: 'B->Dlnu::BR' }
+
+steps:
+  - title: Create masks
+    id: create-masks
+    tasks:
+      - task: create-mask
+        arguments:
+          posterior: posterior
+          mask_name: mask-composite
+      - task: create-mask
+        arguments:
+          posterior: posterior
+          mask_name: mask-used-by-task

--- a/python/eos/analysis_file_TEST.d/unused-entities.yaml
+++ b/python/eos/analysis_file_TEST.d/unused-entities.yaml
@@ -1,9 +1,56 @@
 format_version: 1
 
+observables:
+  'test::unused-observable':
+    latex: 'O'
+    unit: '1'
+    expression: '1.0'
+  'test::manual-constraint-observable':
+    latex: 'O_M'
+    unit: '1'
+    expression: '1.0'
+  'test::manual-constraint-observable-list':
+    latex: 'O_{M,2}'
+    unit: '1'
+    expression: '1.0'
+  'test::figure-only-observable':
+    latex: 'O_F'
+    unit: '1'
+    expression: '[[test::expression-only-parameter]]'
+
+parameters:
+  'test::unused-parameter':
+    latex: 'p'
+    unit: '1'
+    central: 0.0
+    min: -1.0
+    max: +1.0
+  'test::parameter-alias':
+    latex: 'a_0'
+    unit: '1'
+    central: 0.0
+    min: -1.0
+    max: +1.0
+  'test::expression-only-parameter':
+    latex: 'p_E'
+    unit: '1'
+    central: 0.0
+    min: -1.0
+    max: +1.0
+  'test::aliased-parameter':
+    latex: 'a'
+    unit: '1'
+    central: 0.0
+    min: -1.0
+    max: +1.0
+    alias_of:
+      - 'test::parameter-alias'
+
 priors:
   - name: used-prior
     descriptions:
       - { parameter: 'mass::e', type: uniform, min: 0.0, max: 1.0 }
+      - { parameter: 'test::parameter-alias', type: uniform, min: -1.0, max: +1.0 }
   - name: unused-prior
     descriptions:
       - { parameter: 'mass::mu', type: uniform, min: 0.0, max: 1.0 }
@@ -15,6 +62,11 @@ likelihoods:
   - name: unused-likelihood
     constraints:
       - 'B->D::f_++f_0@HPQCD:2015A'
+    manual_constraints:
+      'test::unused-constraint':
+        observable: 'test::manual-constraint-observable'
+        observables:
+          - 'test::manual-constraint-observable-list'
 
 posteriors:
   - name: posterior
@@ -22,6 +74,16 @@ posteriors:
       - used-prior
     likelihood:
       - used-likelihood
+
+figures:
+  - name: figure-using-custom-observable
+    type: single
+    plot:
+      items:
+        - type: constraint
+          constraints: 'B^0->D^+e^-nu::BRs@Belle:2015A'
+          variable: q2
+          observable: 'test::figure-only-observable'
 
 masks:
   - name: mask-used-by-mask
@@ -36,6 +98,7 @@ masks:
   - name: unused-mask
     description:
       - { name: 'B->Dlnu::BR' }
+      - { name: 'test::unused-mask-observable', expression: '1.0' }
 
 steps:
   - title: Create masks

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -42,10 +42,9 @@ class TestAnalysisFile(unittest.TestCase):
     def test_prior_only_analysis_file(self):
 
         # a file without a 'likelihoods' section is a legitimate prior-only analysis; it must load
-        # (with a warning) and expose no likelihoods. Regression test: this previously raised a
-        # KeyError because the (absent) 'likelihoods' entry was accessed unconditionally.
-        with self.assertLogs('EOS', level='WARNING'):
-            af = eos.AnalysisFile(_TESTD / 'no-likelihoods-analysis-file.yaml')
+        # and expose no likelihoods. Regression test: this previously raised a KeyError because the
+        # (absent) 'likelihoods' entry was accessed unconditionally.
+        af = eos.AnalysisFile(_TESTD / 'no-likelihoods-analysis-file.yaml')
         self.assertEqual(dict(af.likelihoods), {})
         af.validate()
 
@@ -113,16 +112,33 @@ class TestAnalysisFileConstructionErrors(unittest.TestCase):
             eos.AnalysisFile(_TESTD / 'invalid' / 'bad-parameter.yaml')
 
     def test_duplicate_step_id(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             eos.AnalysisFile(_TESTD / 'invalid' / 'duplicate-step-id.yaml')
 
     def test_duplicate_mask_name(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             eos.AnalysisFile(_TESTD / 'invalid' / 'duplicate-mask-name.yaml')
 
     def test_unknown_mask_reference(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(RuntimeError):
             eos.AnalysisFile(_TESTD / 'invalid' / 'unknown-mask-ref.yaml')
+
+    def test_multiple_structural_errors_are_reported_together(self):
+        with self.assertRaises(RuntimeError) as context:
+            eos.AnalysisFile(_TESTD / 'invalid' / 'multiple-structural-errors.yaml')
+
+        message = str(context.exception)
+        for fragment in (
+            'priors/incomplete-prior/descriptions[0]/max',
+            'likelihoods/empty-likelihood',
+            'posteriors/broken-posterior/prior[0]',
+            'posteriors/broken-posterior/likelihood[0]',
+            'steps/broken/step/id',
+            'steps/broken/step/tasks[0]/task',
+            'masks/broken-mask/logical_combination',
+            'masks/broken-mask/description[0]/mask_name',
+        ):
+            self.assertIn(fragment, message)
 
 
 class TestAnalysisFileMethods(unittest.TestCase):

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -26,6 +26,7 @@ import os
 from pathlib import Path
 
 from eos.diagnostic import Diagnostic, Severity
+from eos.validation_context import ValidationContext
 
 _TESTD = Path(__file__).parent / 'analysis_file_TEST.d'
 
@@ -361,6 +362,41 @@ class TestAnalysisFileMethods(unittest.TestCase):
 
 class TestAnalysisFileValidation(unittest.TestCase):
     """The reporting (non-raising) branches of ``validate``."""
+
+    def test_unused_priors_likelihoods_and_masks_are_warnings(self):
+        af = eos.AnalysisFile(_TESTD / 'unused-entities.yaml')
+        description = af._description
+
+        structure = list(description.validate_structure())
+        semantics = list(description.validate_semantics(ValidationContext(description)))
+        self.assertFalse(any(
+            diagnostic.severity is Severity.ERROR
+            for diagnostic in structure + semantics
+        ))
+
+        warnings = [
+            diagnostic
+            for diagnostic in semantics
+            if diagnostic.severity is Severity.WARNING
+        ]
+        self.assertEqual(
+            [
+                ('priors', 'unused-prior'),
+                ('likelihoods', 'unused-likelihood'),
+                ('masks', 'unused-mask'),
+            ],
+            [diagnostic.path for diagnostic in warnings],
+        )
+
+        warned_paths = {diagnostic.path for diagnostic in warnings}
+        for path in (
+            ('priors', 'used-prior'),
+            ('likelihoods', 'used-likelihood'),
+            ('masks', 'mask-used-by-mask'),
+            ('masks', 'mask-composite'),
+            ('masks', 'mask-used-by-task'),
+        ):
+            self.assertNotIn(path, warned_paths)
 
     def test_observables_aggregates_unknown_names(self):
         # observables() reports every unknown observable in a prediction, not just the first

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -402,7 +402,27 @@ class TestAnalysisFileValidation(unittest.TestCase):
         self.assertEqual([], list(description.figures[0].validate_semantics(context)))
         self.assertNotIn(name, context.unused('observable'))
 
-    def test_unused_priors_likelihoods_and_masks_are_warnings(self):
+    def test_parameter_alias_lookup_credits_declaration(self):
+        name = 'test::aliased-parameter'
+        alias = 'test::parameter-alias'
+        description = eos.analysis_file_description.AnalysisFileDescription.from_dict(
+            parameters={
+                name: {
+                    'latex': 'a',
+                    'unit': '1',
+                    'central': 0.0,
+                    'min': -1.0,
+                    'max': +1.0,
+                    'alias_of': [alias],
+                },
+            },
+        )
+        context = ValidationContext(description)
+
+        self.assertTrue(context.lookup('parameter', alias))
+        self.assertNotIn(name, context.unused('parameter'))
+
+    def test_unused_entities_are_warnings(self):
         af = eos.AnalysisFile(_TESTD / 'unused-entities.yaml')
         description = af._description
 
@@ -423,6 +443,10 @@ class TestAnalysisFileValidation(unittest.TestCase):
                 ('priors', 'unused-prior'),
                 ('likelihoods', 'unused-likelihood'),
                 ('masks', 'unused-mask'),
+                ('observables', 'test::unused-observable'),
+                ('parameters', 'test::unused-parameter'),
+                ('masks', 'unused-mask', 'description', 'test::unused-mask-observable'),
+                ('likelihoods', 'unused-likelihood', 'manual_constraints', 'test::unused-constraint'),
             ],
             [diagnostic.path for diagnostic in warnings],
         )
@@ -434,6 +458,11 @@ class TestAnalysisFileValidation(unittest.TestCase):
             ('masks', 'mask-used-by-mask'),
             ('masks', 'mask-composite'),
             ('masks', 'mask-used-by-task'),
+            ('parameters', 'test::aliased-parameter'),
+            ('parameters', 'test::expression-only-parameter'),
+            ('observables', 'test::manual-constraint-observable'),
+            ('observables', 'test::manual-constraint-observable-list'),
+            ('observables', 'test::figure-only-observable'),
         ):
             self.assertNotIn(path, warned_paths)
 

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -46,9 +46,96 @@ class TestAnalysisFile(unittest.TestCase):
         # a file without a 'likelihoods' section is a legitimate prior-only analysis; it must load
         # and expose no likelihoods. Regression test: this previously raised a KeyError because the
         # (absent) 'likelihoods' entry was accessed unconditionally.
-        af = eos.AnalysisFile(_TESTD / 'no-likelihoods-analysis-file.yaml')
+        with self.assertNoLogs('EOS', level='WARNING'):
+            af = eos.AnalysisFile(_TESTD / 'no-likelihoods-analysis-file.yaml')
         self.assertEqual(dict(af.likelihoods), {})
+        warnings = [
+            diagnostic
+            for diagnostic in af._description.validate_structure()
+            if diagnostic.severity is Severity.WARNING
+        ]
+        self.assertEqual(
+            [(('likelihoods',), 'No likelihood components found in analysis file')],
+            [(diagnostic.path, diagnostic.message) for diagnostic in warnings],
+        )
         af.validate()
+
+    def test_deprecations_are_located_warning_diagnostics(self):
+        with self.assertNoLogs('EOS', level='WARNING'):
+            description = eos.analysis_file_description.AnalysisFileDescription.from_dict(
+                priors=[{
+                    'name': 'legacy-prior',
+                    'parameters': [
+                        {'constraint': 'B->D::f_++f_0@HPQCD:2015A'},
+                        {
+                            'parameter': 'mass::e',
+                            'type': 'gaussian',
+                            'central': 0.5,
+                            'sigma': 0.1,
+                            'min': 0.0,
+                            'max': 1.0,
+                        },
+                    ],
+                }],
+                likelihoods=[{
+                    'name': 'likelihood',
+                    'constraints': ['B->D::f_++f_0@HPQCD:2015A'],
+                }],
+                posteriors=[{
+                    'name': 'posterior',
+                    'prior': ['legacy-prior'],
+                    'likelihood': ['likelihood'],
+                }],
+            )
+            diagnostics = list(description.validate_structure())
+
+        warnings = {
+            diagnostic.path: diagnostic
+            for diagnostic in diagnostics
+            if diagnostic.severity is Severity.WARNING
+        }
+        self.assertIn(('priors', 'legacy-prior', 'parameters'), warnings)
+        self.assertIn(('priors', 'legacy-prior', 'descriptions', 0, 'type'), warnings)
+        self.assertIn(('priors', 'legacy-prior', 'descriptions', 1), warnings)
+
+    def test_both_prior_description_keys_produce_warning_without_logging(self):
+        with self.assertNoLogs('EOS', level='WARNING'):
+            prior = eos.analysis_file_description.PriorComponent.from_dict(
+                name='legacy-prior',
+                descriptions=[{
+                    'parameter': 'mass::e',
+                    'type': 'uniform',
+                    'min': 0.0,
+                    'max': 1.0,
+                }],
+                parameters=[{
+                    'constraint': 'B->D::f_++f_0@HPQCD:2015A',
+                    'type': 'constraint',
+                }],
+            )
+
+        warnings = [
+            diagnostic
+            for diagnostic in prior.validate_structure()
+            if diagnostic.severity is Severity.WARNING
+        ]
+        self.assertEqual(2, len(warnings))
+        self.assertTrue(all(diagnostic.path == ('parameters',) for diagnostic in warnings))
+
+    def test_task_defaults_are_warning_diagnostics_without_logging(self):
+        with self.assertNoLogs('EOS', level='WARNING'):
+            task = eos.analysis_file_description.TaskComponent.from_dict(
+                task='corner-plot',
+                arguments={'posterior': 'posterior'},
+            )
+
+        warnings = [
+            diagnostic
+            for diagnostic in task.validate_structure()
+            if diagnostic.severity is Severity.WARNING
+        ]
+        self.assertTrue(warnings)
+        self.assertTrue(all(diagnostic.path[:1] == ('arguments',) for diagnostic in warnings))
 
     def test_format_version(self):
 

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -25,6 +25,8 @@ import eos
 import os
 from pathlib import Path
 
+from eos.diagnostic import Diagnostic, Severity
+
 _TESTD = Path(__file__).parent / 'analysis_file_TEST.d'
 
 class TestAnalysisFile(unittest.TestCase):
@@ -249,7 +251,7 @@ class TestAnalysisFileValidation(unittest.TestCase):
         # validate() collects one message per problem rather than raising; the fixture contains
         # many independent problems, so it must return a non-empty list
         self.assertGreater(len(messages), 0)
-        blob = '\n'.join(messages)
+        blob = '\n'.join(str(diagnostic) for diagnostic in messages)
         # a representative selection of the distinct problem classes in the fixture
         self.assertIn('Not::a-parameter', blob)                 # unknown prior parameter
         self.assertIn('Not::a-constraint@Nowhere:2000A', blob)  # unknown constraint
@@ -261,6 +263,32 @@ class TestAnalysisFileValidation(unittest.TestCase):
         self.assertIn('unknown tasks', blob)                    # step default arguments
         self.assertIn("Posterior 'nonexistent-posterior'", blob)  # step task posterior
         self.assertIn('repeatedly', blob)                       # repeated mask expression name
+        # every message is a Diagnostic, including those from the deep phase, so that callers can
+        # filter by severity and location without special-casing the origin of a message
+        self.assertTrue(all(isinstance(message, Diagnostic) for message in messages))
+        self.assertTrue(any(
+            diagnostic.severity is Severity.ERROR and diagnostic.path[0] in ('posteriors', 'predictions')
+            for diagnostic in messages
+        ))
+        semantic_locations = {
+            (diagnostic.path, diagnostic.severity)
+            for diagnostic in messages
+        }
+        self.assertIn(
+            (('priors', 'BAD-PARAM', 'descriptions', 0, 'parameter'), Severity.ERROR),
+            semantic_locations,
+        )
+        self.assertIn(
+            (
+                ('predictions', 'pred-bad-obs', 'observables', 'B->pilnu::NOTREAL', 'name'),
+                Severity.ERROR,
+            ),
+            semantic_locations,
+        )
+        self.assertIn(
+            (('steps', 'bad-step', 'depends_on'), Severity.ERROR),
+            semantic_locations,
+        )
 
 
 if __name__ == '__main__':

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -125,6 +125,46 @@ class TestAnalysisFileConstructionErrors(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             eos.AnalysisFile(_TESTD / 'invalid' / 'unknown-mask-ref.yaml')
 
+    def test_invalid_file_local_component_name(self):
+        with self.assertRaises(RuntimeError) as context:
+            eos.AnalysisFile(_TESTD / 'invalid' / 'bad-component-name.yaml')
+
+        self.assertIn(
+            "likelihoods[1]/name: Invalid character '/' in likelihood name 'a/b'",
+            str(context.exception),
+        )
+
+    def test_slash_in_observable_qualified_name_is_allowed(self):
+        description = eos.analysis_file_description.AnalysisFileDescription.from_dict(
+            priors=[{
+                'name': 'prior',
+                'descriptions': [{
+                    'parameter': 'CKM::abs(V_ub)',
+                    'min': 3.0e-3,
+                    'max': 4.5e-3,
+                    'type': 'uniform',
+                }],
+            }],
+            likelihoods=[{
+                'name': 'likelihood',
+                'constraints': ['B^+->tau^+nu::BR@Belle:2014A;form-factors=BCL2008-4'],
+            }],
+            posteriors=[{
+                'name': 'posterior',
+                'prior': ['prior'],
+                'likelihood': ['likelihood'],
+            }],
+            observables={
+                'Test::ratio/a': {
+                    'latex': r'R/a',
+                    'unit': '1',
+                    'expression': '1.0',
+                },
+            },
+        )
+
+        self.assertEqual([], list(description.validate_structure()))
+
     def test_multiple_structural_errors_are_reported_together(self):
         with self.assertRaises(RuntimeError) as context:
             eos.AnalysisFile(_TESTD / 'invalid' / 'multiple-structural-errors.yaml')
@@ -135,8 +175,8 @@ class TestAnalysisFileConstructionErrors(unittest.TestCase):
             'likelihoods/empty-likelihood',
             'posteriors/broken-posterior/prior[0]',
             'posteriors/broken-posterior/likelihood[0]',
-            'steps/broken/step/id',
-            'steps/broken/step/tasks[0]/task',
+            'steps[0]/id',
+            'steps[0]/tasks[0]/task',
             'masks/broken-mask/logical_combination',
             'masks/broken-mask/description[0]/mask_name',
         ):

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -521,6 +521,25 @@ class TestAnalysisFileValidation(unittest.TestCase):
             semantic_locations,
         )
 
+    def test_fixed_but_unused_parameter(self):
+        # the fixture's posterior fixes one parameter its likelihood uses and one from an unrelated
+        # decay; only the latter has no effect and must be reported
+        af = eos.AnalysisFile(_TESTD / 'fixed-but-unused-parameter.yaml')
+
+        reported = {
+            diagnostic.path[-1]
+            for diagnostic in af.validate(deep=True)
+            if 'is fixed but used by neither' in diagnostic.message
+        }
+        self.assertEqual(reported, {'0->Kpi::M_(+,0)@KSvD2025'})
+        self.assertNotIn('B->pi::b_+^1@BCL2008', reported)
+
+        # the check needs the assembled likelihood, so the side-effect-free phases cannot see it
+        self.assertFalse(any(
+            'is fixed but used by neither' in diagnostic.message
+            for diagnostic in af.validate(deep=False)
+        ))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=5)

--- a/python/eos/analysis_file_TEST.py
+++ b/python/eos/analysis_file_TEST.py
@@ -363,6 +363,45 @@ class TestAnalysisFileMethods(unittest.TestCase):
 class TestAnalysisFileValidation(unittest.TestCase):
     """The reporting (non-raising) branches of ``validate``."""
 
+    @staticmethod
+    def _figure_description(observable, observables=None):
+        return eos.analysis_file_description.AnalysisFileDescription.from_dict(
+            figures=[{
+                'name': 'semantic-figure',
+                'type': 'single',
+                'plot': {
+                    'items': [{
+                        'type': 'constraint',
+                        'constraints': 'B^0->D^+e^-nu::BRs@Belle:2015A',
+                        'variable': 'q2',
+                        'observable': observable,
+                    }],
+                },
+            }],
+            observables=observables or {},
+        )
+
+    def test_figure_unknown_observable_is_located(self):
+        description = self._figure_description('test::unknown-observable')
+        diagnostics = list(description.validate_semantics(ValidationContext(description)))
+
+        self.assertEqual(1, len(diagnostics))
+        self.assertEqual(
+            ('figures', 'semantic-figure', 'plot', 'items', 0, 'observable'),
+            diagnostics[0].path,
+        )
+        self.assertIn("observable 'test::unknown-observable' is unknown", diagnostics[0].message)
+
+    def test_figure_resolves_custom_observable_from_shadow_registry(self):
+        name = 'test::figure-only'
+        description = self._figure_description(name, {
+            name: {'latex': 'x', 'unit': '1', 'expression': '1.0'},
+        })
+        context = ValidationContext(description)
+
+        self.assertEqual([], list(description.figures[0].validate_semantics(context)))
+        self.assertNotIn(name, context.unused('observable'))
+
     def test_unused_priors_likelihoods_and_masks_are_warnings(self):
         af = eos.AnalysisFile(_TESTD / 'unused-entities.yaml')
         description = af._description

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -19,16 +19,45 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
-from .deserializable import Deserializable
+from .deserializable import Deserializable, InvalidComponent
+from .diagnostic import Diagnostic, Severity
 from eos.figure import FigureFactory
 from dataclasses import dataclass, field
 from collections import defaultdict
 import copy as _copy
 import eos
 import inspect
+from collections import Counter
+
+
+class _AnalysisFileDeserializable(Deserializable):
+    @classmethod
+    def from_dict(cls, **kwargs):
+        return Deserializable.make_with_diagnostics(cls, **kwargs)
+
+    def _diagnostics(self):
+        yield from ()
+
+    def validate(self):
+        yield from self._diagnostics()
+
+
+def _segments(raw_children, identifier='name'):
+    return [
+        child[identifier] if isinstance(child, dict) and identifier in child else index
+        for index, child in enumerate(raw_children)
+    ]
+
+
+def _validate_children(children, segments, prefix):
+    assert len(children) == len(segments)
+    for child, segment in zip(children, segments):
+        if hasattr(child, 'validate'):
+            yield from (diagnostic.prefixed(prefix, segment) for diagnostic in child.validate())
+
 
 @dataclass
-class MetadataAuthorDescription(Deserializable):
+class MetadataAuthorDescription(_AnalysisFileDeserializable):
     """Describes a single author in an analysis file's metadata.
 
     :param name: The author's name.
@@ -44,7 +73,7 @@ class MetadataAuthorDescription(Deserializable):
 
 
 @dataclass
-class MetadataDescription(Deserializable):
+class MetadataDescription(_AnalysisFileDeserializable):
     """Describes the metadata of an analysis file.
 
     :param title: A human-readable title for the analysis. Optional.
@@ -58,6 +87,11 @@ class MetadataDescription(Deserializable):
     id:str=''
     authors:list[MetadataAuthorDescription]=field(default_factory=list)
 
+    def validate(self):
+        yield from self._diagnostics()
+        segments = getattr(self, '_author_segments', list(range(len(self.authors))))
+        yield from _validate_children(self.authors, segments, 'authors')
+
     @staticmethod
     def from_dict(**kwargs):
         """Create a :class:`MetadataDescription` from its keyword description.
@@ -68,9 +102,17 @@ class MetadataDescription(Deserializable):
         :rtype: MetadataDescription
         """
         _kwargs = _copy.deepcopy(kwargs)
+        diagnostics = Deserializable.check_keys(MetadataDescription, _kwargs)
+        if diagnostics:
+            return InvalidComponent(diagnostics)
         if 'authors' in kwargs:
+            author_segments = _segments(kwargs['authors'])
             _kwargs['authors'] = [MetadataAuthorDescription.from_dict(**a) for a in kwargs['authors']]
-        return Deserializable.make(MetadataDescription, **_kwargs)
+        else:
+            author_segments = []
+        result = MetadataDescription(**_kwargs)
+        result._author_segments = author_segments
+        return result
 
 
 class PriorDescription:
@@ -92,35 +134,43 @@ class PriorDescription:
         """Create the concrete prior description matching the given keyword description.
 
         :returns: An instance of the concrete :class:`PriorDescription` subtype selected from ``type``.
-        :raises ValueError: If the keys do not identify a known type of prior description.
         """
         if 'type' in kwargs:
             _kwargs = _copy.deepcopy(kwargs)
             _kwargs.pop('type')
             if kwargs['type'] in ("constraint",):
-                return Deserializable.make(ConstraintPriorDescription, **_kwargs)
+                return Deserializable.make_with_diagnostics(ConstraintPriorDescription, **_kwargs)
             elif kwargs['type'] in ("uniform", "flat"):
-                return Deserializable.make(UniformPriorDescription, **_kwargs)
+                return Deserializable.make_with_diagnostics(UniformPriorDescription, **_kwargs)
             elif kwargs['type'] in ("scale",):
-                return Deserializable.make(ScalePriorDescription, **_kwargs)
+                return Deserializable.make_with_diagnostics(ScalePriorDescription, **_kwargs)
             elif kwargs['type'] in ("gauss", "gaussian"):
                 if ('min' in kwargs) != ('max' in kwargs):
-                    raise ValueError('A Gaussian prior description must contain both \'min\' and \'max\' or neither')
+                    missing_bound = 'max' if 'min' in kwargs else 'min'
+                    return InvalidComponent([
+                        Diagnostic(
+                            (missing_bound,),
+                            Severity.ERROR,
+                            'A Gaussian prior description must contain both \'min\' and \'max\' or neither',
+                        ),
+                    ])
                 if 'min' in kwargs:
-                    return Deserializable.make(CurtailedGaussianDescription, **_kwargs)
-                return Deserializable.make(GaussianPriorDescription, **_kwargs)
+                    return Deserializable.make_with_diagnostics(CurtailedGaussianDescription, **_kwargs)
+                return Deserializable.make_with_diagnostics(GaussianPriorDescription, **_kwargs)
             elif kwargs['type'] in ("poisson",):
-                return Deserializable.make(PoissonPriorDescription, **_kwargs)
+                return Deserializable.make_with_diagnostics(PoissonPriorDescription, **_kwargs)
             elif kwargs['type'] in ("transform",):
-                return Deserializable.make(TransformPriorDescription, **_kwargs)
+                return Deserializable.make_with_diagnostics(TransformPriorDescription, **_kwargs)
         elif 'constraint' in kwargs:
             eos.warn('A constraint prior description without a \'type\' key is deprecated and will be removed in a future version of EOS; add \'type: constraint\' instead')
-            return Deserializable.make(ConstraintPriorDescription, **kwargs)
+            return Deserializable.make_with_diagnostics(ConstraintPriorDescription, **kwargs)
 
-        raise ValueError('Unknown type of prior description')
+        return InvalidComponent([
+            Diagnostic(('type',), Severity.ERROR, 'Unknown type of prior description'),
+        ])
 
 @dataclass
-class PoissonPriorDescription(Deserializable):
+class PoissonPriorDescription(_AnalysisFileDeserializable):
     r"""Describes a Poisson prior on a single parameter.
 
     :param parameter: The qualified name of the parameter.
@@ -133,7 +183,7 @@ class PoissonPriorDescription(Deserializable):
     type:str=field(repr=False, init=False, default="poisson")
 
 @dataclass
-class CurtailedGaussianDescription(Deserializable):
+class CurtailedGaussianDescription(_AnalysisFileDeserializable):
     r"""Describes a Gaussian prior truncated to a finite interval (``type: gauss`` with ``min``/``max``).
 
     .. deprecated:: 1.0.21
@@ -159,10 +209,10 @@ class CurtailedGaussianDescription(Deserializable):
     type:str=field(repr=False, init=False, default="gaussian")
 
     def __post_init__(self):
-        eos.warn('The curtailed Gaussian prior description (a \'gauss\'/\'gaussian\' prior with \'min\' and \'max\') is deprecated and will be removed in a future version of EOS; use \'type: gaussian\' without the \'min\'/\'max\' keys instead')
+        pass
 
 @dataclass
-class GaussianPriorDescription(Deserializable):
+class GaussianPriorDescription(_AnalysisFileDeserializable):
     r"""Describes a Gaussian prior on a single parameter.
 
     :param parameter: The qualified name of the parameter.
@@ -179,7 +229,7 @@ class GaussianPriorDescription(Deserializable):
 
 
 @dataclass
-class ScalePriorDescription(Deserializable):
+class ScalePriorDescription(_AnalysisFileDeserializable):
     r"""Describes a prior on a renormalization scale parameter.
 
     :param parameter: The qualified name of the scale parameter.
@@ -201,7 +251,7 @@ class ScalePriorDescription(Deserializable):
     type:str=field(repr=False, init=False, default="scale")
 
 @dataclass
-class UniformPriorDescription(Deserializable):
+class UniformPriorDescription(_AnalysisFileDeserializable):
     r"""Describes a uniform (flat) prior on a single parameter.
 
     :param parameter: The qualified name of the parameter.
@@ -217,7 +267,7 @@ class UniformPriorDescription(Deserializable):
     type:str=field(repr=False, init=False, default="uniform")
 
 @dataclass
-class ConstraintPriorDescription(Deserializable):
+class ConstraintPriorDescription(_AnalysisFileDeserializable):
     r"""Describes a (possibly correlated, multivariate) prior taken from a built-in EOS constraint.
 
     :param constraint: The qualified name of the EOS constraint used as the prior.
@@ -227,7 +277,7 @@ class ConstraintPriorDescription(Deserializable):
     type:str=field(repr=False, init=False, default="constraint")
 
 @dataclass
-class TransformPriorDescription(Deserializable):
+class TransformPriorDescription(_AnalysisFileDeserializable):
     r"""Describes a prior on a linear transformation of several parameters.
 
     :param parameters: The qualified names of the parameters that enter the transformation.
@@ -265,7 +315,7 @@ PriorDescription.registry = {
 }
 
 @dataclass
-class PriorComponent(Deserializable):
+class PriorComponent(_AnalysisFileDeserializable):
     r"""Describes a single named prior, i.e. one entry of an analysis file's ``priors`` list.
 
     A named prior bundles one or more prior descriptions: a single description for a univariate prior, or
@@ -278,6 +328,11 @@ class PriorComponent(Deserializable):
     """
     name:str
     descriptions:list
+
+    def validate(self):
+        yield from self._diagnostics()
+        segments = getattr(self, '_description_segments', list(range(len(self.descriptions))))
+        yield from _validate_children(self.descriptions, segments, 'descriptions')
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -293,17 +348,22 @@ class PriorComponent(Deserializable):
         if "descriptions" in kwargs:
             if "parameters" in kwargs:
                 eos.error(f'Both \'descriptions\' and \'parameters\' are provided for prior component \'{kwargs["name"]}\', ignoring legacy support for \'parameters\'')
-            _kwargs['descriptions'] = [PriorDescription.from_dict(**d) for d in kwargs['descriptions']]
         if "parameters" in kwargs:
             eos.warn(f'\'parameters\' is in the description of prior component \'{kwargs["name"]}\', use \'descriptions\' instead')
-            _kwargs.pop("parameters")
-            _kwargs['descriptions'] = [PriorDescription.from_dict(**d) for d in kwargs['parameters']]
-        return Deserializable.make(cls, **_kwargs)
+            _kwargs['descriptions'] = _kwargs.pop("parameters")
+        diagnostics = Deserializable.check_keys(cls, _kwargs)
+        if diagnostics:
+            return InvalidComponent(diagnostics)
+        description_segments = _segments(_kwargs['descriptions'])
+        _kwargs['descriptions'] = [PriorDescription.from_dict(**d) for d in _kwargs['descriptions']]
+        result = cls(**_kwargs)
+        result._description_segments = description_segments
+        return result
 
 
 
 @dataclass
-class ConstraintLikelihoodDescription(Deserializable):
+class ConstraintLikelihoodDescription(_AnalysisFileDeserializable):
     r"""Describes a likelihood contribution taken from a built-in EOS constraint.
 
     :param constraint: The qualified name of the EOS constraint.
@@ -312,7 +372,7 @@ class ConstraintLikelihoodDescription(Deserializable):
     constraint:eos.QualifiedName
 
 @dataclass
-class ManualConstraintDescription(Deserializable):
+class ManualConstraintDescription(_AnalysisFileDeserializable):
     r"""Describes a likelihood contribution from a constraint defined inline in the analysis file.
 
     :param name: The qualified name under which the manual constraint is registered.
@@ -324,7 +384,7 @@ class ManualConstraintDescription(Deserializable):
     info:dict
 
 @dataclass
-class PyHFConstraintDescription(Deserializable):
+class PyHFConstraintDescription(_AnalysisFileDeserializable):
     r"""Describes a likelihood contribution imported from a pyhf workspace.
 
     :param file: The path to the JSON file specifying the pyhf workspace.
@@ -336,7 +396,7 @@ class PyHFConstraintDescription(Deserializable):
     parameter_map:dict=field(default_factory=dict)
 
 @dataclass
-class LikelihoodComponent(Deserializable):
+class LikelihoodComponent(_AnalysisFileDeserializable):
     r"""Describes a single named likelihood, i.e. one entry of an analysis file's ``likelihoods`` list.
 
     A named likelihood may combine any number of built-in constraints, inline (manual) constraints, and
@@ -348,13 +408,40 @@ class LikelihoodComponent(Deserializable):
     :type constraints: list[ConstraintLikelihoodDescription]
     :param manual_constraints: The inline constraint definitions contributing to the likelihood. Optional.
     :type manual_constraints: list[ManualConstraintDescription]
-    :param pyhf: The pyhf-based contribution to the likelihood. Optional.
-    :type pyhf: PyHFConstraintDescription
+    :param pyhf: The pyhf-based contribution to the likelihood, or None if there is none. Optional.
+    :type pyhf: PyHFConstraintDescription | None
     """
     name:str
     constraints:list=field(default_factory=list)
     manual_constraints:list=field(default_factory=list)
-    pyhf:list=field(default_factory=list)
+    # unlike 'constraints' and 'manual_constraints', a likelihood carries at most one pyhf
+    # contribution; from_dict deserializes it into a single PyHFConstraintDescription
+    pyhf:PyHFConstraintDescription|None=None
+
+    def _diagnostics(self):
+        if not (self.constraints or self.manual_constraints or self.pyhf):
+            yield Diagnostic(
+                (),
+                Severity.ERROR,
+                'LikelihoodComponent must have at least one of constraints, manual_constraints, or pyhf',
+            )
+
+    def validate(self):
+        yield from self._diagnostics()
+        constraint_segments = getattr(self, '_constraint_segments', list(range(len(self.constraints))))
+        yield from _validate_children(self.constraints, constraint_segments, 'constraints')
+        manual_constraint_segments = getattr(
+            self,
+            '_manual_constraint_segments',
+            list(range(len(self.manual_constraints))),
+        )
+        yield from _validate_children(
+            self.manual_constraints,
+            manual_constraint_segments,
+            'manual_constraints',
+        )
+        if self.pyhf:
+            yield from (diagnostic.prefixed('pyhf') for diagnostic in self.pyhf.validate())
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -365,23 +452,39 @@ class LikelihoodComponent(Deserializable):
 
         :returns: The instantiated likelihood component.
         :rtype: LikelihoodComponent
-        :raises ValueError: If none of ``constraints``, ``manual_constraints``, or ``pyhf`` is provided.
         """
-        if not ('constraints' in kwargs or 'manual_constraints' in kwargs or 'pyhf' in kwargs):
-            raise ValueError('LikelihoodComponent must have at least one of constraints, manual_constraints, or pyhf')
         _kwargs = _copy.deepcopy(kwargs)
+        diagnostics = Deserializable.check_keys(cls, _kwargs)
+        if diagnostics:
+            return InvalidComponent(diagnostics)
         if 'constraints' in kwargs:
+            constraint_segments = _segments(kwargs['constraints'])
             _kwargs['constraints'] = [ConstraintLikelihoodDescription.from_dict(constraint=c) for c in kwargs['constraints']]
+        else:
+            constraint_segments = []
         if 'manual_constraints' in kwargs:
-            _kwargs['manual_constraints'] = [ManualConstraintDescription.from_dict(name=n, info=d) for n, d in kwargs['manual_constraints'].items()]
+            raw_manual_constraints = [
+                {'name': name, 'info': info}
+                for name, info in kwargs['manual_constraints'].items()
+            ]
+            manual_constraint_segments = _segments(raw_manual_constraints)
+            _kwargs['manual_constraints'] = [
+                ManualConstraintDescription.from_dict(**description)
+                for description in raw_manual_constraints
+            ]
+        else:
+            manual_constraint_segments = []
         if 'pyhf' in kwargs:
             _kwargs['pyhf'] = PyHFConstraintDescription.from_dict(**kwargs['pyhf'])
-        return Deserializable.make(cls, **_kwargs)
+        result = cls(**_kwargs)
+        result._constraint_segments = constraint_segments
+        result._manual_constraint_segments = manual_constraint_segments
+        return result
 
 
 
 @dataclass
-class PosteriorDescription(Deserializable):
+class PosteriorDescription(_AnalysisFileDeserializable):
     r"""Describes a single named posterior, i.e. one entry of an analysis file's ``posteriors`` list.
 
     A posterior combines one or more named priors with one or more named likelihoods, optionally fixing
@@ -407,7 +510,7 @@ class PosteriorDescription(Deserializable):
 
 
 @dataclass
-class ObservableComponent(Deserializable):
+class ObservableComponent(_AnalysisFileDeserializable):
     r"""Describes a custom observable defined in an analysis file's ``observables`` section.
 
     :param name: The qualified name under which the new observable is registered.
@@ -430,7 +533,7 @@ class ObservableComponent(Deserializable):
 
 
 @dataclass
-class PredictionObservableComponent(Deserializable):
+class PredictionObservableComponent(_AnalysisFileDeserializable):
     r"""Describes a single observable to be predicted, i.e. one entry of a prediction's ``observables`` list.
 
     :param name: The qualified name of the observable to predict.
@@ -445,7 +548,7 @@ class PredictionObservableComponent(Deserializable):
     options:dict=field(default_factory=dict)
 
 @dataclass
-class PredictionDescription(Deserializable):
+class PredictionDescription(_AnalysisFileDeserializable):
     r"""Describes a single named prediction, i.e. one entry of an analysis file's ``predictions`` list.
 
     A prediction lists the observables to be evaluated on previously obtained importance samples,
@@ -465,6 +568,11 @@ class PredictionDescription(Deserializable):
     global_options:dict=field(default_factory=dict)
     fixed_parameters:dict=field(default_factory=dict)
 
+    def validate(self):
+        yield from self._diagnostics()
+        segments = getattr(self, '_observable_segments', list(range(len(self.observables))))
+        yield from _validate_children(self.observables, segments, 'observables')
+
     @classmethod
     def from_dict(cls, **kwargs):
         """Create a :class:`PredictionDescription` from its keyword description.
@@ -475,13 +583,19 @@ class PredictionDescription(Deserializable):
         :rtype: PredictionDescription
         """
         _kwargs = _copy.deepcopy(kwargs)
+        diagnostics = Deserializable.check_keys(cls, _kwargs)
+        if diagnostics:
+            return InvalidComponent(diagnostics)
+        observable_segments = _segments(kwargs["observables"])
         _kwargs["observables"] = [PredictionObservableComponent.from_dict(**o) for o in kwargs["observables"]]
-        return Deserializable.make(cls, **_kwargs)
+        result = cls(**_kwargs)
+        result._observable_segments = observable_segments
+        return result
 
 
 
 @dataclass
-class ParameterComponent(Deserializable):
+class ParameterComponent(_AnalysisFileDeserializable):
     r"""Describes a custom parameter defined in an analysis file's ``parameters`` section.
 
     :param name: The new EOS qualified name of the parameter.
@@ -581,7 +695,7 @@ _task_argument_map = {
 }
 
 @dataclass
-class TaskComponent(Deserializable):
+class TaskComponent(_AnalysisFileDeserializable):
     r"""Describes a single task invocation within a step, i.e. one entry of a step's ``tasks`` list.
 
     :param task: The name of the task to run; must be a registered EOS task.
@@ -593,37 +707,47 @@ class TaskComponent(Deserializable):
     arguments:dict=field(default_factory=dict)
 
     def __post_init__(self):
-        if self.task not in eos.tasks._tasks.keys():
-            raise ValueError(f'Task \'{self.task}\' is not a valid task')
-        task = eos.tasks._tasks[self.task]
-
         self.arguments = {
             (_task_argument_map[(self.task, k)] if (self.task, k) in _task_argument_map else k): v
             for k,v in self.arguments.items()
         }
 
-        provided_arguments = set(self.arguments.keys())
-        # inject 'analysis_file' and 'base_directory' into known arguments
-        # these will be provided implicitly when the task is executed
-        provided_arguments.add('analysis_file')
-        provided_arguments.add('base_directory')
+    def _diagnostics(self):
+        if self.task not in eos.tasks._tasks:
+            yield Diagnostic(('task',), Severity.ERROR, f'Task \'{self.task}\' is not a valid task')
+            return
 
-        known_arguments = set(inspect.signature(task).parameters.keys())
-        default_arguments = { k for k, v in inspect.signature(task).parameters.items() if v.default is not inspect.Parameter.empty }
+        task = eos.tasks._tasks[self.task]
+        provided_arguments = set(self.arguments)
+        # 'analysis_file' and 'base_directory' are provided implicitly when the task is executed.
+        provided_arguments.update(('analysis_file', 'base_directory'))
+
+        known_arguments = set(inspect.signature(task).parameters)
+        default_arguments = {
+            key for key, value in inspect.signature(task).parameters.items()
+            if value.default is not inspect.Parameter.empty
+        }
         required_arguments = known_arguments - default_arguments
 
-        for arg in provided_arguments - known_arguments:
-            raise ValueError(f'Task \'{self.task}\' does not recognize argument \'{arg}\'')
+        # This checks TaskComponent.arguments only. StepComponent.default_arguments is checked in
+        # AnalysisFile.validate() for now and will move to StepComponent.validate() in step 5.
+        for argument in sorted(provided_arguments - known_arguments):
+            yield Diagnostic(
+                ('arguments', argument),
+                Severity.ERROR,
+                f'Task \'{self.task}\' does not recognize argument \'{argument}\'',
+            )
 
-        for arg in required_arguments - provided_arguments:
-            raise ValueError(f'Task \'{self.task}\' requires provision of argument \'{arg}\'')
-
-        for arg in default_arguments - provided_arguments:
-            eos.warn(f'Task \'{self.task}\' has a default value for argument \'{arg}\', which can change across versions; consider providing a value explicitly')
+        for argument in sorted(required_arguments - provided_arguments):
+            yield Diagnostic(
+                ('arguments', argument),
+                Severity.ERROR,
+                f'Task \'{self.task}\' requires provision of argument \'{argument}\'',
+            )
 
 
 @dataclass
-class StepComponent(Deserializable):
+class StepComponent(_AnalysisFileDeserializable):
     r"""Describes a single step of a reproducible analysis, i.e. one entry of an analysis file's ``steps`` list.
 
     A step bundles one or more task invocations, may declare dependencies on other steps, and may supply
@@ -647,13 +771,20 @@ class StepComponent(Deserializable):
     default_arguments:defaultdict=field(default_factory=lambda: defaultdict(dict))
 
     def __post_init__(self):
-        if '/' in self.id:
-            raise ValueError(f'Invalid character \'/\' in step id \'{self.id}\'')
-        if ' ' in self.id:
-            raise ValueError(f'Invalid character \' \' in step id \'{self.id}\'')
-        if len(self.tasks) == 0:
-            raise ValueError(f'Step \'{self.id}\' has no tasks')
         self.default_arguments = defaultdict(dict, self.default_arguments)
+
+    def _diagnostics(self):
+        if '/' in self.id:
+            yield Diagnostic(('id',), Severity.ERROR, f'Invalid character \'/\' in step id \'{self.id}\'')
+        if any(character.isspace() for character in self.id):
+            yield Diagnostic(('id',), Severity.ERROR, f'Invalid whitespace in step id \'{self.id}\'')
+        if not self.tasks:
+            yield Diagnostic(('tasks',), Severity.ERROR, f'Step \'{self.id}\' has no tasks')
+
+    def validate(self):
+        yield from self._diagnostics()
+        segments = getattr(self, '_task_segments', list(range(len(self.tasks))))
+        yield from _validate_children(self.tasks, segments, 'tasks')
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -672,11 +803,17 @@ class StepComponent(Deserializable):
                     (_task_argument_map[(task, k)] if (task, k) in _task_argument_map else k): v
                     for k, v in args.items()
                 }
+        diagnostics = Deserializable.check_keys(cls, _kwargs)
+        if diagnostics:
+            return InvalidComponent(diagnostics)
+        task_segments = _segments(kwargs["tasks"])
         _kwargs["tasks"] = [TaskComponent.from_dict(**t) for t in kwargs["tasks"]]
-        return Deserializable.make(cls, **_kwargs)
+        result = cls(**_kwargs)
+        result._task_segments = task_segments
+        return result
 
 
-class MaskDescription(Deserializable):
+class MaskDescription(_AnalysisFileDeserializable):
     """Polymorphic description of a single entry in a mask's ``description`` list.
 
     This is a dispatcher rather than a concrete description: :meth:`from_dict` inspects the keys of an
@@ -693,14 +830,14 @@ class MaskDescription(Deserializable):
         :rtype: MaskExpressionComponent | MaskNamedComponent | MaskObservableComponent
         """
         if 'expression' in kwargs:
-            return Deserializable.make(MaskExpressionComponent, **kwargs)
+            return Deserializable.make_with_diagnostics(MaskExpressionComponent, **kwargs)
         if 'mask_name' in kwargs:
-            return Deserializable.make(MaskNamedComponent, **kwargs)
+            return Deserializable.make_with_diagnostics(MaskNamedComponent, **kwargs)
         else:
-            return Deserializable.make(MaskObservableComponent, **kwargs)
+            return Deserializable.make_with_diagnostics(MaskObservableComponent, **kwargs)
 
 @dataclass
-class MaskExpressionComponent(Deserializable):
+class MaskExpressionComponent(_AnalysisFileDeserializable):
     r"""Describes a mask entry given by a new observable defined through an expression.
 
     :param expression: The EOS expression that defines the (pseudo-)observable used for masking.
@@ -712,7 +849,7 @@ class MaskExpressionComponent(Deserializable):
     name:str
 
 @dataclass
-class MaskObservableComponent(Deserializable):
+class MaskObservableComponent(_AnalysisFileDeserializable):
     r"""Describes a mask entry given by the name of an existing EOS observable.
 
     :param name: The qualified name of the observable used for masking.
@@ -721,7 +858,7 @@ class MaskObservableComponent(Deserializable):
     name:str
 
 @dataclass
-class MaskNamedComponent(Deserializable):
+class MaskNamedComponent(_AnalysisFileDeserializable):
     r"""Describes a mask entry that refers to another, previously defined mask.
 
     :param mask_name: The name of the previously defined mask to include.
@@ -730,7 +867,7 @@ class MaskNamedComponent(Deserializable):
     mask_name:str
 
 @dataclass
-class MaskComponent(Deserializable):
+class MaskComponent(_AnalysisFileDeserializable):
     r"""Describes a single named mask, i.e. one entry of an analysis file's ``masks`` list.
 
     A mask selects a subset of posterior samples by combining one or more (pseudo-)observables and/or
@@ -748,8 +885,20 @@ class MaskComponent(Deserializable):
     logical_combination: str = "and"
 
     def __post_init__(self):
-        if self.logical_combination not in ['and', 'or']:
-            raise ValueError(f'Invalid logical combination \'{self.logical_combination}\' for mask \'{self.name}\'')
+        pass
+
+    def _diagnostics(self):
+        if self.logical_combination not in ('and', 'or'):
+            yield Diagnostic(
+                ('logical_combination',),
+                Severity.ERROR,
+                f'Invalid logical combination \'{self.logical_combination}\' for mask \'{self.name}\'',
+            )
+
+    def validate(self):
+        yield from self._diagnostics()
+        segments = getattr(self, '_description_segments', list(range(len(self.description))))
+        yield from _validate_children(self.description, segments, 'description')
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -761,8 +910,14 @@ class MaskComponent(Deserializable):
         :rtype: MaskComponent
         """
         _kwargs = _copy.deepcopy(kwargs)
+        diagnostics = Deserializable.check_keys(cls, _kwargs)
+        if diagnostics:
+            return InvalidComponent(diagnostics)
+        description_segments = _segments(kwargs['description'])
         _kwargs['description'] = [MaskDescription.from_dict(**d) for d in kwargs['description']]
-        return Deserializable.make(cls, **_kwargs)
+        result = cls(**_kwargs)
+        result._description_segments = description_segments
+        return result
 
 # Maps the discriminating key of a mask-description entry to the corresponding concrete description
 # class. The canonical dispatch logic lives in MaskDescription.from_dict; this mapping mirrors it and
@@ -775,7 +930,7 @@ MaskDescription.registry = {
 
 
 @dataclass
-class AnalysisFileDescription(Deserializable):
+class AnalysisFileDescription(_AnalysisFileDeserializable):
     r"""Structured, deserialized representation of a complete analysis file.
 
     This is the in-memory counterpart of an analysis file's top-level YAML mapping: each field mirrors
@@ -823,6 +978,127 @@ class AnalysisFileDescription(Deserializable):
     steps:list                   = field(default_factory=list)
     masks:list                   = field(default_factory=list)
 
+    def validate(self):
+        yield from self._diagnostics()
+        if self.metadata:
+            yield from (diagnostic.prefixed('metadata') for diagnostic in self.metadata.validate())
+
+        child_sections = (
+            ('priors', self.priors, '_prior_segments'),
+            ('likelihoods', self.likelihoods, '_likelihood_segments'),
+            ('posteriors', self.posteriors, '_posterior_segments'),
+            ('predictions', self.predictions, '_prediction_segments'),
+            ('figures', self.figures, '_figure_segments'),
+            ('observables', self.observables, '_observable_segments'),
+            ('parameters', self.parameters, '_parameter_segments'),
+            ('steps', self.steps, '_step_segments'),
+            ('masks', self.masks, '_mask_segments'),
+        )
+        for section, children, attribute in child_sections:
+            segments = getattr(self, attribute, list(range(len(children))))
+            yield from _validate_children(children, segments, section)
+
+    def validate_structure(self):
+        yield from self.validate()
+
+        present_sections = getattr(self, '_present_sections', set())
+        if 'priors' not in present_sections:
+            yield Diagnostic(
+                ('priors',),
+                Severity.ERROR,
+                'Cannot load analysis file: need at least one prior component',
+            )
+        if 'likelihoods' not in present_sections:
+            yield Diagnostic(
+                ('likelihoods',),
+                Severity.WARNING,
+                'No likelihood components found in analysis file',
+            )
+        if 'posteriors' not in present_sections:
+            yield Diagnostic(
+                ('posteriors',),
+                Severity.ERROR,
+                'Cannot load analysis file: need at least one posterior',
+            )
+
+        prior_names = {
+            prior.name for prior in self.priors
+            if not isinstance(prior, InvalidComponent)
+        }
+        likelihood_names = {
+            likelihood.name for likelihood in self.likelihoods
+            if not isinstance(likelihood, InvalidComponent)
+        }
+        posterior_segments = getattr(self, '_posterior_segments', list(range(len(self.posteriors))))
+        assert len(self.posteriors) == len(posterior_segments)
+        for posterior, segment in zip(self.posteriors, posterior_segments):
+            if isinstance(posterior, InvalidComponent):
+                continue
+            for index, prior in enumerate(posterior.prior):
+                if prior not in prior_names:
+                    yield Diagnostic(
+                        ('posteriors', segment, 'prior', index),
+                        Severity.ERROR,
+                        f'Posterior \'{posterior.name}\' references prior \'{prior}\' which is not defined',
+                    )
+            for index, likelihood in enumerate(posterior.likelihood):
+                if likelihood not in likelihood_names:
+                    yield Diagnostic(
+                        ('posteriors', segment, 'likelihood', index),
+                        Severity.ERROR,
+                        f'Posterior \'{posterior.name}\' references likelihood \'{likelihood}\' which is not defined',
+                    )
+
+        step_ids = [
+            step.id for step in self.steps
+            if not isinstance(step, InvalidComponent)
+        ]
+        duplicate_step_ids = {
+            step_id for step_id, count in Counter(step_ids).items()
+            if count > 1
+        }
+        for step_id in sorted(duplicate_step_ids):
+            yield Diagnostic(
+                ('steps', step_id, 'id'),
+                Severity.ERROR,
+                f'Duplicate step id \'{step_id}\'; all steps must have a unique id',
+            )
+
+        mask_names = [
+            mask.name for mask in self.masks
+            if not isinstance(mask, InvalidComponent)
+        ]
+        duplicate_mask_names = {
+            mask_name for mask_name, count in Counter(mask_names).items()
+            if count > 1
+        }
+        for mask_name in sorted(duplicate_mask_names):
+            yield Diagnostic(
+                ('masks', mask_name, 'name'),
+                Severity.ERROR,
+                f'Duplicate mask name \'{mask_name}\'; all masks must have a unique name',
+            )
+
+        known_masks = set(mask_names)
+        mask_segments = getattr(self, '_mask_segments', list(range(len(self.masks))))
+        assert len(self.masks) == len(mask_segments)
+        for mask, mask_segment in zip(self.masks, mask_segments):
+            if isinstance(mask, InvalidComponent):
+                continue
+            description_segments = getattr(
+                mask,
+                '_description_segments',
+                list(range(len(mask.description))),
+            )
+            assert len(mask.description) == len(description_segments)
+            for description, description_segment in zip(mask.description, description_segments):
+                if isinstance(description, MaskNamedComponent) and description.mask_name not in known_masks:
+                    yield Diagnostic(
+                        ('masks', mask_segment, 'description', description_segment, 'mask_name'),
+                        Severity.ERROR,
+                        f'Mask {mask.name} references unknown mask {description.mask_name}',
+                    )
+
     @classmethod
     def from_dict(cls, **kwargs):
         r"""Create an :class:`AnalysisFileDescription` from the top-level mapping of an analysis file.
@@ -836,27 +1112,76 @@ class AnalysisFileDescription(Deserializable):
         :rtype: AnalysisFileDescription
         """
         _kwargs = dict(kwargs) # shallow copy: only the top-level keys are reassigned below
+        diagnostics = Deserializable.check_keys(cls, _kwargs)
+        if diagnostics:
+            return InvalidComponent(diagnostics)
         if 'metadata' in kwargs:
             _kwargs['metadata'] = MetadataDescription.from_dict(**kwargs['metadata'])
         if 'priors' in kwargs:
+            prior_segments = _segments(kwargs['priors'])
             _kwargs['priors'] = [PriorComponent.from_dict(**p) for p in kwargs['priors']]
+        else:
+            prior_segments = []
         if 'likelihoods' in kwargs:
+            likelihood_segments = _segments(kwargs['likelihoods'])
             _kwargs['likelihoods'] = [LikelihoodComponent.from_dict(**ll) for ll in kwargs['likelihoods']]
+        else:
+            likelihood_segments = []
         if 'posteriors' in kwargs:
+            posterior_segments = _segments(kwargs['posteriors'])
             _kwargs['posteriors'] = [PosteriorDescription.from_dict(**p) for p in kwargs['posteriors']]
+        else:
+            posterior_segments = []
         if 'predictions' in kwargs:
+            prediction_segments = _segments(kwargs['predictions'])
             _kwargs['predictions'] = [PredictionDescription.from_dict(**p) for p in kwargs['predictions']]
+        else:
+            prediction_segments = []
         if 'figures' in kwargs:
+            figure_segments = _segments(kwargs['figures'])
             _kwargs['figures'] = [FigureFactory.from_dict(**f) for f in kwargs['figures']]
+        else:
+            figure_segments = []
         if 'observables' in kwargs:
-            _kwargs['observables'] = [ObservableComponent.from_dict(name=n, **d) for n, d in kwargs['observables'].items()]
+            raw_observables = [
+                {'name': name, **description}
+                for name, description in kwargs['observables'].items()
+            ]
+            observable_segments = _segments(raw_observables)
+            _kwargs['observables'] = [ObservableComponent.from_dict(**o) for o in raw_observables]
+        else:
+            observable_segments = []
         if 'parameters' in kwargs:
-            _kwargs['parameters'] = [ParameterComponent.from_dict(name=n, **d) for n, d in kwargs['parameters'].items()]
+            raw_parameters = [
+                {'name': name, **description}
+                for name, description in kwargs['parameters'].items()
+            ]
+            parameter_segments = _segments(raw_parameters)
+            _kwargs['parameters'] = [ParameterComponent.from_dict(**p) for p in raw_parameters]
+        else:
+            parameter_segments = []
         if 'steps' in kwargs:
+            step_segments = _segments(kwargs['steps'], identifier='id')
             _kwargs['steps'] = [StepComponent.from_dict(**s) for s in kwargs['steps']]
+        else:
+            step_segments = []
         if 'masks' in kwargs:
+            mask_segments = _segments(kwargs['masks'])
             _kwargs['masks'] = [MaskComponent.from_dict(**m) for m in kwargs['masks']]
-        return Deserializable.make(cls, **_kwargs)
+        else:
+            mask_segments = []
+        result = cls(**_kwargs)
+        result._prior_segments = prior_segments
+        result._likelihood_segments = likelihood_segments
+        result._posterior_segments = posterior_segments
+        result._prediction_segments = prediction_segments
+        result._figure_segments = figure_segments
+        result._observable_segments = observable_segments
+        result._parameter_segments = parameter_segments
+        result._step_segments = step_segments
+        result._mask_segments = mask_segments
+        result._present_sections = set(kwargs)
+        return result
 
 # AnalysisFile schema
 

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -190,7 +190,6 @@ class PriorDescription:
             elif kwargs['type'] in ("transform",):
                 return Deserializable.make_with_diagnostics(TransformPriorDescription, **_kwargs)
         elif 'constraint' in kwargs:
-            eos.warn('A constraint prior description without a \'type\' key is deprecated and will be removed in a future version of EOS; add \'type: constraint\' instead')
             return Deserializable.make_with_diagnostics(ConstraintPriorDescription, **kwargs)
 
         return InvalidComponent([
@@ -236,8 +235,14 @@ class CurtailedGaussianDescription(_AnalysisFileDeserializable):
     max:float
     type:str=field(repr=False, init=False, default="gaussian")
 
-    def __post_init__(self):
-        pass
+    def _diagnostics(self):
+        yield Diagnostic(
+            (),
+            Severity.WARNING,
+            'The curtailed Gaussian prior description (a \'gauss\'/\'gaussian\' prior with \'min\' and \'max\') '
+            'is deprecated and will be removed in a future version of EOS; use \'type: gaussian\' without the '
+            '\'min\'/\'max\' keys instead',
+        )
 
 @dataclass
 class GaussianPriorDescription(_AnalysisFileDeserializable):
@@ -359,6 +364,27 @@ class PriorComponent(_AnalysisFileDeserializable):
 
     def _diagnostics(self):
         yield from _check_file_local_name(self.name, 'prior name', ('name',))
+        if getattr(self, '_has_legacy_parameters', False):
+            yield Diagnostic(
+                ('parameters',),
+                Severity.WARNING,
+                f'\'parameters\' is in the description of prior component \'{self.name}\', use \'descriptions\' '
+                'instead',
+            )
+        if getattr(self, '_has_descriptions_and_parameters', False):
+            yield Diagnostic(
+                ('parameters',),
+                Severity.WARNING,
+                f'Both \'descriptions\' and \'parameters\' are provided for prior component \'{self.name}\', '
+                'ignoring legacy support for \'parameters\'',
+            )
+        for segment in getattr(self, '_descriptions_without_type', ()):
+            yield Diagnostic(
+                ('descriptions', segment, 'type'),
+                Severity.WARNING,
+                'A constraint prior description without a \'type\' key is deprecated and will be removed in a '
+                'future version of EOS; add \'type: constraint\' instead',
+            )
 
     def validate_structure(self):
         yield from self._diagnostics()
@@ -406,11 +432,9 @@ class PriorComponent(_AnalysisFileDeserializable):
         :rtype: PriorComponent
         """
         _kwargs = _copy.deepcopy(kwargs)
-        if "descriptions" in kwargs:
-            if "parameters" in kwargs:
-                eos.error(f'Both \'descriptions\' and \'parameters\' are provided for prior component \'{kwargs["name"]}\', ignoring legacy support for \'parameters\'')
-        if "parameters" in kwargs:
-            eos.warn(f'\'parameters\' is in the description of prior component \'{kwargs["name"]}\', use \'descriptions\' instead')
+        has_legacy_parameters = "parameters" in kwargs
+        has_descriptions_and_parameters = "descriptions" in kwargs and has_legacy_parameters
+        if has_legacy_parameters:
             _kwargs['descriptions'] = _kwargs.pop("parameters")
         diagnostics = Deserializable.check_keys(cls, _kwargs)
         if diagnostics:
@@ -419,6 +443,13 @@ class PriorComponent(_AnalysisFileDeserializable):
         _kwargs['descriptions'] = [PriorDescription.from_dict(**d) for d in _kwargs['descriptions']]
         result = cls(**_kwargs)
         result._description_segments = description_segments
+        result._has_legacy_parameters = has_legacy_parameters
+        result._has_descriptions_and_parameters = has_descriptions_and_parameters
+        result._descriptions_without_type = tuple(
+            segment
+            for description, segment in zip(kwargs.get('parameters', kwargs.get('descriptions', ())), description_segments)
+            if 'type' not in description and 'constraint' in description
+        )
         return result
 
 
@@ -910,6 +941,14 @@ class TaskComponent(_AnalysisFileDeserializable):
                 ('arguments', argument),
                 Severity.ERROR,
                 f'Task \'{self.task}\' requires provision of argument \'{argument}\'',
+            )
+
+        for argument in sorted(default_arguments - provided_arguments):
+            yield Diagnostic(
+                ('arguments', argument),
+                Severity.WARNING,
+                f'Task \'{self.task}\' has a default value for argument \'{argument}\', which can change across '
+                'versions; consider providing a value explicitly',
             )
 
 

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -59,6 +59,16 @@ def _validate_children(children, segments, prefix):
             yield from (diagnostic.prefixed(prefix, segment) for diagnostic in validator())
 
 
+def _check_qualified(context, value, kind, path):
+    try:
+        qn = eos.QualifiedName(value)
+    except RuntimeError as e:
+        yield Diagnostic(path, Severity.ERROR, f"'{value}' is not a valid qualified name: {e}")
+        return
+    if not context.lookup(kind, qn):
+        yield Diagnostic(path, Severity.ERROR, f"{kind} '{value}' is unknown to EOS")
+
+
 @dataclass
 class MetadataAuthorDescription(_AnalysisFileDeserializable):
     """Describes a single author in an analysis file's metadata.
@@ -345,25 +355,27 @@ class PriorComponent(_AnalysisFileDeserializable):
             # single parameter (uniform, scale, gauss, poisson), a single constraint (constraint
             # priors), or a list of parameters (transform priors). An InvalidComponent has none of
             # them and is skipped here; its own diagnostics come from the structural phase.
-            if hasattr(description, 'parameter') and not context.lookup('parameter', description.parameter):
-                yield Diagnostic(
+            if hasattr(description, 'parameter'):
+                yield from _check_qualified(
+                    context,
+                    description.parameter,
+                    'parameter',
                     ('descriptions', segment, 'parameter'),
-                    Severity.ERROR,
-                    f"Error in prior {self.name}: Parameter '{description.parameter}' not known to EOS",
                 )
-            if hasattr(description, 'constraint') and not context.lookup('constraint', description.constraint):
-                yield Diagnostic(
+            if hasattr(description, 'constraint'):
+                yield from _check_qualified(
+                    context,
+                    description.constraint,
+                    'constraint',
                     ('descriptions', segment, 'constraint'),
-                    Severity.ERROR,
-                    f"Error in prior {self.name}: Constraint '{description.constraint}' not known to EOS",
                 )
             for index, parameter in enumerate(getattr(description, 'parameters', ())):
-                if not context.lookup('parameter', parameter):
-                    yield Diagnostic(
-                        ('descriptions', segment, 'parameters', index),
-                        Severity.ERROR,
-                        f"Error in prior {self.name}: Parameter '{parameter}' not known to EOS",
-                    )
+                yield from _check_qualified(
+                    context,
+                    parameter,
+                    'parameter',
+                    ('descriptions', segment, 'parameters', index),
+                )
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -478,12 +490,12 @@ class LikelihoodComponent(_AnalysisFileDeserializable):
         constraint_segments = getattr(self, '_constraint_segments', list(range(len(self.constraints))))
         assert len(self.constraints) == len(constraint_segments)
         for description, segment in zip(self.constraints, constraint_segments):
-            if not context.lookup('constraint', description.constraint):
-                yield Diagnostic(
-                    ('constraints', segment),
-                    Severity.ERROR,
-                    f"Error in likelihood {self.name}: Constraint '{description.constraint}'  not known to EOS",
-                )
+            yield from _check_qualified(
+                context,
+                description.constraint,
+                'constraint',
+                ('constraints', segment),
+            )
 
         known_constraints = eos.Constraints()
         manual_segments = getattr(
@@ -493,6 +505,12 @@ class LikelihoodComponent(_AnalysisFileDeserializable):
         )
         assert len(self.manual_constraints) == len(manual_segments)
         for manual, segment in zip(self.manual_constraints, manual_segments):
+            yield from _check_qualified(
+                context,
+                manual.name,
+                'constraint',
+                ('manual_constraints', segment, 'name'),
+            )
             try:
                 known_constraints[manual.name]
                 yield Diagnostic(
@@ -569,12 +587,12 @@ class PosteriorDescription(_AnalysisFileDeserializable):
 
     def validate_semantics(self, context):
         for parameter in self.fixed_parameters:
-            if not context.lookup('parameter', parameter):
-                yield Diagnostic(
-                    ('fixed_parameters', parameter),
-                    Severity.ERROR,
-                    f"Error in posterior {self.name}: Fixed parameter '{parameter}' not known to EOS",
-                )
+            yield from _check_qualified(
+                context,
+                parameter,
+                'parameter',
+                ('fixed_parameters', parameter),
+            )
 
 
 
@@ -646,20 +664,20 @@ class PredictionDescription(_AnalysisFileDeserializable):
         segments = getattr(self, '_observable_segments', list(range(len(self.observables))))
         assert len(self.observables) == len(segments)
         for observable, segment in zip(self.observables, segments):
-            if not context.lookup('observable', observable.name):
-                yield Diagnostic(
-                    ('observables', segment, 'name'),
-                    Severity.ERROR,
-                    f"Error in prediction {self.name}: Observable '{observable.name}' not known to EOS",
-                )
+            yield from _check_qualified(
+                context,
+                observable.name,
+                'observable',
+                ('observables', segment, 'name'),
+            )
 
         for parameter in self.fixed_parameters:
-            if not context.lookup('parameter', parameter):
-                yield Diagnostic(
-                    ('fixed_parameters', parameter),
-                    Severity.ERROR,
-                    f"Error in prediction {self.name}: Fixed parameter '{parameter}' not known to EOS",
-                )
+            yield from _check_qualified(
+                context,
+                parameter,
+                'parameter',
+                ('fixed_parameters', parameter),
+            )
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -708,6 +726,15 @@ class ParameterComponent(_AnalysisFileDeserializable):
     min:float
     max:float
     alias_of:list=field(default_factory=list)
+
+    def validate_semantics(self, context):
+        for index, alias in enumerate(self.alias_of):
+            yield from _check_qualified(
+                context,
+                alias,
+                'parameter',
+                ('alias_of', index),
+            )
 
 
 
@@ -968,6 +995,9 @@ class MaskObservableComponent(_AnalysisFileDeserializable):
     """
     name:str
 
+    def validate_semantics(self, context):
+        yield from _check_qualified(context, self.name, 'observable', ('name',))
+
 @dataclass
 class MaskNamedComponent(_AnalysisFileDeserializable):
     r"""Describes a mask entry that refers to another, previously defined mask.
@@ -1010,6 +1040,16 @@ class MaskComponent(_AnalysisFileDeserializable):
         yield from self._diagnostics()
         segments = getattr(self, '_description_segments', list(range(len(self.description))))
         yield from _validate_children(self.description, segments, 'description')
+
+    def validate_semantics(self, context):
+        segments = getattr(self, '_description_segments', list(range(len(self.description))))
+        assert len(self.description) == len(segments)
+        for description, segment in zip(self.description, segments):
+            if hasattr(description, 'validate_semantics'):
+                yield from (
+                    diagnostic.prefixed('description', segment)
+                    for diagnostic in description.validate_semantics(context)
+                )
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -1216,7 +1256,9 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
             ('likelihoods', self.likelihoods, '_likelihood_segments'),
             ('posteriors', self.posteriors, '_posterior_segments'),
             ('predictions', self.predictions, '_prediction_segments'),
+            ('parameters', self.parameters, '_parameter_segments'),
             ('steps', self.steps, '_step_segments'),
+            ('masks', self.masks, '_mask_segments'),
         )
         for section, children, attribute in child_sections:
             segments = getattr(self, attribute, list(range(len(children))))

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -617,6 +617,33 @@ class ObservableComponent(_AnalysisFileDeserializable):
     expression:str
     options:dict=field(default_factory=dict)
 
+    def validate_semantics(self, context):
+        try:
+            references = eos.analyze_expression(self.expression)
+        except RuntimeError as error:
+            message = str(error)
+            if message.startswith('Parsing Error:'):
+                yield Diagnostic(
+                    ('expression',),
+                    Severity.ERROR,
+                    f'Expression does not parse: {message}',
+                )
+                return
+            elif 'is not a valid qualified name:' in message:
+                yield Diagnostic(
+                    ('expression',),
+                    Severity.ERROR,
+                    f'Expression contains a malformed qualified name: {message}',
+                )
+                return
+            else:
+                raise
+
+        for observable in references.observables:
+            yield from _check_qualified(context, observable.full(), 'observable', ('expression',))
+        for parameter in references.parameters:
+            yield from _check_qualified(context, parameter.full(), 'parameter', ('expression',))
+
 
 
 @dataclass
@@ -986,6 +1013,33 @@ class MaskExpressionComponent(_AnalysisFileDeserializable):
     expression:str
     name:str
 
+    def validate_semantics(self, context):
+        try:
+            references = eos.analyze_expression(self.expression)
+        except RuntimeError as error:
+            message = str(error)
+            if message.startswith('Parsing Error:'):
+                yield Diagnostic(
+                    ('expression',),
+                    Severity.ERROR,
+                    f'Expression does not parse: {message}',
+                )
+                return
+            elif 'is not a valid qualified name:' in message:
+                yield Diagnostic(
+                    ('expression',),
+                    Severity.ERROR,
+                    f'Expression contains a malformed qualified name: {message}',
+                )
+                return
+            else:
+                raise
+
+        for observable in references.observables:
+            yield from _check_qualified(context, observable.full(), 'observable', ('expression',))
+        for parameter in references.parameters:
+            yield from _check_qualified(context, parameter.full(), 'parameter', ('expression',))
+
 @dataclass
 class MaskObservableComponent(_AnalysisFileDeserializable):
     r"""Describes a mask entry given by the name of an existing EOS observable.
@@ -1256,6 +1310,7 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
             ('likelihoods', self.likelihoods, '_likelihood_segments'),
             ('posteriors', self.posteriors, '_posterior_segments'),
             ('predictions', self.predictions, '_prediction_segments'),
+            ('observables', self.observables, '_observable_segments'),
             ('parameters', self.parameters, '_parameter_segments'),
             ('steps', self.steps, '_step_segments'),
             ('masks', self.masks, '_mask_segments'),

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -20,7 +20,7 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 from .deserializable import Deserializable, InvalidComponent
-from .diagnostic import Diagnostic, Severity
+from .diagnostic import Diagnostic, Severity, _check_qualified
 from eos.figure import FigureFactory
 from dataclasses import dataclass, field
 from collections import defaultdict
@@ -65,16 +65,6 @@ def _validate_children(children, segments, prefix):
             validator = getattr(child, 'validate', None)
         if validator is not None:
             yield from (diagnostic.prefixed(prefix, segment) for diagnostic in validator())
-
-
-def _check_qualified(context, value, kind, path):
-    try:
-        qn = eos.QualifiedName(value)
-    except RuntimeError as e:
-        yield Diagnostic(path, Severity.ERROR, f"'{value}' is not a valid qualified name: {e}")
-        return
-    if not context.lookup(kind, qn):
-        yield Diagnostic(path, Severity.ERROR, f"{kind} '{value}' is unknown to EOS")
 
 
 def _check_file_local_name(value, kind, path):
@@ -1420,6 +1410,7 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
             ('likelihoods', self.likelihoods, '_likelihood_segments'),
             ('posteriors', self.posteriors, '_posterior_segments'),
             ('predictions', self.predictions, '_prediction_segments'),
+            ('figures', self.figures, '_figure_segments'),
             ('observables', self.observables, '_observable_segments'),
             ('parameters', self.parameters, '_parameter_segments'),
             ('steps', self.steps, '_step_segments'),

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -545,12 +545,24 @@ class LikelihoodComponent(_AnalysisFileDeserializable):
         )
         assert len(self.manual_constraints) == len(manual_segments)
         for manual, segment in zip(self.manual_constraints, manual_segments):
-            yield from _check_qualified(
-                context,
-                manual.name,
-                'constraint',
-                ('manual_constraints', segment, 'name'),
-            )
+            # Manual-constraint schemas vary by block type and are otherwise opaque here. An exotic
+            # block type may therefore hide additional observable references that validation cannot see.
+            if 'observable' in manual.info:
+                yield from _check_qualified(
+                    context,
+                    manual.info['observable'],
+                    'observable',
+                    ('manual_constraints', segment, 'info', 'observable'),
+                )
+            if 'observables' in manual.info:
+                for index, observable in enumerate(manual.info['observables']):
+                    yield from _check_qualified(
+                        context,
+                        observable,
+                        'observable',
+                        ('manual_constraints', segment, 'info', 'observables', index),
+                    )
+
             try:
                 known_constraints[manual.name]
                 yield Diagnostic(
@@ -1467,10 +1479,14 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
                 f"Error in masks: Name '{name}' is used repeatedly",
             )
 
+        # These reports are advisory: parameters can be consumed outside the file (or supplied as
+        # fixed_parameters by a caller), and manual-constraint info is only partially inspectable.
         tracked_sections = (
             ('prior', 'priors', self.priors, '_prior_segments'),
             ('likelihood', 'likelihoods', self.likelihoods, '_likelihood_segments'),
             ('mask', 'masks', self.masks, '_mask_segments'),
+            ('observable', 'observables', self.observables, '_observable_segments'),
+            ('parameter', 'parameters', self.parameters, '_parameter_segments'),
         )
         for kind, section, children, attribute in tracked_sections:
             unused = context.unused(kind)
@@ -1482,6 +1498,49 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
                         (section, segment),
                         Severity.WARNING,
                         f"{kind.capitalize()} '{child.name}' is unused",
+                    )
+
+        unused_observables = context.unused('observable')
+        mask_segments = getattr(self, '_mask_segments', list(range(len(self.masks))))
+        assert len(self.masks) == len(mask_segments)
+        for mask, mask_segment in zip(self.masks, mask_segments):
+            if isinstance(mask, InvalidComponent):
+                continue
+            description_segments = getattr(
+                mask,
+                '_description_segments',
+                list(range(len(mask.description))),
+            )
+            assert len(mask.description) == len(description_segments)
+            for description, description_segment in zip(mask.description, description_segments):
+                if (
+                    isinstance(description, MaskExpressionComponent)
+                    and description.name in unused_observables
+                ):
+                    yield Diagnostic(
+                        ('masks', mask_segment, 'description', description_segment),
+                        Severity.WARNING,
+                        f"Observable '{description.name}' is unused",
+                    )
+
+        unused_constraints = context.unused('constraint')
+        likelihood_segments = getattr(self, '_likelihood_segments', list(range(len(self.likelihoods))))
+        assert len(self.likelihoods) == len(likelihood_segments)
+        for likelihood, likelihood_segment in zip(self.likelihoods, likelihood_segments):
+            if isinstance(likelihood, InvalidComponent):
+                continue
+            manual_segments = getattr(
+                likelihood,
+                '_manual_constraint_segments',
+                list(range(len(likelihood.manual_constraints))),
+            )
+            assert len(likelihood.manual_constraints) == len(manual_segments)
+            for manual, manual_segment in zip(likelihood.manual_constraints, manual_segments):
+                if not isinstance(manual, InvalidComponent) and str(manual.name) in unused_constraints:
+                    yield Diagnostic(
+                        ('likelihoods', likelihood_segment, 'manual_constraints', manual_segment),
+                        Severity.WARNING,
+                        f"Constraint '{manual.name}' is unused",
                     )
 
     @classmethod

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -38,7 +38,7 @@ class _AnalysisFileDeserializable(Deserializable):
     def _diagnostics(self):
         yield from ()
 
-    def validate(self):
+    def validate_structure(self):
         yield from self._diagnostics()
 
 
@@ -52,8 +52,11 @@ def _segments(raw_children, identifier='name'):
 def _validate_children(children, segments, prefix):
     assert len(children) == len(segments)
     for child, segment in zip(children, segments):
-        if hasattr(child, 'validate'):
-            yield from (diagnostic.prefixed(prefix, segment) for diagnostic in child.validate())
+        validator = getattr(child, 'validate_structure', None)
+        if validator is None:
+            validator = getattr(child, 'validate', None)
+        if validator is not None:
+            yield from (diagnostic.prefixed(prefix, segment) for diagnostic in validator())
 
 
 @dataclass
@@ -87,7 +90,7 @@ class MetadataDescription(_AnalysisFileDeserializable):
     id:str=''
     authors:list[MetadataAuthorDescription]=field(default_factory=list)
 
-    def validate(self):
+    def validate_structure(self):
         yield from self._diagnostics()
         segments = getattr(self, '_author_segments', list(range(len(self.authors))))
         yield from _validate_children(self.authors, segments, 'authors')
@@ -329,10 +332,38 @@ class PriorComponent(_AnalysisFileDeserializable):
     name:str
     descriptions:list
 
-    def validate(self):
+    def validate_structure(self):
         yield from self._diagnostics()
         segments = getattr(self, '_description_segments', list(range(len(self.descriptions))))
         yield from _validate_children(self.descriptions, segments, 'descriptions')
+
+    def validate_semantics(self, context):
+        segments = getattr(self, '_description_segments', list(range(len(self.descriptions))))
+        assert len(self.descriptions) == len(segments)
+        for description, segment in zip(self.descriptions, segments):
+            # The concrete prior descriptions reference EOS entities through one of three fields: a
+            # single parameter (uniform, scale, gauss, poisson), a single constraint (constraint
+            # priors), or a list of parameters (transform priors). An InvalidComponent has none of
+            # them and is skipped here; its own diagnostics come from the structural phase.
+            if hasattr(description, 'parameter') and not context.lookup('parameter', description.parameter):
+                yield Diagnostic(
+                    ('descriptions', segment, 'parameter'),
+                    Severity.ERROR,
+                    f"Error in prior {self.name}: Parameter '{description.parameter}' not known to EOS",
+                )
+            if hasattr(description, 'constraint') and not context.lookup('constraint', description.constraint):
+                yield Diagnostic(
+                    ('descriptions', segment, 'constraint'),
+                    Severity.ERROR,
+                    f"Error in prior {self.name}: Constraint '{description.constraint}' not known to EOS",
+                )
+            for index, parameter in enumerate(getattr(description, 'parameters', ())):
+                if not context.lookup('parameter', parameter):
+                    yield Diagnostic(
+                        ('descriptions', segment, 'parameters', index),
+                        Severity.ERROR,
+                        f"Error in prior {self.name}: Parameter '{parameter}' not known to EOS",
+                    )
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -426,7 +457,7 @@ class LikelihoodComponent(_AnalysisFileDeserializable):
                 'LikelihoodComponent must have at least one of constraints, manual_constraints, or pyhf',
             )
 
-    def validate(self):
+    def validate_structure(self):
         yield from self._diagnostics()
         constraint_segments = getattr(self, '_constraint_segments', list(range(len(self.constraints))))
         yield from _validate_children(self.constraints, constraint_segments, 'constraints')
@@ -441,7 +472,36 @@ class LikelihoodComponent(_AnalysisFileDeserializable):
             'manual_constraints',
         )
         if self.pyhf:
-            yield from (diagnostic.prefixed('pyhf') for diagnostic in self.pyhf.validate())
+            yield from (diagnostic.prefixed('pyhf') for diagnostic in self.pyhf.validate_structure())
+
+    def validate_semantics(self, context):
+        constraint_segments = getattr(self, '_constraint_segments', list(range(len(self.constraints))))
+        assert len(self.constraints) == len(constraint_segments)
+        for description, segment in zip(self.constraints, constraint_segments):
+            if not context.lookup('constraint', description.constraint):
+                yield Diagnostic(
+                    ('constraints', segment),
+                    Severity.ERROR,
+                    f"Error in likelihood {self.name}: Constraint '{description.constraint}'  not known to EOS",
+                )
+
+        known_constraints = eos.Constraints()
+        manual_segments = getattr(
+            self,
+            '_manual_constraint_segments',
+            list(range(len(self.manual_constraints))),
+        )
+        assert len(self.manual_constraints) == len(manual_segments)
+        for manual, segment in zip(self.manual_constraints, manual_segments):
+            try:
+                known_constraints[manual.name]
+                yield Diagnostic(
+                    ('manual_constraints', segment),
+                    Severity.ERROR,
+                    f"Error in likelihood {self.name}: The manual constraint named '{manual.name}' matches an already defined constraint name",
+                )
+            except RuntimeError:
+                pass
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -507,6 +567,15 @@ class PosteriorDescription(_AnalysisFileDeserializable):
     global_options:dict=field(default_factory=dict)
     fixed_parameters:dict=field(default_factory=dict)
 
+    def validate_semantics(self, context):
+        for parameter in self.fixed_parameters:
+            if not context.lookup('parameter', parameter):
+                yield Diagnostic(
+                    ('fixed_parameters', parameter),
+                    Severity.ERROR,
+                    f"Error in posterior {self.name}: Fixed parameter '{parameter}' not known to EOS",
+                )
+
 
 
 @dataclass
@@ -568,10 +637,29 @@ class PredictionDescription(_AnalysisFileDeserializable):
     global_options:dict=field(default_factory=dict)
     fixed_parameters:dict=field(default_factory=dict)
 
-    def validate(self):
+    def validate_structure(self):
         yield from self._diagnostics()
         segments = getattr(self, '_observable_segments', list(range(len(self.observables))))
         yield from _validate_children(self.observables, segments, 'observables')
+
+    def validate_semantics(self, context):
+        segments = getattr(self, '_observable_segments', list(range(len(self.observables))))
+        assert len(self.observables) == len(segments)
+        for observable, segment in zip(self.observables, segments):
+            if not context.lookup('observable', observable.name):
+                yield Diagnostic(
+                    ('observables', segment, 'name'),
+                    Severity.ERROR,
+                    f"Error in prediction {self.name}: Observable '{observable.name}' not known to EOS",
+                )
+
+        for parameter in self.fixed_parameters:
+            if not context.lookup('parameter', parameter):
+                yield Diagnostic(
+                    ('fixed_parameters', parameter),
+                    Severity.ERROR,
+                    f"Error in prediction {self.name}: Fixed parameter '{parameter}' not known to EOS",
+                )
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -730,7 +818,7 @@ class TaskComponent(_AnalysisFileDeserializable):
         required_arguments = known_arguments - default_arguments
 
         # This checks TaskComponent.arguments only. StepComponent.default_arguments is checked in
-        # AnalysisFile.validate() for now and will move to StepComponent.validate() in step 5.
+        # StepComponent.validate_semantics().
         for argument in sorted(provided_arguments - known_arguments):
             yield Diagnostic(
                 ('arguments', argument),
@@ -781,10 +869,33 @@ class StepComponent(_AnalysisFileDeserializable):
         if not self.tasks:
             yield Diagnostic(('tasks',), Severity.ERROR, f'Step \'{self.id}\' has no tasks')
 
-    def validate(self):
+    def validate_structure(self):
         yield from self._diagnostics()
         segments = getattr(self, '_task_segments', list(range(len(self.tasks))))
         yield from _validate_children(self.tasks, segments, 'tasks')
+
+    def validate_semantics(self, context):
+        unknown_tasks = self.default_arguments.keys() - eos.tasks._tasks.keys()
+        if unknown_tasks:
+            yield Diagnostic(
+                ('default_arguments',),
+                Severity.ERROR,
+                f"Step '{self.id}' has default arguments for unknown tasks: {unknown_tasks}",
+            )
+
+        for task_component in self.tasks:
+            if task_component.task not in eos.tasks._tasks:
+                continue
+            task = eos.tasks._tasks[task_component.task]
+            # TaskComponent.arguments is checked by TaskComponent._diagnostics() in phase 1.
+            provided_arguments = self.default_arguments[task_component.task].keys()
+            known_arguments = set(inspect.signature(task).parameters)
+            for argument in provided_arguments - known_arguments:
+                yield Diagnostic(
+                    ('default_arguments', task_component.task, argument),
+                    Severity.ERROR,
+                    f"Task '{task_component.task}' does not recognize argument '{argument}'",
+                )
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -895,7 +1006,7 @@ class MaskComponent(_AnalysisFileDeserializable):
                 f'Invalid logical combination \'{self.logical_combination}\' for mask \'{self.name}\'',
             )
 
-    def validate(self):
+    def validate_structure(self):
         yield from self._diagnostics()
         segments = getattr(self, '_description_segments', list(range(len(self.description))))
         yield from _validate_children(self.description, segments, 'description')
@@ -978,10 +1089,10 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
     steps:list                   = field(default_factory=list)
     masks:list                   = field(default_factory=list)
 
-    def validate(self):
+    def validate_structure_children(self):
         yield from self._diagnostics()
         if self.metadata:
-            yield from (diagnostic.prefixed('metadata') for diagnostic in self.metadata.validate())
+            yield from (diagnostic.prefixed('metadata') for diagnostic in self.metadata.validate_structure())
 
         child_sections = (
             ('priors', self.priors, '_prior_segments'),
@@ -999,7 +1110,7 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
             yield from _validate_children(children, segments, section)
 
     def validate_structure(self):
-        yield from self.validate()
+        yield from self.validate_structure_children()
 
         present_sections = getattr(self, '_present_sections', set())
         if 'priors' not in present_sections:
@@ -1098,6 +1209,65 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
                         Severity.ERROR,
                         f'Mask {mask.name} references unknown mask {description.mask_name}',
                     )
+
+    def validate_semantics(self, context):
+        child_sections = (
+            ('priors', self.priors, '_prior_segments'),
+            ('likelihoods', self.likelihoods, '_likelihood_segments'),
+            ('posteriors', self.posteriors, '_posterior_segments'),
+            ('predictions', self.predictions, '_prediction_segments'),
+            ('steps', self.steps, '_step_segments'),
+        )
+        for section, children, attribute in child_sections:
+            segments = getattr(self, attribute, list(range(len(children))))
+            assert len(children) == len(segments)
+            for child, segment in zip(children, segments):
+                if hasattr(child, 'validate_semantics'):
+                    yield from (
+                        diagnostic.prefixed(section, segment)
+                        for diagnostic in child.validate_semantics(context)
+                    )
+
+        step_ids = {step.id for step in self.steps}
+        step_segments = getattr(self, '_step_segments', list(range(len(self.steps))))
+        assert len(self.steps) == len(step_segments)
+        for step, segment in zip(self.steps, step_segments):
+            unknown_dependencies = set(step.depends_on) - step_ids
+            if unknown_dependencies:
+                yield Diagnostic(
+                    ('steps', segment, 'depends_on'),
+                    Severity.ERROR,
+                    f"Step '{step.id}' depends on unknown steps: {unknown_dependencies}",
+                )
+
+            task_segments = getattr(step, '_task_segments', list(range(len(step.tasks))))
+            assert len(step.tasks) == len(task_segments)
+            for task, task_segment in zip(step.tasks, task_segments):
+                if 'posterior' in task.arguments:
+                    posterior = task.arguments['posterior']
+                    if not context.lookup('posterior', posterior):
+                        yield Diagnostic(
+                            ('steps', segment, 'tasks', task_segment, 'arguments', 'posterior'),
+                            Severity.ERROR,
+                            f"Error in step {step.id}: Posterior '{posterior}' not known to EOS",
+                        )
+
+        expression_names = [
+            description.name
+            for mask in self.masks
+            for description in mask.description
+            if isinstance(description, MaskExpressionComponent)
+        ]
+        repeated_names = {
+            name for name, count in Counter(expression_names).items()
+            if count > 1
+        }
+        for name in repeated_names:
+            yield Diagnostic(
+                ('masks',),
+                Severity.ERROR,
+                f"Error in masks: Name '{name}' is used repeatedly",
+            )
 
     @classmethod
     def from_dict(cls, **kwargs):

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -1438,6 +1438,41 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
                         for diagnostic in child.validate_semantics(context)
                     )
 
+        # A posterior must not fix a parameter that one of its own priors varies: the prior wins, so
+        # the fixed value is silently ignored and the file does not describe the intended analysis.
+        # Only the parameters a prior names explicitly are known here; the parameters varied by a
+        # constraint prior are determined by EOS and are therefore not covered.
+        priors_by_name = {
+            prior.name: prior for prior in self.priors
+            if not isinstance(prior, InvalidComponent)
+        }
+        posterior_segments = getattr(self, '_posterior_segments', list(range(len(self.posteriors))))
+        assert len(self.posteriors) == len(posterior_segments)
+        for posterior, segment in zip(self.posteriors, posterior_segments):
+            if isinstance(posterior, InvalidComponent):
+                continue
+            varied = {}
+            for prior_name in posterior.prior:
+                prior = priors_by_name.get(prior_name)
+                if prior is None:
+                    continue
+                for description in prior.descriptions:
+                    names = []
+                    if hasattr(description, 'parameter'):
+                        names.append(description.parameter)
+                    names.extend(getattr(description, 'parameters', ()))
+                    for name in names:
+                        varied.setdefault(str(name), prior_name)
+            for parameter in posterior.fixed_parameters:
+                prior_name = varied.get(str(parameter))
+                if prior_name is not None:
+                    yield Diagnostic(
+                        ('posteriors', segment, 'fixed_parameters', str(parameter)),
+                        Severity.WARNING,
+                        f"Parameter '{parameter}' is fixed by posterior '{posterior.name}' but "
+                        f"varied by its prior '{prior_name}'",
+                    )
+
         step_ids = {step.id for step in self.steps}
         step_segments = getattr(self, '_step_segments', list(range(len(self.steps))))
         assert len(self.steps) == len(step_segments)

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -44,7 +44,15 @@ class _AnalysisFileDeserializable(Deserializable):
 
 def _segments(raw_children, identifier='name'):
     return [
-        child[identifier] if isinstance(child, dict) and identifier in child else index
+        child[identifier]
+        if (
+            isinstance(child, dict)
+            and identifier in child
+            and isinstance(child[identifier], str)
+            and '/' not in child[identifier]
+            and not any(character.isspace() for character in child[identifier])
+        )
+        else index
         for index, child in enumerate(raw_children)
     ]
 
@@ -67,6 +75,13 @@ def _check_qualified(context, value, kind, path):
         return
     if not context.lookup(kind, qn):
         yield Diagnostic(path, Severity.ERROR, f"{kind} '{value}' is unknown to EOS")
+
+
+def _check_file_local_name(value, kind, path):
+    if '/' in value:
+        yield Diagnostic(path, Severity.ERROR, f"Invalid character '/' in {kind} '{value}'")
+    if any(character.isspace() for character in value):
+        yield Diagnostic(path, Severity.ERROR, f"Invalid whitespace in {kind} '{value}'")
 
 
 @dataclass
@@ -342,6 +357,9 @@ class PriorComponent(_AnalysisFileDeserializable):
     name:str
     descriptions:list
 
+    def _diagnostics(self):
+        yield from _check_file_local_name(self.name, 'prior name', ('name',))
+
     def validate_structure(self):
         yield from self._diagnostics()
         segments = getattr(self, '_description_segments', list(range(len(self.descriptions))))
@@ -462,6 +480,7 @@ class LikelihoodComponent(_AnalysisFileDeserializable):
     pyhf:PyHFConstraintDescription|None=None
 
     def _diagnostics(self):
+        yield from _check_file_local_name(self.name, 'likelihood name', ('name',))
         if not (self.constraints or self.manual_constraints or self.pyhf):
             yield Diagnostic(
                 (),
@@ -585,6 +604,9 @@ class PosteriorDescription(_AnalysisFileDeserializable):
     global_options:dict=field(default_factory=dict)
     fixed_parameters:dict=field(default_factory=dict)
 
+    def _diagnostics(self):
+        yield from _check_file_local_name(self.name, 'posterior name', ('name',))
+
     def validate_semantics(self, context):
         for parameter in self.fixed_parameters:
             yield from _check_qualified(
@@ -681,6 +703,9 @@ class PredictionDescription(_AnalysisFileDeserializable):
     observables:list
     global_options:dict=field(default_factory=dict)
     fixed_parameters:dict=field(default_factory=dict)
+
+    def _diagnostics(self):
+        yield from _check_file_local_name(self.name, 'prediction name', ('name',))
 
     def validate_structure(self):
         yield from self._diagnostics()
@@ -916,10 +941,7 @@ class StepComponent(_AnalysisFileDeserializable):
         self.default_arguments = defaultdict(dict, self.default_arguments)
 
     def _diagnostics(self):
-        if '/' in self.id:
-            yield Diagnostic(('id',), Severity.ERROR, f'Invalid character \'/\' in step id \'{self.id}\'')
-        if any(character.isspace() for character in self.id):
-            yield Diagnostic(('id',), Severity.ERROR, f'Invalid whitespace in step id \'{self.id}\'')
+        yield from _check_file_local_name(self.id, 'step id', ('id',))
         if not self.tasks:
             yield Diagnostic(('tasks',), Severity.ERROR, f'Step \'{self.id}\' has no tasks')
 
@@ -1083,6 +1105,7 @@ class MaskComponent(_AnalysisFileDeserializable):
         pass
 
     def _diagnostics(self):
+        yield from _check_file_local_name(self.name, 'mask name', ('name',))
         if self.logical_combination not in ('and', 'or'):
             yield Diagnostic(
                 ('logical_combination',),

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -639,6 +639,10 @@ class PosteriorDescription(_AnalysisFileDeserializable):
         yield from _check_file_local_name(self.name, 'posterior name', ('name',))
 
     def validate_semantics(self, context):
+        for prior in self.prior:
+            context.lookup('prior', prior)
+        for likelihood in self.likelihood:
+            context.lookup('likelihood', likelihood)
         for parameter in self.fixed_parameters:
             yield from _check_qualified(
                 context,
@@ -892,6 +896,13 @@ _task_argument_map = {
     ('draw-figure', 'F'): 'format', ('draw-figure', 'FORMAT'): 'format',
 }
 
+_mask_task_arguments = frozenset({
+    ('find-mode', 'mask_name'),
+    ('predict-observables', 'mask_name'),
+    ('corner-plot', 'mask_name'),
+    ('create-mask', 'mask_name'),
+})
+
 @dataclass
 class TaskComponent(_AnalysisFileDeserializable):
     r"""Describes a single task invocation within a step, i.e. one entry of a step's ``tasks`` list.
@@ -951,6 +962,18 @@ class TaskComponent(_AnalysisFileDeserializable):
                 'versions; consider providing a value explicitly',
             )
 
+    def validate_semantics(self, context):
+        for task, argument in _mask_task_arguments:
+            if self.task != task or argument not in self.arguments:
+                continue
+            mask_name = self.arguments[argument]
+            if mask_name is not None and not context.lookup('mask', mask_name):
+                yield Diagnostic(
+                    ('arguments', argument),
+                    Severity.ERROR,
+                    f"Task '{self.task}' references unknown mask '{mask_name}'",
+                )
+
 
 @dataclass
 class StepComponent(_AnalysisFileDeserializable):
@@ -998,7 +1021,14 @@ class StepComponent(_AnalysisFileDeserializable):
                 f"Step '{self.id}' has default arguments for unknown tasks: {unknown_tasks}",
             )
 
-        for task_component in self.tasks:
+        task_segments = getattr(self, '_task_segments', list(range(len(self.tasks))))
+        assert len(self.tasks) == len(task_segments)
+        for task_component, task_segment in zip(self.tasks, task_segments):
+            if hasattr(task_component, 'validate_semantics'):
+                yield from (
+                    diagnostic.prefixed('tasks', task_segment)
+                    for diagnostic in task_component.validate_semantics(context)
+                )
             if task_component.task not in eos.tasks._tasks:
                 continue
             task = eos.tasks._tasks[task_component.task]
@@ -1011,6 +1041,20 @@ class StepComponent(_AnalysisFileDeserializable):
                     Severity.ERROR,
                     f"Task '{task_component.task}' does not recognize argument '{argument}'",
                 )
+
+            for registered_task, argument in _mask_task_arguments:
+                if registered_task != task_component.task:
+                    continue
+                arguments = self.default_arguments[task_component.task]
+                if argument not in arguments:
+                    continue
+                mask_name = arguments[argument]
+                if mask_name is not None and not context.lookup('mask', mask_name):
+                    yield Diagnostic(
+                        ('default_arguments', task_component.task, argument),
+                        Severity.ERROR,
+                        f"Task '{task_component.task}' references unknown mask '{mask_name}'",
+                    )
 
     @classmethod
     def from_dict(cls, **kwargs):
@@ -1121,6 +1165,10 @@ class MaskNamedComponent(_AnalysisFileDeserializable):
     :type mask_name: str
     """
     mask_name:str
+
+    def validate_semantics(self, context):
+        context.lookup('mask', self.mask_name)
+        yield from ()
 
 @dataclass
 class MaskComponent(_AnalysisFileDeserializable):
@@ -1427,6 +1475,23 @@ class AnalysisFileDescription(_AnalysisFileDeserializable):
                 Severity.ERROR,
                 f"Error in masks: Name '{name}' is used repeatedly",
             )
+
+        tracked_sections = (
+            ('prior', 'priors', self.priors, '_prior_segments'),
+            ('likelihood', 'likelihoods', self.likelihoods, '_likelihood_segments'),
+            ('mask', 'masks', self.masks, '_mask_segments'),
+        )
+        for kind, section, children, attribute in tracked_sections:
+            unused = context.unused(kind)
+            segments = getattr(self, attribute, list(range(len(children))))
+            assert len(children) == len(segments)
+            for child, segment in zip(children, segments):
+                if not isinstance(child, InvalidComponent) and child.name in unused:
+                    yield Diagnostic(
+                        (section, segment),
+                        Severity.WARNING,
+                        f"{kind.capitalize()} '{child.name}' is unused",
+                    )
 
     @classmethod
     def from_dict(cls, **kwargs):

--- a/python/eos/analysis_file_description_TEST.py
+++ b/python/eos/analysis_file_description_TEST.py
@@ -14,9 +14,12 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
 import unittest
+from dataclasses import asdict
 
 import eos
 
+from eos.deserializable import InvalidComponent
+from eos.diagnostic import Severity
 from eos.analysis_file_description import (
     MetadataAuthorDescription,
     MetadataDescription,
@@ -110,17 +113,29 @@ class PriorDescriptionTests(unittest.TestCase):
             PoissonPriorDescription)
 
     def test_unknown_type(self):
-        with self.assertRaises(ValueError):
-            PriorDescription.from_dict(parameter='p', type='not-a-type')
-        with self.assertRaises(ValueError):
-            PriorDescription.from_dict()
+        unknown = PriorDescription.from_dict(parameter='p', type='not-a-type')
+        missing = PriorDescription.from_dict()
+        for desc in (unknown, missing):
+            self.assertIsInstance(desc, InvalidComponent)
+            diagnostics = list(desc.validate())
+            self.assertEqual(len(diagnostics), 1)
+            self.assertEqual(diagnostics[0].path, ('type',))
+            self.assertEqual(diagnostics[0].severity, Severity.ERROR)
+            self.assertEqual(diagnostics[0].message, 'Unknown type of prior description')
 
     def test_gaussian_requires_both_bounds(self):
         "A gaussian prior with only one of 'min'/'max' is rejected with a clear error."
-        with self.assertRaises(ValueError):
-            PriorDescription.from_dict(parameter='p', type='gaussian', central=0.0, sigma=1.0, min=-1.0)
-        with self.assertRaises(ValueError):
-            PriorDescription.from_dict(parameter='p', type='gaussian', central=0.0, sigma=1.0, max=1.0)
+        missing_max = PriorDescription.from_dict(
+            parameter='p', type='gaussian', central=0.0, sigma=1.0, min=-1.0)
+        missing_min = PriorDescription.from_dict(
+            parameter='p', type='gaussian', central=0.0, sigma=1.0, max=1.0)
+        for desc, path in ((missing_max, ('max',)), (missing_min, ('min',))):
+            self.assertIsInstance(desc, InvalidComponent)
+            diagnostics = list(desc.validate())
+            self.assertEqual(len(diagnostics), 1)
+            self.assertEqual(diagnostics[0].path, path)
+            self.assertEqual(diagnostics[0].severity, Severity.ERROR)
+            self.assertIn('must contain both', diagnostics[0].message)
 
 
 class PoissonPriorDescriptionTests(unittest.TestCase):
@@ -183,8 +198,13 @@ class ScalePriorDescriptionTests(unittest.TestCase):
     def test_missing_field(self):
         "Check that an incomplete scale prior description is rejected."
 
-        with self.assertRaises(ValueError):
-            PriorDescription.from_dict(parameter='mass::b(MSbar)', type='scale', min=0.0, max=1.0)
+        desc = PriorDescription.from_dict(parameter='mass::b(MSbar)', type='scale', min=0.0, max=1.0)
+        self.assertIsInstance(desc, InvalidComponent)
+        self.assertEqual(
+            [(d.path, d.severity, d.message) for d in desc.validate()],
+            [(('lambda_scale',), Severity.ERROR, "Missing mandatory key 'lambda_scale'"),
+             (('mu_0',), Severity.ERROR, "Missing mandatory key 'mu_0'")],
+        )
 
 
 class UniformPriorDescriptionTests(unittest.TestCase):
@@ -305,8 +325,11 @@ class LikelihoodComponentTests(unittest.TestCase):
         self.assertIsInstance(comp.pyhf, PyHFConstraintDescription)
 
     def test_requires_at_least_one_source(self):
-        with self.assertRaises(ValueError):
-            LikelihoodComponent.from_dict(name='empty')
+        comp = LikelihoodComponent.from_dict(name='empty')
+        diagnostics = list(comp._diagnostics())
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(diagnostics[0].severity, Severity.ERROR)
+        self.assertIn('must have at least one', diagnostics[0].message)
 
 
 class PosteriorDescriptionTests(unittest.TestCase):
@@ -416,12 +439,30 @@ class TaskComponentTests(unittest.TestCase):
         self.assertNotIn('F', comp.arguments)
 
     def test_invalid_task(self):
-        with self.assertRaises(ValueError):
-            TaskComponent.from_dict(task='not-a-real-task', arguments={})
+        comp = TaskComponent.from_dict(task='not-a-real-task', arguments={})
+        diagnostics = list(comp._diagnostics())
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(diagnostics[0].path, ('task',))
+        self.assertEqual(diagnostics[0].severity, Severity.ERROR)
 
     def test_unknown_argument(self):
-        with self.assertRaises(ValueError):
-            TaskComponent.from_dict(task='corner-plot', arguments={'posterior': 'CKM-all', 'not_an_argument': 1})
+        comp = TaskComponent.from_dict(
+            task='corner-plot',
+            arguments={'posterior': 'CKM-all', 'not_an_argument': 1},
+        )
+        diagnostics = list(comp._diagnostics())
+        self.assertTrue(any(
+            d.path == ('arguments', 'not_an_argument') and d.severity == Severity.ERROR
+            for d in diagnostics
+        ))
+
+    def test_missing_required_argument(self):
+        comp = TaskComponent.from_dict(task='corner-plot', arguments={})
+        diagnostics = list(comp._diagnostics())
+        self.assertTrue(any(
+            d.path == ('arguments', 'posterior') and d.severity == Severity.ERROR
+            for d in diagnostics
+        ))
 
 
 class StepComponentTests(unittest.TestCase):
@@ -437,14 +478,16 @@ class StepComponentTests(unittest.TestCase):
         self.assertIsInstance(comp.tasks[0], TaskComponent)
 
     def test_invalid_id(self):
-        with self.assertRaises(ValueError):
-            StepComponent.from_dict(title='t', id='has/slash', tasks=self._tasks())
-        with self.assertRaises(ValueError):
-            StepComponent.from_dict(title='t', id='has space', tasks=self._tasks())
+        slash = StepComponent.from_dict(title='t', id='has/slash', tasks=self._tasks())
+        whitespace = StepComponent.from_dict(title='t', id='has space', tasks=self._tasks())
+        self.assertTrue(any(d.path == ('id',) for d in slash._diagnostics()))
+        self.assertTrue(any(d.path == ('id',) for d in whitespace._diagnostics()))
 
     def test_empty_tasks(self):
-        with self.assertRaises(ValueError):
-            StepComponent.from_dict(title='t', id='no-tasks', tasks=[])
+        comp = StepComponent.from_dict(title='t', id='no-tasks', tasks=[])
+        diagnostics = list(comp._diagnostics())
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(diagnostics[0].path, ('tasks',))
 
 
 class MaskDescriptionTests(unittest.TestCase):
@@ -501,12 +544,15 @@ class MaskComponentTests(unittest.TestCase):
         self.assertIsInstance(comp.description[1], MaskNamedComponent)
 
     def test_invalid_logical_combination(self):
-        with self.assertRaises(ValueError):
-            MaskComponent.from_dict(
-                name='my-mask',
-                description=[{'name': 'B->pilnu::BR'}],
-                logical_combination='xor',
-            )
+        comp = MaskComponent.from_dict(
+            name='my-mask',
+            description=[{'name': 'B->pilnu::BR'}],
+            logical_combination='xor',
+        )
+        diagnostics = list(comp._diagnostics())
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(diagnostics[0].path, ('logical_combination',))
+        self.assertEqual(diagnostics[0].severity, Severity.ERROR)
 
 
 class AnalysisFileDescriptionTests(unittest.TestCase):
@@ -565,8 +611,88 @@ class AnalysisFileDescriptionTests(unittest.TestCase):
 
     def test_unknown_top_level_key_is_rejected(self):
         "An unrecognized top-level key is rejected rather than silently ignored."
-        with self.assertRaises(ValueError):
-            AnalysisFileDescription.from_dict(not_a_section=42)
+        desc = AnalysisFileDescription.from_dict(not_a_section=42)
+        self.assertIsInstance(desc, InvalidComponent)
+        diagnostics = list(desc.validate())
+        self.assertEqual(len(diagnostics), 1)
+        self.assertEqual(diagnostics[0].path, ('not_a_section',))
+
+    def test_validate_recurses_and_prefixes_raw_child_segments(self):
+        desc = AnalysisFileDescription.from_dict(
+            priors=[{
+                'name': 'FF',
+                'descriptions': [{'type': 'uniform', 'parameter': 'x', 'min': 0.0}],
+            }],
+            likelihoods=[{'name': 'empty'}],
+            steps=[{
+                'title': 'Broken step',
+                'id': 'broken',
+                'tasks': [{'arguments': {}}],
+            }],
+        )
+
+        diagnostics = list(desc.validate())
+        self.assertIn(('priors', 'FF', 'descriptions', 0, 'max'), [d.path for d in diagnostics])
+        self.assertIn(('likelihoods', 'empty'), [d.path for d in diagnostics])
+        self.assertIn(('steps', 'broken', 'tasks', 0, 'task'), [d.path for d in diagnostics])
+
+    def test_raw_child_segments_are_not_serialized(self):
+        desc = AnalysisFileDescription.from_dict(
+            priors=[{
+                'name': 'P',
+                'descriptions': [
+                    {'type': 'uniform', 'parameter': 'x', 'min': 0.0, 'max': 1.0},
+                ],
+            }],
+        )
+
+        serialized = asdict(desc)
+        self.assertFalse(any(key.startswith('_') for key in serialized))
+        self.assertFalse(any(key.startswith('_') for key in serialized['priors'][0]))
+
+    def test_validate_structure_checks_whole_file(self):
+        desc = AnalysisFileDescription.from_dict(
+            priors=[{
+                'name': 'P',
+                'descriptions': [
+                    {'type': 'uniform', 'parameter': 'x', 'min': 0.0, 'max': 1.0},
+                ],
+            }],
+            likelihoods=[{'name': 'L', 'constraints': ['x::constraint']}],
+            posteriors=[{
+                'name': 'posterior',
+                'prior': ['missing-prior'],
+                'likelihood': ['missing-likelihood'],
+            }],
+            steps=[
+                {'title': 'First', 'id': 'duplicate', 'tasks': []},
+                {'title': 'Second', 'id': 'duplicate', 'tasks': []},
+            ],
+            masks=[
+                {'name': 'duplicate-mask', 'description': [{'mask_name': 'missing-mask'}]},
+                {'name': 'duplicate-mask', 'description': []},
+            ],
+        )
+
+        diagnostics = list(desc.validate_structure())
+        paths = [diagnostic.path for diagnostic in diagnostics]
+        self.assertIn(('posteriors', 'posterior', 'prior', 0), paths)
+        self.assertIn(('posteriors', 'posterior', 'likelihood', 0), paths)
+        self.assertIn(('steps', 'duplicate', 'id'), paths)
+        self.assertIn(('masks', 'duplicate-mask', 'name'), paths)
+        self.assertIn(
+            ('masks', 'duplicate-mask', 'description', 0, 'mask_name'),
+            paths,
+        )
+
+    def test_validate_structure_checks_section_presence(self):
+        desc = AnalysisFileDescription.from_dict()
+        diagnostics = list(desc.validate_structure())
+
+        by_path = {diagnostic.path: diagnostic for diagnostic in diagnostics}
+        self.assertEqual(by_path[('priors',)].severity, Severity.ERROR)
+        self.assertEqual(by_path[('likelihoods',)].severity, Severity.WARNING)
+        self.assertEqual(by_path[('posteriors',)].severity, Severity.ERROR)
 
 
 if __name__ == '__main__':

--- a/python/eos/analysis_file_description_TEST.py
+++ b/python/eos/analysis_file_description_TEST.py
@@ -20,6 +20,7 @@ import eos
 
 from eos.deserializable import InvalidComponent
 from eos.diagnostic import Severity
+from eos.validation_context import ValidationContext
 from eos.analysis_file_description import (
     MetadataAuthorDescription,
     MetadataDescription,
@@ -717,6 +718,46 @@ class AnalysisFileDescriptionTests(unittest.TestCase):
         self.assertEqual(by_path[('priors',)].severity, Severity.ERROR)
         self.assertEqual(by_path[('likelihoods',)].severity, Severity.WARNING)
         self.assertEqual(by_path[('posteriors',)].severity, Severity.ERROR)
+
+    def test_fixed_parameter_varied_by_own_prior(self):
+        "A posterior that fixes a parameter one of its own priors varies is contradictory."
+        desc = AnalysisFileDescription.from_dict(
+            priors=[
+                {'name': 'varies-mB', 'descriptions': [
+                    {'type': 'uniform', 'parameter': 'mass::B_d', 'min': 5.2, 'max': 5.4}]},
+                {'name': 'varies-two', 'descriptions': [
+                    {'type': 'transform', 'parameters': ['mass::B_u', 'mass::B_s'],
+                     'shift': [0.0, 0.0], 'transform': [[1.0, 0.0], [0.0, 1.0]],
+                     'min': [5.0, 5.0], 'max': [5.5, 5.5]}]},
+                {'name': 'varies-elsewhere', 'descriptions': [
+                    {'type': 'uniform', 'parameter': 'mass::e', 'min': 0.0, 'max': 1.0}]},
+            ],
+            likelihoods=[{'name': 'll', 'constraints': ['B->pi::f_++f_0@RBC+UKQCD:2015A']}],
+            posteriors=[{
+                'name': 'post',
+                'prior': ['varies-mB', 'varies-two'],
+                'likelihood': ['ll'],
+                'fixed_parameters': {
+                    'mass::B_d': 5.28,   # varied by 'varies-mB'          -> reported
+                    'mass::B_s': 5.37,   # varied by 'varies-two'         -> reported
+                    'mass::e': 0.0005,   # varied by a prior this posterior does not use -> silent
+                    'mass::tau': 1.777,  # varied by no prior at all      -> silent
+                },
+            }],
+        )
+
+        reported = {
+            diagnostic.path[-1]: diagnostic
+            for diagnostic in desc.validate_semantics(ValidationContext(desc))
+            if 'fixed by posterior' in diagnostic.message
+        }
+        self.assertEqual(set(reported), {'mass::B_d', 'mass::B_s'})
+        for diagnostic in reported.values():
+            # a warning, not an error: an error would abort the deep phase and hide every deep
+            # finding elsewhere in the file
+            self.assertEqual(diagnostic.severity, Severity.WARNING)
+        self.assertIn("varied by its prior 'varies-mB'", reported['mass::B_d'].message)
+        self.assertIn("varied by its prior 'varies-two'", reported['mass::B_s'].message)
 
 
 if __name__ == '__main__':

--- a/python/eos/analysis_file_description_TEST.py
+++ b/python/eos/analysis_file_description_TEST.py
@@ -117,7 +117,7 @@ class PriorDescriptionTests(unittest.TestCase):
         missing = PriorDescription.from_dict()
         for desc in (unknown, missing):
             self.assertIsInstance(desc, InvalidComponent)
-            diagnostics = list(desc.validate())
+            diagnostics = list(desc.validate_structure())
             self.assertEqual(len(diagnostics), 1)
             self.assertEqual(diagnostics[0].path, ('type',))
             self.assertEqual(diagnostics[0].severity, Severity.ERROR)
@@ -131,7 +131,7 @@ class PriorDescriptionTests(unittest.TestCase):
             parameter='p', type='gaussian', central=0.0, sigma=1.0, max=1.0)
         for desc, path in ((missing_max, ('max',)), (missing_min, ('min',))):
             self.assertIsInstance(desc, InvalidComponent)
-            diagnostics = list(desc.validate())
+            diagnostics = list(desc.validate_structure())
             self.assertEqual(len(diagnostics), 1)
             self.assertEqual(diagnostics[0].path, path)
             self.assertEqual(diagnostics[0].severity, Severity.ERROR)
@@ -201,7 +201,7 @@ class ScalePriorDescriptionTests(unittest.TestCase):
         desc = PriorDescription.from_dict(parameter='mass::b(MSbar)', type='scale', min=0.0, max=1.0)
         self.assertIsInstance(desc, InvalidComponent)
         self.assertEqual(
-            [(d.path, d.severity, d.message) for d in desc.validate()],
+            [(d.path, d.severity, d.message) for d in desc.validate_structure()],
             [(('lambda_scale',), Severity.ERROR, "Missing mandatory key 'lambda_scale'"),
              (('mu_0',), Severity.ERROR, "Missing mandatory key 'mu_0'")],
         )
@@ -489,6 +489,30 @@ class StepComponentTests(unittest.TestCase):
         self.assertEqual(len(diagnostics), 1)
         self.assertEqual(diagnostics[0].path, ('tasks',))
 
+    def test_task_and_default_arguments_are_checked_in_separate_phases(self):
+        comp = StepComponent.from_dict(
+            title='t',
+            id='separate-argument-checks',
+            tasks=[{
+                'task': 'corner-plot',
+                'arguments': {
+                    'posterior': 'CKM-all',
+                    'not_a_task_argument': 1,
+                },
+            }],
+            default_arguments={
+                'corner-plot': {
+                    'not_a_default_argument': 2,
+                },
+            },
+        )
+
+        structural = list(comp.validate_structure())
+        semantic = list(comp.validate_semantics(None))
+        self.assertTrue(any('not_a_task_argument' in diagnostic.message for diagnostic in structural))
+        self.assertFalse(any('not_a_task_argument' in diagnostic.message for diagnostic in semantic))
+        self.assertTrue(any('not_a_default_argument' in diagnostic.message for diagnostic in semantic))
+
 
 class MaskDescriptionTests(unittest.TestCase):
 
@@ -613,7 +637,7 @@ class AnalysisFileDescriptionTests(unittest.TestCase):
         "An unrecognized top-level key is rejected rather than silently ignored."
         desc = AnalysisFileDescription.from_dict(not_a_section=42)
         self.assertIsInstance(desc, InvalidComponent)
-        diagnostics = list(desc.validate())
+        diagnostics = list(desc.validate_structure())
         self.assertEqual(len(diagnostics), 1)
         self.assertEqual(diagnostics[0].path, ('not_a_section',))
 
@@ -631,7 +655,7 @@ class AnalysisFileDescriptionTests(unittest.TestCase):
             }],
         )
 
-        diagnostics = list(desc.validate())
+        diagnostics = list(desc.validate_structure())
         self.assertIn(('priors', 'FF', 'descriptions', 0, 'max'), [d.path for d in diagnostics])
         self.assertIn(('likelihoods', 'empty'), [d.path for d in diagnostics])
         self.assertIn(('steps', 'broken', 'tasks', 0, 'task'), [d.path for d in diagnostics])

--- a/python/eos/deserializable.py
+++ b/python/eos/deserializable.py
@@ -16,6 +16,19 @@
 import os as _os
 import yaml as _yaml
 
+from dataclasses import MISSING, dataclass, fields
+
+from .diagnostic import Diagnostic, Severity
+
+
+@dataclass
+class InvalidComponent:
+    diagnostics: list
+
+    def validate(self, *args, **kwargs):
+        yield from self.diagnostics
+
+
 class Deserializable:
     """
     Utility class to create instances of classes from YAML data.
@@ -65,6 +78,35 @@ class Deserializable:
             raise ValueError(f'When creating {cls.__name__} from {kwargs}: {e}')
 
         return result
+
+    @staticmethod
+    def check_keys(cls, kwargs) -> list:
+        known = {f.name for f in fields(cls) if f.init}
+        required = {
+            f.name for f in fields(cls)
+            if f.init and f.default is MISSING and f.default_factory is MISSING
+        }
+        unknown = kwargs.keys() - known
+        missing = required - kwargs.keys()
+
+        diagnostics = [
+            Diagnostic((key,), Severity.ERROR, f"Unknown key '{key}'")
+            for key in sorted(unknown)
+        ]
+        diagnostics.extend(
+            Diagnostic((key,), Severity.ERROR, f"Missing mandatory key '{key}'")
+            for key in sorted(missing)
+        )
+
+        return diagnostics
+
+    @staticmethod
+    def make_with_diagnostics(cls, **kwargs):
+        diagnostics = Deserializable.check_keys(cls, kwargs)
+        if diagnostics:
+            return InvalidComponent(diagnostics)
+
+        return cls(**kwargs)
 
     @classmethod
     def from_dict(cls, **kwargs):

--- a/python/eos/deserializable.py
+++ b/python/eos/deserializable.py
@@ -25,7 +25,7 @@ from .diagnostic import Diagnostic, Severity
 class InvalidComponent:
     diagnostics: list
 
-    def validate(self, *args, **kwargs):
+    def validate_structure(self, *args, **kwargs):
         yield from self.diagnostics
 
 

--- a/python/eos/deserializable_TEST.py
+++ b/python/eos/deserializable_TEST.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import unittest
+
+from dataclasses import dataclass, field
+
+from eos.deserializable import Deserializable, InvalidComponent
+from eos.diagnostic import Severity
+
+
+@dataclass
+class _Description(Deserializable):
+    first: str
+    second: int
+    third: float
+    optional: bool = False
+    type: str = field(repr=False, init=False, default='description')
+
+
+@dataclass
+class _ConstructionObserver(Deserializable):
+    value: str
+
+    constructed = False
+
+    def __post_init__(self):
+        _ConstructionObserver.constructed = True
+        raise RuntimeError('constructor called')
+
+
+class DeserializableTests(unittest.TestCase):
+
+    def test_reports_all_missing_mandatory_keys(self):
+        result = Deserializable.make_with_diagnostics(_Description)
+
+        self.assertIsInstance(result, InvalidComponent)
+        self.assertEqual(
+            {diagnostic.path for diagnostic in result.diagnostics},
+            {('first',), ('second',), ('third',)}
+        )
+        self.assertTrue(all(diagnostic.severity is Severity.ERROR for diagnostic in result.diagnostics))
+
+    def test_reports_unknown_and_missing_keys_together(self):
+        result = Deserializable.make_with_diagnostics(_Description, first='value', unknown=None)
+
+        self.assertIsInstance(result, InvalidComponent)
+        self.assertEqual(
+            {diagnostic.path for diagnostic in result.validate()},
+            {('unknown',), ('second',), ('third',)}
+        )
+
+    def test_init_false_field_is_not_required_and_is_rejected_if_supplied(self):
+        valid = Deserializable.make_with_diagnostics(_Description, first='value', second=2, third=3.0)
+        self.assertIsInstance(valid, _Description)
+
+        invalid = Deserializable.make_with_diagnostics(
+            _Description, first='value', second=2, third=3.0, type='other'
+        )
+        self.assertIsInstance(invalid, InvalidComponent)
+        self.assertEqual([('type',)], [diagnostic.path for diagnostic in invalid.diagnostics])
+
+    def test_well_formed_mapping_returns_instance(self):
+        result = Deserializable.make_with_diagnostics(
+            _Description, first='value', second=2, third=3.0, optional=True
+        )
+
+        self.assertEqual(
+            _Description(first='value', second=2, third=3.0, optional=True),
+            result
+        )
+
+    def test_check_keys_does_not_construct(self):
+        _ConstructionObserver.constructed = False
+
+        diagnostics = Deserializable.check_keys(_ConstructionObserver, {'value': 'valid'})
+
+        self.assertEqual([], diagnostics)
+        self.assertFalse(_ConstructionObserver.constructed)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)

--- a/python/eos/deserializable_TEST.py
+++ b/python/eos/deserializable_TEST.py
@@ -58,7 +58,7 @@ class DeserializableTests(unittest.TestCase):
 
         self.assertIsInstance(result, InvalidComponent)
         self.assertEqual(
-            {diagnostic.path for diagnostic in result.validate()},
+            {diagnostic.path for diagnostic in result.validate_structure()},
             {('unknown',), ('second',), ('third',)}
         )
 

--- a/python/eos/diagnostic.py
+++ b/python/eos/diagnostic.py
@@ -58,3 +58,15 @@ class Diagnostic:
 
     def __str__(self) -> str:
         return f'{self.location()}: {self.message}'
+
+
+def _check_qualified(context, value, kind, path):
+    import eos
+
+    try:
+        qn = eos.QualifiedName(value)
+    except RuntimeError as e:
+        yield Diagnostic(path, Severity.ERROR, f"'{value}' is not a valid qualified name: {e}")
+        return
+    if not context.lookup(kind, qn):
+        yield Diagnostic(path, Severity.ERROR, f"{kind} '{value}' is unknown to EOS")

--- a/python/eos/diagnostic.py
+++ b/python/eos/diagnostic.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from dataclasses import dataclass
+import enum
+
+
+class Severity(enum.Enum):
+    ERROR = 'error'
+    WARNING = 'warning'
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    path: tuple
+    severity: Severity
+    message: str
+
+    def prefixed(self, *segments) -> 'Diagnostic':
+        return Diagnostic(tuple(segments) + self.path, self.severity, self.message)
+
+    def location(self) -> str:
+        result = ''
+        for segment in self.path:
+            if isinstance(segment, int):
+                result += f'[{segment}]'
+            else:
+                if result:
+                    result += '/'
+                result += segment
+
+        return result
+
+    def _sort_key(self):
+        path = tuple((0, segment) if isinstance(segment, str) else (1, segment) for segment in self.path)
+        return path, self.severity.value
+
+    def __lt__(self, other):
+        if not isinstance(other, Diagnostic):
+            return NotImplemented
+
+        return self._sort_key() < other._sort_key()
+
+    def __str__(self) -> str:
+        return f'{self.location()}: {self.message}'

--- a/python/eos/diagnostic_TEST.py
+++ b/python/eos/diagnostic_TEST.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import unittest
+
+from eos.diagnostic import Diagnostic, Severity
+
+
+class DiagnosticTests(unittest.TestCase):
+
+    def test_location(self):
+        cases = (
+            ((), ''),
+            ((0, 'min'), '[0]/min'),
+            (('items', 0, 1, 'min'), 'items[0][1]/min'),
+            (('likelihoods', 'LLH2', 'constraints', 0), 'likelihoods/LLH2/constraints[0]'),
+            (('priors', 'FF', 'descriptions', 2, 'min'), 'priors/FF/descriptions[2]/min'),
+            (('observable', 'B_c->J/psi::FormFactors@HPQCD:2025A'), 'observable/B_c->J/psi::FormFactors@HPQCD:2025A'),
+        )
+
+        for path, expected in cases:
+            with self.subTest(path=path):
+                diagnostic = Diagnostic(path, Severity.ERROR, 'message')
+                self.assertEqual(diagnostic.location(), expected)
+
+    def test_prefixed(self):
+        original = Diagnostic(('min',), Severity.WARNING, 'message')
+        prefixed = original.prefixed('priors', 'FF', 'descriptions', 2)
+
+        self.assertEqual(original.path, ('min',))
+        self.assertEqual(prefixed.path, ('priors', 'FF', 'descriptions', 2, 'min'))
+        self.assertIsNot(original, prefixed)
+
+    def test_str(self):
+        diagnostic = Diagnostic(('priors', 0), Severity.ERROR, 'invalid prior')
+        self.assertEqual(str(diagnostic), 'priors[0]: invalid prior')
+
+    def test_sorting_with_mixed_path_segments(self):
+        diagnostics = [
+            Diagnostic((0,), Severity.WARNING, 'index'),
+            Diagnostic(('priors',), Severity.WARNING, 'warning'),
+            Diagnostic(('priors',), Severity.ERROR, 'error'),
+        ]
+
+        self.assertEqual(
+            sorted(diagnostics),
+            [diagnostics[2], diagnostics[1], diagnostics[0]],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/eos/figure/figure.py
+++ b/python/eos/figure/figure.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from eos.analysis_file_context import AnalysisFileContext
 from eos.deserializable import Deserializable
+from eos.diagnostic import Diagnostic, Severity
 
 from .plot import Plot, PlotFactory
 from .common import Watermark
@@ -33,6 +34,14 @@ import yaml as _yaml
 class Figure(ABC, Deserializable):
     r"""Base class for figures to be drawn using matplotlib."""
     name:str=field(default=None)
+
+    def validate_structure(self):
+        if self.name is None:
+            return
+        if '/' in self.name:
+            yield Diagnostic(('name',), Severity.ERROR, f"Invalid character '/' in figure name '{self.name}'")
+        if any(character.isspace() for character in self.name):
+            yield Diagnostic(('name',), Severity.ERROR, f"Invalid whitespace in figure name '{self.name}'")
 
     @abstractmethod
     def draw(self, context:AnalysisFileContext=None, output:str|None=None):

--- a/python/eos/figure/figure.py
+++ b/python/eos/figure/figure.py
@@ -35,6 +35,9 @@ class Figure(ABC, Deserializable):
     r"""Base class for figures to be drawn using matplotlib."""
     name:str=field(default=None)
 
+    def validate_semantics(self, context):
+        yield from ()
+
     def validate_structure(self):
         if self.name is None:
             return
@@ -95,6 +98,12 @@ class SingleFigure(Figure):
     def __post_init__(self):
         self._figure, self._ax = plt.subplots(figsize=self.size)
 
+    def validate_semantics(self, context):
+        yield from (
+            diagnostic.prefixed('plot')
+            for diagnostic in self.plot.validate_semantics(context)
+        )
+
     def draw(self, context:AnalysisFileContext=None, output:str|list[str]|None=None):
         """Draw the single-plot figure.
 
@@ -153,6 +162,12 @@ class Inset(Deserializable):
 
     def __post_init__(self):
         pass
+
+    def validate_semantics(self, context):
+        yield from (
+            diagnostic.prefixed('plot')
+            for diagnostic in self.plot.validate_semantics(context)
+        )
 
     def prepare(self, context, ax):
         """Prepare the inset plot for drawing.
@@ -234,6 +249,16 @@ class InsetFigure(Figure):
 
     def __post_init__(self):
         self._figure, self._ax = plt.subplots(figsize=self.size)
+
+    def validate_semantics(self, context):
+        yield from (
+            diagnostic.prefixed('plot')
+            for diagnostic in self.plot.validate_semantics(context)
+        )
+        yield from (
+            diagnostic.prefixed('inset')
+            for diagnostic in self.inset.validate_semantics(context)
+        )
 
     def draw(self, context:AnalysisFileContext=None, output:str|list[str]|None=None):
         """Draw the inset figure.
@@ -352,6 +377,13 @@ class GridFigure(Figure):
         axes = self._gridspec.subplots(sharex=sharex, sharey=sharey, squeeze=False)
         self._axes = axes.flatten('C') # flatten to row-major style
         self._watermark_idx = self._resolve_watermark_plot(nrow, ncol)
+
+    def validate_semantics(self, context):
+        for index, plot in enumerate(self.plots):
+            yield from (
+                diagnostic.prefixed('plots', index)
+                for diagnostic in plot.validate_semantics(context)
+            )
 
     def _resolve_watermark_plot(self, nrow, ncol):
         "Resolve the watermark_plot field to a single flattened (row-major) index, or None for all plots."

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -19,6 +19,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from eos.analysis_file_context import AnalysisFileContext
 from eos.deserializable import Deserializable
+from eos.diagnostic import _check_qualified
 
 import inspect
 import eos
@@ -573,6 +574,13 @@ class ObservableItem(Item):
         self._observable = eos.Observable.make(self.observable, self._parameters, self._kinematics, self._options)
 
         self._xvalues = _np.linspace(self.range[0], self.range[1], self.resolution)
+
+    def validate_semantics(self, context):
+        yield from _check_qualified(context, self.observable, 'observable', ('observable',))
+        for parameter in self.fixed_parameters or {}:
+            yield from _check_qualified(
+                context, parameter, 'parameter', ('fixed_parameters', parameter)
+            )
 
 
     def prepare(self, context:AnalysisFileContext=None):
@@ -2055,6 +2063,10 @@ class ConstraintItem(Item):
     range:tuple[int, int]|None=field(default=None)
     rescale_by_width:bool=False
 
+    def validate_semantics(self, context):
+        if self.observable is not None:
+            yield from _check_qualified(context, self.observable, 'observable', ('observable',))
+
     _api_doc = inspect.cleandoc("""\
     Plotting Constraints
     --------------------
@@ -2373,6 +2385,13 @@ class TwoDimensionalConstraintItem(Item):
         self.sigmas = sorted(self.sigmas, reverse=True)
         self._alphas = _np.linspace(0.0, self.alpha, len(self.sigmas) + 1)[1:]
 
+    def validate_semantics(self, context):
+        for axis, spec in (('x', self.x), ('y', self.y)):
+            if spec is not None:
+                yield from _check_qualified(
+                    context, spec['observable'], 'observable', (axis, 'observable')
+                )
+
     @staticmethod
     def _name(observable):
         "Return the bare observable name (without options) used to match an axis observable."
@@ -2558,6 +2577,10 @@ class ConstraintResidueItem(Item):
     range:tuple[int, int]|None=field(default=None)
     parameters:dict[eos.QualifiedName,float]|None=field(default=None)
     rescale_by_width:bool=False
+
+    def validate_semantics(self, context):
+        if self.observable is not None:
+            yield from _check_qualified(context, self.observable, 'observable', ('observable',))
 
     _api_doc = inspect.cleandoc("""\
     Plotting Constraints
@@ -3184,6 +3207,13 @@ class ComplexPlaneItem(Item):
         self._xvalues = _np.linspace(self._xrange[0], self._xrange[1], self.resolution)
         self._yvalues = _np.linspace(self._yrange[0], self._yrange[1], self.resolution)
         self._cvalues = _np.reshape([[x + 1.0j * y for y in self._yvalues] for x in self._xvalues], (self.resolution**2))
+
+    def validate_semantics(self, context):
+        yield from _check_qualified(context, self.observable, 'observable', ('observable',))
+        for parameter in self.fixed_parameters or {}:
+            yield from _check_qualified(
+                context, parameter, 'parameter', ('fixed_parameters', parameter)
+            )
 
     def evaluate(self, c:complex):
         """Evaluate the observable at a complex-valued kinematic variable.

--- a/python/eos/figure/item_TEST.py
+++ b/python/eos/figure/item_TEST.py
@@ -23,6 +23,7 @@ import tempfile
 
 from eos.analysis_file_context import AnalysisFileContext
 from eos.figure.item import BandHandle, BandHandler, CompositeRegionHandle, CompositeRegionHandler
+from eos.validation_context import ValidationContext
 from matplotlib import colors as mcolors
 from matplotlib import pyplot as plt
 from matplotlib import transforms as mtransforms
@@ -53,6 +54,23 @@ class ItemColorCyclerTests(unittest.TestCase):
         self.assertEqual(ItemColorCycler.next_color(), colors[0])
 
 class ObservableItemTests(unittest.TestCase):
+
+    def test_validate_semantics_checks_fixed_parameters(self):
+        item = eos.figure.ItemFactory.from_yaml("""
+        type: observable
+        observable: 'B->Dlnu::dBR/dq2'
+        variable: q2
+        range: [0.1, 1.0]
+        fixed_parameters: { 'test::unknown-parameter': 1.0 }
+        """)
+        description = eos.analysis_file_description.AnalysisFileDescription.from_dict()
+        diagnostics = list(item.validate_semantics(ValidationContext(description)))
+
+        self.assertEqual(1, len(diagnostics))
+        self.assertEqual(
+            ('fixed_parameters', 'test::unknown-parameter'),
+            diagnostics[0].path,
+        )
 
     def test_full(self):
 

--- a/python/eos/figure/plot.py
+++ b/python/eos/figure/plot.py
@@ -364,6 +364,9 @@ class YAxis(Deserializable):
 class Plot(ABC, Deserializable):
     r"""Base class for plots to be drawn into a figure."""
 
+    def validate_semantics(self, context):
+        yield from ()
+
     @abstractmethod
     def prepare(self, context:AnalysisFileContext=None):
         """Prepare the plot for drawing.
@@ -425,6 +428,14 @@ class TwoDimensionalPlot(Plot):
     title:str=None
     xaxis:XAxis=field(default_factory=XAxis)
     yaxis:YAxis=field(default_factory=YAxis)
+
+    def validate_semantics(self, context):
+        for index, item in enumerate(self.items):
+            if hasattr(item, 'validate_semantics'):
+                yield from (
+                    diagnostic.prefixed('items', index)
+                    for diagnostic in item.validate_semantics(context)
+                )
 
     _api_doc = inspect.cleandoc("""
     Drawing a 2D Plot Along a Single Set of Axes

--- a/python/eos/reporting_TEST.d/analysis.yaml
+++ b/python/eos/reporting_TEST.d/analysis.yaml
@@ -11,7 +11,8 @@ priors:
 
 likelihoods:
   - name: LH
-    constraints: []
+    constraints:
+      - 'B^+->tau^+nu::BR@Belle:2014A;form-factors=BCL2008-4'
 
 posteriors:
   - name: CKM

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -66,7 +66,7 @@ class LogfileHandler:
 
 _tasks = {}
 
-def task(name, output, mode=lambda **kwargs: 'w', modules=None, logfile=True):
+def task(name, output, mode=lambda **kwargs: 'w', modules=None, logfile=True, load_analysis_file=True):
     """Decorator that registers a function as a named EOS task.
 
     The decorated function is wrapped so that, on each invocation, it imports any optional ``modules``,
@@ -88,6 +88,9 @@ def task(name, output, mode=lambda **kwargs: 'w', modules=None, logfile=True):
     :type modules: list[str] | None
     :param logfile: Whether to capture the task's log output into a log file in the output directory. Defaults to True.
     :type logfile: bool
+    :param load_analysis_file: Whether to resolve a string ``analysis_file`` argument into an
+        :class:`eos.AnalysisFile` before invoking the task. Defaults to True.
+    :type load_analysis_file: bool
     :returns: A decorator that registers and returns the wrapped task function.
     """
     if modules is None:
@@ -115,7 +118,7 @@ def task(name, output, mode=lambda **kwargs: 'w', modules=None, logfile=True):
             }
             _args.update(zip(func.__code__.co_varnames, args))
             _args.update(kwargs)
-            if 'analysis_file' in _args and type(_args['analysis_file']) is str:
+            if load_analysis_file and 'analysis_file' in _args and type(_args['analysis_file']) is str:
                 _args.update({ 'analysis_file': eos.AnalysisFile(_args['analysis_file'])})
             # create output directory if needed directly or for logging
             if output or logfile:

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -32,7 +32,10 @@ import warnings
 import dynesty as _dynesty
 
 from dataclasses import asdict
+from .analysis_file_description import AnalysisFileDescription
+from .diagnostic import Severity
 from .ipython import __ipython__
+from .validation_context import ValidationContext
 
 class LogfileHandler:
     """Context manager that redirects EOS log output to a file for the duration of a ``with`` block.
@@ -978,15 +981,44 @@ def corner_plot(analysis_file:str, posterior:str, base_directory:str='./', forma
         fig.savefig(os.path.join(base_directory, 'data', posterior, 'plots', f'{filename}.{f}'))
 
 
-@task('validate', '', logfile=False)
-def validate(analysis_file:str):
+@task('validate', '', logfile=False, load_analysis_file=False)
+def validate(analysis_file:str, deep:bool=True):
     """
-    Validates the analysis file by checking that all posteriors and all prediction sets can be created.
+    Validates the analysis file structurally and semantically, then by default checks that all
+    posteriors and prediction sets can be created. The deep phase inserts declarations into the
+    process-wide EOS registries; once it has run, those registries are contaminated for the
+    remainder of the process. Use ``deep=False`` for idempotent, side-effect-free validation.
 
-    :param analysis_file: The name of the analysis file that describes the named posterior, or an object of class `eos.AnalysisFile`.
-    :type analysis_file: str or :class:`eos.AnalysisFile`
+    :param analysis_file: The name of the analysis file to validate.
+    :type analysis_file: str
+    :param deep: If True, additionally check that all posteriors and prediction sets can be created. Defaults to True.
+    :type deep: bool
     """
-    analysis_file.validate()
+    description = AnalysisFileDescription.from_yaml_file(analysis_file)
+    structural_diagnostics = list(description.validate_structure())
+    if any(diagnostic.severity is Severity.ERROR for diagnostic in structural_diagnostics):
+        for diagnostic in structural_diagnostics:
+            print(diagnostic)
+        return structural_diagnostics
+
+    semantic_diagnostics = list(description.validate_semantics(ValidationContext(description)))
+    diagnostics = structural_diagnostics + semantic_diagnostics
+
+    # Abort before the deep phase if the file is already known to be invalid: constructing an
+    # eos.AnalysisFile declares this file's custom parameters and inserts its custom observables
+    # into the process-wide EOS registries, which cannot be undone. Running it for a file whose
+    # semantics do not hold contaminates the process and yields only cascading errors.
+    if not deep or any(diagnostic.severity is Severity.ERROR for diagnostic in semantic_diagnostics):
+        for diagnostic in diagnostics:
+            print(diagnostic)
+        return diagnostics
+
+    # Only warnings remain at this point. Print them here, since eos.AnalysisFile.validate() reports
+    # the semantic and deep phases but knows nothing about the structural one.
+    for diagnostic in structural_diagnostics:
+        print(diagnostic)
+
+    return structural_diagnostics + eos.AnalysisFile(analysis_file).validate(deep=True)
 
 
 def _calculate_mask(observable: eos.Observable, analysis_parameters: eos.Parameters, data: eos.data.ImportanceSamples):

--- a/python/eos/validation_context.py
+++ b/python/eos/validation_context.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+# vim: set sw=4 sts=4 et tw=120 :
+
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from types import MappingProxyType
+
+from .analysis_file_description import MaskExpressionComponent
+
+
+class ValidationContext:
+    """Read-only entity lookup context for one analysis file.
+
+    The context snapshots the names declared by an
+    :class:`~eos.analysis_file_description.AnalysisFileDescription`. Lookups first
+    consult this per-file shadow registry and then, for EOS entities, the
+    corresponding real registry. Constructing and querying a context never inserts
+    into or otherwise changes an EOS registry.
+
+    :param description: The deserialized analysis file whose declarations should
+        be visible during semantic validation.
+    :type description: eos.analysis_file_description.AnalysisFileDescription
+    """
+
+    _LOCAL_KINDS = frozenset(('prior', 'likelihood', 'mask', 'posterior'))
+
+    def __init__(self, description):
+        import eos
+
+        observables = {observable.name for observable in description.observables}
+        for mask in description.masks:
+            observables.update(
+                item.name for item in mask.description
+                if isinstance(item, MaskExpressionComponent)
+            )
+
+        parameters = {parameter.name for parameter in description.parameters}
+        for parameter in description.parameters:
+            parameters.update(parameter.alias_of)
+
+        constraints = {
+            constraint.name
+            for likelihood in description.likelihoods
+            for constraint in likelihood.manual_constraints
+        }
+
+        self._shadow = MappingProxyType({
+            'observable': frozenset(observables),
+            'parameter': frozenset(parameters),
+            'constraint': frozenset(constraints),
+            'prior': frozenset(prior.name for prior in description.priors),
+            'likelihood': frozenset(likelihood.name for likelihood in description.likelihoods),
+            'mask': frozenset(mask.name for mask in description.masks),
+            'posterior': frozenset(posterior.name for posterior in description.posteriors),
+        })
+        self._real_registries = MappingProxyType({
+            'observable': eos.Observables(),
+            'parameter': eos.Parameters(),
+            'constraint': eos.Constraints(),
+        })
+
+    def lookup(self, kind, qn):
+        """Return whether *qn* exists in the file shadow or the real EOS registry.
+
+        ``kind`` is one of ``observable``, ``parameter``, ``constraint``,
+        ``prior``, ``likelihood``, ``mask``, or ``posterior``. The final four
+        namespaces are local to an analysis file and therefore have no real-registry
+        fallback.
+        """
+        if kind not in self._shadow:
+            raise ValueError(f'Unknown validation entity kind: {kind!r}')
+
+        name = str(qn)
+        if name in self._shadow[kind]:
+            return True
+
+        if kind in self._LOCAL_KINDS:
+            return False
+
+        import eos
+
+        qn = eos.QualifiedName(name)
+        if kind == 'parameter':
+            return self._real_registries[kind].has(qn)
+        if kind == 'observable':
+            if qn in self._real_registries[kind]:
+                return True
+            # EOS resolves an observable name through Observable::make, which synthesises a
+            # parameter observable whenever the name names a parameter rather than a registered
+            # observable. A manual constraint may therefore constrain 'decay-constant::K_u'
+            # directly, and an expression may reference it as <<decay-constant::K_u>>. Such a name
+            # is a valid observable name, so fall back to the parameter namespace before reporting
+            # it as unknown.
+            return self.lookup('parameter', qn)
+        if kind == 'constraint':
+            try:
+                self._real_registries[kind][qn]
+                return True
+            except RuntimeError:
+                return False
+
+        raise AssertionError(f'Unhandled validation entity kind: {kind!r}')

--- a/python/eos/validation_context.py
+++ b/python/eos/validation_context.py
@@ -16,6 +16,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+from collections import Counter
 from types import MappingProxyType
 
 from .analysis_file_description import MaskExpressionComponent
@@ -66,6 +67,10 @@ class ValidationContext:
             'mask': frozenset(mask.name for mask in description.masks),
             'posterior': frozenset(posterior.name for posterior in description.posteriors),
         })
+        self._counts = {
+            kind: Counter({name: 0 for name in names})
+            for kind, names in self._shadow.items()
+        }
         self._real_registries = MappingProxyType({
             'observable': eos.Observables(),
             'parameter': eos.Parameters(),
@@ -85,6 +90,7 @@ class ValidationContext:
 
         name = str(qn)
         if name in self._shadow[kind]:
+            self._counts[kind][name] += 1
             return True
 
         if kind in self._LOCAL_KINDS:
@@ -94,22 +100,39 @@ class ValidationContext:
 
         qn = eos.QualifiedName(name)
         if kind == 'parameter':
-            return self._real_registries[kind].has(qn)
-        if kind == 'observable':
-            if qn in self._real_registries[kind]:
-                return True
-            # EOS resolves an observable name through Observable::make, which synthesises a
-            # parameter observable whenever the name names a parameter rather than a registered
-            # observable. A manual constraint may therefore constrain 'decay-constant::K_u'
-            # directly, and an expression may reference it as <<decay-constant::K_u>>. Such a name
-            # is a valid observable name, so fall back to the parameter namespace before reporting
-            # it as unknown.
-            return self.lookup('parameter', qn)
-        if kind == 'constraint':
+            found = self._real_registries[kind].has(qn)
+        elif kind == 'observable':
+            found = qn in self._real_registries[kind]
+        elif kind == 'constraint':
             try:
                 self._real_registries[kind][qn]
-                return True
+                found = True
             except RuntimeError:
-                return False
+                found = False
+        else:
+            raise AssertionError(f'Unhandled validation entity kind: {kind!r}')
 
-        raise AssertionError(f'Unhandled validation entity kind: {kind!r}')
+        if found:
+            self._counts[kind][name] += 1
+            return True
+
+        # EOS resolves an observable name through Observable::make, which synthesises a parameter
+        # observable whenever the name names a parameter rather than a registered observable. A
+        # manual constraint may therefore constrain 'decay-constant::K_u' directly, and an
+        # expression may reference it as <<decay-constant::K_u>>. Such a name is a valid observable
+        # name, so fall back to the parameter namespace before reporting it as unknown; the
+        # reference is then credited to the parameter, which is what it actually uses.
+        if kind == 'observable':
+            return self.lookup('parameter', qn)
+
+        return False
+
+    def unused(self, kind):
+        """Return the names of shadow entities of *kind* that have not been looked up."""
+        if kind not in self._shadow:
+            raise ValueError(f'Unknown validation entity kind: {kind!r}')
+
+        return frozenset(
+            name for name in self._shadow[kind]
+            if self._counts[kind][name] == 0
+        )

--- a/python/eos/validation_context.py
+++ b/python/eos/validation_context.py
@@ -49,14 +49,19 @@ class ValidationContext:
             )
 
         parameters = {parameter.name for parameter in description.parameters}
+        parameter_aliases = {}
         for parameter in description.parameters:
             parameters.update(parameter.alias_of)
+            for alias in parameter.alias_of:
+                parameter_aliases.setdefault(alias, set()).add(parameter.name)
 
-        constraints = {
-            constraint.name
-            for likelihood in description.likelihoods
-            for constraint in likelihood.manual_constraints
-        }
+        constraints = set()
+        likelihood_constraints = {}
+        for likelihood in description.likelihoods:
+            names = {constraint.name for constraint in likelihood.manual_constraints}
+            constraints.update(names)
+            if names:
+                likelihood_constraints[likelihood.name] = names
 
         self._shadow = MappingProxyType({
             'observable': frozenset(observables),
@@ -71,6 +76,14 @@ class ValidationContext:
             kind: Counter({name: 0 for name in names})
             for kind, names in self._shadow.items()
         }
+        self._parameter_aliases = MappingProxyType({
+            alias: frozenset(declarations)
+            for alias, declarations in parameter_aliases.items()
+        })
+        self._likelihood_constraints = MappingProxyType({
+            likelihood: frozenset(names)
+            for likelihood, names in likelihood_constraints.items()
+        })
         self._real_registries = MappingProxyType({
             'observable': eos.Observables(),
             'parameter': eos.Parameters(),
@@ -91,6 +104,17 @@ class ValidationContext:
         name = str(qn)
         if name in self._shadow[kind]:
             self._counts[kind][name] += 1
+            if kind == 'parameter':
+                for declaration in self._parameter_aliases.get(name, ()):
+                    self._counts[kind][declaration] += 1
+            elif kind == 'likelihood':
+                # A manual constraint is never referenced by name: it is used by virtue of being
+                # declared inside a likelihood, whose manual_constraints AnalysisFile.analysis()
+                # passes straight to eos.Analysis. Credit a likelihood's manual constraints along
+                # with the likelihood, so that only those in an unused likelihood are reported --
+                # and that likelihood is itself reported alongside them.
+                for constraint in self._likelihood_constraints.get(name, ()):
+                    self._counts['constraint'][constraint] += 1
             return True
 
         if kind in self._LOCAL_KINDS:

--- a/python/eos/validation_context_TEST.py
+++ b/python/eos/validation_context_TEST.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import unittest
+
+import eos
+
+from eos.analysis_file_description import AnalysisFileDescription
+from eos.validation_context import ValidationContext
+
+
+class ValidationContextTests(unittest.TestCase):
+
+    @staticmethod
+    def _description(tag):
+        return AnalysisFileDescription.from_dict(
+            priors=[{
+                'name': f'prior-{tag}',
+                'descriptions': [{
+                    'parameter': f'test::{tag}',
+                    'type': 'uniform',
+                    'min': 0.0,
+                    'max': 1.0,
+                }],
+            }],
+            likelihoods=[{
+                'name': f'likelihood-{tag}',
+                'manual_constraints': {
+                    f'test::{tag}-constraint': {'type': 'Gaussian'},
+                },
+            }],
+            posteriors=[{
+                'name': f'posterior-{tag}',
+                'prior': [f'prior-{tag}'],
+                'likelihood': [f'likelihood-{tag}'],
+                'fixed_parameters': {
+                    f'test::{tag}-alias': 0.5,
+                },
+            }],
+            predictions=[{
+                'name': f'prediction-{tag}',
+                'observables': [{
+                    'name': f'test::{tag}-observable',
+                }],
+            }],
+            observables={
+                f'test::{tag}-observable': {
+                    'latex': tag,
+                    'unit': '1',
+                    'expression': '1',
+                },
+            },
+            parameters={
+                f'test::{tag}': {
+                    'latex': tag,
+                    'unit': '1',
+                    'central': 0.5,
+                    'min': 0.0,
+                    'max': 1.0,
+                    'alias_of': [f'test::{tag}-alias'],
+                },
+            },
+            masks=[{
+                'name': f'mask-{tag}',
+                'description': [{
+                    'name': f'test::{tag}-mask-observable',
+                    'expression': '1',
+                }],
+            }],
+        )
+
+    def test_lookup_uses_shadow_and_real_registries(self):
+        context = ValidationContext(self._description('one'))
+
+        for kind, name in (
+            ('observable', 'test::one-observable'),
+            ('observable', 'test::one-mask-observable'),
+            ('parameter', 'test::one'),
+            ('parameter', 'test::one-alias'),
+            ('constraint', 'test::one-constraint'),
+            ('prior', 'prior-one'),
+            ('likelihood', 'likelihood-one'),
+            ('mask', 'mask-one'),
+            ('posterior', 'posterior-one'),
+        ):
+            self.assertTrue(context.lookup(kind, name), (kind, name))
+
+        self.assertTrue(context.lookup('parameter', eos.QualifiedName('mass::e')))
+        self.assertTrue(context.lookup('observable', eos.QualifiedName('B->Dlnu::BR')))
+        self.assertTrue(context.lookup(
+            'constraint',
+            eos.QualifiedName('B->D::f_++f_0@HPQCD:2015A'),
+        ))
+        self.assertFalse(context.lookup('parameter', 'test::not-declared'))
+        self.assertFalse(context.lookup('prior', 'prior-not-declared'))
+
+    def test_contexts_are_file_local(self):
+        first = ValidationContext(self._description('first'))
+        second = ValidationContext(self._description('second'))
+
+        for kind, first_name, second_name in (
+            ('observable', 'test::first-observable', 'test::second-observable'),
+            ('parameter', 'test::first', 'test::second'),
+            ('constraint', 'test::first-constraint', 'test::second-constraint'),
+            ('prior', 'prior-first', 'prior-second'),
+            ('likelihood', 'likelihood-first', 'likelihood-second'),
+            ('mask', 'mask-first', 'mask-second'),
+            ('posterior', 'posterior-first', 'posterior-second'),
+        ):
+            self.assertTrue(first.lookup(kind, first_name))
+            self.assertFalse(first.lookup(kind, second_name))
+            self.assertTrue(second.lookup(kind, second_name))
+            self.assertFalse(second.lookup(kind, first_name))
+
+    def test_phases_one_and_two_are_idempotent_and_do_not_change_registries(self):
+        parameter_names_before = tuple(str(parameter.name()) for parameter in eos.Parameters())
+        observable_names_before = tuple(str(name) for name, _ in eos.Observables())
+        custom_parameter = eos.QualifiedName('test::idempotent-first')
+        custom_observable = eos.QualifiedName('test::idempotent-first-observable')
+        self.assertFalse(eos.Parameters().has(custom_parameter))
+        self.assertNotIn(custom_observable, eos.Observables())
+
+        first_description = self._description('idempotent-first')
+        first_diagnostics = (
+            list(first_description.validate_structure()),
+            list(first_description.validate_semantics(ValidationContext(first_description))),
+        )
+        repeated_diagnostics = (
+            list(first_description.validate_structure()),
+            list(first_description.validate_semantics(ValidationContext(first_description))),
+        )
+        self.assertEqual(first_diagnostics, repeated_diagnostics)
+        self.assertEqual(first_diagnostics[1], [])
+
+        second_description = self._description('idempotent-second')
+        list(second_description.validate_structure())
+        list(second_description.validate_semantics(ValidationContext(second_description)))
+
+        self.assertEqual(
+            parameter_names_before,
+            tuple(str(parameter.name()) for parameter in eos.Parameters()),
+        )
+        self.assertEqual(
+            observable_names_before,
+            tuple(str(name) for name, _ in eos.Observables()),
+        )
+        self.assertFalse(eos.Parameters().has(custom_parameter))
+        self.assertNotIn(custom_observable, eos.Observables())
+
+        first_context = ValidationContext(first_description)
+        second_context = ValidationContext(second_description)
+        self.assertFalse(first_context.lookup('parameter', 'test::idempotent-second'))
+        self.assertFalse(second_context.lookup('parameter', 'test::idempotent-first'))
+
+    def test_unknown_kind_is_rejected(self):
+        context = ValidationContext(self._description('one'))
+        with self.assertRaisesRegex(ValueError, 'Unknown validation entity kind'):
+            context.lookup('prediction', 'anything')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)

--- a/python/eos/validation_context_TEST.py
+++ b/python/eos/validation_context_TEST.py
@@ -18,6 +18,7 @@ import unittest
 import eos
 
 from eos.analysis_file_description import AnalysisFileDescription
+from eos.diagnostic import Severity
 from eos.validation_context import ValidationContext
 
 
@@ -142,7 +143,12 @@ class ValidationContextTests(unittest.TestCase):
             list(first_description.validate_semantics(ValidationContext(first_description))),
         )
         self.assertEqual(first_diagnostics, repeated_diagnostics)
-        self.assertEqual(first_diagnostics[1], [])
+        # this test is about idempotence and registry immutability, not about the exact set of
+        # diagnostics: assert only that neither phase reports an error. The fixture legitimately
+        # contains unused entities, which are reported as warnings, and further warning-level
+        # checks may be added without invalidating what is tested here.
+        for phase in first_diagnostics:
+            self.assertEqual([d for d in phase if d.severity is Severity.ERROR], [])
 
         second_description = self._description('idempotent-second')
         list(second_description.validate_structure())

--- a/python/eos_TEST.py
+++ b/python/eos_TEST.py
@@ -71,6 +71,20 @@ class QualifiedNameTests(unittest.TestCase):
         self.assertNotEqual(qn1, qn3)
 
 
+class ExpressionAnalysisTests(unittest.TestCase):
+
+    def test_referenced_names_without_registry_mutation(self):
+        "Check expression analysis returns referenced names without changing the observable registry."
+        import eos
+
+        number_of_observables = len(list(eos.Observables()))
+        references = eos.analyze_expression('<<B->pilnu::BR;l=tau>>')
+
+        self.assertEqual([name.full() for name in references.observables], ['B->pilnu::BR;l=tau'])
+        self.assertEqual(references.parameters, [])
+        self.assertEqual(len(list(eos.Observables())), number_of_observables)
+
+
 class ReferenceNameTests(unittest.TestCase):
 
     def test_creation(self):

--- a/src/scripts/eos-analysis
+++ b/src/scripts/eos-analysis
@@ -506,6 +506,10 @@ Validates the analysis file by checking that all posteriors and all prediction s
 ''',
         help = 'Validate the analysis file.'
     )
+    parser_validate.add_argument('--no-deep',
+        help = 'Only perform side-effect-free structural and semantic validation.',
+        dest = 'deep', action = 'store_false', default = True
+    )
     parser_validate.set_defaults(cmd = cmd_validate)
 
 


### PR DESCRIPTION
This splits the validation into a structural and a semantic part. Moreover, the validation does no longer load the analysis file. Instead, the ``AnalysisFileDescription`` and all its helper classes are used. As a bonus, this means that multiple analysis files can be validated without suffering through side effects by inserting custom parameters, observables, or constraints.

I think this resolves issue #1030. @MJKirk please confirm.

Validation now outputs the location as well:
```
$ eos-analysis validate -f src/scripts/eos-analysis_TEST.d/analysis.yaml --no-deep
priors/CKM/parameters: 'parameters' is in the description of prior component 'CKM', use 'descriptions' instead
priors/FF-norm/parameters: 'parameters' is in the description of prior component 'FF-norm', use 'descriptions' instead
priors/FF-shape/parameters: 'parameters' is in the description of prior component 'FF-shape', use 'descriptions' instead
steps/CKM+FF.find-mode/tasks[0]/arguments/chain: Task 'find-mode' has a default value for argument 'chain', which can change across versions; consider providing a value explicitly
steps/CKM+FF.find-mode/tasks[0]/arguments/importance_samples: Task 'find-mode' has a default value for argument 'importance_samples', which can change across versions; consider providing a value explicitly
steps/CKM+FF.find-mode/tasks[0]/arguments/mask_name: Task 'find-mode' has a default value for argument 'mask_name', which can change across versions; consider providing a value explicitly
steps/CKM+FF.find-mode/tasks[0]/arguments/optimizations: Task 'find-mode' has a default value for argument 'optimizations', which can change across versions; consider providing a value explicitly
steps/CKM+FF.find-mode/tasks[0]/arguments/start_point: Task 'find-mode' has a default value for argument 'start_point', which can change across versions; consider providing a value explicitly
steps/CKM+FF.sample/tasks[0]/arguments/N: Task 'sample-mcmc' has a default value for argument 'N', which can change across versions; consider providing a value explicitly
steps/CKM+FF.sample/tasks[0]/arguments/cov_scale: Task 'sample-mcmc' has a default value for argument 'cov_scale', which can change across versions; consider providing a value explicitly
steps/CKM+FF.sample/tasks[0]/arguments/preruns: Task 'sample-mcmc' has a default value for argument 'preruns', which can change across versions; consider providing a value explicitly
steps/CKM+FF.sample/tasks[0]/arguments/start_point: Task 'sample-mcmc' has a default value for argument 'start_point', which can change across versions; consider providing a value explicitly
...
```

- 2dbd6de0 [utils] Introduce a helper function ``eos::exp::parse_expression``.
- f36c1e8b [eos] Add means to analyze an expression for used observables and parameters.
- dcfed44b [python] Export ``analyze_expression``.
- 23bc76d4 [python] Add new class ``eos.Diagnostic``.
- 2d961fd0 [python] Add means to deserialize with diagnostic checks.
- 1ca3cc98 [python] Collect structural analysis-file diagnostics.
- 61a7ac1f [python] Add per-file validation context and semantic validation phase to ``eos.AnalysisFile`` and helpers.
- 84d30d58 [python] Pass qualified-name validation through a single helper.
- 285ef8d6 [python] Validate analysis-file expressions using the C++ parser.
- cb1d0bbf [python] Fix invalid (empty) likelihood component in test fixture.
- 1cd0b282 [python] Enforce safe file-local names in analysis files.
- 993e6130 [python] Convert analysis-file deprecations to warning diagnostics.
- caa424e0 [python] Detect unused priors, likelihoods, and masks when validating an analysis file.
- 6b80437b [python] Pass figure item validation through semantic validation context.
- 1c30e4fb [python] Detect unused custom parameters, observables, and constraints defined in an analysis file.
- 7c6eddbc [python] Enable tasks to skip eager analysis file loading.
- bf97497f [python] Drive analysis validation through structural and semantic phases.
- c9536d79 [python] Detect parameters that a posterior fixes and its own prior varies.
- 22587077 [python] Detect fixed parameters that a posterior does not use.
- e97a6b9b [eos] Update changelog for PR #1217.