### PR TITLE
Implement tensor form factors for B*->D(*) transitions in the HQE, following BGJvD:2025A

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,8 @@
 - Add the ``eos-data check``, ``create``, ``publish``, and ``register`` commands for validating analysis datasets, creating citable dataset tags, publishing GitHub releases for Zenodo, and registering published datasets (D. van Dyk)
 - Expose the ``name_part()``, ``year_part()``, and ``index_part()`` accessors of ``eos.ReferenceName`` to Python, which ``eos.References``' ``year`` and ``index`` filters require (D. van Dyk)
 - Add a ``has()`` member function to the ``Constraints``, ``Kinematics``, ``Observables``, ``Options``, ``Parameters``, ``References``, and ``SignalPDFs`` classes, and export it to Python as ``__contains__``, so that ``name in eos.Constraints()`` and its analogues report membership (D. van Dyk)
+- Add the ``Bbar^*->D`` and ``Bbar^*->D^*`` tensor form factors in the HQE parametrisation, following [BGJvD:2025A]; the ``FormFactors<VToP>`` and ``FormFactors<VToV>`` interfaces gain ``h_tbar_1`` to ``h_tbar_3`` and ``h_t4`` to ``h_t10`` respectively (D. van Dyk)
+- Add the reference [BGJvD:2025A] and cite it from ``BGLCoefficients`` and ``HQETUnitarityBounds``, which implement its BGL coefficients for the tensor form factors and its ``1^+`` and ``1^-`` tensor bounds (D. van Dyk)
 
 ### Deprecated
 
@@ -53,6 +55,9 @@
 - Fix ``eos.figure.UncertaintyBandItem`` to compare the options of the requested ``observable`` against those recorded in the data file as strings, in lieu of comparing them against ``qnp::OptionKey`` and ``qnp::OptionValue`` objects that never equal them, which silently plotted predictions computed with other options (D. van Dyk)
 - Fix ``eos.figure.ConstraintItem``, ``ConstraintResidueItem``, and ``TwoDimensionalConstraintItem`` to report an unknown constraint as a ``ValueError``, in lieu of the ``RuntimeError`` that reached the user because the guard tested the looked-up entry for falsiness after the lookup had already raised (D. van Dyk)
 - Fix three diagnostic messages in ``eos.figure.ConstraintItem`` and ``eos.figure.ConstraintResidueItem`` that lacked an ``f`` prefix and therefore reported the names of skipped observables as literal braces (D. van Dyk)
+- Use the mass parameters, rather than compile-time constants, when converting ``q2`` to ``w`` in the ``V->V`` HQE form factors, as the other three transitions already did; setting ``mass::B_d^*`` or ``mass::D_u^*`` previously had no effect on the ``Bbar^*->D^*`` form factors (D. van Dyk)
+- Correct the normalization constants ``K`` passed to the outer function ``_phi`` for the tensor form factors ``t_1``, ``t_2``, ``t_23``, and ``f_t`` in the ``BGL1997``-like parametrization (D. van Dyk)
+- Evaluate the HQET form factors at zero recoil independently of the compiler's use of fused multiply-add: reconstructing ``q2`` from the meson masses reproduces ``w = 1`` only up to rounding, and the auxiliary functions ``r`` and ``Omega`` returned NaN whenever it landed a few ulps below the endpoint (D. van Dyk)
 
 
 ## [v1.0.21] - 2026-08-05

--- a/eos/form-factors/mesonic-processes.hh
+++ b/eos/form-factors/mesonic-processes.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2020-2025 Danny van Dyk
+ * Copyright (c) 2020-2026 Danny van Dyk
  * Copyright (c) 2025      Florian Herren
  * Copyright (c) 2026      Nico Gubernari
  *
@@ -509,8 +509,6 @@ namespace eos
             static const constexpr char * label      = "B^*->D^*";
             static const constexpr char * name_Bst   = "mass::B_d^*";
             static const constexpr char * name_V     = "mass::D_u^*";
-            static const constexpr double m_V1       = 5.324;
-            static const constexpr double m_V2       = 2.010;
             static const constexpr double m_Bc       = 6.2751;
             static const constexpr double mR2_0m     = (m_Bc + 0.000) * (m_Bc + 0.000);
             static const constexpr double mR2_1m     = (m_Bc + 0.056) * (m_Bc + 0.056);

--- a/eos/form-factors/mesonic.hh
+++ b/eos/form-factors/mesonic.hh
@@ -332,6 +332,15 @@ namespace eos
             virtual double h_8(const double & s) const  = 0;
             virtual double h_9(const double & s) const  = 0;
             virtual double h_10(const double & s) const = 0;
+
+            // tensor current
+            virtual double h_t4(const double & s) const  = 0;
+            virtual double h_t5(const double & s) const  = 0;
+            virtual double h_t6(const double & s) const  = 0;
+            virtual double h_t7(const double & s) const  = 0;
+            virtual double h_t8(const double & s) const  = 0;
+            virtual double h_t9(const double & s) const  = 0;
+            virtual double h_t10(const double & s) const = 0;
     };
 
     template <> class FormFactorFactory<VToV>

--- a/eos/form-factors/mesonic.hh
+++ b/eos/form-factors/mesonic.hh
@@ -2,7 +2,7 @@
 
 /*
  * Copyright (c) 2022 Stephan Kuerten
- * Copyright (c) 2010-2024 Danny van Dyk
+ * Copyright (c) 2010-2026 Danny van Dyk
  * Copyright (c) 2015 Christoph Bobeth
  * Copyright (c) 2022 Philip Lüghausen
  * Copyright (c) 2010 Christian Wacker
@@ -295,6 +295,11 @@ namespace eos
             virtual double h_abar_1(const double & s) const = 0;
             virtual double h_abar_2(const double & s) const = 0;
             virtual double h_abar_3(const double & s) const = 0;
+
+            // tensor current
+            virtual double h_tbar_1(const double & s) const = 0;
+            virtual double h_tbar_2(const double & s) const = 0;
+            virtual double h_tbar_3(const double & s) const = 0;
     };
 
     template <> class FormFactorFactory<VToP>

--- a/eos/form-factors/parametric-bgjvd2019-impl.hh
+++ b/eos/form-factors/parametric-bgjvd2019-impl.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 tw=120 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2018-2023 Danny van Dyk
+ * Copyright (c) 2018-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -1160,6 +1160,95 @@ namespace eos
     }
 
     template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToP>::h_tbar_1(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi   = _xi(q2);
+        const double chi2 = _chi2(q2);
+        const double chi3 = _chi3(q2);
+
+        const double eps_b = _LambdaBar() / (2.0 * m_b_pole);
+        const double eps_c = _LambdaBar() / (2.0 * m_c_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L1 = -4.0 * (w - 1.0) * chi2 + 12.0 * chi3;
+        const double L2 = -4.0 * chi3;
+
+        double result  = (1.0 + as * (_CT1(w, z) + (w - 1.0) / 2.0 * (_CT2(w, z) - _CT3(w, z))));
+        result        += eps_b * L2;
+        result        += eps_c * L1;
+        result        += eps_c * eps_c * _l1(w);
+
+        return result * xi;
+    }
+
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToP>::h_tbar_2(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi  = _xi(q2);
+        const double eta = _eta(q2);
+
+        const double eps_b = _LambdaBar() / (2.0 * m_b_pole);
+        const double eps_c = _LambdaBar() / (2.0 * m_c_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L4 = 2.0 * eta - 1.0;
+        const double L5 = -1.0;
+
+        double result  = (0.0 - as * (w + 1.0) / 2.0 * (_CT2(w, z) + _CT3(w, z)));
+        result        += eps_b * L5;
+        result        -= eps_c * L4;
+        result        -= eps_c * eps_c * _l4(w);
+
+        return result * xi;
+    }
+
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToP>::h_tbar_3(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi   = _xi(q2);
+        const double eta  = _eta(q2);
+        const double chi2 = _chi2(q2);
+
+        const double eps_b = _LambdaBar() / (2.0 * m_b_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L3 = 4.0 * chi2;
+        const double L6 = -2.0 * (1.0 + eta) / (w + 1.0);
+
+        double result  = (0.0 - as * _CT3(w, z));
+        result        += eps_b * (L6 - L3);
+
+        return result * xi;
+    }
+
+    template <typename Process_>
     Diagnostics
     HQETFormFactors<Process_, VToP>::diagnostics() const
     {
@@ -1290,16 +1379,25 @@ namespace eos
             results.add(Diagnostics::Entry{ h_abar_2(_q2(1.4)), "h_Abar2(w = 1.4)" });
             results.add(Diagnostics::Entry{ h_abar_3(_q2(1.4)), "h_Abar3(w = 1.4)" });
             results.add(Diagnostics::Entry{ h_vbar(_q2(1.4)), "h_Vbar (w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_tbar_1(_q2(1.4)), "h_Tbar1(w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_tbar_2(_q2(1.4)), "h_Tbar2(w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_tbar_3(_q2(1.4)), "h_Tbar3(w = 1.4)" });
 
             results.add(Diagnostics::Entry{ h_abar_1(_q2(1.2)), "h_Abar1(w = 1.2)" });
             results.add(Diagnostics::Entry{ h_abar_2(_q2(1.2)), "h_Abar2(w = 1.2)" });
             results.add(Diagnostics::Entry{ h_abar_3(_q2(1.2)), "h_Abar3(w = 1.2)" });
             results.add(Diagnostics::Entry{ h_vbar(_q2(1.2)), "h_Vbar (w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_tbar_1(_q2(1.2)), "h_Tbar1(w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_tbar_2(_q2(1.2)), "h_Tbar2(w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_tbar_3(_q2(1.2)), "h_Tbar3(w = 1.2)" });
 
             results.add(Diagnostics::Entry{ h_abar_1(_q2(1.0)), "h_Abar1(w = 1.0)" });
             results.add(Diagnostics::Entry{ h_abar_2(_q2(1.0)), "h_Abar2(w = 1.0)" });
             results.add(Diagnostics::Entry{ h_abar_3(_q2(1.0)), "h_Abar3(w = 1.0)" });
             results.add(Diagnostics::Entry{ h_vbar(_q2(1.0)), "h_Vbar (w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_tbar_1(_q2(1.0)), "h_Tbar1(w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_tbar_2(_q2(1.0)), "h_Tbar2(w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_tbar_3(_q2(1.0)), "h_Tbar3(w = 1.0)" });
         }
 
         return results;

--- a/eos/form-factors/parametric-bgjvd2019-impl.hh
+++ b/eos/form-factors/parametric-bgjvd2019-impl.hh
@@ -1742,6 +1742,200 @@ namespace eos
         return result * xi;
     }
 
+    // tensor current
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToV>::h_t4(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi   = _xi(q2);
+        const double chi3 = _chi3(q2);
+
+        const double eps_b = _LambdaBar() / (2.0 * m_b_pole);
+        const double eps_c = _LambdaBar() / (2.0 * m_c_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L2 = -4.0 * chi3;
+        const double L5 = -1.0;
+
+        double result  = (1.0 + as * _CT1(w, z));
+        result        += (eps_b + eps_c) * (L2 - (w - 1.0) / (w + 1.0) * L5);
+        result        += eps_c * eps_c * (_l2(w) - (w - 1.0) / (w + 1.0) * _l5(w));
+
+        return result * xi;
+    }
+
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToV>::h_t5(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi   = _xi(q2);
+        const double eta  = _eta(q2);
+        const double chi2 = _chi2(q2);
+        const double chi3 = _chi3(q2);
+
+        const double eps_b = _LambdaBar() / (2.0 * m_b_pole);
+        const double eps_c = _LambdaBar() / (2.0 * m_c_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L2 = -4.0 * chi3;
+        const double L3 = 4.0 * chi2;
+        const double L5 = -1.0;
+        const double L6 = -2.0 * (1.0 + eta) / (w + 1.0);
+
+        double result  = (1.0 + as * (_CT1(w, z) + _CT3(w, z)));
+        result        += eps_b * (L2 - L5);
+        result        += eps_c * (L2 + L6 - L3 - L5);
+        result        += eps_c * eps_c * (_l2(w) + _l6(w) - _l3(w) - _l5(w));
+
+        return result * xi;
+    }
+
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToV>::h_t6(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi   = _xi(q2);
+        const double eta  = _eta(q2);
+        const double chi2 = _chi2(q2);
+        const double chi3 = _chi3(q2);
+
+        const double eps_b = _LambdaBar() / (2.0 * m_b_pole);
+        const double eps_c = _LambdaBar() / (2.0 * m_c_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L2 = -4.0 * chi3;
+        const double L3 = 4.0 * chi2;
+        const double L5 = -1.0;
+        const double L6 = -2.0 * (1.0 + eta) / (w + 1.0);
+
+        double result  = (1.0 + as * (_CT1(w, z) - _CT2(w, z)));
+        result        += eps_b * (L2 + L6 - L3 - L5);
+        result        += eps_c * (L2 - L5);
+        result        += eps_c * eps_c * (_l2(w) - _l5(w));
+
+        return result * xi;
+    }
+
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToV>::h_t7(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi   = _xi(q2);
+        const double chi3 = _chi3(q2);
+
+        const double eps_b = _LambdaBar() / (2.0 * m_b_pole);
+        const double eps_c = _LambdaBar() / (2.0 * m_c_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L2 = -4.0 * chi3;
+        const double L5 = -1.0;
+
+        // C_{T_4} vanishes at this order, cf. [BGJvD:2025A] below eq. (2.27)
+        double result  = (1.0 + as * (_CT1(w, z) - _CT2(w, z) + _CT3(w, z)));
+        result        += (eps_b + eps_c) * (L2 - L5);
+        result        += eps_c * eps_c * (_l2(w) - _l5(w));
+
+        return result * xi;
+    }
+
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToV>::h_t8(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi   = _xi(q2);
+        const double eta  = _eta(q2);
+        const double chi2 = _chi2(q2);
+
+        const double eps_b = _LambdaBar() / (2.0 * m_b_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L3 = 4.0 * chi2;
+        const double L6 = -2.0 * (1.0 + eta) / (w + 1.0);
+
+        double result  = (0.0 + as * _CT3(w, z));
+        result        -= eps_b * (L3 + L6);
+
+        return result * xi;
+    }
+
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToV>::h_t9(const double & q2) const
+    {
+        const double m_b_pole = _m_b_pole();
+        const double m_c_pole = _m_c_pole();
+
+        const double w = this->_w(q2);
+        const double z = m_c_pole / m_b_pole;
+
+        const double as = _alpha_s() / M_PI;
+
+        const double xi   = _xi(q2);
+        const double eta  = _eta(q2);
+        const double chi2 = _chi2(q2);
+
+        const double eps_c = _LambdaBar() / (2.0 * m_c_pole);
+
+        // chi_1 is absorbed into def. of xi for LP and LV
+        const double L3 = 4.0 * chi2;
+        const double L6 = -2.0 * (1.0 + eta) / (w + 1.0);
+
+        double result  = (0.0 + as * _CT2(w, z));
+        result        += eps_c * (L3 + L6);
+        result        += eps_c * eps_c * (_l3(w) + _l6(w));
+
+        return result * xi;
+    }
+
+    template <typename Process_>
+    double
+    HQETFormFactors<Process_, VToV>::h_t10(const double &) const
+    {
+        // proportional to C_{T_4}, which vanishes to the order we are working at,
+        // cf. [BGJvD:2025A], eq. (2.41) and the discussion below eq. (2.44)
+        return 0.0;
+    }
+
     template <typename Process_>
     Diagnostics
     HQETFormFactors<Process_, VToV>::diagnostics() const
@@ -1879,6 +2073,13 @@ namespace eos
             results.add(Diagnostics::Entry{ h_8(_q2(1.4)), "h_8 (w = 1.4)" });
             results.add(Diagnostics::Entry{ h_9(_q2(1.4)), "h_9 (w = 1.4)" });
             results.add(Diagnostics::Entry{ h_10(_q2(1.4)), "h_10(w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_t4(_q2(1.4)), "h_T4 (w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_t5(_q2(1.4)), "h_T5 (w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_t6(_q2(1.4)), "h_T6 (w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_t7(_q2(1.4)), "h_T7 (w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_t8(_q2(1.4)), "h_T8 (w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_t9(_q2(1.4)), "h_T9 (w = 1.4)" });
+            results.add(Diagnostics::Entry{ h_t10(_q2(1.4)), "h_T10(w = 1.4)" });
 
             results.add(Diagnostics::Entry{ h_1(_q2(1.2)), "h_1 (w = 1.2)" });
             results.add(Diagnostics::Entry{ h_2(_q2(1.2)), "h_2 (w = 1.2)" });
@@ -1890,6 +2091,13 @@ namespace eos
             results.add(Diagnostics::Entry{ h_8(_q2(1.2)), "h_8 (w = 1.2)" });
             results.add(Diagnostics::Entry{ h_9(_q2(1.2)), "h_9 (w = 1.2)" });
             results.add(Diagnostics::Entry{ h_10(_q2(1.2)), "h_10(w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_t4(_q2(1.2)), "h_T4 (w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_t5(_q2(1.2)), "h_T5 (w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_t6(_q2(1.2)), "h_T6 (w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_t7(_q2(1.2)), "h_T7 (w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_t8(_q2(1.2)), "h_T8 (w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_t9(_q2(1.2)), "h_T9 (w = 1.2)" });
+            results.add(Diagnostics::Entry{ h_t10(_q2(1.2)), "h_T10(w = 1.2)" });
 
             results.add(Diagnostics::Entry{ h_1(_q2(1.0)), "h_1 (w = 1.0)" });
             results.add(Diagnostics::Entry{ h_2(_q2(1.0)), "h_2 (w = 1.0)" });
@@ -1901,6 +2109,13 @@ namespace eos
             results.add(Diagnostics::Entry{ h_8(_q2(1.0)), "h_8 (w = 1.0)" });
             results.add(Diagnostics::Entry{ h_9(_q2(1.0)), "h_9 (w = 1.0)" });
             results.add(Diagnostics::Entry{ h_10(_q2(1.0)), "h_10(w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_t4(_q2(1.0)), "h_T4 (w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_t5(_q2(1.0)), "h_T5 (w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_t6(_q2(1.0)), "h_T6 (w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_t7(_q2(1.0)), "h_T7 (w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_t8(_q2(1.0)), "h_T8 (w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_t9(_q2(1.0)), "h_T9 (w = 1.0)" });
+            results.add(Diagnostics::Entry{ h_t10(_q2(1.0)), "h_T10(w = 1.0)" });
         }
 
         return results;

--- a/eos/form-factors/parametric-bgjvd2019-impl.hh
+++ b/eos/form-factors/parametric-bgjvd2019-impl.hh
@@ -1407,25 +1407,27 @@ namespace eos
     double
     HQETFormFactors<Process_, VToV>::_w(const double & q2) const
     {
-        static constexpr double mV1 = Process_::m_V1, mV12 = power_of<2>(Process_::m_V1);
-        static constexpr double mV2 = Process_::m_V2, mV22 = power_of<2>(Process_::m_V2);
+        const double m_Bst = this->_m_Bst(), m_Bst2 = power_of<2>(m_Bst);
+        const double m_V = this->_m_V(), m_V2 = power_of<2>(m_V);
 
-        return (mV12 + mV22 - q2) / (2.0 * mV1 * mV2);
+        return (m_Bst2 + m_V2 - q2) / (2.0 * m_Bst * m_V);
     }
 
     template <typename Process_>
     double
     HQETFormFactors<Process_, VToV>::_q2(const double & w) const
     {
-        static constexpr double mV1 = Process_::m_V1, mV12 = power_of<2>(Process_::m_V1);
-        static constexpr double mV2 = Process_::m_V2, mV22 = power_of<2>(Process_::m_V2);
+        const double m_Bst = this->_m_Bst(), m_Bst2 = power_of<2>(m_Bst);
+        const double m_V = this->_m_V(), m_V2 = power_of<2>(m_V);
 
-        return mV12 + mV22 - 2.0 * mV1 * mV2 * w;
+        return m_Bst2 + m_V2 - 2.0 * m_Bst * m_V * w;
     }
 
     template <typename Process_>
     HQETFormFactors<Process_, VToV>::HQETFormFactors(const Parameters & p, const Options & o) :
-        HQETFormFactorBase(p, o, Process_::hqe_prefix)
+        HQETFormFactorBase(p, o, Process_::hqe_prefix),
+        _m_Bst(p[Process_::name_Bst], *static_cast<ParameterUser *>(this)),
+        _m_V(p[Process_::name_V], *static_cast<ParameterUser *>(this))
     {
         static const Log::OneTimeMessage message_HQET_FFs_VToV(std::string("HQETFormFactors<") + Process_::label + ",VToV>",
                                                                ll_warning,

--- a/eos/form-factors/parametric-bgjvd2019.hh
+++ b/eos/form-factors/parametric-bgjvd2019.hh
@@ -466,6 +466,9 @@ namespace eos
     template <typename Process_> class HQETFormFactors<Process_, VToV> : public HQETFormFactorBase, public FormFactors<VToV>
     {
         private:
+            UsedParameter _m_Bst;
+            UsedParameter _m_V;
+
             /*
              * Kinematics
              */

--- a/eos/form-factors/parametric-bgjvd2019.hh
+++ b/eos/form-factors/parametric-bgjvd2019.hh
@@ -187,17 +187,19 @@ namespace eos
                 return w - std::sqrt(w * w - 1.0);
             }
 
+            // the expansion is used on both sides of w = 1, since a q2 computed from
+            // the meson masses reaches the endpoint only up to rounding
             inline double
             _r(const double & w) const
             {
+                if (std::abs(w - 1.0) < 1.0e-5)
+                {
+                    return 1.0 - (w - 1.0) / 3.0;
+                }
+
                 if (w < 1.0)
                 {
                     return std::numeric_limits<double>::quiet_NaN();
-                }
-
-                if (w - 1.0 < 1.0e-5)
-                {
-                    return 1.0 - (w - 1.0) / 3.0;
                 }
 
                 return std::log(_wp(w)) / std::sqrt(w * w - 1.0);
@@ -206,16 +208,16 @@ namespace eos
             inline double
             _Omega(const double & w, const double & z) const
             {
+                const double lnz = std::log(z);
+
+                if (std::abs(w - 1.0) < 1.0e-5)
+                {
+                    return -1.0 - (1.0 + z) / (1.0 - z) * lnz;
+                }
+
                 if (w < 1.0)
                 {
                     return std::numeric_limits<double>::quiet_NaN();
-                }
-
-                const double lnz = std::log(z);
-
-                if (w - 1.0 < 1.0e-5)
-                {
-                    return -1.0 - (1.0 + z) / (1.0 - z) * lnz;
                 }
 
                 const double wm = _wm(w);

--- a/eos/form-factors/parametric-bgjvd2019.hh
+++ b/eos/form-factors/parametric-bgjvd2019.hh
@@ -494,6 +494,15 @@ namespace eos
             virtual double h_9(const double & q2) const override;
             virtual double h_10(const double & q2) const override;
 
+            // tensor current, cf. [BGJvD:2025A], eqs. (2.35) to (2.41)
+            virtual double h_t4(const double & q2) const override;
+            virtual double h_t5(const double & q2) const override;
+            virtual double h_t6(const double & q2) const override;
+            virtual double h_t7(const double & q2) const override;
+            virtual double h_t8(const double & q2) const override;
+            virtual double h_t9(const double & q2) const override;
+            virtual double h_t10(const double & q2) const override;
+
             Diagnostics diagnostics() const;
 
             using HQETFormFactorBase::references;

--- a/eos/form-factors/parametric-bgjvd2019.hh
+++ b/eos/form-factors/parametric-bgjvd2019.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 tw=120 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2018-2023 Danny van Dyk
+ * Copyright (c) 2018-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -446,6 +446,11 @@ namespace eos
             virtual double h_abar_2(const double & q2) const override;
             virtual double h_abar_3(const double & q2) const override;
             virtual double h_vbar(const double & q2) const override;
+
+            // tensor current, cf. [BGJvD:2025A], eqs. (2.32) to (2.34)
+            virtual double h_tbar_1(const double & q2) const override;
+            virtual double h_tbar_2(const double & q2) const override;
+            virtual double h_tbar_3(const double & q2) const override;
 
             Diagnostics diagnostics() const;
 

--- a/eos/form-factors/parametric-bgjvd2019_TEST.cc
+++ b/eos/form-factors/parametric-bgjvd2019_TEST.cc
@@ -2009,5 +2009,14 @@ class BstarToDDstarTensorRelationsTest : public TestCase
                 // proportional to C_{T_4}, which vanishes at this order
                 TEST_CHECK_NEARLY_EQUAL(h_T10, 0.0, eps);
             }
+
+            // a q2 computed from the meson masses reaches w = 1 only up to rounding,
+            // and the form factors must not depend on which side it lands on
+            {
+                static const double delta = 1.0e-12;
+
+                TEST_CHECK_NEARLY_EQUAL(ff_bstar_d.h_tbar_1(q2(m_Bst, m_D, 1.0 - delta)), ff_bstar_d.h_tbar_1(q2(m_Bst, m_D, 1.0)), 1.0e-8);
+                TEST_CHECK_NEARLY_EQUAL(ff_bstar_dstar.h_t5(q2(m_Bst, m_Dst, 1.0 - delta)), ff_bstar_dstar.h_t5(q2(m_Bst, m_Dst, 1.0)), 1.0e-8);
+            }
         }
 } bstar_to_d_dstar_tensor_relations_test;

--- a/eos/form-factors/parametric-bgjvd2019_TEST.cc
+++ b/eos/form-factors/parametric-bgjvd2019_TEST.cc
@@ -1864,6 +1864,13 @@ class BstarToDstarHQETFormFactorsTest : public TestCase
                 std::make_pair(-0.043281, eps), // h_{8}
                 std::make_pair(+0.110892, eps), // h_{9}
                 std::make_pair(+0.064994, eps), // h_{10}
+                std::make_pair(+0.644829, eps), // h_{T4}
+                std::make_pair(+0.679595, eps), // h_{T5}
+                std::make_pair(+0.710440, eps), // h_{T6}
+                std::make_pair(+0.774769, eps), // h_{T7}
+                std::make_pair(+0.082281, eps), // h_{T8}
+                std::make_pair(-0.164908, eps), // h_{T9}
+                std::make_pair(+0.000000, eps), // h_{T10}
 
                 /* HQET form factors at w = 1.2 */
                 std::make_pair(+0.757916, eps), // h_{1}
@@ -1876,6 +1883,13 @@ class BstarToDstarHQETFormFactorsTest : public TestCase
                 std::make_pair(-0.048579, eps), // h_{8}
                 std::make_pair(+0.147242, eps), // h_{9}
                 std::make_pair(+0.081839, eps), // h_{10}
+                std::make_pair(+0.779274, eps), // h_{T4}
+                std::make_pair(+0.811839, eps), // h_{T5}
+                std::make_pair(+0.859355, eps), // h_{T6}
+                std::make_pair(+0.940417, eps), // h_{T7}
+                std::make_pair(+0.102269, eps), // h_{T8}
+                std::make_pair(-0.204735, eps), // h_{T9}
+                std::make_pair(+0.000000, eps), // h_{T10}
 
                 /* HQET form factors at w = 1.0 */
                 std::make_pair(+0.954434, eps), // h_{1}
@@ -1888,6 +1902,13 @@ class BstarToDstarHQETFormFactorsTest : public TestCase
                 std::make_pair(-0.055498, eps), // h_{8}
                 std::make_pair(+0.200220, eps), // h_{9}
                 std::make_pair(+0.105747, eps), // h_{10}
+                std::make_pair(+0.961350, eps), // h_{T4}
+                std::make_pair(+0.989113, eps), // h_{T5}
+                std::make_pair(+1.061858, eps), // h_{T6}
+                std::make_pair(+1.166680, eps), // h_{T7}
+                std::make_pair(+0.129964, eps), // h_{T8}
+                std::make_pair(-0.260108, eps), // h_{T9}
+                std::make_pair(+0.000000, eps), // h_{T10}
             };
 
             TEST_CHECK_DIAGNOSTICS(diag, ref);
@@ -1938,14 +1959,19 @@ class BstarToDDstarTensorRelationsTest : public TestCase
                 { "z-order-sslp"_ok, "1"_ov }
             };
 
-            HQETFormFactors<BToD, PToP>     ff_d(p, oo);
-            HQETFormFactors<BToDstar, PToV> ff_dstar(p, oo);
-            HQETFormFactors<BstarToD, VToP> ff_bstar_d(p, oo);
+            HQETFormFactors<BToD, PToP>         ff_d(p, oo);
+            HQETFormFactors<BToDstar, PToV>     ff_dstar(p, oo);
+            HQETFormFactors<BstarToD, VToP>     ff_bstar_d(p, oo);
+            HQETFormFactors<BstarToDstar, VToV> ff_bstar_dstar(p, oo);
 
-            const double m_B   = p["mass::B_d"].evaluate();
-            const double m_Bst = p["mass::B_d^*"].evaluate();
-            const double m_D   = p["mass::D_u"].evaluate();
-            const double m_Dst = p["mass::D_u^*"].evaluate();
+            const double m_B      = p["mass::B_d"].evaluate();
+            const double m_Bst    = p["mass::B_d^*"].evaluate();
+            const double m_D      = p["mass::D_u"].evaluate();
+            const double m_Dst    = p["mass::D_u^*"].evaluate();
+            // unlike the other three transitions, V->V converts q2 to w with the
+            // compile-time masses of the process rather than with the parameters
+            const double m_Bst_vv = BstarToDstar::m_V1;
+            const double m_Dst_vv = BstarToDstar::m_V2;
 
             auto q2 = [](const double & m_1, const double & m_2, const double & w) -> double { return m_1 * m_1 + m_2 * m_2 - 2.0 * m_1 * m_2 * w; };
 
@@ -1961,12 +1987,31 @@ class BstarToDDstarTensorRelationsTest : public TestCase
                 const double h_T2bar = ff_bstar_d.h_tbar_2(q2(m_Bst, m_D, w));
                 const double h_T3bar = ff_bstar_d.h_tbar_3(q2(m_Bst, m_D, w));
 
+                const double h_T4  = ff_bstar_dstar.h_t4(q2(m_Bst_vv, m_Dst_vv, w));
+                const double h_T5  = ff_bstar_dstar.h_t5(q2(m_Bst_vv, m_Dst_vv, w));
+                const double h_T6  = ff_bstar_dstar.h_t6(q2(m_Bst_vv, m_Dst_vv, w));
+                const double h_T7  = ff_bstar_dstar.h_t7(q2(m_Bst_vv, m_Dst_vv, w));
+                const double h_T8  = ff_bstar_dstar.h_t8(q2(m_Bst_vv, m_Dst_vv, w));
+                const double h_T9  = ff_bstar_dstar.h_t9(q2(m_Bst_vv, m_Dst_vv, w));
+                const double h_T10 = ff_bstar_dstar.h_t10(q2(m_Bst_vv, m_Dst_vv, w));
+
                 // C_{T_1}: h_T1 and h_Tbar1 share their alpha_s term
                 TEST_CHECK_NEARLY_EQUAL(h_T1bar, h_T1, eps);
                 // C_{T_2} + C_{T_3}
                 TEST_CHECK_NEARLY_EQUAL(-h_T2bar, h_T2, eps);
+                TEST_CHECK_NEARLY_EQUAL((w + 1.0) / 2.0 * (h_T5 - h_T6), h_T2, eps);
                 // C_{T_2} - C_{T_3}
                 TEST_CHECK_NEARLY_EQUAL((w + 1.0) / 2.0 * (h_T3 + h_T3bar), h_T1 - h_T, eps);
+                // C_{T_2}
+                TEST_CHECK_NEARLY_EQUAL(h_T9, h_T3, eps);
+                TEST_CHECK_NEARLY_EQUAL(h_T4 - h_T6, h_T9, eps);
+                // C_{T_3}
+                TEST_CHECK_NEARLY_EQUAL(-h_T8, h_T3bar, eps);
+                TEST_CHECK_NEARLY_EQUAL(h_T5 - h_T4, -h_T3bar, eps);
+                // C_{T_1} - C_{T_2} + C_{T_3}
+                TEST_CHECK_NEARLY_EQUAL(h_T7, h_T, eps);
+                // proportional to C_{T_4}, which vanishes at this order
+                TEST_CHECK_NEARLY_EQUAL(h_T10, 0.0, eps);
             }
         }
 } bstar_to_d_dstar_tensor_relations_test;

--- a/eos/form-factors/parametric-bgjvd2019_TEST.cc
+++ b/eos/form-factors/parametric-bgjvd2019_TEST.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2018-2025 Danny van Dyk
+ * Copyright (c) 2018-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -1681,18 +1681,27 @@ class BstarToDHQETFormFactorsTest : public TestCase
                 std::make_pair(-0.082947, eps), // h_{Abar2}
                 std::make_pair(+0.712066, eps), // h_{Abar3}
                 std::make_pair(+0.760677, eps), // h_{Vbar}
+                std::make_pair(+0.662150, eps), // h_{Tbar1}
+                std::make_pair(+0.015929, eps), // h_{Tbar2}
+                std::make_pair(-0.064329, eps), // h_{Tbar3}
 
                 /* HQET form factors at w = 1.2 */
                 std::make_pair(+0.779087, eps), // h_{Abar1}
                 std::make_pair(-0.103046, eps), // h_{Abar2}
                 std::make_pair(+0.866333, eps), // h_{Abar3}
                 std::make_pair(+0.928731, eps), // h_{Vbar}
+                std::make_pair(+0.818295, eps), // h_{Tbar1}
+                std::make_pair(+0.016255, eps), // h_{Tbar2}
+                std::make_pair(-0.081062, eps), // h_{Tbar3}
 
                 /* HQET form factors at w = 1.0 */
                 std::make_pair(+0.969229, eps), // h_{Abar1}
                 std::make_pair(-0.130890, eps), // h_{Abar2}
                 std::make_pair(+1.078436, eps), // h_{Abar3}
                 std::make_pair(+1.160604, eps), // h_{Vbar}
+                std::make_pair(+1.031318, eps), // h_{Tbar1}
+                std::make_pair(+0.019816, eps), // h_{Tbar2}
+                std::make_pair(-0.104821, eps), // h_{Tbar3}
             };
 
             TEST_CHECK_DIAGNOSTICS(diag, ref);
@@ -1884,3 +1893,80 @@ class BstarToDstarHQETFormFactorsTest : public TestCase
             TEST_CHECK_DIAGNOSTICS(diag, ref);
         }
 } bstar_to_dstar_hqet_form_factors_test;
+
+// Relations among the tensor form factors of the different transitions, exact once
+// the power corrections are switched off. They fix the sign of the (w - 1) / 2
+// (C_{T_2} - C_{T_3}) term of [BGJvD:2025A], eq. (2.32).
+class BstarToDDstarTensorRelationsTest : public TestCase
+{
+    public:
+        BstarToDDstarTensorRelationsTest() :
+            TestCase("bstar_to_d_dstar_tensor_relations_test")
+        {
+        }
+
+        virtual void
+        run() const
+        {
+            static const double eps = 1.0e-10;
+
+            Parameters p                     = Parameters::Defaults();
+            p["B(*)->D(*)::xi'(1)@HQET"]     = -0.849472;
+            p["B(*)->D(*)::xi''(1)@HQET"]    = 2.0 * 0.583711;
+            p["B(*)->D(*)::chi_2(1)@HQET"]   = -0.0600533;
+            p["B(*)->D(*)::chi_2'(1)@HQET"]  = 6.97061e-6;
+            p["B(*)->D(*)::chi_2''(1)@HQET"] = 0.0314499;
+            p["B(*)->D(*)::chi_3'(1)@HQET"]  = 0.0400298;
+            p["B(*)->D(*)::chi_3''(1)@HQET"] = -0.039123;
+            p["B(*)->D(*)::eta(1)@HQET"]     = 0.604052;
+            p["B(*)->D(*)::eta'(1)@HQET"]    = -0.00545745;
+            p["B(*)->D(*)::eta''(1)@HQET"]   = -0.268764;
+            p["B(*)->D(*)::l_1(1)@HQET"]     = +0.111274;
+            p["B(*)->D(*)::l_2(1)@HQET"]     = -2.01963;
+            p["B(*)->D(*)::l_3(1)@HQET"]     = 0.0687349;
+            p["B(*)->D(*)::l_4(1)@HQET"]     = -2.02231;
+            p["B(*)->D(*)::l_5(1)@HQET"]     = 4.21978;
+            p["B(*)->D(*)::l_6(1)@HQET"]     = 4.52949;
+            p["B(*)->D(*)::a@HQET"]          = 1.0;
+            // mBar = m_b^pole - lambda_1 / (2 m_b^1S) makes LambdaBar and therefore
+            // both epsilon_b and epsilon_c vanish identically
+            p["B(*)->D(*)::mBar@HQET"]       = 4.81260180042463;
+
+            auto oo = Options{
+                {   "z-order-lp"_ok, "2"_ov },
+                {  "z-order-slp"_ok, "2"_ov },
+                { "z-order-sslp"_ok, "1"_ov }
+            };
+
+            HQETFormFactors<BToD, PToP>     ff_d(p, oo);
+            HQETFormFactors<BToDstar, PToV> ff_dstar(p, oo);
+            HQETFormFactors<BstarToD, VToP> ff_bstar_d(p, oo);
+
+            const double m_B   = p["mass::B_d"].evaluate();
+            const double m_Bst = p["mass::B_d^*"].evaluate();
+            const double m_D   = p["mass::D_u"].evaluate();
+            const double m_Dst = p["mass::D_u^*"].evaluate();
+
+            auto q2 = [](const double & m_1, const double & m_2, const double & w) -> double { return m_1 * m_1 + m_2 * m_2 - 2.0 * m_1 * m_2 * w; };
+
+            for (const double & w : { 1.0, 1.1, 1.2, 1.3, 1.4 })
+            {
+                const double h_T = ff_d.h_T(q2(m_B, m_D, w));
+
+                const double h_T1 = ff_dstar.h_t1(q2(m_B, m_Dst, w));
+                const double h_T2 = ff_dstar.h_t2(q2(m_B, m_Dst, w));
+                const double h_T3 = ff_dstar.h_t3(q2(m_B, m_Dst, w));
+
+                const double h_T1bar = ff_bstar_d.h_tbar_1(q2(m_Bst, m_D, w));
+                const double h_T2bar = ff_bstar_d.h_tbar_2(q2(m_Bst, m_D, w));
+                const double h_T3bar = ff_bstar_d.h_tbar_3(q2(m_Bst, m_D, w));
+
+                // C_{T_1}: h_T1 and h_Tbar1 share their alpha_s term
+                TEST_CHECK_NEARLY_EQUAL(h_T1bar, h_T1, eps);
+                // C_{T_2} + C_{T_3}
+                TEST_CHECK_NEARLY_EQUAL(-h_T2bar, h_T2, eps);
+                // C_{T_2} - C_{T_3}
+                TEST_CHECK_NEARLY_EQUAL((w + 1.0) / 2.0 * (h_T3 + h_T3bar), h_T1 - h_T, eps);
+            }
+        }
+} bstar_to_d_dstar_tensor_relations_test;

--- a/eos/form-factors/parametric-bgjvd2019_TEST.cc
+++ b/eos/form-factors/parametric-bgjvd2019_TEST.cc
@@ -1964,14 +1964,10 @@ class BstarToDDstarTensorRelationsTest : public TestCase
             HQETFormFactors<BstarToD, VToP>     ff_bstar_d(p, oo);
             HQETFormFactors<BstarToDstar, VToV> ff_bstar_dstar(p, oo);
 
-            const double m_B      = p["mass::B_d"].evaluate();
-            const double m_Bst    = p["mass::B_d^*"].evaluate();
-            const double m_D      = p["mass::D_u"].evaluate();
-            const double m_Dst    = p["mass::D_u^*"].evaluate();
-            // unlike the other three transitions, V->V converts q2 to w with the
-            // compile-time masses of the process rather than with the parameters
-            const double m_Bst_vv = BstarToDstar::m_V1;
-            const double m_Dst_vv = BstarToDstar::m_V2;
+            const double m_B   = p["mass::B_d"].evaluate();
+            const double m_Bst = p["mass::B_d^*"].evaluate();
+            const double m_D   = p["mass::D_u"].evaluate();
+            const double m_Dst = p["mass::D_u^*"].evaluate();
 
             auto q2 = [](const double & m_1, const double & m_2, const double & w) -> double { return m_1 * m_1 + m_2 * m_2 - 2.0 * m_1 * m_2 * w; };
 
@@ -1987,13 +1983,13 @@ class BstarToDDstarTensorRelationsTest : public TestCase
                 const double h_T2bar = ff_bstar_d.h_tbar_2(q2(m_Bst, m_D, w));
                 const double h_T3bar = ff_bstar_d.h_tbar_3(q2(m_Bst, m_D, w));
 
-                const double h_T4  = ff_bstar_dstar.h_t4(q2(m_Bst_vv, m_Dst_vv, w));
-                const double h_T5  = ff_bstar_dstar.h_t5(q2(m_Bst_vv, m_Dst_vv, w));
-                const double h_T6  = ff_bstar_dstar.h_t6(q2(m_Bst_vv, m_Dst_vv, w));
-                const double h_T7  = ff_bstar_dstar.h_t7(q2(m_Bst_vv, m_Dst_vv, w));
-                const double h_T8  = ff_bstar_dstar.h_t8(q2(m_Bst_vv, m_Dst_vv, w));
-                const double h_T9  = ff_bstar_dstar.h_t9(q2(m_Bst_vv, m_Dst_vv, w));
-                const double h_T10 = ff_bstar_dstar.h_t10(q2(m_Bst_vv, m_Dst_vv, w));
+                const double h_T4  = ff_bstar_dstar.h_t4(q2(m_Bst, m_Dst, w));
+                const double h_T5  = ff_bstar_dstar.h_t5(q2(m_Bst, m_Dst, w));
+                const double h_T6  = ff_bstar_dstar.h_t6(q2(m_Bst, m_Dst, w));
+                const double h_T7  = ff_bstar_dstar.h_t7(q2(m_Bst, m_Dst, w));
+                const double h_T8  = ff_bstar_dstar.h_t8(q2(m_Bst, m_Dst, w));
+                const double h_T9  = ff_bstar_dstar.h_t9(q2(m_Bst, m_Dst, w));
+                const double h_T10 = ff_bstar_dstar.h_t10(q2(m_Bst, m_Dst, w));
 
                 // C_{T_1}: h_T1 and h_Tbar1 share their alpha_s term
                 TEST_CHECK_NEARLY_EQUAL(h_T1bar, h_T1, eps);

--- a/eos/form-factors/parametric-bgl1997-impl.hh
+++ b/eos/form-factors/parametric-bgl1997-impl.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2020-2025 Danny van Dyk
+ * Copyright (c) 2020-2026 Danny van Dyk
  * Copyright (c) 2020      Nico Gubernari
  * Copyright (c) 2020      Christoph Bobeth
  * Copyright (c) 2025      Maximilian Hoverath
@@ -230,7 +230,7 @@ namespace eos
     double
     BGL1997FormFactors<Process_, PToV>::t_1(const double & s) const
     {
-        const double phi      = _phi(s, _traits.t_0, 24.0, 3, 3, 2, _traits.chi_T_1m);
+        const double phi      = _phi(s, _traits.t_0, 16.0, 3, 3, 2, _traits.chi_T_1m);
         const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = _a_T1[0] + _a_T1[1] * z + _a_T1[2] * z * z + _a_T1[3] * z * z * z;
         const double blaschke = _traits.blaschke_1m(s);
@@ -260,7 +260,7 @@ namespace eos
     double
     BGL1997FormFactors<Process_, PToV>::t_2(const double & s) const
     {
-        const double phi      = _phi(s, _traits.t_0, 24.0 / (_traits.tp() * _traits.tm()), 1, 1, 2, _traits.chi_T_1p);
+        const double phi      = _phi(s, _traits.t_0, 16.0 / (_traits.tp() * _traits.tm()), 1, 1, 2, _traits.chi_T_1p);
         const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = a_T2_0() + _a_T2[0] * z + _a_T2[1] * z * z + _a_T2[2] * z * z * z;
         const double blaschke = _traits.blaschke_1p(s);
@@ -280,10 +280,11 @@ namespace eos
     double
     BGL1997FormFactors<Process_, PToV>::a_T23_0() const
     {
+        /* a_T23_0 determined from T2(t_-) = 8 mB mV^2 / ((mB + mV) * (mB^2 + 3 mV^2 - t_-)) T23(t_-) */
+        /* note: T_i ~ 1.0 / x_i * sum_n a_n z^n */
         const double z     = _traits._z(_traits.tm(), _traits.t_0, _traits.tp());
-        const double x_T2  = _traits.blaschke_1p(_traits.tm()) * _phi(_traits.tm(), _traits.t_0, 24.0 / (_traits.tp() * _traits.tm()), 1, 1, 2, _traits.chi_T_1p);
-        const double x_T23 = _traits.blaschke_1p(_traits.tm())
-                             * _phi(_traits.tm(), _traits.t_0, 3.0 * _traits.tp() / (power_of<2>(_mB) * power_of<2>(_mV)), 1, 1, 1, _traits.chi_T_1p)
+        const double x_T2  = _traits.blaschke_1p(_traits.tm()) * _phi(_traits.tm(), _traits.t_0, 16.0 / (_traits.tp() * _traits.tm()), 1, 1, 2, _traits.chi_T_1p);
+        const double x_T23 = _traits.blaschke_1p(_traits.tm()) * _phi(_traits.tm(), _traits.t_0, _traits.tp() / (power_of<2>(_mB) * power_of<2>(_mV)), 1, 1, 1, _traits.chi_T_1p)
                              / (8.0 * _mB * power_of<2>(_mV)) * ((_mB + _mV) * (power_of<2>(_mB) + 3.0 * power_of<2>(_mV) - _traits.tm()));
         std::array<double, 4> an, zn;
         zn[0] = 1.0;
@@ -300,7 +301,7 @@ namespace eos
     double
     BGL1997FormFactors<Process_, PToV>::t_23(const double & s) const
     {
-        const double phi      = _phi(s, _traits.t_0, 3.0 * _traits.tp() / (power_of<2>(_mB) * power_of<2>(_mV)), 1.0, 1.0, 1.0, _traits.chi_T_1p);
+        const double phi      = _phi(s, _traits.t_0, _traits.tp() / (power_of<2>(_mB) * power_of<2>(_mV)), 1.0, 1.0, 1.0, _traits.chi_T_1p);
         const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = a_T23_0() + _a_T23[0] * z + _a_T23[1] * z * z + _a_T23[2] * z * z * z;
         const double blaschke = _traits.blaschke_1p(s);
@@ -532,7 +533,7 @@ namespace eos
     double
     BGL1997FormFactors<Process_, PToP>::f_t(const double & s) const
     {
-        const double phi      = _phi(s, _traits.t_0, 48.0 * _traits.tp(), 3, 3, 1, _traits.chi_T_1m);
+        const double phi      = _phi(s, _traits.t_0, 16.0 * _traits.tp(), 3, 3, 1, _traits.chi_T_1m);
         const double z        = _traits._z(s, _traits.t_0, _traits.tp());
         const double series   = _a_f_t[0] + _a_f_t[1] * z + _a_f_t[2] * z * z + _a_f_t[3] * z * z * z;
         const double blaschke = _traits.blaschke_1m(s);

--- a/eos/form-factors/parametric-bgl1997_TEST.cc
+++ b/eos/form-factors/parametric-bgl1997_TEST.cc
@@ -3,6 +3,7 @@
 /*
  * Copyright (c) 2020 Christoph Bobeth
  * Copyright (c) 2023 Nico Gubernari
+ * Copyright (c) 2024-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -179,19 +180,19 @@ class BGL1997FormFactorsTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(ff.F1(t_m), (mB - mV) * ff.f(t_m), eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.F2(0.0), F2factor * ff.F1(0.0), eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(-2.0), 0.0869380, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+1.0), 0.0928776, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+4.0), 0.1000316, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(-2.0), 0.0709846, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+1.0), 0.0758342, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+4.0), 0.0816755, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.a_T2_0(), 2.4837e-4, 1.0e-8);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(-2.0), 0.0935896, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+1.0), 0.0893296, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+4.0), 0.0847745, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(-2.0), 0.0764157, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+1.0), 0.0729373, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+4.0), 0.0692181, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.a_T23_0(), 6.3477e-4, 1.0e-8);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(-2.0), 0.0802478, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+1.0), 0.0820204, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+4.0), 0.0842156, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.a_T23_0(), 8.7541e-4, 1.0e-8);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(-2.0), 0.0619518, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+1.0), 0.0640365, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+4.0), 0.0665671, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.t_1(0.0), ff.t_2(0.0), eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.t_23(t_m), (mB + mV) * (mB * mB + 3.0 * mV * mV - t_m) / (8.0 * mB * mV * mV) * ff.t_2(t_m), eps);
@@ -253,19 +254,19 @@ class BGL1997FormFactorsTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(ff.F1(t_m), (mB - mV) * ff.f(t_m), eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.F2(0.0), F2factor * ff.F1(0.0), eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(-2.0), 0.331549, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+1.0), 0.360687, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+4.0), 0.395877, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(-2.0), 0.270708, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+1.0), 0.294499, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+4.0), 0.323232, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.a_T2_0(), 1.099e-3, 1.0e-7);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(-2.0), 0.347005, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+1.0), 0.352278, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+4.0), 0.358958, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(-2.0), 0.283329, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+1.0), 0.287634, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+4.0), 0.293088, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.a_T23_0(), 3.118e-3, 5.0e-7);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(-2.0), 0.363425, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+1.0), 0.382876, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+4.0), 0.406004, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.a_T23_0(), 4.3747e-3, 5.0e-7);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(-2.0), 0.291430, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+1.0), 0.308205, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+4.0), 0.328157, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.t_1(0.0), ff.t_2(0.0), eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.t_23(t_m), (mB + mV) * (mB * mB + 3.0 * mV * mV - t_m) / (8.0 * mB * mV * mV) * ff.t_2(t_m), eps);
@@ -318,9 +319,9 @@ class BGL1997FormFactorsTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(ff.f_0(+1.0), 0.089937, eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.f_0(+4.0), 0.091600, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(-2.0), 0.041750, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+1.0), 0.044758, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+4.0), 0.048361, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(-2.0), 0.024104, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+1.0), 0.025841, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+4.0), 0.027921, eps);
 
                 p["B->D::a^f+_0@BGL1997"] = 0.4e-02;
                 p["B->D::a^f+_1@BGL1997"] = 0.3e-02;
@@ -346,9 +347,9 @@ class BGL1997FormFactorsTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(ff.f_0(+1.0), 0.345695, eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.f_0(+4.0), 0.353446, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(-2.0), 0.158273, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+1.0), 0.172925, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+4.0), 0.190572, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(-2.0), 0.091379, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+1.0), 0.0998383, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+4.0), 0.110027, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.saturation_0m_a(), 0.0, eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.saturation_0p_v(), 4.28612e-04, eps);
@@ -490,19 +491,19 @@ class BGL1997FormFactorsTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(ff.F1(t_m), (mB - mV) * ff.f(t_m), eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.F2(0.0), F2factor * ff.F1(0.0), eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(-2.0), 0.0920823, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+1.0), 0.0983392, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+4.0), 0.1058720, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(-2.0), 0.0751849, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+1.0), 0.0802936, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+4.0), 0.0864441, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.a_T2_0(), 2.0313e-4, 1.0e-8);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(-2.0), 0.0992379, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+1.0), 0.0945217, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+4.0), 0.0894548, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(-2.0), 0.0810274, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+1.0), 0.0771766, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+4.0), 0.0730395, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.a_T23_0(), 6.0662e-4, 1.0e-8);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(-2.0), 0.0843247, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+1.0), 0.0860918, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+4.0), 0.0882836, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.a_T23_0(), 8.57896e-4, 1.0e-8);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(-2.0), 0.0649728, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+1.0), 0.0671066, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+4.0), 0.0696974, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.t_1(0.0), ff.t_2(0.0), eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.t_23(t_m), (mB + mV) * (mB * mB + 3.0 * mV * mV - t_m) / (8.0 * mB * mV * mV) * ff.t_2(t_m), eps);
@@ -564,19 +565,19 @@ class BGL1997FormFactorsTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(ff.F1(t_m), (mB - mV) * ff.f(t_m), eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.F2(0.0), F2factor * ff.F1(0.0), eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(-2.0), 0.338307, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+1.0), 0.368130, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+4.0), 0.404149, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(-2.0), 0.276227, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+1.0), 0.300577, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_1(+4.0), 0.329986, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.a_T2_0(), 1.0357e-3, 1.0e-7);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(-2.0), 0.354159, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+1.0), 0.359504, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+4.0), 0.366256, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(-2.0), 0.289170, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+1.0), 0.293534, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_2(+4.0), 0.299047, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.a_T23_0(), 3.093e-3, 5.0e-7);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(-2.0), 0.370258, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+1.0), 0.390147, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+4.0), 0.413790, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.a_T23_0(), 4.37441e-3, 5.0e-7);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(-2.0), 0.296821, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+1.0), 0.313981, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.t_23(+4.0), 0.334390, eps);
 
                 TEST_CHECK_NEARLY_EQUAL(ff.t_1(0.0), ff.t_2(0.0), eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.t_23(t_m), (mB + mV) * (mB * mB + 3.0 * mV * mV - t_m) / (8.0 * mB * mV * mV) * ff.t_2(t_m), eps);
@@ -625,9 +626,9 @@ class BGL1997FormFactorsTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(ff.f_0(+1.0), 0.0960806, eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.f_0(+4.0), 0.097888, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(-2.0), 0.044609, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+1.0), 0.047804, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+4.0), 0.051628, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(-2.0), 0.025755, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+1.0), 0.0275997, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+4.0), 0.0298074, eps);
 
                 p["B->D::a^f+_0@BGL1997"] = 0.4e-02;
                 p["B->D::a^f+_1@BGL1997"] = 0.3e-02;
@@ -653,9 +654,9 @@ class BGL1997FormFactorsTest : public TestCase
                 TEST_CHECK_NEARLY_EQUAL(ff.f_0(+1.0), 0.353879, eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.f_0(+4.0), 0.361979, eps);
 
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(-2.0), 0.161964, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+1.0), 0.177010, eps);
-                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+4.0), 0.195134, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(-2.0), 0.09351, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+1.0), 0.102197, eps);
+                TEST_CHECK_NEARLY_EQUAL(ff.f_t(+4.0), 0.112661, eps);
             }
         }
 } BGL1997_form_factor_test;

--- a/eos/form-factors/unitarity-bounds.cc
+++ b/eos/form-factors/unitarity-bounds.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 tw=140 et foldmethod=marker : */
 
 /*
- * Copyright (c) 2019-2025 Danny van Dyk
+ * Copyright (c) 2019-2026 Danny van Dyk
  * Copyright (c) 2019-2024 Nico Gubernari
  *
  * This file is part of the EOS project. EOS is free software;
@@ -3499,7 +3499,7 @@ namespace eos
 
     BGLCoefficients::~BGLCoefficients() = default;
 
-    const std::set<ReferenceName> BGLCoefficients::references{};
+    const std::set<ReferenceName> BGLCoefficients::references{ "BGJvD:2019A"_rn, "BGJvD:2025A"_rn };
 
     // B -> D form factors
     // {{{
@@ -5201,7 +5201,7 @@ namespace eos
         return _imp->bound_1m_T();
     }
 
-    const std::set<ReferenceName> HQETUnitarityBounds::references{};
+    const std::set<ReferenceName> HQETUnitarityBounds::references{ "BGJvD:2019A"_rn, "BGJvD:2025A"_rn };
 
     // clang-format off
     std::vector<OptionSpecification>::const_iterator

--- a/eos/references.yaml
+++ b/eos/references.yaml
@@ -431,6 +431,13 @@ BGJvD:2019A:
     id: oai:arXiv.org:1912.09335
   inspire-id: Bordone:2019guc
   title: Heavy-Quark expansion for ${{\bar{B}}_s\rightarrow D^{(*)}_s}$ form factors and unitarity bounds beyond the ${SU(3)_F}$ limit
+BGJvD:2025A:
+  authors: Bordone, M. and Gubernari, N. and Jung, M. and van Dyk, D.
+  eprint:
+    archive: arXiv
+    id: oai:arXiv.org:2507.03569
+  inspire-id: Bordone:2025jur
+  title: Challenging ${\bar{B}_{(s)} \to D^{(*)}_{(s)}}$ form factors with the heavy quark expansion
 BGL:1997A:
   authors: Boyd, C.G. and Grinstein, B. and Lebed, R.F.
   eprint:


### PR DESCRIPTION
- d862ec6d [eos] Add BGJvD:2025A reference.
- 5a8a06a1 [eos] Reference the unitarity bounds of tensor form factors.
- 523444f1 [form-factors] Add B^*->D tensor form factors in the HQE.
- ed31e630 [form-factors] Add B^*->D^* tensor form factors in the HQE.
- 5ad75f46 [form-factors] Use the mass parameters in the V->V HQE kinematics.
- de7d9b3d [form-factors] Fix handling of tensor form factors in the BGL1997-like parametrization.
- a9bec7c8 [form-factors] Evaluate the HQET form factors robustly at zero recoil.
- 1d866e96 [eos] Update changelog for PR #1220.

Github: resolves issue #898