### PR TITLE
Adding options to figure framework

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -90,6 +90,8 @@
 - Detect newly introduced C++ compiler warnings in the CI/CD workflows using ``g++``'s SARIF diagnostics output, providing native code-scanning annotations on pull requests and failing the build on any warning not present in a committed baseline (D. van Dyk)
 - Add ``eos.LogPrior.External``, which wraps a user-supplied Python factory (providing ``evaluate()``, ``sample()``, and ``compute_cdf()`` callables) as a prior (D. van Dyk)
 - Add the means to ensure a minimum effective sample size for the final samples produced by ``sample-nested``, exposed through the ``eos-analysis`` command-line interface (D. van Dyk)
+- Add an optional ``levels`` field to ``UncertaintyBandItem`` and ``BinnedUncertaintyItem`` items that modifies the plotted credibility interval (D. Suelmann)
+- Add an optional ``band`` field to ``BinnedUncertaintyItem`` items to plot different parts of the band separately (D. Suelmann)
 
 ### Deprecated
 

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -841,6 +841,9 @@ class UncertaintyBandItem(Item):
             if band_type not in ['area', 'outer', 'median']:
                 raise ValueError(f"Unrecognized band type '{band_type}'; must be one of 'area', 'outer', or 'median'")
 
+        if len(self.band) == 0:
+            raise ValueError("Parameter 'band' must contain at least one of 'area', 'outer', or 'median'")
+
         if self.interpolation not in ['linear', 'cubic']:
             raise ValueError(f"Unrecognized interpolation type '{self.interpolation}'; must be either 'linear' or 'cubic'")
 
@@ -990,6 +993,11 @@ class BinnedUncertaintyItem(Item):
 
     This routine expects the uncertainty propagation to have produced a data file.
 
+    :param band: A set of strings that determines which parts of the uncertainty band to draw. Can be any combination of ``'area'``, ``'outer'``, or ``'median'``.
+        Defaults to ``{'area', 'outer', 'median'}``.
+        ``'area'`` fills the area between the lower and upper bounds of the uncertainty band,
+        ``'outer'`` draws the outer lines of the uncertainty band, and ``'median'`` draws the median line of the uncertainty band.
+    :type band: set[str] | list[str] | str
     :param datafile: The path to an existing data file of type :class:`eos.data.Prediction` that contains the uncertainty estimates.
     :type datafile: str
     :param levels: The credibility levels that shall be visualized in percent (optional) ordered from lowest to highest. Defaults to [68.27].
@@ -1020,6 +1028,7 @@ class BinnedUncertaintyItem(Item):
         figure.draw()
     """
 
+    band:set[str]|list[str]|str=field(default_factory=lambda : {'area', 'outer', 'median'})
     datafile:str
     levels:list[float]=field(default_factory=lambda: [68.27])
     range:tuple[float, float]|None=field(default=None)
@@ -1028,6 +1037,20 @@ class BinnedUncertaintyItem(Item):
 
     def __post_init__(self):
         super().__post_init__()
+
+        if isinstance(self.band, str):
+            self.band = {self.band}
+        elif isinstance(self.band, list):
+            self.band = set(self.band)
+        elif not isinstance(self.band, set):
+            raise TypeError(f"Parameter 'band' must be a string, list of strings, or a set of strings, not {type(self.band).__name__}")
+
+        for band_type in self.band:
+            if band_type not in ['area', 'outer', 'median']:
+                raise ValueError(f"Unrecognized band type '{band_type}'; must be one of 'area', 'outer', or 'median'")
+
+        if len(self.band) == 0:
+            raise ValueError("Parameter 'band' must contain at least one of 'area', 'outer', or 'median'")
 
         for level in self.levels:
             if level <= 0 or level >= 100:
@@ -1065,8 +1088,8 @@ class BinnedUncertaintyItem(Item):
     def draw(self, ax):
         """Draw the binned uncertainty band on the provided axes.
 
-        For each bin, the central 68% interval and the median are drawn as a filled box with
-        outer and median lines, optionally rescaled by the inverse of the bin width.
+        Depending on the ``band`` setting, fills the area between the lower and upper bounds,
+        draws the outer lines, and/or draws the median line, optionally all rescaled by the inverse of the bin width.
 
         :param ax: The matplotlib axes onto which the band is drawn.
         :type ax: matplotlib.axes.Axes
@@ -1090,20 +1113,28 @@ class BinnedUncertaintyItem(Item):
                 ocentral /= width
                 ohi      /= width
                 eos.debug(f"{xmin} ... {xmax} -> {ocentral} with interval {olo} .. {ohi}")
-                ax.fill_between([xmin, xmax], [olo, olo], [ohi, ohi], lw=0, color=self.color, alpha=alpha, label=label)
-                ax.plot([xmin, xmax], [olo,      olo],      color=self.color, alpha=alpha, lw=self.linewidth, ls=self.linestyle)
-                ax.plot([xmin, xmax], [ocentral, ocentral], color=self.color, alpha=alpha, lw=self.linewidth, ls=self.linestyle)
-                ax.plot([xmin, xmax], [ohi,      ohi],      color=self.color, alpha=alpha, lw=self.linewidth, ls=self.linestyle)
+
+                if 'area' in self.band:
+                    ax.fill_between([xmin, xmax], [olo, olo], [ohi, ohi], lw=0, color=self.color, alpha=alpha, label=label)
+                    label = None # do not label anything else if we fill the band area
+                if 'outer' in self.band:
+                    ax.plot([xmin, xmax], [olo,      olo],                              alpha=alpha, color=self.color, label=label, lw=self.linewidth, ls=self.linestyle)
+                    ax.plot([xmin, xmax], [ohi,      ohi],                              alpha=alpha, color=self.color,              lw=self.linewidth, ls=self.linestyle)
+                    label = None # do not label anything else if we plot the outer lines
+                if 'median' in self.band:
+                    ax.plot([xmin, xmax], [ocentral, ocentral],                         alpha=alpha, color=self.color, label=label, lw=self.linewidth, ls=self.linestyle)
                 label = None
 
     def legend(self):
         """Return the item's legend entry as a list of handle/label pairs.
 
-        Since this item draws one nested region per requested credibility level, the key is
+        The key shows those parts of the band that the ``band`` option selects, i.e. the filled
+        area, the outer lines as the key's boundary, and the median line across its middle. Since
+        this item draws one nested region per requested credibility level, the filled area is
         subdivided into one swatch per region, each carrying the shade that region shows in the
-        plot; see :meth:`Item._legend_composite_patch`.
+        plot; see :meth:`Item._legend_band`.
         """
-        return self._legend_composite_patch(self._alphas)
+        return self._legend_band(self.band, self._alphas)
 
 
 @dataclass(kw_only=True)

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2023-2026 Danny van Dyk
+# Copyright (c) 2026      Dominik Suelmann
 # Copyright (c) 2023      Philip Lueghausen
 #
 # This file is part of the EOS project. EOS is free software;
@@ -579,7 +580,7 @@ class ExpressionItem(Item):
 
 @dataclass(kw_only=True)
 class UncertaintyBandItem(Item):
-    """Plots the 68% uncertainty band as a function of one kinematic variable or one parameter.
+    """Plots the 68.27% (default) uncertainty band as a function of one kinematic variable or one parameter.
 
     This routine requires EOS data file to have been produced, typically by running ``predict-observables`` task.
 
@@ -592,6 +593,8 @@ class UncertaintyBandItem(Item):
     :type datafile: str
     :param interpolation: The type of interpolation to be used for the band. Can be either ``linear`` (default) or ``cubic``.
     :type interpolation: str
+    :param levels: The credibility levels that shall be visualized in percent (optional) ordered from lowest to highest. Defaults to [68.27].
+    :type levels: list[float]
     :param range: A tuple of two float values (min, max) representing the range of the kinematic variable to be plotted on the x-axis.
     :type range: tuple[float, float] | None
     :param resolution: The number of points to be used for the interpolation of the band. Defaults to 100.
@@ -627,6 +630,7 @@ class UncertaintyBandItem(Item):
     band:set[str]|list[str]|str=field(default_factory=lambda : {'area', 'outer', 'median'})
     datafile:str
     interpolation:str=field(default='linear')
+    levels:list[float]=field(default_factory=lambda: [68.27])
     range:tuple[float, float]|None=field(default=None)
     resolution:int=field(default=100)
     variable:str|None=field(default=None)
@@ -695,6 +699,9 @@ class UncertaintyBandItem(Item):
             if band_type not in ['area', 'outer', 'median']:
                 raise ValueError(f"Unrecognized band type '{band_type}'; must be one of 'area', 'outer', or 'median'")
 
+        if 'outer' not in self.band and 'median' not in self.band:
+            self.linewidth = 0.0
+
         if self.interpolation not in ['linear', 'cubic']:
             raise ValueError(f"Unrecognized interpolation type '{self.interpolation}'; must be either 'linear' or 'cubic'")
 
@@ -706,6 +713,14 @@ class UncertaintyBandItem(Item):
             if self.range[0] >= self.range[1]:
                 raise ValueError(f"Range must be a tuple of two values (min, max) with max > min, not {self.range}")
 
+        for level in self.levels:
+            if level < 0 or level >= 100:
+                raise ValueError(f"Credibility level '{level}' is not in the interval (0, 100)")
+
+        # draw the largest contour first (lowest opacity) and the smallest last (highest opacity),
+        # so that nested contours remain visible
+        self.levels = sorted(self.levels, reverse=True)
+        self._alphas = _np.linspace(0.0, self.alpha, len(self.levels) + 1)[1:]
 
     def prepare(self, context:AnalysisFileContext=None):
         """Prepare the uncertainty band for drawing.
@@ -767,27 +782,32 @@ class UncertaintyBandItem(Item):
         _samples = self._datafile.samples[:, _observable_mask]
         _weights = self._datafile.weights
 
-        _ovalues_lower   = []
-        _ovalues_central = []
-        _ovalues_higher  = []
-        INTERVAL = [0.15865, 0.5, 0.84135]  # central 68% interval
-        for i in range(len(_samples[0])):
-            lower, central, higher = _np.quantile(_samples[:, i], q = INTERVAL, weights = _weights, method='inverted_cdf', axis=0)
-            _ovalues_lower.append(lower)
-            _ovalues_central.append(central)
-            _ovalues_higher.append(higher)
+        self._ovalues_lower   = []
+        self._ovalues_central = []
+        self._ovalues_higher  = []
 
-        self._xvalues = _np.linspace(_np.min(_xvalues), _np.max(_xvalues), self.resolution)
+        for level in self.levels:
+            _ovalues_lower   = []
+            _ovalues_central = []
+            _ovalues_higher  = []
+            INTERVAL = [0.5-level/100/2, 0.5, 0.5+level/100/2]
+            for i in range(len(_samples[0])):
+                lower, central, higher = _np.quantile(_samples[:, i], q = INTERVAL, weights = _weights, method='inverted_cdf', axis=0)
+                _ovalues_lower.append(lower)
+                _ovalues_central.append(central)
+                _ovalues_higher.append(higher)
 
-        if self.interpolation == "linear":
-            interpolate = lambda x, y, xv: _np.interp(xv, x, y)
-        elif self.interpolation == "cubic":
-            from scipy.interpolate import CubicSpline
-            interpolate = lambda x, y, xv: CubicSpline(x, y)(xv)
+            self._xvalues = _np.linspace(_np.min(_xvalues), _np.max(_xvalues), self.resolution)
 
-        self._ovalues_lower   = interpolate(_xvalues, _ovalues_lower,   self._xvalues)
-        self._ovalues_central = interpolate(_xvalues, _ovalues_central, self._xvalues)
-        self._ovalues_higher  = interpolate(_xvalues, _ovalues_higher,  self._xvalues)
+            if self.interpolation == "linear":
+                interpolate = lambda x, y, xv: _np.interp(xv, x, y)
+            elif self.interpolation == "cubic":
+                from scipy.interpolate import CubicSpline
+                interpolate = lambda x, y, xv: CubicSpline(x, y)(xv)
+
+            self._ovalues_lower.append(interpolate(_xvalues, _ovalues_lower,   self._xvalues))
+            self._ovalues_central.append(interpolate(_xvalues, _ovalues_central, self._xvalues))
+            self._ovalues_higher.append(interpolate(_xvalues, _ovalues_higher,  self._xvalues))
 
         if self.range is not None:
             self._xvalues         = _np.ma.masked_outside(self._xvalues,         self.range[0], self.range[1])
@@ -801,20 +821,31 @@ class UncertaintyBandItem(Item):
         :param ax: The matplotlib axes onto which the band is drawn.
         :type ax: matplotlib.axes.Axes
         """
-        label = self.label
-        if 'area' in self.band:
-            ax.fill_between(self._xvalues, self._ovalues_lower, self._ovalues_higher, alpha=self.alpha, color=self.color, label=label, lw=0)
-            label = None # do not label anything else if we fill the band area
-        if 'outer' in self.band:
-            ax.plot(self._xvalues, self._ovalues_lower,                               alpha=self.alpha, color=self.color, label=label, lw=self.linewidth, ls=self.linestyle)
-            ax.plot(self._xvalues, self._ovalues_higher,                              alpha=self.alpha, color=self.color,              lw=self.linewidth, ls=self.linestyle)
-            label = None # do not label anything else if we plot the outer lines
-        if 'median' in self.band:
-            ax.plot(self._xvalues, self._ovalues_central,                             alpha=self.alpha, color=self.color, label=label, lw=self.linewidth, ls=self.linestyle)
+        for alpha, ovalues_lower, ovalues_central, ovalues_higher in zip(self._alphas, self._ovalues_lower, self._ovalues_central, self._ovalues_higher):
+            label = self.label
+            if 'area' in self.band:
+                ax.fill_between(self._xvalues, ovalues_lower, ovalues_higher, alpha=alpha, color=self.color, label=label, lw=0)
+                label = None # do not label anything else if we fill the band area
+            if 'outer' in self.band:
+                ax.plot(self._xvalues, ovalues_lower,                               alpha=alpha, color=self.color, label=label, lw=self.linewidth, ls=self.linestyle)
+                ax.plot(self._xvalues, ovalues_higher,                              alpha=alpha, color=self.color,              lw=self.linewidth, ls=self.linestyle)
+                label = None # do not label anything else if we plot the outer lines
+            if 'median' in self.band:
+                ax.plot(self._xvalues, ovalues_central,                             alpha=alpha, color=self.color, label=label, lw=self.linewidth, ls=self.linestyle)
 
     def legend(self):
-        """Return the item's legend entry in form of its handle(s) and label(s)."""
-        return self._legend_patch()
+        """Return the item's legend entry as a list of handle/label pairs.
+
+        Provides a filled rectangle handle when band areas are drawn, and a line handle otherwise.
+
+        Since this item draws one nested region per requested confidence level, the key is
+        subdivided into one swatch per region, each carrying the shade that region shows in the
+        plot; see :meth:`Item._legend_composite_patch`.
+        """
+        if 'area' in self.band:
+            return self._legend_composite_patch(self._alphas)
+        else:
+            return self._legend_line()
 
 
 @dataclass(kw_only=True)
@@ -825,6 +856,8 @@ class BinnedUncertaintyItem(Item):
 
     :param datafile: The path to an existing data file of type :class:`eos.data.Prediction` that contains the uncertainty estimates.
     :type datafile: str
+    :param levels: The credibility levels that shall be visualized in percent (optional) ordered from lowest to highest. Defaults to [68.27].
+    :type levels: list[float]
     :param range: A tuple of two float values (min, max) representing the range of the kinematic variable to be plotted on the x-axis.
     :type range: tuple[float, float] | None
     :param rescale_by_width: If set to ``True``, the uncertainty band will be rescaled by the inverse of the width of the bin. Defaults to ``False``.
@@ -852,9 +885,22 @@ class BinnedUncertaintyItem(Item):
     """
 
     datafile:str
+    levels:list[float]=field(default_factory=lambda: [68.27])
     range:tuple[float, float]|None=field(default=None)
     rescale_by_width:bool=field(default=False)
     variable:str
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        for level in self.levels:
+            if level <= 0 or level >= 100:
+                raise ValueError(f"Credibility level '{level}' is not in the interval (0, 100)")
+
+        # draw the largest contour first (lowest opacity) and the smallest last (highest opacity),
+        # so that nested contours remain visible
+        self.levels = sorted(self.levels, reverse=True)
+        self._alphas = _np.linspace(0.0, self.alpha, len(self.levels) + 1)[1:]
 
     def prepare(self, context:AnalysisFileContext=None):
         """Prepare the binned uncertainty band for drawing.
@@ -890,32 +936,38 @@ class BinnedUncertaintyItem(Item):
         :type ax: matplotlib.axes.Axes
         """
 
-        ovalues_lower   = []
-        ovalues_central = []
-        ovalues_higher  = []
-        for i in range(len(self._xvalues)):
-            lower, central, higher = _np.quantile(self._datafile.samples[:, i], [0.15865, 0.5, 0.84135], weights=self._datafile.weights, method='inverted_cdf')
-            ovalues_lower.append(lower)
-            ovalues_central.append(central)
-            ovalues_higher.append(higher)
+        for level, alpha in zip(self.levels, self._alphas):
+            ovalues_lower   = []
+            ovalues_central = []
+            ovalues_higher  = []
+            for i in range(len(self._xvalues)):
+                lower, central, higher = _np.quantile(self._datafile.samples[:, i], [0.5-level/100/2, 0.5, 0.5+level/100/2], weights=self._datafile.weights, method='inverted_cdf')
+                ovalues_lower.append(lower)
+                ovalues_central.append(central)
+                ovalues_higher.append(higher)
 
-        label = self.label
+            label = self.label
 
-        for [xmin, xmax], olo, ocentral, ohi in zip(self._xvalues, ovalues_lower, ovalues_central, ovalues_higher):
-            width = (xmax - xmin) if self.rescale_by_width else 1
-            olo      /= width
-            ocentral /= width
-            ohi      /= width
-            eos.debug(f"{xmin} ... {xmax} -> {ocentral} with interval {olo} .. {ohi}")
-            ax.fill_between([xmin, xmax], [olo, olo], [ohi, ohi], lw=0, color=self.color, alpha=self.alpha, label=label)
-            ax.plot([xmin, xmax], [olo,      olo],      color=self.color, alpha=self.alpha, lw=self.linewidth, ls=self.linestyle)
-            ax.plot([xmin, xmax], [ocentral, ocentral], color=self.color, alpha=self.alpha, lw=self.linewidth, ls=self.linestyle)
-            ax.plot([xmin, xmax], [ohi,      ohi],      color=self.color, alpha=self.alpha, lw=self.linewidth, ls=self.linestyle)
-            label = None
+            for [xmin, xmax], olo, ocentral, ohi in zip(self._xvalues, ovalues_lower, ovalues_central, ovalues_higher):
+                width = (xmax - xmin) if self.rescale_by_width else 1
+                olo      /= width
+                ocentral /= width
+                ohi      /= width
+                eos.debug(f"{xmin} ... {xmax} -> {ocentral} with interval {olo} .. {ohi}")
+                ax.fill_between([xmin, xmax], [olo, olo], [ohi, ohi], lw=0, color=self.color, alpha=alpha, label=label)
+                ax.plot([xmin, xmax], [olo,      olo],      color=self.color, alpha=alpha, lw=self.linewidth, ls=self.linestyle)
+                ax.plot([xmin, xmax], [ocentral, ocentral], color=self.color, alpha=alpha, lw=self.linewidth, ls=self.linestyle)
+                ax.plot([xmin, xmax], [ohi,      ohi],      color=self.color, alpha=alpha, lw=self.linewidth, ls=self.linestyle)
+                label = None
 
     def legend(self):
-        """Return the item's legend entry in form of its handle(s) and label(s)."""
-        return self._legend_patch()
+        """Return the item's legend entry as a list of handle/label pairs.
+
+        Since this item draws one nested region per requested credibility level, the key is
+        subdivided into one swatch per region, each carrying the shade that region shows in the
+        plot; see :meth:`Item._legend_composite_patch`.
+        """
+        return self._legend_composite_patch(self._alphas)
 
 
 @dataclass(kw_only=True)

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -835,7 +835,7 @@ class UncertaintyBandItem(Item):
         elif isinstance(self.band, list):
             self.band = set(self.band)
         elif not isinstance(self.band, set):
-            raise TypeError(f"Parameter 'band' must be a string, list of string, or a set of strings, not {type(self.band).__name__}")
+            raise TypeError(f"Parameter 'band' must be a string, list of strings, or a set of strings, not {type(self.band).__name__}")
 
         for band_type in self.band:
             if band_type not in ['area', 'outer', 'median']:

--- a/python/eos/figure/item.py
+++ b/python/eos/figure/item.py
@@ -114,6 +114,30 @@ class CompositeRegionHandler(_matplotlib.legend_handler.HandlerBase):
     prevents internal dividers from appearing between adjacent swatches.
     """
 
+    @staticmethod
+    def _swatches(facecolors, xdescent, ydescent, width, height, trans):
+        "Abutting swatches, one per facecolor and each without an outline, which together span the full width of the key."
+        swatches = []
+        bounds   = _np.linspace(-xdescent, -xdescent + width, len(facecolors) + 1)
+        for facecolor, lower, upper in zip(facecolors, bounds[:-1], bounds[1:]):
+            swatch = _matplotlib.patches.Rectangle((lower, -ydescent), upper - lower, height,
+                                                   facecolor=facecolor, edgecolor='none', linewidth=0.0)
+            swatch.set_transform(trans)
+            swatches.append(swatch)
+
+        return swatches
+
+    @staticmethod
+    def _boundary(handle, xdescent, ydescent, width, height, trans):
+        "An unfilled boundary spanning the entire key, in the line style carried by the handle."
+        boundary = _matplotlib.patches.Rectangle((-xdescent, -ydescent), width, height, fill=False,
+                                                 edgecolor=handle.edgecolor,
+                                                 linewidth=handle.linewidth,
+                                                 linestyle=handle.linestyle)
+        boundary.set_transform(trans)
+
+        return boundary
+
     def create_artists(self, legend, orig_handle, xdescent, ydescent, width, height, fontsize, trans):
         """Create the artists that make up the composite legend key.
 
@@ -136,31 +160,110 @@ class CompositeRegionHandler(_matplotlib.legend_handler.HandlerBase):
         :returns: The swatches, followed by the boundary drawn around them.
         :rtype: list[matplotlib.artist.Artist]
         """
-        artists = []
-
-        # abutting swatches, one per region and each without an outline, which together span the
-        # full width of the key
-        bounds = _np.linspace(-xdescent, -xdescent + width, len(orig_handle.facecolors) + 1)
-        for facecolor, lower, upper in zip(orig_handle.facecolors, bounds[:-1], bounds[1:]):
-            swatch = _matplotlib.patches.Rectangle((lower, -ydescent), upper - lower, height,
-                                                   facecolor=facecolor, edgecolor='none', linewidth=0.0)
-            swatch.set_transform(trans)
-            artists.append(swatch)
-
-        # a single boundary around the composite, in the line style of the outermost region
-        boundary = _matplotlib.patches.Rectangle((-xdescent, -ydescent), width, height, fill=False,
-                                                 edgecolor=orig_handle.edgecolor,
-                                                 linewidth=orig_handle.linewidth,
-                                                 linestyle=orig_handle.linestyle)
-        boundary.set_transform(trans)
-        artists.append(boundary)
+        # one swatch per region, followed by a single boundary around the composite in the line
+        # style of the outermost region
+        artists = self._swatches(orig_handle.facecolors, xdescent, ydescent, width, height, trans)
+        artists.append(self._boundary(orig_handle, xdescent, ydescent, width, height, trans))
 
         return artists
 
 
-# make the composite key available to every legend, so that items returning a CompositeRegionHandle
-# need not thread a handler map through the plot's legend
-_matplotlib.legend.Legend.update_default_handler_map({ CompositeRegionHandle: CompositeRegionHandler() })
+class BandHandle:
+    """A legend handle for items that draw a band as a selection of its parts.
+
+    Items such as :class:`UncertaintyBandItem` draw only those parts of a band that their ``band``
+    option requests: the area between the band's outer bounds, the outer bounds themselves, and the
+    band's median. A key that always shows a filled and bounded swatch (as produced by
+    :meth:`Item._legend_patch` or :meth:`Item._legend_composite_patch`) therefore matches the drawn
+    item only when every part is drawn.
+
+    This handle instead shows exactly the parts that the item draws: the filled area as the abutting
+    swatches of a composite key (see :class:`CompositeRegionHandle`), the outer bounds as the
+    boundary around these swatches, and the median as a horizontal line across the middle of the
+    key. Rendering is performed by :class:`BandHandler`, which is registered as the default legend
+    handler for this class.
+
+    :param facecolors: The fill colors of the swatches, in the order in which they appear from left to right, as for :class:`CompositeRegionHandle`. Empty if the band's area is not filled.
+    :type facecolors: list
+    :param edgecolor: The color of the boundary and of the median line.
+    :type edgecolor: object
+    :param linewidth: The width of the boundary and of the median line.
+    :type linewidth: float
+    :param linestyle: The style of the boundary and of the median line.
+    :type linestyle: str
+    :param boundary: Whether the swatches are bounded, i.e. whether the item draws the band's outer bounds.
+    :type boundary: bool
+    :param median: Whether a horizontal line is drawn across the middle of the key, i.e. whether the item draws the band's median.
+    :type median: bool
+    """
+
+    def __init__(self, facecolors=(), edgecolor=None, linewidth=1.0, linestyle='solid', boundary=False, median=False):
+        if not facecolors and not boundary and not median:
+            raise ValueError('a band legend handle requires at least one of a facecolor, a boundary, or a median line')
+
+        self.facecolors = list(facecolors)
+        self.edgecolor  = edgecolor
+        self.linewidth  = linewidth
+        self.linestyle  = linestyle
+        self.boundary   = boundary
+        self.median     = median
+
+
+class BandHandler(CompositeRegionHandler):
+    """Renders a :class:`BandHandle` as those parts of a band that the item draws.
+
+    The parts occupy the area that the legend allots to a single key: the swatches of the filled
+    area span its full width, the boundary encloses them, and the median line runs across its
+    middle. Parts that the item does not draw are omitted, so that a band drawn as a median alone
+    is keyed by a single line, just as an ordinary line key.
+    """
+
+    def create_artists(self, legend, orig_handle, xdescent, ydescent, width, height, fontsize, trans):
+        """Create the artists that make up the band's legend key.
+
+        :param legend: The legend for which the artists are created.
+        :type legend: matplotlib.legend.Legend
+        :param orig_handle: The handle to be rendered.
+        :type orig_handle: BandHandle
+        :param xdescent: The offset of the key's left edge, measured to the left of the origin.
+        :type xdescent: float
+        :param ydescent: The offset of the key's bottom edge, measured below the origin.
+        :type ydescent: float
+        :param width: The width allotted to the key.
+        :type width: float
+        :param height: The height allotted to the key.
+        :type height: float
+        :param fontsize: The font size of the legend. Unused; accepted for interface consistency.
+        :type fontsize: float
+        :param trans: The transform to be applied to the artists.
+        :type trans: matplotlib.transforms.Transform
+        :returns: The swatches of the filled area, followed by the boundary around them and by the median line, omitting whichever parts the item does not draw.
+        :rtype: list[matplotlib.artist.Artist]
+        """
+        artists = self._swatches(orig_handle.facecolors, xdescent, ydescent, width, height, trans)
+
+        if orig_handle.boundary:
+            artists.append(self._boundary(orig_handle, xdescent, ydescent, width, height, trans))
+
+        if orig_handle.median:
+            # the median runs across the middle of the key, just as it runs between the band's outer
+            # bounds in the plot
+            median = _matplotlib.lines.Line2D((-xdescent, -xdescent + width), (-ydescent + 0.5 * height,) * 2,
+                                              color=orig_handle.edgecolor,
+                                              linewidth=orig_handle.linewidth,
+                                              linestyle=orig_handle.linestyle)
+            median.set_transform(trans)
+            artists.append(median)
+
+        return artists
+
+
+# make the composite and band keys available to every legend, so that items returning one of these
+# handles need not thread a handler map through the plot's legend
+_matplotlib.legend.Legend.update_default_handler_map({
+    CompositeRegionHandle: CompositeRegionHandler(),
+    BandHandle:            BandHandler(),
+})
 
 
 @dataclass(kw_only=True)
@@ -215,17 +318,33 @@ class Item(Deserializable):
         handle = _matplotlib.patches.Rectangle((0, 0), 1, 1, color=self.color, alpha=self.alpha)
         return [(handle, self.label)]
 
-    def _legend_composite_patch(self, alphas):
-        """A subdivided swatch matching a set of nested, translucent regions.
+    def _composite_facecolors(self, alphas):
+        """The shades that a set of nested, translucent regions shows in the plot.
 
         The regions are drawn on top of one another, so the opacity the eye perceives for a region
         is not that region's own opacity but the accumulated opacity of that region and of every
-        region enclosing it. This method composites the given opacities accordingly and returns a
-        :class:`CompositeRegionHandle` whose swatches carry the resulting shades, so that each
-        shade in the key also occurs in the plot.
+        region enclosing it. This method composites the given opacities accordingly, so that each
+        resulting shade also occurs in the plot.
 
-        The swatches run from the innermost region at the left to the outermost region at the right,
-        so that opacity decreases from left to right.
+        The shades run from the innermost region first to the outermost region last, i.e. in the
+        order in which the swatches of a composite key appear from left to right, so that opacity
+        decreases from left to right.
+
+        :param alphas: The opacities of the regions' fills, ordered from the outermost region to the innermost, as passed to the drawing routine.
+        :type alphas: list[float] | numpy.ndarray
+        :returns: The composited shades, as colors that matplotlib can resolve.
+        :rtype: list
+        """
+        # Accumulating requires the outermost region first, while the shades run the other way
+        # round, so the result is reversed for display.
+        accumulated = 1.0 - _np.cumprod(1.0 - _np.asarray(alphas, dtype=float))
+        return [_matplotlib.colors.to_rgba(self.color, alpha) for alpha in accumulated[::-1]]
+
+    def _legend_composite_patch(self, alphas):
+        """A subdivided swatch matching a set of nested, translucent regions.
+
+        Returns a :class:`CompositeRegionHandle` whose swatches carry the shades that the regions
+        show in the plot; see :meth:`_composite_facecolors`.
 
         :param alphas: The opacities of the regions' fills, ordered from the outermost region to the innermost, as passed to the drawing routine.
         :type alphas: list[float] | numpy.ndarray
@@ -235,18 +354,41 @@ class Item(Deserializable):
         if not self.label:
             return []
 
-        # The opacity accumulated by compositing each region's fill onto the fills enclosing it.
-        # Accumulating requires the outermost region first, while the swatches run the other way
-        # round, so the resulting shades are reversed for display.
-        accumulated = 1.0 - _np.cumprod(1.0 - _np.asarray(alphas, dtype=float))
-        facecolors  = [_matplotlib.colors.to_rgba(self.color, alpha) for alpha in accumulated[::-1]]
-
         # The outermost region bounds the drawn item, so its line style is the one that bounds the
         # key. The boundary is drawn opaque rather than at that region's opacity, which would leave
         # it too faint to read: delineating the key and conveying the line style is the boundary's
         # purpose here, while the swatches carry the opacity information.
-        handle = CompositeRegionHandle(facecolors, edgecolor=self.color,
+        handle = CompositeRegionHandle(self._composite_facecolors(alphas), edgecolor=self.color,
                                        linewidth=self.linewidth, linestyle=self.linestyle)
+        return [(handle, self.label)]
+
+    def _legend_band(self, band, alphas):
+        """A swatch matching a band, showing only those of its parts that are drawn.
+
+        The ``band`` option of items such as :class:`UncertaintyBandItem` selects which parts of a
+        band are drawn: the area between the band's outer bounds, the outer bounds themselves, and
+        the band's median. This method returns a :class:`BandHandle` that shows exactly these parts,
+        so that a band drawn as a median alone is keyed by a line rather than by a filled swatch.
+
+        The filled area is keyed by one swatch per drawn region, each carrying the shade that region
+        shows in the plot; see :meth:`_composite_facecolors`.
+
+        :param band: The parts of the band that are drawn, as any combination of ``'area'``, ``'outer'``, and ``'median'``.
+        :type band: set[str]
+        :param alphas: The opacities of the regions' fills, ordered from the outermost region to the innermost, as passed to the drawing routine.
+        :type alphas: list[float] | numpy.ndarray
+        :returns: A list containing a single ``(handle, label)`` pair if a label is set, otherwise empty.
+        :rtype: list[tuple[matplotlib.artist.Artist, str]]
+        """
+        if not self.label:
+            return []
+
+        # The boundary and the median line are drawn opaque rather than at the regions' opacity,
+        # which would leave them too faint to read: conveying the line style is their purpose here,
+        # while the swatches carry the opacity information.
+        handle = BandHandle(self._composite_facecolors(alphas) if 'area' in band else (),
+                            edgecolor=self.color, linewidth=self.linewidth, linestyle=self.linestyle,
+                            boundary=('outer' in band), median=('median' in band))
         return [(handle, self.label)]
 
     def _legend_marker(self, marker, alpha=None):
@@ -699,9 +841,6 @@ class UncertaintyBandItem(Item):
             if band_type not in ['area', 'outer', 'median']:
                 raise ValueError(f"Unrecognized band type '{band_type}'; must be one of 'area', 'outer', or 'median'")
 
-        if 'outer' not in self.band and 'median' not in self.band:
-            self.linewidth = 0.0
-
         if self.interpolation not in ['linear', 'cubic']:
             raise ValueError(f"Unrecognized interpolation type '{self.interpolation}'; must be either 'linear' or 'cubic'")
 
@@ -836,16 +975,13 @@ class UncertaintyBandItem(Item):
     def legend(self):
         """Return the item's legend entry as a list of handle/label pairs.
 
-        Provides a filled rectangle handle when band areas are drawn, and a line handle otherwise.
-
-        Since this item draws one nested region per requested confidence level, the key is
+        The key shows those parts of the band that the ``band`` option selects, i.e. the filled
+        area, the outer lines as the key's boundary, and the median line across its middle. Since
+        this item draws one nested region per requested credibility level, the filled area is
         subdivided into one swatch per region, each carrying the shade that region shows in the
-        plot; see :meth:`Item._legend_composite_patch`.
+        plot; see :meth:`Item._legend_band`.
         """
-        if 'area' in self.band:
-            return self._legend_composite_patch(self._alphas)
-        else:
-            return self._legend_line()
+        return self._legend_band(self.band, self._alphas)
 
 
 @dataclass(kw_only=True)

--- a/python/eos/figure/item_TEST.py
+++ b/python/eos/figure/item_TEST.py
@@ -22,7 +22,7 @@ import os
 import tempfile
 
 from eos.analysis_file_context import AnalysisFileContext
-from eos.figure.item import CompositeRegionHandle, CompositeRegionHandler
+from eos.figure.item import BandHandle, BandHandler, CompositeRegionHandle, CompositeRegionHandler
 from matplotlib import colors as mcolors
 from matplotlib import pyplot as plt
 from matplotlib import transforms as mtransforms
@@ -226,6 +226,110 @@ class UncertaintyBandItemTests(unittest.TestCase):
             item.draw(ax)
         except Exception as e:
             self.fail(f"Error when testing item of type 'observable': {e}")
+
+    def test_legend(self):
+
+        # the key of a labelled band is a single entry that reflects the 'band' option; the item
+        # need not be prepared, since the key is determined by the item's options alone
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nlabel: 'band'")
+        entries = item.legend()
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0][0], BandHandle)
+        self.assertEqual(entries[0][1], 'band')
+
+        # by default every part of the band is drawn, so the key shows a swatch for the single
+        # credibility level, the boundary formed by the outer lines, and the median line
+        handle = entries[0][0]
+        self.assertEqual(len(handle.facecolors), 1)
+        self.assertTrue(handle.boundary)
+        self.assertTrue(handle.median)
+
+        # the filled area carries one swatch per drawn region, with the shades of the drawn regions,
+        # i.e. with opacity decreasing from the innermost region at the left to the outermost at the
+        # right; see CompositeRegionHandle
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nlabel: 'band'\nlevels: [68.27, 95.45]")
+        handle = item.legend()[0][0]
+        self.assertEqual(len(handle.facecolors), 2)
+        opacities = [mcolors.to_rgba(facecolor)[3] for facecolor in handle.facecolors]
+        self.assertEqual(opacities, sorted(opacities, reverse=True))
+
+        # a band drawn as a median alone is keyed by neither a swatch nor a boundary ...
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nlabel: 'band'\nband: 'median'\n"
+                                                "color: 'C0'\nlinestyle: 'dashed'")
+        handle = item.legend()[0][0]
+        self.assertEqual(handle.facecolors, [])
+        self.assertFalse(handle.boundary)
+        self.assertTrue(handle.median)
+
+        # ... but by a single line across the middle of the key, spanning its full width, i.e. the
+        # key an ordinary line handle would produce. The handler does not consult the legend it is
+        # passed, so None suffices here.
+        artists = BandHandler().create_artists(None, handle, 0.0, 0.0, 30.0, 10.0, 10.0,
+                                              mtransforms.IdentityTransform())
+        self.assertEqual(len(artists), 1)
+        self.assertIsInstance(artists[0], Line2D)
+        self.assertEqual(list(artists[0].get_xdata()), [0.0, 30.0])
+        self.assertEqual(list(artists[0].get_ydata()), [5.0, 5.0])
+        self.assertEqual(mcolors.to_rgba(artists[0].get_color()), mcolors.to_rgba(item.color))
+        self.assertEqual(artists[0].get_linestyle(), '--')
+
+        # the outer lines alone are keyed by an unfilled boundary and nothing else
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nlabel: 'band'\nband: 'outer'")
+        handle = item.legend()[0][0]
+        self.assertEqual(handle.facecolors, [])
+        self.assertTrue(handle.boundary)
+        self.assertFalse(handle.median)
+        artists = BandHandler().create_artists(None, handle, 0.0, 0.0, 30.0, 10.0, 10.0,
+                                              mtransforms.IdentityTransform())
+        self.assertEqual(len(artists), 1)
+        self.assertIsInstance(artists[0], Rectangle)
+        self.assertFalse(artists[0].get_fill())
+
+        # the filled area alone is keyed by swatches, with neither a boundary nor a median line
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nlabel: 'band'\nband: ['area']\n"
+                                                "levels: [68.27, 95.45]")
+        handle = item.legend()[0][0]
+        self.assertEqual(len(handle.facecolors), 2)
+        self.assertFalse(handle.boundary)
+        self.assertFalse(handle.median)
+        artists = BandHandler().create_artists(None, handle, 0.0, 0.0, 30.0, 10.0, 10.0,
+                                              mtransforms.IdentityTransform())
+        self.assertEqual(len(artists), 2)
+        for swatch in artists:
+            self.assertTrue(swatch.get_fill())
+            self.assertEqual(swatch.get_linewidth(), 0.0)
+
+        # with every part drawn, the key shows the swatches, a boundary around them, and the median
+        # line across their middle, all in the item's line style
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nlabel: 'band'\n"
+                                                "band: ['area', 'outer', 'median']\nlevels: [68.27, 95.45]\n"
+                                                "linestyle: 'dashed'")
+        handle = item.legend()[0][0]
+        artists = BandHandler().create_artists(None, handle, 0.0, 0.0, 30.0, 10.0, 10.0,
+                                               mtransforms.IdentityTransform())
+        self.assertEqual(len(artists), len(handle.facecolors) + 2)
+        swatches, boundary, median = artists[:-2], artists[-2], artists[-1]
+        # the swatches abut and together span exactly the width allotted to the key
+        self.assertAlmostEqual(sum(swatch.get_width() for swatch in swatches), 30.0, places=12)
+        for lower, upper in zip(swatches[:-1], swatches[1:]):
+            self.assertAlmostEqual(lower.get_x() + lower.get_width(), upper.get_x(), places=12)
+        # a single unfilled boundary spans the whole key
+        self.assertFalse(boundary.get_fill())
+        self.assertAlmostEqual(boundary.get_width(), 30.0, places=12)
+        self.assertEqual(boundary.get_linestyle(), 'dashed')
+        # the median line is vertically centered within the key and spans its full width
+        self.assertIsInstance(median, Line2D)
+        self.assertEqual(list(median.get_xdata()), [0.0, 30.0])
+        self.assertEqual(list(median.get_ydata()), [5.0, 5.0])
+        self.assertEqual(median.get_linestyle(), '--')
+
+        # a key that shows none of the band's parts is rejected rather than rendered as an empty key
+        with self.assertRaises(ValueError):
+            BandHandle()
+
+        # an unlabelled band contributes no entry
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'")
+        self.assertEqual(list(item.legend()), [])
 
 class BinnedUncertaintyItemTests(unittest.TestCase):
 

--- a/python/eos/figure/item_TEST.py
+++ b/python/eos/figure/item_TEST.py
@@ -227,6 +227,23 @@ class UncertaintyBandItemTests(unittest.TestCase):
         except Exception as e:
             self.fail(f"Error when testing item of type 'observable': {e}")
 
+        try:
+            input = """
+            type: uncertainty
+            label: '$\\ell=\\mu$'
+            variable: 'q2'
+            levels: [95]
+            range: [0.02, 11.63]
+            band: ['area']
+            datafile: 'eos/data/prediction_TEST.d/predictions'
+            """
+            item = eos.figure.ItemFactory.from_yaml(input)
+            item.prepare(context=AnalysisFileContext(base_directory=os.path.join(os.environ['SOURCE_DIR'])))
+            _, ax = plt.subplots()
+            item.draw(ax)
+        except Exception as e:
+            self.fail(f"Error when testing item of type 'observable': {e}")
+
     def test_legend(self):
 
         # the key of a labelled band is a single entry that reflects the 'band' option; the item
@@ -349,6 +366,73 @@ class BinnedUncertaintyItemTests(unittest.TestCase):
             item.draw(ax)
         except Exception as e:
             self.fail(f"Error when testing item of type 'observable': {e}")
+
+        try:
+            input = """
+            type: uncertainty-binned
+            label: '$\\ell=\\mu$'
+            variable: 'q2'
+            range: [0.02, 11.63]
+            band: ['area']
+            datafile: 'eos/data/prediction_TEST.d/predictions-binned'
+            """
+            item = eos.figure.ItemFactory.from_yaml(input)
+            item.prepare(context=AnalysisFileContext(base_directory=os.path.join(os.environ['SOURCE_DIR'])))
+            _, ax = plt.subplots()
+            item.draw(ax)
+        except Exception as e:
+            self.fail(f"Error when testing item of type 'observable': {e}")
+
+    def test_legend(self):
+
+        # as for an unbinned band, the key of a labelled item reflects the 'band' option; the item
+        # need not be prepared, since the key is determined by the item's options alone
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'q2'\ndatafile: 'x'\nlabel: 'band'")
+        entries = item.legend()
+        self.assertEqual(len(entries), 1)
+        self.assertIsInstance(entries[0][0], BandHandle)
+        self.assertEqual(entries[0][1], 'band')
+
+        # by default every part of the band is drawn, so the key shows a swatch for the single
+        # credibility level, the boundary formed by the outer lines, and the median line
+        handle = entries[0][0]
+        self.assertEqual(len(handle.facecolors), 1)
+        self.assertTrue(handle.boundary)
+        self.assertTrue(handle.median)
+
+        # the filled area carries one swatch per drawn region
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'q2'\ndatafile: 'x'\nlabel: 'band'\n"
+                                                "levels: [68.27, 95.45]")
+        self.assertEqual(len(item.legend()[0][0].facecolors), 2)
+
+        # a band drawn as a median alone is keyed by neither a swatch nor a boundary, i.e. by the
+        # single line that an ordinary line handle would produce
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'q2'\ndatafile: 'x'\nlabel: 'band'\n"
+                                                "band: 'median'")
+        handle = item.legend()[0][0]
+        self.assertEqual(handle.facecolors, [])
+        self.assertFalse(handle.boundary)
+        self.assertTrue(handle.median)
+
+        # the outer lines alone are keyed by an unfilled boundary
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'q2'\ndatafile: 'x'\nlabel: 'band'\n"
+                                                "band: 'outer'")
+        handle = item.legend()[0][0]
+        self.assertEqual(handle.facecolors, [])
+        self.assertTrue(handle.boundary)
+        self.assertFalse(handle.median)
+
+        # the filled area alone is keyed by swatches, with neither a boundary nor a median line
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'q2'\ndatafile: 'x'\nlabel: 'band'\n"
+                                                "band: ['area']")
+        handle = item.legend()[0][0]
+        self.assertEqual(len(handle.facecolors), 1)
+        self.assertFalse(handle.boundary)
+        self.assertFalse(handle.median)
+
+        # an unlabelled band contributes no entry
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'q2'\ndatafile: 'x'")
+        self.assertEqual(list(item.legend()), [])
 
 class ConstraintItemTests(unittest.TestCase):
 
@@ -1318,6 +1402,10 @@ class UncertaintyBandItemValidationTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nband: 'nonsense'")
 
+        # an empty band set is rejected
+        with self.assertRaises(ValueError):
+            eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nband: []")
+
         # an unknown interpolation type is rejected
         with self.assertRaises(ValueError):
             eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\ninterpolation: 'quadratic'")
@@ -1335,6 +1423,35 @@ class UncertaintyBandItemValidationTests(unittest.TestCase):
             eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nrange: [2.0, 1.0]")
 
 class BinnedUncertaintyItemValidationTests(unittest.TestCase):
+
+    def test_band_normalization(self):
+
+        # a single band type given as a string is normalized to a set
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'nonexistent'\n"
+                                                "datafile: 'eos/data/prediction_TEST.d/predictions-binned'\nband: 'median'")
+        self.assertEqual(item.band, {'median'})
+
+        # a list of band types is normalized to a set
+        item = eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'nonexistent'\n"
+                                                "datafile: 'eos/data/prediction_TEST.d/predictions-binned'\nband: ['area', 'outer']")
+        self.assertEqual(item.band, {'area', 'outer'})
+
+    def test_invalid(self):
+
+        # a 'band' that is neither a string, list, nor set is rejected
+        with self.assertRaisesRegex(ValueError, "must be a string, list of strings"):
+            eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'nonexistent'\n"
+                                                "datafile: 'eos/data/prediction_TEST.d/predictions-binned'\nband: 5")
+
+        # an unknown band type is rejected
+        with self.assertRaises(ValueError):
+            eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'nonexistent'\n"
+                                                "datafile: 'eos/data/prediction_TEST.d/predictions-binned'\nband: 'nonsense'")
+
+        # an empty band set is rejected
+        with self.assertRaises(ValueError):
+            eos.figure.ItemFactory.from_yaml("type: uncertainty-binned\nvariable: 'nonexistent'\n"
+                                                "datafile: 'eos/data/prediction_TEST.d/predictions-binned'\nband: []")
 
     def test_missing_binned_kinematics(self):
 

--- a/python/eos/figure/item_TEST.py
+++ b/python/eos/figure/item_TEST.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2025-2026 Danny van Dyk
+# Copyright (c) 2026      Dominik Suelmann
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -215,6 +216,7 @@ class UncertaintyBandItemTests(unittest.TestCase):
             type: uncertainty
             label: '$\\ell=\\mu$'
             variable: 'q2'
+            levels: [95]
             range: [0.02, 11.63]
             datafile: 'eos/data/prediction_TEST.d/predictions'
             """
@@ -1215,6 +1217,10 @@ class UncertaintyBandItemValidationTests(unittest.TestCase):
         # an unknown interpolation type is rejected
         with self.assertRaises(ValueError):
             eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\ninterpolation: 'quadratic'")
+
+        # a level value larger than 100 is rejected
+        with self.assertRaisesRegex(ValueError, "not in the interval"):
+            eos.figure.ItemFactory.from_yaml("type: uncertainty\ndatafile: 'x'\nlevels: [150]")
 
         # a range that is not a pair is rejected
         with self.assertRaises(ValueError):


### PR DESCRIPTION
I add two optional arguments to items of the figure framework.

1. Level option to UncertaintyBandItem to change the credibility interval that is plotted
2. Band option to BinnedUncertaintyItem similar to the band option in UncertaintyBandItem