### PR TITLE
Modify ``eos-data`` to implement a new dataset release workflow

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@
 - Add the ``mass::D_u,0@HME`` and ``mass::D_u,1@HME`` parameters (D. van Dyk)
 - Add the ``mass::Lambda_c(2595)@HME``, ``mass::Lambda_c(2625)@HME``, and ``mass::Lambda(1520)@HME`` parameters (D. van Dyk)
 - Add the ``Lambda_b->Lambda(1520)::tp_v@SE``, ``Lambda_b->Lambda(1520)::tp_a@SE``, and ``Lambda_b->Lambda(1520)::t0@SE`` parameters (D. van Dyk)
+- Add the ``eos-data check``, ``create``, ``publish``, and ``register`` commands for validating analysis datasets, creating citable dataset tags, publishing GitHub releases for Zenodo, and registering published datasets (D. van Dyk)
 
 ### Deprecated
 

--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -39,7 +39,7 @@ Homepage = "https://eos.github.io/"
 
 [tool.setuptools]
 zip-safe = false
-packages = ["eos", "eos.data", "eos.plot", "eos.figure", "_eos_data"]
+packages = ["eos", "eos.cli", "eos.data", "eos.plot", "eos.figure", "_eos_data"]
 
 [tool.setuptools.package-dir]
 eos = "python/eos"

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -17,6 +17,11 @@ EXTRA_DIST = \
 	eos/validation_context.py \
 	eos/config.py \
 	eos/constraint.py \
+	eos/cli/__init__.py \
+	eos/cli/data.py \
+	eos/cli/data_checks.py \
+	eos/cli/data_checks_TEST.d \
+	eos/cli/data_checks_TEST.d/valid \
 	eos/datasets.py \
 	eos/datasets_TEST.d \
 	eos/datasets_file_description.py \
@@ -112,6 +117,12 @@ eos_SCRIPTS = \
 	eos/tasks.py \
 	eos/pyhf_likelihood.py
 
+eosclidir = $(pkgpythondir)/cli
+eoscli_SCRIPTS = \
+	eos/cli/__init__.py \
+	eos/cli/data.py \
+	eos/cli/data_checks.py
+
 eosdatadir = $(pkgpythondir)/data
 eosdata_SCRIPTS = \
 	eos/data/__init__.py \
@@ -163,6 +174,8 @@ TESTS = \
 	eos/analysis_file_TEST.py \
 	eos/analysis_file_context_TEST.py \
 	eos/analysis_file_description_TEST.py \
+	eos/cli/data_checks_TEST.py \
+	eos/cli/data_TEST.py \
 	eos/validation_context_TEST.py \
 	eos/datasets_TEST.py \
 	eos/datasets_file_description_TEST.py \

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -23,6 +23,8 @@ EXTRA_DIST = \
 	eos/cli/data_checks_dataset.py \
 	eos/cli/data_checks_dataset_TEST.py \
 	eos/cli/data_github.py \
+	eos/cli/data_register.py \
+	eos/cli/data_register_TEST.py \
 	eos/cli/data_release.py \
 	eos/cli/data_release_execution.py \
 	eos/cli/data_release_execution_TEST.py \
@@ -131,6 +133,7 @@ eoscli_SCRIPTS = \
 	eos/cli/data_checks.py \
 	eos/cli/data_checks_dataset.py \
 	eos/cli/data_github.py \
+	eos/cli/data_register.py \
 	eos/cli/data_release.py \
 	eos/cli/data_release_execution.py
 
@@ -187,6 +190,7 @@ TESTS = \
 	eos/analysis_file_description_TEST.py \
 	eos/cli/data_checks_TEST.py \
 	eos/cli/data_checks_dataset_TEST.py \
+	eos/cli/data_register_TEST.py \
 	eos/cli/data_release_TEST.py \
 	eos/cli/data_release_execution_TEST.py \
 	eos/cli/data_TEST.py \

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -22,6 +22,11 @@ EXTRA_DIST = \
 	eos/cli/data_checks.py \
 	eos/cli/data_checks_dataset.py \
 	eos/cli/data_checks_dataset_TEST.py \
+	eos/cli/data_github.py \
+	eos/cli/data_release.py \
+	eos/cli/data_release_execution.py \
+	eos/cli/data_release_execution_TEST.py \
+	eos/cli/data_release_TEST.py \
 	eos/cli/data_checks_TEST.d \
 	eos/cli/data_checks_TEST.d/valid \
 	eos/datasets.py \
@@ -124,7 +129,10 @@ eoscli_SCRIPTS = \
 	eos/cli/__init__.py \
 	eos/cli/data.py \
 	eos/cli/data_checks.py \
-	eos/cli/data_checks_dataset.py
+	eos/cli/data_checks_dataset.py \
+	eos/cli/data_github.py \
+	eos/cli/data_release.py \
+	eos/cli/data_release_execution.py
 
 eosdatadir = $(pkgpythondir)/data
 eosdata_SCRIPTS = \
@@ -179,6 +187,8 @@ TESTS = \
 	eos/analysis_file_description_TEST.py \
 	eos/cli/data_checks_TEST.py \
 	eos/cli/data_checks_dataset_TEST.py \
+	eos/cli/data_release_TEST.py \
+	eos/cli/data_release_execution_TEST.py \
 	eos/cli/data_TEST.py \
 	eos/validation_context_TEST.py \
 	eos/datasets_TEST.py \

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -20,6 +20,8 @@ EXTRA_DIST = \
 	eos/cli/__init__.py \
 	eos/cli/data.py \
 	eos/cli/data_checks.py \
+	eos/cli/data_checks_dataset.py \
+	eos/cli/data_checks_dataset_TEST.py \
 	eos/cli/data_checks_TEST.d \
 	eos/cli/data_checks_TEST.d/valid \
 	eos/datasets.py \
@@ -121,7 +123,8 @@ eosclidir = $(pkgpythondir)/cli
 eoscli_SCRIPTS = \
 	eos/cli/__init__.py \
 	eos/cli/data.py \
-	eos/cli/data_checks.py
+	eos/cli/data_checks.py \
+	eos/cli/data_checks_dataset.py
 
 eosdatadir = $(pkgpythondir)/data
 eosdata_SCRIPTS = \
@@ -175,6 +178,7 @@ TESTS = \
 	eos/analysis_file_context_TEST.py \
 	eos/analysis_file_description_TEST.py \
 	eos/cli/data_checks_TEST.py \
+	eos/cli/data_checks_dataset_TEST.py \
 	eos/cli/data_TEST.py \
 	eos/validation_context_TEST.py \
 	eos/datasets_TEST.py \

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -101,6 +101,8 @@ class MetadataDescription(_AnalysisFileDeserializable):
 
     :param title: A human-readable title for the analysis. Optional.
     :type title: str
+    :param description: A human-readable description of the analysis. Optional.
+    :type description: str
     :param id: A unique identifier for the analysis. Optional.
     :type id: str
     :param authors: The list of authors of the analysis. Optional.
@@ -109,6 +111,7 @@ class MetadataDescription(_AnalysisFileDeserializable):
     title:str=''
     id:str=''
     authors:list[MetadataAuthorDescription]=field(default_factory=list)
+    description:str=''
 
     def validate_structure(self):
         yield from self._diagnostics()

--- a/python/eos/analysis_file_description.py
+++ b/python/eos/analysis_file_description.py
@@ -89,6 +89,11 @@ class MetadataAuthorDescription(_AnalysisFileDeserializable):
     affiliation:str=''
     email:str=''
 
+    def _diagnostics(self):
+        for field_name in ('name', 'affiliation', 'email'):
+            if not isinstance(getattr(self, field_name), str):
+                yield Diagnostic((field_name,), Severity.ERROR, f'{field_name} must be a string')
+
 
 @dataclass
 class MetadataDescription(_AnalysisFileDeserializable):
@@ -1034,7 +1039,7 @@ class StepComponent(_AnalysisFileDeserializable):
             if task_component.task not in eos.tasks._tasks:
                 continue
             task = eos.tasks._tasks[task_component.task]
-            # TaskComponent.arguments is checked by TaskComponent._diagnostics() in phase 1.
+            # TaskComponent.arguments is checked by TaskComponent._diagnostics().
             provided_arguments = self.default_arguments[task_component.task].keys()
             known_arguments = set(inspect.signature(task).parameters)
             for argument in provided_arguments - known_arguments:

--- a/python/eos/analysis_file_description_TEST.py
+++ b/python/eos/analysis_file_description_TEST.py
@@ -66,6 +66,17 @@ class MetadataAuthorDescriptionTests(unittest.TestCase):
         self.assertEqual(author.affiliation, '')
         self.assertEqual(author.email, '')
 
+    def test_fields_must_be_strings(self):
+        for field_name in ('name', 'affiliation', 'email'):
+            with self.subTest(field_name=field_name):
+                values = {'name': 'Jane Doe', 'affiliation': '', 'email': ''}
+                values[field_name] = 7
+                author = MetadataAuthorDescription.from_dict(**values)
+                diagnostics = list(author.validate_structure())
+                self.assertEqual(len(diagnostics), 1)
+                self.assertEqual(diagnostics[0].path, (field_name,))
+                self.assertEqual(diagnostics[0].message, f'{field_name} must be a string')
+
 
 class MetadataDescriptionTests(unittest.TestCase):
 

--- a/python/eos/analysis_file_description_TEST.py
+++ b/python/eos/analysis_file_description_TEST.py
@@ -84,10 +84,12 @@ class MetadataDescriptionTests(unittest.TestCase):
         md = MetadataDescription.from_dict(
             title='My Analysis',
             id='my-analysis',
+            description='A detailed analysis description.',
             authors=[{'name': 'Jane Doe'}, {'name': 'John Roe', 'email': 'john@example.org'}],
         )
         self.assertEqual(md.title, 'My Analysis')
         self.assertEqual(md.id, 'my-analysis')
+        self.assertEqual(md.description, 'A detailed analysis description.')
         # the authors are deserialized into MetadataAuthorDescription instances
         self.assertEqual(len(md.authors), 2)
         self.assertIsInstance(md.authors[0], MetadataAuthorDescription)
@@ -98,6 +100,7 @@ class MetadataDescriptionTests(unittest.TestCase):
         self.assertEqual(md.title, '')
         self.assertEqual(md.id, '')
         self.assertEqual(md.authors, [])
+        self.assertEqual(md.description, '')
 
 
 class PriorDescriptionTests(unittest.TestCase):

--- a/python/eos/cli/__init__.py
+++ b/python/eos/cli/__init__.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-
-# Copyright (c) 2024-2026 Danny van Dyk
+# Copyright (c) 2026 Danny van Dyk
 #
 # This file is part of the EOS project. EOS is free software;
 # you can redistribute it and/or modify it under the terms of the GNU General
@@ -14,8 +12,3 @@
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
-
-from eos.cli.data import main
-
-if __name__ == '__main__':
-    raise SystemExit(main())

--- a/python/eos/cli/data.py
+++ b/python/eos/cli/data.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from contextlib import redirect_stderr, redirect_stdout
+import logging
+import sys
+from typing import TextIO
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Download and manage public EOS datasets')
+    common_subparser = argparse.ArgumentParser(add_help=False)
+    common_subparser.add_argument(
+        '-v', '--verbose',
+        help='Increase the verbosity of the script',
+        dest='verbose', action='count', default=0,
+    )
+    subparsers = parser.add_subparsers(title='commands', dest='command')
+
+    parser_download = subparsers.add_parser(
+        'download',
+        parents=[common_subparser],
+        description='Download a single public EOS dataset from Github or Zenodo.',
+        help='Download a public EOS dataset.',
+    )
+    parser_download.add_argument('id', metavar='ID', help='The unique id of the public EOS dataset.')
+    parser_download.set_defaults(cmd=cmd_download)
+
+    parser_list = subparsers.add_parser(
+        'list',
+        parents=[common_subparser],
+        description='List the ids of all public EOS datasets.',
+        help='List the ids of all public EOS datasets.',
+    )
+    parser_list.set_defaults(cmd=cmd_list)
+
+    parser_update = subparsers.add_parser(
+        'update',
+        parents=[common_subparser],
+        description='Update the list of public EOS datasets from Github.',
+        help='Update the list of public EOS datasets from Github.',
+    )
+    parser_update.set_defaults(cmd=cmd_update)
+
+    return parser
+
+
+def _configure_logging(verbosity: int) -> None:
+    levels = {
+        0: logging.ERROR,
+        1: logging.WARNING,
+        2: logging.INFO,
+        3: logging.DEBUG,
+    }
+    logging.basicConfig(level=levels[min(verbosity, 3)])
+
+
+def _datasets():
+    from ..datasets import DataSets
+
+    return DataSets()
+
+
+def cmd_download(args: argparse.Namespace, **_kwargs) -> int:
+    _datasets().download(args.id)
+    return 0
+
+
+def cmd_list(args: argparse.Namespace, *, stdout: TextIO = sys.stdout, **_kwargs) -> int:
+    for dataset_id, dataset in _datasets().datasets():
+        print(f'{dataset_id:<9}  -  {dataset.title}', file=stdout)
+        print(f'{"":<9}     {", ".join(dataset.authors)}', file=stdout)
+    return 0
+
+
+def cmd_update(args: argparse.Namespace, **_kwargs) -> int:
+    _datasets().update()
+    return 0
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    parser = _parser()
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            args = parser.parse_args(argv)
+    except SystemExit as error:
+        return int(error.code)
+
+    if not hasattr(args, 'cmd') or not callable(args.cmd):
+        parser.print_help(file=stdout)
+        return 2
+
+    _configure_logging(args.verbose)
+    return args.cmd(
+        args,
+        stdout=stdout,
+        stderr=stderr,
+    )

--- a/python/eos/cli/data.py
+++ b/python/eos/cli/data.py
@@ -19,8 +19,16 @@ import argparse
 from collections.abc import Sequence
 from contextlib import redirect_stderr, redirect_stdout
 import logging
+from pathlib import Path
 import sys
 from typing import TextIO
+
+from .data_checks import CheckContext, CheckFactory, CheckScope, PlainTextRenderer, run_checks
+
+
+def create_check_factory() -> CheckFactory:
+    """Return an empty check registry."""
+    return CheckFactory()
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -58,6 +66,38 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser_update.set_defaults(cmd=cmd_update)
 
+    parser_check = subparsers.add_parser(
+        'check',
+        parents=[common_subparser],
+        description='Check an EOS dataset candidate.',
+        help='Check an EOS dataset candidate.',
+    )
+    parser_check.add_argument(
+        '--analysis-file',
+        action='append',
+        default=None,
+        metavar='PATH',
+        help='Select an analysis file relative to DIRECTORY; repeat for multiple files.',
+    )
+    parser_check.add_argument(
+        '--main-analysis-file',
+        metavar='PATH',
+        help='Select the main analysis file from the analysis files.',
+    )
+    parser_check.add_argument(
+        '-i', '--interactive',
+        action='store_true',
+        help='Use interactive checking (not yet available).',
+    )
+    parser_check.add_argument(
+        'directory',
+        nargs='?',
+        default='.',
+        metavar='DIRECTORY',
+        help='Dataset directory to check (default: current directory).',
+    )
+    parser_check.set_defaults(cmd=cmd_check)
+
     return parser
 
 
@@ -94,11 +134,36 @@ def cmd_update(args: argparse.Namespace, **_kwargs) -> int:
     return 0
 
 
+def cmd_check(
+    args: argparse.Namespace,
+    *,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+    check_factory: CheckFactory | None = None,
+) -> int:
+    if args.interactive:
+        print('eos-data check: interactive operation is not yet available', file=stderr)
+        return 2
+
+    context = CheckContext(
+        dataset_root=Path(args.directory).resolve(),
+        analysis_paths=tuple(Path(path) for path in (args.analysis_file or ())),
+        main_analysis_path=(
+            Path(args.main_analysis_file) if args.main_analysis_file is not None else None
+        ),
+    )
+    factory = check_factory if check_factory is not None else create_check_factory()
+    result = run_checks(factory, context, scope=CheckScope.BASIC)
+    PlainTextRenderer().write(result, stdout)
+    return result.exit_status
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
     stdout: TextIO = sys.stdout,
     stderr: TextIO = sys.stderr,
+    check_factory: CheckFactory | None = None,
 ) -> int:
     parser = _parser()
     try:
@@ -116,4 +181,5 @@ def main(
         args,
         stdout=stdout,
         stderr=stderr,
+        check_factory=check_factory,
     )

--- a/python/eos/cli/data.py
+++ b/python/eos/cli/data.py
@@ -32,6 +32,14 @@ from .data_checks import (
     run_checks,
 )
 from .data_checks_dataset import register_dataset_checks
+from .data_github import GitHubClient, GitHubError
+from .data_release import (
+    LocalGitClient, ReleasePlanningError, SourceCheckError,
+    plan_create, plan_publish, render_create_plan, render_publish_plan,
+)
+from .data_release_execution import (
+    ReleaseExecutionError, execute_create, execute_publish,
+)
 
 
 def create_check_factory() -> CheckFactory:
@@ -109,6 +117,33 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser_check.set_defaults(cmd=cmd_check)
 
+    parser_create = subparsers.add_parser(
+        'create',
+        parents=[common_subparser],
+        description='Create an EOS dataset commit and transfer its annotated tag.',
+        help='Create and transfer an EOS dataset tag.',
+    )
+    parser_create.add_argument('base_id', metavar='BASE_ID')
+    parser_create.add_argument('source', metavar='URL_TO_ANALYSIS_REPO')
+    parser_create.add_argument('--analysis-file', action='append', default=None, metavar='PATH')
+    parser_create.add_argument('--main-analysis-file', metavar='PATH')
+    choice = parser_create.add_mutually_exclusive_group()
+    choice.add_argument('--revision', action='store_true')
+    choice.add_argument('--replace', action='store_true')
+    parser_create.add_argument('-i', '--interactive', action='store_true')
+    parser_create.add_argument('--dry-run', action='store_true')
+    parser_create.set_defaults(cmd=cmd_create)
+
+    parser_publish = subparsers.add_parser(
+        'publish',
+        parents=[common_subparser],
+        description='Publish an EOS dataset tag and then update its release branch.',
+        help='Publish an EOS dataset tag.',
+    )
+    parser_publish.add_argument('data_id', metavar='DATA_ID')
+    parser_publish.add_argument('--dry-run', action='store_true')
+    parser_publish.set_defaults(cmd=cmd_publish)
+
     return parser
 
 
@@ -164,6 +199,7 @@ def cmd_check(
     stdout: TextIO | None = None,
     stderr: TextIO | None = None,
     check_factory: CheckFactory | None = None,
+    **_kwargs,
 ) -> int:
     stdout = sys.stdout if stdout is None else stdout
     stderr = sys.stderr if stderr is None else stderr
@@ -184,12 +220,96 @@ def cmd_check(
     return result.exit_status
 
 
+def cmd_create(
+    args: argparse.Namespace,
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    check_factory: CheckFactory | None = None,
+    git_client=None,
+    github_client=None,
+) -> int:
+    stdout = sys.stdout if stdout is None else stdout
+    stderr = sys.stderr if stderr is None else stderr
+    if args.interactive:
+        print('eos-data create: interactive operation is not yet available', file=stderr)
+        return 2
+    git = LocalGitClient() if git_client is None else git_client
+    github = GitHubClient() if github_client is None else github_client
+    factory = create_check_factory() if check_factory is None else check_factory
+    try:
+        plan = plan_create(
+            args.base_id, args.source, Path.cwd(),
+            analysis_files=args.analysis_file or (),
+            main_analysis_file=args.main_analysis_file,
+            revision=args.revision,
+            replace=args.replace,
+            git=git,
+            github=github,
+            check_factory=factory,
+        )
+        if args.dry_run:
+            stdout.write(render_create_plan(plan))
+            return 0
+        result = execute_create(plan, git=git, github=github, check_factory=factory)
+        print(f'Created {result.data_id} at commit {result.commit_id}', file=stdout)
+        print(f'Local/remote annotated tag object: {result.local_tag_object_id}', file=stdout)
+        if result.old_tag_object_id is not None:
+            print(
+                f'Replaced tag object {result.old_tag_object_id} with {result.remote_tag_object_id}; '
+                f'commit {result.old_commit_id} with {result.commit_id}',
+                file=stdout,
+            )
+        return 0
+    except SourceCheckError as error:
+        print(error, file=stderr)
+        return int(error.result.exit_status)
+    except (ReleasePlanningError, ReleaseExecutionError, GitHubError) as error:
+        print(f'eos-data create: {error}', file=stderr)
+        return 2
+
+
+def cmd_publish(
+    args: argparse.Namespace,
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    check_factory: CheckFactory | None = None,
+    git_client=None,
+    github_client=None,
+) -> int:
+    stdout = sys.stdout if stdout is None else stdout
+    stderr = sys.stderr if stderr is None else stderr
+    git = LocalGitClient() if git_client is None else git_client
+    github = GitHubClient() if github_client is None else github_client
+    factory = create_check_factory() if check_factory is None else check_factory
+    try:
+        plan = plan_publish(
+            args.data_id, Path.cwd(), git=git, github=github, check_factory=factory,
+        )
+        if args.dry_run:
+            stdout.write(render_publish_plan(plan))
+            return 0
+        result = execute_publish(plan, git=git, github=github, check_factory=factory)
+        print(f'Published {result.data_id}: {result.release_url}', file=stdout)
+        print(f'Remote branch {result.branch_name} -> {result.branch_commit_id}', file=stdout)
+        return 0
+    except SourceCheckError as error:
+        print(error, file=stderr)
+        return int(error.result.exit_status)
+    except (ReleasePlanningError, ReleaseExecutionError, GitHubError) as error:
+        print(f'eos-data publish: {error}', file=stderr)
+        return 2
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
     stdout: TextIO | None = None,
     stderr: TextIO | None = None,
     check_factory: CheckFactory | None = None,
+    git_client=None,
+    github_client=None,
 ) -> int:
     stdout = sys.stdout if stdout is None else stdout
     stderr = sys.stderr if stderr is None else stderr
@@ -210,4 +330,6 @@ def main(
             stdout=stdout,
             stderr=stderr,
             check_factory=check_factory,
+            git_client=git_client,
+            github_client=github_client,
         )

--- a/python/eos/cli/data.py
+++ b/python/eos/cli/data.py
@@ -40,6 +40,9 @@ from .data_release import (
 from .data_release_execution import (
     ReleaseExecutionError, execute_create, execute_publish,
 )
+from .data_register import (
+    RegistrationError, execute_register, plan_register, render_register_plan,
+)
 
 
 def create_check_factory() -> CheckFactory:
@@ -143,6 +146,21 @@ def _parser() -> argparse.ArgumentParser:
     parser_publish.add_argument('data_id', metavar='DATA_ID')
     parser_publish.add_argument('--dry-run', action='store_true')
     parser_publish.set_defaults(cmd=cmd_publish)
+
+    parser_register = subparsers.add_parser(
+        'register',
+        parents=[common_subparser],
+        description='Register a completed Zenodo release in datasets.yaml.',
+        help='Register a completed Zenodo release.',
+    )
+    parser_register.add_argument('data_id', metavar='ID')
+    parser_register.add_argument('--doi', required=True, metavar='DOI')
+    parser_register.add_argument('--keyword', required=True, action='append', metavar='KEYWORD')
+    parser_register.add_argument('--eos-version', required=True, metavar='VERSION')
+    parser_register.add_argument('--likelihood', action='append', default=None, metavar='NAME:FILENAME:FILETYPE')
+    parser_register.add_argument('--repo', default='eos/data', metavar='OWNER/REPO')
+    parser_register.add_argument('--dry-run', action='store_true')
+    parser_register.set_defaults(cmd=cmd_register)
 
     return parser
 
@@ -299,6 +317,47 @@ def cmd_publish(
         return int(error.result.exit_status)
     except (ReleasePlanningError, ReleaseExecutionError, GitHubError) as error:
         print(f'eos-data publish: {error}', file=stderr)
+        return 2
+
+
+def cmd_register(
+    args: argparse.Namespace,
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    check_factory: CheckFactory | None = None,
+    git_client=None,
+    github_client=None,
+) -> int:
+    stdout = sys.stdout if stdout is None else stdout
+    stderr = sys.stderr if stderr is None else stderr
+    git = LocalGitClient() if git_client is None else git_client
+    github = GitHubClient(repository=args.repo) if github_client is None else github_client
+    factory = create_check_factory() if check_factory is None else check_factory
+    try:
+        plan = plan_register(
+            args.data_id, doi=args.doi, keywords=args.keyword,
+            eos_version=args.eos_version, likelihoods=args.likelihood or (),
+            repository=args.repo, github=github, check_factory=factory,
+        )
+        if args.dry_run:
+            stdout.write(render_register_plan(plan))
+            return 0
+        result = execute_register(plan, git=git, github=github, check_factory=factory)
+        print(
+            f'Registered {result.data_id} on {result.branch_name} at {result.commit_id}',
+            file=stdout,
+        )
+        print(
+            f"Create a pull request from branch '{result.branch_name}' to complete registration.",
+            file=stdout,
+        )
+        return 0
+    except SourceCheckError as error:
+        print(error, file=stderr)
+        return int(error.result.exit_status)
+    except (RegistrationError, ReleasePlanningError, GitHubError) as error:
+        print(f'eos-data register: {error}', file=stderr)
         return 2
 
 

--- a/python/eos/cli/data.py
+++ b/python/eos/cli/data.py
@@ -17,18 +17,27 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Sequence
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 import logging
 from pathlib import Path
 import sys
 from typing import TextIO
 
-from .data_checks import CheckContext, CheckFactory, CheckScope, PlainTextRenderer, run_checks
+from .data_checks import (
+    CheckContext,
+    CheckFactory,
+    CheckScope,
+    PlainTextRenderer,
+    register_basic_checks,
+    run_checks,
+)
 
 
 def create_check_factory() -> CheckFactory:
-    """Return an empty check registry."""
-    return CheckFactory()
+    """Return the built-in check registry."""
+    factory = CheckFactory()
+    register_basic_checks(factory)
+    return factory
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -101,14 +110,26 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _configure_logging(verbosity: int) -> None:
+@contextmanager
+def _configured_logging(verbosity: int, stderr: TextIO):
+    import eos
+
     levels = {
         0: logging.ERROR,
         1: logging.WARNING,
         2: logging.INFO,
         3: logging.DEBUG,
     }
-    logging.basicConfig(level=levels[min(verbosity, 3)])
+    handler = eos.stderr_handler
+    previous_level = handler.level
+    previous_stream = handler.stream
+    handler.setLevel(levels[min(verbosity, 3)])
+    handler.setStream(stderr)
+    try:
+        yield
+    finally:
+        handler.setStream(previous_stream)
+        handler.setLevel(previous_level)
 
 
 def _datasets():
@@ -122,7 +143,8 @@ def cmd_download(args: argparse.Namespace, **_kwargs) -> int:
     return 0
 
 
-def cmd_list(args: argparse.Namespace, *, stdout: TextIO = sys.stdout, **_kwargs) -> int:
+def cmd_list(args: argparse.Namespace, *, stdout: TextIO | None = None, **_kwargs) -> int:
+    stdout = sys.stdout if stdout is None else stdout
     for dataset_id, dataset in _datasets().datasets():
         print(f'{dataset_id:<9}  -  {dataset.title}', file=stdout)
         print(f'{"":<9}     {", ".join(dataset.authors)}', file=stdout)
@@ -137,16 +159,18 @@ def cmd_update(args: argparse.Namespace, **_kwargs) -> int:
 def cmd_check(
     args: argparse.Namespace,
     *,
-    stdout: TextIO = sys.stdout,
-    stderr: TextIO = sys.stderr,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
     check_factory: CheckFactory | None = None,
 ) -> int:
+    stdout = sys.stdout if stdout is None else stdout
+    stderr = sys.stderr if stderr is None else stderr
     if args.interactive:
         print('eos-data check: interactive operation is not yet available', file=stderr)
         return 2
 
     context = CheckContext(
-        dataset_root=Path(args.directory).resolve(),
+        dataset_root=Path(args.directory),
         analysis_paths=tuple(Path(path) for path in (args.analysis_file or ())),
         main_analysis_path=(
             Path(args.main_analysis_file) if args.main_analysis_file is not None else None
@@ -161,10 +185,12 @@ def cmd_check(
 def main(
     argv: Sequence[str] | None = None,
     *,
-    stdout: TextIO = sys.stdout,
-    stderr: TextIO = sys.stderr,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
     check_factory: CheckFactory | None = None,
 ) -> int:
+    stdout = sys.stdout if stdout is None else stdout
+    stderr = sys.stderr if stderr is None else stderr
     parser = _parser()
     try:
         with redirect_stdout(stdout), redirect_stderr(stderr):
@@ -174,12 +200,12 @@ def main(
 
     if not hasattr(args, 'cmd') or not callable(args.cmd):
         parser.print_help(file=stdout)
-        return 2
+        return 0
 
-    _configure_logging(args.verbose)
-    return args.cmd(
-        args,
-        stdout=stdout,
-        stderr=stderr,
-        check_factory=check_factory,
-    )
+    with _configured_logging(args.verbose, stderr):
+        return args.cmd(
+            args,
+            stdout=stdout,
+            stderr=stderr,
+            check_factory=check_factory,
+        )

--- a/python/eos/cli/data.py
+++ b/python/eos/cli/data.py
@@ -31,12 +31,14 @@ from .data_checks import (
     register_basic_checks,
     run_checks,
 )
+from .data_checks_dataset import register_dataset_checks
 
 
 def create_check_factory() -> CheckFactory:
     """Return the built-in check registry."""
     factory = CheckFactory()
     register_basic_checks(factory)
+    register_dataset_checks(factory)
     return factory
 
 
@@ -177,7 +179,7 @@ def cmd_check(
         ),
     )
     factory = check_factory if check_factory is not None else create_check_factory()
-    result = run_checks(factory, context, scope=CheckScope.BASIC)
+    result = run_checks(factory, context, scope=CheckScope.COMPLETE)
     PlainTextRenderer().write(result, stdout)
     return result.exit_status
 

--- a/python/eos/cli/data_TEST.py
+++ b/python/eos/cli/data_TEST.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import io
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+import eos
+
+from eos.cli import data
+
+
+FIXTURE = Path(os.environ.get('SOURCE_DIR', Path(__file__).parents[2])) / 'eos/cli/data_checks_TEST.d/valid'
+
+
+class FakeDataSets:
+    def __init__(self):
+        self.downloaded = []
+        self.updated = False
+
+    def download(self, dataset_id):
+        self.downloaded.append(dataset_id)
+
+    def update(self):
+        self.updated = True
+
+    def datasets(self):
+        item = type('DataSet', (), {'title': 'A title', 'authors': ['Jane Doe']})()
+        return [('2026-01', item)]
+
+
+class ParserCompatibilityTests(unittest.TestCase):
+    def test_legacy_download_list_and_update_dispatch(self):
+        fake = FakeDataSets()
+        with mock.patch.object(data, '_datasets', return_value=fake):
+            self.assertEqual(data.main(['download', '2026-01']), 0)
+            output = io.StringIO()
+            self.assertEqual(data.main(['list'], stdout=output), 0)
+            self.assertEqual(data.main(['update']), 0)
+        self.assertEqual(fake.downloaded, ['2026-01'])
+        self.assertTrue(fake.updated)
+        self.assertIn('2026-01', output.getvalue())
+
+    def test_check_defaults_and_repeatable_options(self):
+        args = data._parser().parse_args(['check'])
+        self.assertEqual(args.directory, '.')
+        self.assertIsNone(args.analysis_file)
+        args = data._parser().parse_args([
+            'check', '--analysis-file', 'one.yaml', '--analysis-file', 'two.yaml',
+            '--main-analysis-file', 'two.yaml', 'dataset',
+        ])
+        self.assertEqual(args.analysis_file, ['one.yaml', 'two.yaml'])
+        self.assertEqual(args.main_analysis_file, 'two.yaml')
+        self.assertEqual(args.directory, 'dataset')
+
+    def test_interactive_aliases_are_rejected(self):
+        for option in ('-i', '--interactive'):
+            with self.subTest(option=option):
+                error = io.StringIO()
+                self.assertEqual(data.main(['check', option], stderr=error), 2)
+                self.assertIn('not yet available', error.getvalue())
+
+    def test_help_and_missing_command(self):
+        output = io.StringIO()
+        self.assertEqual(data.main(['--help'], stdout=output), 0)
+        self.assertIn('check', output.getvalue())
+        output = io.StringIO()
+        self.assertEqual(data.main([], stdout=output), 0)
+        self.assertIn('usage:', output.getvalue())
+
+    def test_default_streams_are_resolved_at_call_time(self):
+        output = io.StringIO()
+        with mock.patch.object(sys, 'stdout', output):
+            self.assertEqual(data.main(['--help']), 0)
+        self.assertIn('usage:', output.getvalue())
+
+        error = io.StringIO()
+        with mock.patch.object(sys, 'stderr', error):
+            self.assertEqual(data.main(['check', '--interactive']), 2)
+        self.assertIn('not yet available', error.getvalue())
+
+    def test_logging_uses_injected_stderr_and_reconfigures_each_call(self):
+        fake = FakeDataSets()
+
+        def update():
+            eos.info('update log message')
+            fake.updated = True
+
+        fake.update = update
+        verbose_error = io.StringIO()
+        quiet_error = io.StringIO()
+        with mock.patch.object(data, '_datasets', return_value=fake):
+            self.assertEqual(data.main(['update', '-vv'], stderr=verbose_error), 0)
+            self.assertEqual(data.main(['update'], stderr=quiet_error), 0)
+        self.assertIn('update log message', verbose_error.getvalue())
+        self.assertNotIn('update log message', quiet_error.getvalue())
+
+    def test_wheel_package_configuration_includes_cli(self):
+        project = Path(os.environ['SOURCE_DIR']).parent / 'pyproject.toml.in'
+        package_line = next(
+            line for line in project.read_text(encoding='utf-8').splitlines()
+            if line.startswith('packages = ')
+        )
+        self.assertIn('"eos.cli"', package_line)
+
+    def test_main_propagates_check_exit_status(self):
+        for fixture, expected in ((FIXTURE, 0), (FIXTURE / 'missing', 1)):
+            with self.subTest(expected=expected):
+                self.assertEqual(data.main(['check', str(fixture)], stdout=io.StringIO()), expected)
+        incomplete_factory = data.CheckFactory()
+        incomplete_factory.declare('not-registered', scope=data.CheckScope.BASIC)
+        self.assertEqual(
+            data.main(
+                ['check', str(FIXTURE)],
+                stdout=io.StringIO(),
+                check_factory=incomplete_factory,
+            ),
+            2,
+        )
+
+
+class IsolationTests(unittest.TestCase):
+    def test_noninteractive_check_imports_neither_rich_nor_gh_and_uses_no_network(self):
+        removed = {name: module for name, module in sys.modules.items() if name == 'rich' or name.startswith('rich.')}
+        for name in removed:
+            sys.modules.pop(name)
+        old_path = os.environ.get('PATH')
+        try:
+            os.environ['PATH'] = ''
+            with mock.patch('socket.create_connection', side_effect=AssertionError('network access')):
+                self.assertEqual(data.main(['check', str(FIXTURE)], stdout=io.StringIO()), 0)
+            self.assertFalse(any(name == 'rich' or name.startswith('rich.') for name in sys.modules))
+        finally:
+            if old_path is None:
+                os.environ.pop('PATH', None)
+            else:
+                os.environ['PATH'] = old_path
+            sys.modules.update(removed)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/eos/cli/data_TEST.py
+++ b/python/eos/cli/data_TEST.py
@@ -23,6 +23,8 @@ from unittest import mock
 import eos
 
 from eos.cli import data
+from eos.cli.data_checks import CheckResult, Finding, Severity
+from eos.cli.data_release import SourceCheckError
 
 
 FIXTURE = Path(os.environ.get('SOURCE_DIR', Path(__file__).parents[2])) / 'eos/cli/data_checks_TEST.d/valid'
@@ -68,11 +70,38 @@ class ParserCompatibilityTests(unittest.TestCase):
         self.assertEqual(args.main_analysis_file, 'two.yaml')
         self.assertEqual(args.directory, 'dataset')
 
+    def test_create_and_publish_interfaces(self):
+        args = data._parser().parse_args([
+            'create', '2026-01', '/analysis', '--analysis-file', 'one.yaml',
+            '--analysis-file', 'two.yaml', '--main-analysis-file', 'two.yaml',
+            '--revision', '--dry-run',
+        ])
+        self.assertEqual((args.base_id, args.source), ('2026-01', '/analysis'))
+        self.assertEqual(args.analysis_file, ['one.yaml', 'two.yaml'])
+        self.assertTrue(args.revision)
+        self.assertTrue(args.dry_run)
+        args = data._parser().parse_args(['publish', '2026-01v2', '--dry-run'])
+        self.assertEqual(args.data_id, '2026-01v2')
+        self.assertTrue(args.dry_run)
+
+        error = io.StringIO()
+        self.assertEqual(
+            data.main(['create', '2026-01', '/analysis', '--revision', '--replace'], stderr=error),
+            2,
+        )
+
     def test_interactive_aliases_are_rejected(self):
         for option in ('-i', '--interactive'):
             with self.subTest(option=option):
                 error = io.StringIO()
                 self.assertEqual(data.main(['check', option], stderr=error), 2)
+                self.assertIn('not yet available', error.getvalue())
+        for option in ('-i', '--interactive'):
+            with self.subTest(command='create', option=option):
+                error = io.StringIO()
+                self.assertEqual(
+                    data.main(['create', '2026-01', '/analysis', option], stderr=error), 2,
+                )
                 self.assertIn('not yet available', error.getvalue())
 
     def test_help_and_missing_command(self):
@@ -132,6 +161,23 @@ class ParserCompatibilityTests(unittest.TestCase):
             ),
             2,
         )
+
+    def test_create_preserves_source_check_exit_status(self):
+        validation = SourceCheckError(CheckResult(findings=(
+            Finding('analysis.metadata', Severity.ERROR, 'invalid'),
+        )))
+        infrastructure = SourceCheckError(CheckResult(failure='runner unavailable'))
+        for error, expected in ((validation, 1), (infrastructure, 2)):
+            with self.subTest(expected=expected), mock.patch.object(
+                data, 'plan_create', side_effect=error,
+            ):
+                self.assertEqual(
+                    data.main(
+                        ['create', '2026-01', '/analysis'],
+                        stdout=io.StringIO(), stderr=io.StringIO(),
+                    ),
+                    expected,
+                )
 
 
 class IsolationTests(unittest.TestCase):

--- a/python/eos/cli/data_checks.py
+++ b/python/eos/cli/data_checks.py
@@ -49,18 +49,22 @@ class ExitStatus(IntEnum):
 
 class CheckScope(IntEnum):
     BASIC = 1
+    COMPLETE = 2
 
 
 class CacheKey(Enum):
     ANALYSIS_SELECTION_VALID = 'analysis-selection-valid'
     ANALYSIS_METADATA_VALID = 'analysis-metadata-valid'
     ANALYSIS_METADATA = 'analysis-metadata'
+    ANALYSIS_DOCUMENTS = 'analysis-documents'
     ANALYSIS_AUTHOR_NAMES = 'analysis-author-names'
     ANALYSIS_CONSISTENCY_VALID = 'analysis-consistency-valid'
     COMMON_ANALYSIS_ID = 'common-analysis-id'
     COMMON_AUTHORS_NORMALIZED = 'common-authors-normalized'
     ZENODO_CREATORS_VALID = 'zenodo-creators-valid'
     ZENODO_CREATORS_NORMALIZED = 'zenodo-creators-normalized'
+    ZENODO_METADATA = 'zenodo-metadata'
+    FILE_INVENTORY = 'file-inventory'
 
 
 def _immutable_mapping(values: Mapping[str, Any] | None) -> Mapping[str, Any]:
@@ -192,6 +196,8 @@ class CheckFactory:
             if not ready:
                 names = ', '.join(remaining)
                 raise ValueError(f'cyclic check prerequisites: {names}')
+            ready_scope = min(remaining[name].scope for name in ready)
+            ready = [name for name in ready if remaining[name].scope == ready_scope]
             for name in ready:
                 if name in self._checks:
                     ordered.append(self._checks[name])
@@ -502,6 +508,7 @@ def check_analysis_metadata(context: CheckContext) -> Iterable[Finding]:
         return
 
     metadata_by_path: dict[Path, Mapping[str, Any]] = {}
+    documents_by_path: dict[Path, Mapping[str, Any]] = {}
     author_names: dict[Path, tuple[str, ...]] = {}
     valid = True
     for path in context.analysis_paths:
@@ -529,6 +536,7 @@ def check_analysis_metadata(context: CheckContext) -> Iterable[Finding]:
                 details={'field': 'metadata'},
             )
             continue
+        documents_by_path[path] = document
         metadata_by_path[path] = metadata
 
         analysis_id = metadata.get('id')
@@ -570,6 +578,7 @@ def check_analysis_metadata(context: CheckContext) -> Iterable[Finding]:
                     )
 
     context.cache[CacheKey.ANALYSIS_METADATA] = metadata_by_path
+    context.cache[CacheKey.ANALYSIS_DOCUMENTS] = documents_by_path
     context.cache[CacheKey.ANALYSIS_AUTHOR_NAMES] = author_names
     context.cache[CacheKey.ANALYSIS_METADATA_VALID] = valid
 
@@ -676,6 +685,7 @@ def check_zenodo_metadata(context: CheckContext) -> Iterable[Finding]:
     if not isinstance(document, Mapping):
         yield _finding(check_id, Severity.ERROR, '.zenodo.json must contain a JSON object.', path=path)
         return
+    context.cache[CacheKey.ZENODO_METADATA] = document
     creators = document.get('creators')
     creator_names: list[str] = []
     creators_valid = True

--- a/python/eos/cli/data_checks.py
+++ b/python/eos/cli/data_checks.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from dataclasses import dataclass, field
+from enum import Enum, IntEnum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Protocol, TextIO
+
+
+class Severity(Enum):
+    ERROR = 'error'
+    WARNING = 'warning'
+    INFO = 'info'
+
+
+class ExitStatus(IntEnum):
+    SUCCESS = 0
+    CHECK_ERRORS = 1
+    USAGE_OR_INFRASTRUCTURE = 2
+
+
+class CheckScope(IntEnum):
+    BASIC = 1
+
+
+def _immutable_mapping(values: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    return MappingProxyType(dict(values or {}))
+
+
+@dataclass(frozen=True)
+class InteractiveQuestion:
+    prompt: str
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, 'details', _immutable_mapping(self.details))
+
+
+@dataclass(frozen=True)
+class Finding:
+    check_id: str
+    severity: Severity
+    message: str
+    path: Path | None = None
+    details: Mapping[str, Any] = field(default_factory=dict)
+    question: InteractiveQuestion | None = None
+
+    def __post_init__(self) -> None:
+        if not self.check_id:
+            raise ValueError('a finding requires a nonempty check identifier')
+        if not self.message:
+            raise ValueError('a finding requires a nonempty message')
+        if self.path is not None:
+            object.__setattr__(self, 'path', Path(self.path))
+        object.__setattr__(self, 'details', _immutable_mapping(self.details))
+
+
+@dataclass
+class CheckContext:
+    dataset_root: Path
+    analysis_paths: tuple[Path, ...] = ()
+    main_analysis_path: Path | None = None
+    cache: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.dataset_root = Path(self.dataset_root)
+        self.analysis_paths = tuple(Path(path) for path in self.analysis_paths)
+        if self.main_analysis_path is not None:
+            self.main_analysis_path = Path(self.main_analysis_path)
+
+    def cached(self, key: str, loader: Callable[[], Any]) -> Any:
+        if key not in self.cache:
+            self.cache[key] = loader()
+        return self.cache[key]
+
+
+class CheckFunction(Protocol):
+    def __call__(self, context: CheckContext) -> Iterable[Finding]:
+        ...
+
+
+@dataclass(frozen=True)
+class CheckDeclaration:
+    name: str
+    scope: CheckScope
+    needs: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError('a check declaration requires a nonempty name')
+        if not isinstance(self.scope, CheckScope):
+            raise TypeError('a check declaration requires a valid scope')
+        object.__setattr__(self, 'needs', frozenset(self.needs))
+
+
+@dataclass(frozen=True)
+class RegisteredCheck:
+    declaration: CheckDeclaration
+    function: CheckFunction
+
+
+class CheckFactory:
+    """An ordered, closed registry of dataset checks."""
+
+    def __init__(self) -> None:
+        self._declarations: dict[str, CheckDeclaration] = {}
+        self._checks: dict[str, RegisteredCheck] = {}
+
+    def declare(
+        self, name: str, *, scope: CheckScope, needs: Iterable[str] = (),
+    ) -> CheckDeclaration:
+        if name in self._declarations:
+            raise ValueError(f"check '{name}' is already declared")
+
+        declaration = CheckDeclaration(name=name, scope=scope, needs=frozenset(needs))
+        self._declarations[name] = declaration
+        return declaration
+
+    def register(self, name: str, function: CheckFunction) -> None:
+        if name not in self._declarations:
+            raise KeyError(f"unknown check registration: '{name}'")
+        if name in self._checks:
+            raise ValueError(f"check '{name}' is already registered")
+        if not callable(function):
+            raise TypeError(f"check '{name}' is not callable")
+
+        self._checks[name] = RegisteredCheck(self._declarations[name], function)
+
+    def checks(self, *, scope: CheckScope) -> tuple[RegisteredCheck, ...]:
+        return tuple(
+            self._checks[name]
+            for name, declaration in self._declarations.items()
+            if declaration.scope <= scope and name in self._checks
+        )
+
+    def missing(self, *, scope: CheckScope) -> tuple[CheckDeclaration, ...]:
+        return tuple(
+            declaration
+            for name, declaration in self._declarations.items()
+            if declaration.scope <= scope and name not in self._checks
+        )
+
+    def __len__(self) -> int:
+        return len(self._checks)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    findings: tuple[Finding, ...] = ()
+    failure: str | None = None
+
+    @property
+    def completed(self) -> bool:
+        return self.failure is None
+
+    @property
+    def exit_status(self) -> ExitStatus:
+        if not self.completed:
+            return ExitStatus.USAGE_OR_INFRASTRUCTURE
+        if any(finding.severity is Severity.ERROR for finding in self.findings):
+            return ExitStatus.CHECK_ERRORS
+        return ExitStatus.SUCCESS
+
+
+class CheckRunner:
+    def __init__(self, factory: CheckFactory, *, scope: CheckScope) -> None:
+        self._checks = factory.checks(scope=scope)
+        self._missing = factory.missing(scope=scope)
+
+    def run(self, context: CheckContext) -> CheckResult:
+        if self._missing:
+            names = ', '.join(declaration.name for declaration in self._missing)
+            return CheckResult(failure=f'unregistered built-in checks: {names}')
+        if not self._checks:
+            return CheckResult(failure='built-in dataset checks are not installed')
+
+        findings: list[Finding] = []
+        try:
+            for registered in self._checks:
+                produced = registered.function(context)
+                for finding in produced:
+                    if not isinstance(finding, Finding):
+                        raise TypeError(
+                            f"check '{registered.declaration.name}' returned a non-Finding value"
+                        )
+                    findings.append(finding)
+        except SystemExit as error:
+            return CheckResult(tuple(findings), f'a check attempted to exit with status {error.code}')
+        except Exception as error:
+            return CheckResult(tuple(findings), f'{type(error).__name__}: {error}')
+
+        return CheckResult(tuple(findings))
+
+
+class PlainTextRenderer:
+    def render(self, result: CheckResult) -> str:
+        lines = []
+        for finding in result.findings:
+            location = f' {finding.path}' if finding.path is not None else ''
+            lines.append(
+                f'{finding.severity.value.upper()} [{finding.check_id}]{location}: {finding.message}'
+            )
+
+        counts = {
+            severity: sum(finding.severity is severity for finding in result.findings)
+            for severity in Severity
+        }
+        if result.failure is not None:
+            lines.append(f'ERROR [infrastructure]: {result.failure}')
+            lines.append('Summary: checks did not complete.')
+        else:
+            lines.append(
+                'Summary: '
+                f'{counts[Severity.ERROR]} error(s), '
+                f'{counts[Severity.WARNING]} warning(s), '
+                f'{counts[Severity.INFO]} info finding(s).'
+            )
+
+        return '\n'.join(lines) + '\n'
+
+    def write(self, result: CheckResult, stream: TextIO) -> None:
+        stream.write(self.render(result))
+
+
+def run_checks(
+    factory: CheckFactory,
+    context: CheckContext,
+    *,
+    scope: CheckScope,
+) -> CheckResult:
+    return CheckRunner(factory, scope=scope).run(context)

--- a/python/eos/cli/data_checks.py
+++ b/python/eos/cli/data_checks.py
@@ -15,18 +15,30 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
+import json
 from pathlib import Path
+import re
 from types import MappingProxyType
 from typing import Any, Protocol, TextIO
+import unicodedata
+
+import yaml
+
+from ..analysis_file_description import MetadataAuthorDescription
+from ..deserializable import load_yaml_file
+from ..diagnostic import Severity
 
 
-class Severity(Enum):
-    ERROR = 'error'
-    WARNING = 'warning'
-    INFO = 'info'
+_ANALYSIS_ID = re.compile(r'^[0-9]{4}-[0-9]{2}$')
+_DATASET_ID = re.compile(r'^[0-9]{4}-[0-9]{2}(?:v([2-9]|[1-9][0-9]+))?$')
+_ZENODO_TITLE = re.compile(
+    r'^EOS/DATA-(?P<dataset_id>[^:]+): Supplementary material for '
+    r'EOS/ANALYSIS-(?P<analysis_id>[^\s]+)$'
+)
+_WHITESPACE = re.compile(r'\s+')
 
 
 class ExitStatus(IntEnum):
@@ -37,6 +49,18 @@ class ExitStatus(IntEnum):
 
 class CheckScope(IntEnum):
     BASIC = 1
+
+
+class CacheKey(Enum):
+    ANALYSIS_SELECTION_VALID = 'analysis-selection-valid'
+    ANALYSIS_METADATA_VALID = 'analysis-metadata-valid'
+    ANALYSIS_METADATA = 'analysis-metadata'
+    ANALYSIS_AUTHOR_NAMES = 'analysis-author-names'
+    ANALYSIS_CONSISTENCY_VALID = 'analysis-consistency-valid'
+    COMMON_ANALYSIS_ID = 'common-analysis-id'
+    COMMON_AUTHORS_NORMALIZED = 'common-authors-normalized'
+    ZENODO_CREATORS_VALID = 'zenodo-creators-valid'
+    ZENODO_CREATORS_NORMALIZED = 'zenodo-creators-normalized'
 
 
 def _immutable_mapping(values: Mapping[str, Any] | None) -> Mapping[str, Any]:
@@ -76,18 +100,13 @@ class CheckContext:
     dataset_root: Path
     analysis_paths: tuple[Path, ...] = ()
     main_analysis_path: Path | None = None
-    cache: MutableMapping[str, Any] = field(default_factory=dict)
+    cache: MutableMapping[CacheKey, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         self.dataset_root = Path(self.dataset_root)
         self.analysis_paths = tuple(Path(path) for path in self.analysis_paths)
         if self.main_analysis_path is not None:
             self.main_analysis_path = Path(self.main_analysis_path)
-
-    def cached(self, key: str, loader: Callable[[], Any]) -> Any:
-        if key not in self.cache:
-            self.cache[key] = loader()
-        return self.cache[key]
 
 
 class CheckFunction(Protocol):
@@ -143,11 +162,43 @@ class CheckFactory:
         self._checks[name] = RegisteredCheck(self._declarations[name], function)
 
     def checks(self, *, scope: CheckScope) -> tuple[RegisteredCheck, ...]:
-        return tuple(
-            self._checks[name]
+        enabled = {
+            name: declaration
             for name, declaration in self._declarations.items()
-            if declaration.scope <= scope and name in self._checks
-        )
+            if declaration.scope <= scope
+        }
+        for declaration in enabled.values():
+            unknown = declaration.needs - self._declarations.keys()
+            if unknown:
+                names = ', '.join(sorted(unknown))
+                raise ValueError(f"check '{declaration.name}' has unknown prerequisite(s): {names}")
+            unavailable = declaration.needs - enabled.keys()
+            if unavailable:
+                names = ', '.join(sorted(unavailable))
+                raise ValueError(
+                    f"check '{declaration.name}' depends on check(s) outside the requested "
+                    f'scope: {names}'
+                )
+
+        ordered: list[RegisteredCheck] = []
+        remaining = dict(enabled)
+        completed: set[str] = set()
+        while remaining:
+            ready = [
+                name
+                for name, declaration in remaining.items()
+                if declaration.needs <= completed
+            ]
+            if not ready:
+                names = ', '.join(remaining)
+                raise ValueError(f'cyclic check prerequisites: {names}')
+            for name in ready:
+                if name in self._checks:
+                    ordered.append(self._checks[name])
+                completed.add(name)
+                del remaining[name]
+
+        return tuple(ordered)
 
     def missing(self, *, scope: CheckScope) -> tuple[CheckDeclaration, ...]:
         return tuple(
@@ -191,8 +242,19 @@ class CheckRunner:
             return CheckResult(failure='built-in dataset checks are not installed')
 
         findings: list[Finding] = []
-        try:
-            for registered in self._checks:
+        failures: list[str] = []
+        failed_checks: set[str] = set()
+        for registered in self._checks:
+            failed_needs = registered.declaration.needs & failed_checks
+            if failed_needs:
+                names = ', '.join(sorted(failed_needs))
+                failures.append(
+                    f"check '{registered.declaration.name}' did not run because prerequisite "
+                    f'check(s) failed: {names}'
+                )
+                failed_checks.add(registered.declaration.name)
+                continue
+            try:
                 produced = registered.function(context)
                 for finding in produced:
                     if not isinstance(finding, Finding):
@@ -200,12 +262,18 @@ class CheckRunner:
                             f"check '{registered.declaration.name}' returned a non-Finding value"
                         )
                     findings.append(finding)
-        except SystemExit as error:
-            return CheckResult(tuple(findings), f'a check attempted to exit with status {error.code}')
-        except Exception as error:
-            return CheckResult(tuple(findings), f'{type(error).__name__}: {error}')
+            except SystemExit as error:
+                failed_checks.add(registered.declaration.name)
+                failures.append(
+                    f"check '{registered.declaration.name}' attempted to exit with status {error.code}"
+                )
+            except Exception as error:
+                failed_checks.add(registered.declaration.name)
+                failures.append(
+                    f"check '{registered.declaration.name}' failed: {type(error).__name__}: {error}"
+                )
 
-        return CheckResult(tuple(findings))
+        return CheckResult(tuple(findings), '; '.join(failures) or None)
 
 
 class PlainTextRenderer:
@@ -245,3 +313,593 @@ def run_checks(
     scope: CheckScope,
 ) -> CheckResult:
     return CheckRunner(factory, scope=scope).run(context)
+
+
+def _finding(
+    check_id: str,
+    severity: Severity,
+    message: str,
+    *,
+    path: Path | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> Finding:
+    return Finding(check_id, severity, message, path, details or {})
+
+
+def _relative_path(root: Path, path: Path) -> Path:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return path
+
+
+def _resolve_inside(root: Path, value: Path) -> Path | None:
+    candidate = value if value.is_absolute() else root / value
+    candidate = candidate.resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def check_analysis_file_selection(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'analysis-files.selection'
+    root = context.dataset_root.resolve()
+    context.dataset_root = root
+    context.cache[CacheKey.ANALYSIS_SELECTION_VALID] = False
+
+    if not root.is_dir():
+        yield _finding(check_id, Severity.ERROR, 'Dataset root is not a directory.', path=root)
+        return
+
+    requested = context.analysis_paths
+    if not requested:
+        default = root / 'analysis.yaml'
+        if not default.is_file():
+            yield _finding(
+                check_id,
+                Severity.ERROR,
+                'No root analysis.yaml exists; supply every analysis file explicitly with '
+                'repeatable --analysis-file options.',
+                path=default,
+            )
+            return
+        selected = [default.resolve()]
+    else:
+        selected = []
+        seen: set[Path] = set()
+        invalid = False
+        for requested_path in requested:
+            resolved = _resolve_inside(root, requested_path)
+            display_path = requested_path if requested_path.is_absolute() else root / requested_path
+            if resolved is None:
+                invalid = True
+                yield _finding(
+                    check_id,
+                    Severity.ERROR,
+                    'Selected analysis file is outside the dataset root.',
+                    path=display_path,
+                )
+                continue
+            if resolved in seen:
+                invalid = True
+                yield _finding(
+                    check_id,
+                    Severity.ERROR,
+                    'Selected analysis file is duplicated.',
+                    path=_relative_path(root, resolved),
+                )
+                continue
+            seen.add(resolved)
+            if resolved.suffix.lower() not in ('.yaml', '.yml'):
+                invalid = True
+                yield _finding(
+                    check_id,
+                    Severity.ERROR,
+                    'Selected analysis file must have a .yaml or .yml suffix.',
+                    path=_relative_path(root, resolved),
+                )
+                continue
+            if not resolved.is_file():
+                invalid = True
+                yield _finding(
+                    check_id,
+                    Severity.ERROR,
+                    'Selected analysis path is not a regular file.',
+                    path=_relative_path(root, resolved),
+                )
+                continue
+            selected.append(resolved)
+        if invalid:
+            return
+
+    requested_main = context.main_analysis_path
+    if len(selected) == 1:
+        main = selected[0]
+        if requested_main is not None:
+            resolved_main = _resolve_inside(root, requested_main)
+            if resolved_main != main:
+                yield _finding(
+                    check_id,
+                    Severity.ERROR,
+                    '--main-analysis-file conflicts with the automatically selected analysis file.',
+                    path=requested_main,
+                )
+                return
+    else:
+        if requested_main is None:
+            yield _finding(
+                check_id,
+                Severity.ERROR,
+                'Multiple analysis files require --main-analysis-file.',
+            )
+            return
+        main = _resolve_inside(root, requested_main)
+        if main is None or main not in selected:
+            yield _finding(
+                check_id,
+                Severity.ERROR,
+                '--main-analysis-file must identify one of the selected analysis files.',
+                path=requested_main,
+            )
+            return
+
+    context.analysis_paths = tuple(selected)
+    context.main_analysis_path = main
+    context.cache[CacheKey.ANALYSIS_SELECTION_VALID] = True
+
+
+def _usable_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _usable_name(value: Any) -> bool:
+    return _usable_string(value) and any(character.isalnum() for character in value)
+
+
+def _load_yaml(path: Path) -> tuple[Any, str | None]:
+    try:
+        return load_yaml_file(path), None
+    except (OSError, UnicodeError, yaml.YAMLError) as error:
+        return None, str(error)
+
+
+def _author_names(metadata: Mapping[str, Any]) -> tuple[list[str], list[str]]:
+    authors = metadata.get('authors')
+    if not isinstance(authors, list):
+        return [], ['metadata.authors must be a list']
+    if not authors:
+        return [], ['metadata.authors must not be empty']
+
+    names: list[str] = []
+    errors: list[str] = []
+    for index, author in enumerate(authors):
+        if not isinstance(author, Mapping):
+            errors.append(f'metadata.authors[{index}].name must be a nonempty string')
+            continue
+        if not all(isinstance(key, str) for key in author):
+            errors.append(f'metadata.authors[{index}] must use string keys')
+            continue
+
+        description = MetadataAuthorDescription.from_dict(**author)
+        for diagnostic in description.validate_structure():
+            errors.append(
+                f'metadata.authors[{index}].{diagnostic.location()}: {diagnostic.message}'
+            )
+        if not _usable_name(author.get('name')):
+            errors.append(f'metadata.authors[{index}].name must be a nonempty string')
+        else:
+            names.append(author['name'].strip())
+    return names, errors
+
+
+def check_analysis_metadata(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'analysis-metadata.parse'
+    context.cache[CacheKey.ANALYSIS_METADATA_VALID] = False
+    if not context.cache[CacheKey.ANALYSIS_SELECTION_VALID]:
+        yield _finding(check_id, Severity.INFO, 'Skipped because analysis-file selection failed.')
+        return
+
+    metadata_by_path: dict[Path, Mapping[str, Any]] = {}
+    author_names: dict[Path, tuple[str, ...]] = {}
+    valid = True
+    for path in context.analysis_paths:
+        display = _relative_path(context.dataset_root, path)
+        document, error = _load_yaml(path)
+        if error is not None:
+            valid = False
+            yield _finding(
+                check_id, Severity.ERROR, f'Cannot parse YAML: {error}', path=display,
+                details={'field': '$'},
+            )
+            continue
+        if not isinstance(document, Mapping):
+            valid = False
+            yield _finding(
+                check_id, Severity.ERROR, 'Analysis YAML must be a top-level mapping.', path=display,
+                details={'field': '$'},
+            )
+            continue
+        metadata = document.get('metadata')
+        if not isinstance(metadata, Mapping):
+            valid = False
+            yield _finding(
+                check_id, Severity.ERROR, 'metadata must be a mapping.', path=display,
+                details={'field': 'metadata'},
+            )
+            continue
+        metadata_by_path[path] = metadata
+
+        analysis_id = metadata.get('id')
+        if not _usable_string(analysis_id):
+            valid = False
+            yield _finding(
+                check_id, Severity.ERROR, 'metadata.id must be a nonempty string.', path=display,
+                details={'field': 'metadata.id'},
+            )
+        elif _ANALYSIS_ID.fullmatch(analysis_id) is None:
+            valid = False
+            yield _finding(
+                check_id, Severity.ERROR,
+                'metadata.id must have exactly the YYYY-NN form without a revision suffix.',
+                path=display, details={'field': 'metadata.id', 'value': analysis_id},
+            )
+
+        names, author_errors = _author_names(metadata)
+        if author_errors:
+            valid = False
+            for message in author_errors:
+                yield _finding(
+                    check_id, Severity.ERROR, message + '.', path=display,
+                    details={'field': message.split(' must', 1)[0]},
+                )
+        else:
+            author_names[path] = tuple(names)
+
+        if path == context.main_analysis_path:
+            # 'description' is Optional on MetadataDescription -- an ongoing or unofficial
+            # analysis need not have one -- but the release process requires it.
+            for field_name in ('title', 'description'):
+                if not _usable_string(metadata.get(field_name)):
+                    valid = False
+                    yield _finding(
+                        check_id, Severity.ERROR,
+                        f'metadata.{field_name} must be a nonempty string in the main analysis file.',
+                        path=display, details={'field': f'metadata.{field_name}'},
+                    )
+
+    context.cache[CacheKey.ANALYSIS_METADATA] = metadata_by_path
+    context.cache[CacheKey.ANALYSIS_AUTHOR_NAMES] = author_names
+    context.cache[CacheKey.ANALYSIS_METADATA_VALID] = valid
+
+
+def _normalize_name(name: str) -> str:
+    value = unicodedata.normalize('NFKC', name).casefold().strip()
+    if value.count(',') == 1:
+        family, given = value.split(',', 1)
+        if family.strip() and given.strip():
+            value = f'{given} {family}'
+    value = ''.join(
+        character
+        if unicodedata.category(character)[0] in ('L', 'M', 'N')
+        else ' '
+        for character in value
+    )
+    return _WHITESPACE.sub(' ', value).strip()
+
+
+def _unique_normalized(names: Iterable[str]) -> tuple[dict[str, str], list[str]]:
+    normalized: dict[str, str] = {}
+    duplicates: list[str] = []
+    for name in names:
+        key = _normalize_name(name)
+        if key in normalized:
+            duplicates.append(name)
+        else:
+            normalized[key] = name
+    return normalized, duplicates
+
+
+def check_analysis_consistency(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'analysis-metadata.consistency'
+    context.cache[CacheKey.ANALYSIS_CONSISTENCY_VALID] = False
+    if not context.cache[CacheKey.ANALYSIS_METADATA_VALID]:
+        yield _finding(check_id, Severity.INFO, 'Skipped because analysis metadata is invalid.')
+        return
+
+    metadata_by_path = context.cache[CacheKey.ANALYSIS_METADATA]
+    authors_by_path = context.cache[CacheKey.ANALYSIS_AUTHOR_NAMES]
+    ids = {path: metadata_by_path[path]['id'] for path in context.analysis_paths}
+    common_id = ids[context.analysis_paths[0]]
+    valid = True
+    for path, analysis_id in ids.items():
+        if analysis_id != common_id:
+            valid = False
+            yield _finding(
+                check_id, Severity.ERROR,
+                f"Analysis ID '{analysis_id}' differs from common ID '{common_id}'.",
+                path=_relative_path(context.dataset_root, path),
+                details={'field': 'metadata.id', 'expected': common_id, 'actual': analysis_id},
+            )
+
+    normalized_authors: dict[Path, dict[str, str]] = {}
+    for path, names in authors_by_path.items():
+        normalized, duplicates = _unique_normalized(names)
+        normalized_authors[path] = normalized
+        for duplicate in duplicates:
+            valid = False
+            yield _finding(
+                check_id, Severity.ERROR,
+                f"Duplicate or unresolved analysis author '{duplicate}'.",
+                path=_relative_path(context.dataset_root, path),
+                details={'field': 'metadata.authors', 'name': duplicate},
+            )
+
+    common_authors = set(normalized_authors[context.analysis_paths[0]])
+    for path in context.analysis_paths[1:]:
+        current_authors = set(normalized_authors[path])
+        if current_authors != common_authors:
+            valid = False
+            yield _finding(
+                check_id, Severity.ERROR,
+                'Analysis author set differs from the common author set.',
+                path=_relative_path(context.dataset_root, path),
+                details={
+                    'field': 'metadata.authors',
+                    'missing': sorted(common_authors - current_authors),
+                    'additional': sorted(current_authors - common_authors),
+                },
+            )
+
+    if valid:
+        context.cache[CacheKey.COMMON_ANALYSIS_ID] = common_id
+        context.cache[CacheKey.COMMON_AUTHORS_NORMALIZED] = normalized_authors[
+            context.analysis_paths[0]
+        ]
+        context.cache[CacheKey.ANALYSIS_CONSISTENCY_VALID] = True
+
+
+def check_zenodo_metadata(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'zenodo-metadata.basic'
+    context.cache[CacheKey.ZENODO_CREATORS_VALID] = False
+    path = context.dataset_root / '.zenodo.json'
+    if not path.is_file():
+        yield _finding(check_id, Severity.ERROR, 'Required root .zenodo.json is missing.', path=path)
+        return
+    try:
+        with path.open('r', encoding='utf-8') as stream:
+            document = json.load(stream)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        yield _finding(check_id, Severity.ERROR, f'Cannot parse JSON: {error}', path=path)
+        return
+    if not isinstance(document, Mapping):
+        yield _finding(check_id, Severity.ERROR, '.zenodo.json must contain a JSON object.', path=path)
+        return
+    creators = document.get('creators')
+    creator_names: list[str] = []
+    creators_valid = True
+    if not isinstance(creators, list) or not creators:
+        creators_valid = False
+        yield _finding(
+            check_id, Severity.ERROR, 'creators must be a nonempty list.', path=path,
+            details={'field': 'creators'},
+        )
+    else:
+        for index, creator in enumerate(creators):
+            if not isinstance(creator, Mapping) or not _usable_name(creator.get('name')):
+                creators_valid = False
+                yield _finding(
+                    check_id, Severity.ERROR,
+                    f'creators[{index}].name must be a nonempty string.', path=path,
+                    details={'field': f'creators[{index}].name'},
+                )
+            else:
+                creator_names.append(creator['name'].strip())
+    if creators_valid:
+        normalized, duplicates = _unique_normalized(creator_names)
+        if duplicates:
+            creators_valid = False
+            for duplicate in duplicates:
+                yield _finding(
+                    check_id, Severity.ERROR, f"Duplicate creator '{duplicate}'.", path=path,
+                    details={'field': 'creators', 'name': duplicate},
+                )
+        else:
+            context.cache[CacheKey.ZENODO_CREATORS_NORMALIZED] = normalized
+            context.cache[CacheKey.ZENODO_CREATORS_VALID] = True
+
+    title = document.get('title')
+    if not isinstance(title, str):
+        yield _finding(
+            check_id, Severity.ERROR, 'title must be a string.', path=path,
+            details={'field': 'title'},
+        )
+    else:
+        match = _ZENODO_TITLE.fullmatch(title)
+        if match is None:
+            yield _finding(
+                check_id, Severity.ERROR,
+                'title must exactly match "EOS/DATA-{dataset-id}: Supplementary material for '
+                'EOS/ANALYSIS-{analysis-id}".',
+                path=path, details={'field': 'title', 'value': title},
+            )
+        else:
+            dataset_id = match.group('dataset_id')
+            if _DATASET_ID.fullmatch(dataset_id) is None:
+                yield _finding(
+                    check_id, Severity.ERROR,
+                    'The dataset ID embedded in title must be YYYY-NN or YYYY-NNvN with N >= 2.',
+                    path=path, details={'field': 'title', 'dataset_id': dataset_id},
+                )
+            if context.cache[CacheKey.ANALYSIS_CONSISTENCY_VALID]:
+                expected = context.cache[CacheKey.COMMON_ANALYSIS_ID]
+                actual = match.group('analysis_id')
+                if actual != expected:
+                    yield _finding(
+                        check_id, Severity.ERROR,
+                        f"The analysis ID embedded in title is '{actual}', expected '{expected}'.",
+                        path=path,
+                        details={'field': 'title', 'expected': expected, 'actual': actual},
+                    )
+            else:
+                yield _finding(
+                    check_id, Severity.INFO,
+                    'Skipped embedded analysis-ID comparison because analysis metadata is invalid.',
+                    path=path,
+                )
+
+    description = document.get('description')
+    if not isinstance(description, str):
+        yield _finding(
+            check_id, Severity.ERROR, 'description must be a string.', path=path,
+            details={'field': 'description'},
+        )
+    elif context.cache[CacheKey.ANALYSIS_METADATA_VALID]:
+        main_metadata = context.cache[CacheKey.ANALYSIS_METADATA][context.main_analysis_path]
+        expected = main_metadata['description']
+        if description != expected:
+            yield _finding(
+                check_id, Severity.ERROR,
+                'description does not exactly equal main analysis metadata.description.',
+                path=path, details={'field': 'description'},
+            )
+    else:
+        yield _finding(
+            check_id, Severity.INFO,
+            'Skipped description comparison because main analysis metadata is invalid.', path=path,
+        )
+
+
+def _without_diacritics(value: str) -> str:
+    return ''.join(
+        character
+        for character in unicodedata.normalize('NFKD', value)
+        if not unicodedata.combining(character)
+    )
+
+
+def _initial_parts_match(left_parts: list[str], right_parts: list[str]) -> bool:
+    if len(left_parts) != len(right_parts) or left_parts == right_parts:
+        return False
+    for left_part, right_part in zip(left_parts, right_parts):
+        if left_part == right_part:
+            continue
+        if len(left_part) == 1 and right_part.startswith(left_part):
+            continue
+        if len(right_part) == 1 and left_part.startswith(right_part):
+            continue
+        return False
+    return True
+
+
+def _ambiguous_match(left: str, right: str) -> tuple[str, ...]:
+    left_plain = _without_diacritics(left)
+    right_plain = _without_diacritics(right)
+    left_parts = left_plain.split()
+    right_parts = right_plain.split()
+    reasons: list[str] = []
+
+    if left_plain == right_plain and left != right:
+        reasons.append('diacritics')
+    elif sorted(left_parts) == sorted(right_parts) and left_parts != right_parts:
+        reasons.append('name-order')
+        if left_plain != left or right_plain != right:
+            reasons.append('diacritics')
+    elif _initial_parts_match(left_parts, right_parts):
+        reasons.append('initials')
+        if left_plain != left or right_plain != right:
+            reasons.append('diacritics')
+    elif _initial_parts_match(left_parts, list(reversed(right_parts))):
+        reasons.extend(('initials', 'name-order'))
+        if left_plain != left or right_plain != right:
+            reasons.append('diacritics')
+
+    return tuple(reasons)
+
+
+def check_creator_consistency(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'authors.creator-consistency'
+    if not context.cache[CacheKey.ANALYSIS_CONSISTENCY_VALID]:
+        yield _finding(check_id, Severity.INFO, 'Skipped because analysis author metadata is invalid.')
+        return
+    if not context.cache[CacheKey.ZENODO_CREATORS_VALID]:
+        yield _finding(check_id, Severity.INFO, 'Skipped because Zenodo creator metadata is invalid.')
+        return
+
+    authors = context.cache[CacheKey.COMMON_AUTHORS_NORMALIZED]
+    creators = context.cache[CacheKey.ZENODO_CREATORS_NORMALIZED]
+    unmatched_authors = set(authors) - set(creators)
+    unmatched_creators = set(creators) - set(authors)
+    candidates = [
+        (author, creator, reasons)
+        for author in sorted(unmatched_authors)
+        for creator in sorted(unmatched_creators)
+        if (reasons := _ambiguous_match(author, creator))
+    ]
+    ambiguous_authors = {author for author, _creator, _reasons in candidates}
+    ambiguous_creators = {creator for _author, creator, _reasons in candidates}
+
+    for author, creator, reasons in candidates:
+        yield Finding(
+            check_id,
+            Severity.WARNING,
+            f"Plausible but ambiguous author/creator match: '{authors[author]}' and "
+            f"'{creators[creator]}'.",
+            context.dataset_root / '.zenodo.json',
+            {
+                'analysis_author': authors[author],
+                'zenodo_creator': creators[creator],
+                'analysis_normalized': author,
+                'creator_normalized': creator,
+                'reasons': reasons,
+            },
+            InteractiveQuestion(
+                'Do these names identify the same person?',
+                {
+                    'analysis_author': authors[author],
+                    'zenodo_creator': creators[creator],
+                    'reasons': reasons,
+                },
+            ),
+        )
+
+    for author in sorted(unmatched_authors - ambiguous_authors):
+        yield _finding(
+            check_id, Severity.ERROR,
+            f"Analysis author '{authors[author]}' is missing from Zenodo creators.",
+            path=context.dataset_root / '.zenodo.json',
+            details={'analysis_author': authors[author]},
+        )
+    for creator in sorted(unmatched_creators - ambiguous_creators):
+        yield _finding(
+            check_id, Severity.ERROR,
+            f"Zenodo creator '{creators[creator]}' is not an analysis author.",
+            path=context.dataset_root / '.zenodo.json',
+            details={'zenodo_creator': creators[creator]},
+        )
+
+
+def register_basic_checks(factory: CheckFactory) -> None:
+    checks = (
+        ('analysis-files.selection', (), check_analysis_file_selection),
+        ('analysis-metadata.parse', ('analysis-files.selection',), check_analysis_metadata),
+        (
+            'analysis-metadata.consistency',
+            ('analysis-metadata.parse',),
+            check_analysis_consistency,
+        ),
+        (
+            'zenodo-metadata.basic',
+            ('analysis-metadata.consistency',),
+            check_zenodo_metadata,
+        ),
+        (
+            'authors.creator-consistency',
+            ('analysis-metadata.consistency', 'zenodo-metadata.basic'),
+            check_creator_consistency,
+        ),
+    )
+    for name, needs, function in checks:
+        factory.declare(name, scope=CheckScope.BASIC, needs=needs)
+        factory.register(name, function)

--- a/python/eos/cli/data_checks_TEST.d/valid/.zenodo.json
+++ b/python/eos/cli/data_checks_TEST.d/valid/.zenodo.json
@@ -2,7 +2,10 @@
   "title": "EOS/DATA-2026-01: Supplementary material for EOS/ANALYSIS-2026-01",
   "description": "A minimal dataset description.",
   "creators": [
-    {"name": "Doe, Jane"},
-    {"name": "John Roe"}
-  ]
+    {"name": "Doe, Jane", "affiliation": "Example University"},
+    {"name": "John Roe", "affiliation": "Example Institute"}
+  ],
+  "upload_type": "dataset",
+  "license": "CC-BY-4.0",
+  "grants": []
 }

--- a/python/eos/cli/data_checks_TEST.d/valid/.zenodo.json
+++ b/python/eos/cli/data_checks_TEST.d/valid/.zenodo.json
@@ -1,0 +1,8 @@
+{
+  "title": "EOS/DATA-2026-01: Supplementary material for EOS/ANALYSIS-2026-01",
+  "description": "A minimal dataset description.",
+  "creators": [
+    {"name": "Doe, Jane"},
+    {"name": "John Roe"}
+  ]
+}

--- a/python/eos/cli/data_checks_TEST.d/valid/README.md
+++ b/python/eos/cli/data_checks_TEST.d/valid/README.md
@@ -1,0 +1,1 @@
+# A minimal dataset

--- a/python/eos/cli/data_checks_TEST.d/valid/analysis.yaml
+++ b/python/eos/cli/data_checks_TEST.d/valid/analysis.yaml
@@ -1,0 +1,7 @@
+metadata:
+  id: 2026-01
+  title: A minimal analysis
+  description: A minimal dataset description.
+  authors:
+    - name: Jane Doe
+    - name: John Roe

--- a/python/eos/cli/data_checks_TEST.py
+++ b/python/eos/cli/data_checks_TEST.py
@@ -1,0 +1,464 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import yaml
+
+from eos.cli.data import create_check_factory
+from eos.cli.data_checks import (
+    CheckContext,
+    CheckFactory,
+    CheckResult,
+    CheckRunner,
+    CheckScope,
+    ExitStatus,
+    Finding,
+    PlainTextRenderer,
+    Severity,
+    _normalize_name,
+    check_analysis_metadata,
+    run_checks,
+)
+
+
+FIXTURES = Path(os.environ.get('SOURCE_DIR', Path(__file__).parents[2])) / 'eos/cli/data_checks_TEST.d'
+
+
+def analysis_document(*, analysis_id='2026-01', title='Title', description='Description', authors=None):
+    return {
+        'metadata': {
+            'id': analysis_id,
+            'title': title,
+            'description': description,
+            'authors': [{'name': name} for name in (authors or ['Jane Doe'])],
+        },
+    }
+
+
+def zenodo_document(*, dataset_id='2026-01', analysis_id='2026-01', description='Description', creators=None):
+    return {
+        'title': f'EOS/DATA-{dataset_id}: Supplementary material for EOS/ANALYSIS-{analysis_id}',
+        'description': description,
+        'creators': [{'name': name} for name in (creators or ['Jane Doe'])],
+    }
+
+
+class Dataset:
+    def __init__(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self._temporary.name)
+
+    def close(self):
+        self._temporary.cleanup()
+
+    def yaml(self, relative, document):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(document, sort_keys=False), encoding='utf-8')
+        return path
+
+    def text(self, relative, text):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding='utf-8')
+        return path
+
+    def json(self, document):
+        (self.root / '.zenodo.json').write_text(json.dumps(document), encoding='utf-8')
+
+    def valid(self, **kwargs):
+        document = analysis_document(**kwargs)
+        self.yaml('analysis.yaml', document)
+        metadata = document['metadata']
+        self.json(zenodo_document(
+            analysis_id=metadata['id'],
+            description=metadata['description'],
+            creators=[author['name'] for author in metadata['authors']],
+        ))
+
+    def run(self, *, files=(), main=None):
+        context = CheckContext(self.root, tuple(Path(path) for path in files), Path(main) if main else None)
+        return run_checks(create_check_factory(), context, scope=CheckScope.BASIC), context
+
+
+class DatasetTestCase(unittest.TestCase):
+    def setUp(self):
+        self.dataset = Dataset()
+
+    def tearDown(self):
+        self.dataset.close()
+
+
+class InfrastructureTests(unittest.TestCase):
+    def test_factory_rejects_duplicate_and_unknown_registration(self):
+        factory = CheckFactory()
+        factory.declare('one', scope=CheckScope.BASIC)
+        with self.assertRaises(ValueError):
+            factory.declare('one', scope=CheckScope.BASIC)
+        with self.assertRaises(KeyError):
+            factory.register('unknown', lambda _context: ())
+        factory.register('one', lambda _context: ())
+        with self.assertRaises(ValueError):
+            factory.register('one', lambda _context: ())
+
+    def test_runner_continues_after_check_error_and_reports_infrastructure_failure(self):
+        factory = CheckFactory()
+        factory.declare('broken', scope=CheckScope.BASIC)
+        factory.register('broken', lambda _context: (_ for _ in ()).throw(RuntimeError('boom')))
+        factory.declare('independent', scope=CheckScope.BASIC)
+        factory.register('independent', lambda _context: [Finding('independent', Severity.INFO, 'ran')])
+        result = CheckRunner(factory, scope=CheckScope.BASIC).run(CheckContext(Path('.')))
+        self.assertEqual([finding.message for finding in result.findings], ['ran'])
+        self.assertEqual(result.exit_status, ExitStatus.USAGE_OR_INFRASTRUCTURE)
+        self.assertIn("check 'broken' failed", result.failure)
+
+    def test_runner_rejects_missing_checks_and_non_findings(self):
+        missing = CheckFactory()
+        missing.declare('missing', scope=CheckScope.BASIC)
+        self.assertEqual(CheckRunner(missing, scope=CheckScope.BASIC).run(CheckContext('.')).exit_status, 2)
+        invalid = CheckFactory()
+        invalid.declare('invalid', scope=CheckScope.BASIC)
+        invalid.register('invalid', lambda _context: ['not a finding'])
+        self.assertEqual(CheckRunner(invalid, scope=CheckScope.BASIC).run(CheckContext('.')).exit_status, 2)
+
+    def test_factory_orders_prerequisites_and_rejects_invalid_graphs(self):
+        calls = []
+        factory = CheckFactory()
+        factory.declare('dependent', scope=CheckScope.BASIC, needs=('prerequisite',))
+        factory.register('dependent', lambda _context: calls.append('dependent') or ())
+        factory.declare('prerequisite', scope=CheckScope.BASIC)
+        factory.register('prerequisite', lambda _context: calls.append('prerequisite') or ())
+        self.assertEqual(CheckRunner(factory, scope=CheckScope.BASIC).run(CheckContext('.')).exit_status, 0)
+        self.assertEqual(calls, ['prerequisite', 'dependent'])
+
+        unknown = CheckFactory()
+        unknown.declare('check', scope=CheckScope.BASIC, needs=('missing',))
+        unknown.register('check', lambda _context: ())
+        with self.assertRaisesRegex(ValueError, 'unknown prerequisite'):
+            unknown.checks(scope=CheckScope.BASIC)
+
+        cyclic = CheckFactory()
+        cyclic.declare('one', scope=CheckScope.BASIC, needs=('two',))
+        cyclic.declare('two', scope=CheckScope.BASIC, needs=('one',))
+        cyclic.register('one', lambda _context: ())
+        cyclic.register('two', lambda _context: ())
+        with self.assertRaisesRegex(ValueError, 'cyclic check prerequisites'):
+            cyclic.checks(scope=CheckScope.BASIC)
+
+    def test_runner_does_not_run_dependents_after_prerequisite_failure(self):
+        calls = []
+        factory = CheckFactory()
+        factory.declare('broken', scope=CheckScope.BASIC)
+        factory.register('broken', lambda _context: 1 / 0)
+        factory.declare('dependent', scope=CheckScope.BASIC, needs=('broken',))
+        factory.register('dependent', lambda _context: calls.append('dependent') or ())
+        factory.declare('independent', scope=CheckScope.BASIC)
+        factory.register('independent', lambda _context: calls.append('independent') or ())
+        result = CheckRunner(factory, scope=CheckScope.BASIC).run(CheckContext('.'))
+        self.assertEqual(result.exit_status, 2)
+        self.assertEqual(calls, ['independent'])
+        self.assertIn('did not run because prerequisite', result.failure)
+
+    def test_missing_cache_state_is_an_infrastructure_failure(self):
+        factory = CheckFactory()
+        factory.declare('prerequisite', scope=CheckScope.BASIC)
+        factory.register('prerequisite', lambda _context: ())
+        factory.declare('metadata', scope=CheckScope.BASIC, needs=('prerequisite',))
+        factory.register('metadata', check_analysis_metadata)
+        result = CheckRunner(factory, scope=CheckScope.BASIC).run(CheckContext('.'))
+        self.assertEqual(result.exit_status, 2)
+        self.assertIn('KeyError', result.failure)
+
+    def test_renderer_order_summary_and_exit_outcomes(self):
+        findings = (
+            Finding('first', Severity.WARNING, 'warning'),
+            Finding('second', Severity.INFO, 'information'),
+        )
+        result = CheckResult(findings)
+        rendered = PlainTextRenderer().render(result)
+        self.assertLess(rendered.index('[first]'), rendered.index('[second]'))
+        self.assertIn('Summary: 0 error(s), 1 warning(s), 1 info finding(s).', rendered)
+        self.assertEqual(result.exit_status, 0)
+        self.assertEqual(CheckResult((Finding('bad', Severity.ERROR, 'error'),)).exit_status, 1)
+        self.assertEqual(CheckResult(failure='failed').exit_status, 2)
+
+    def test_name_normalization(self):
+        self.assertEqual(_normalize_name('  DOE,  Jane-Mary '), 'jane mary doe')
+        self.assertEqual(_normalize_name('Ａlice O\N{COMBINING DIAERESIS}zil'), _normalize_name('Alice \N{LATIN SMALL LETTER O WITH DIAERESIS}zil'))
+        self.assertNotEqual(_normalize_name('Jose'), _normalize_name('Jos\N{LATIN SMALL LETTER E WITH ACUTE}'))
+
+
+class SelectionTests(DatasetTestCase):
+    def test_missing_root_analysis(self):
+        result, _ = self.dataset.run()
+        self.assertEqual(result.exit_status, 1)
+        self.assertIn('supply every analysis file explicitly', result.findings[0].message)
+
+    def test_valid_sole_root_is_automatically_main_and_does_not_mutate(self):
+        source = FIXTURES / 'valid'
+        before = {path.name: path.read_bytes() for path in source.iterdir()}
+        context = CheckContext(source)
+        first = run_checks(create_check_factory(), context, scope=CheckScope.BASIC)
+        second = run_checks(create_check_factory(), CheckContext(source), scope=CheckScope.BASIC)
+        self.assertEqual(first.exit_status, 0)
+        self.assertEqual(context.main_analysis_path, (source / 'analysis.yaml').resolve())
+        self.assertEqual(first.findings, second.findings)
+        self.assertEqual(before, {path.name: path.read_bytes() for path in source.iterdir()})
+
+    def test_invalid_findings_have_stable_check_order_and_summary_counts(self):
+        self.dataset.text('analysis.yaml', 'metadata: [')
+        self.dataset.text('.zenodo.json', '{')
+        first, _ = self.dataset.run()
+        second, _ = self.dataset.run()
+        self.assertEqual(first.findings, second.findings)
+        self.assertEqual(
+            [finding.check_id for finding in first.findings],
+            [
+                'analysis-metadata.parse',
+                'analysis-metadata.consistency',
+                'zenodo-metadata.basic',
+                'authors.creator-consistency',
+            ],
+        )
+        rendered = PlainTextRenderer().render(first)
+        self.assertIn('Summary: 2 error(s), 0 warning(s), 2 info finding(s).', rendered)
+
+    def test_explicit_one_and_multiple_file_selection(self):
+        self.dataset.yaml('one.yaml', analysis_document())
+        self.dataset.yaml('nested/two.yml', analysis_document())
+        self.dataset.json(zenodo_document())
+        one, one_context = self.dataset.run(files=['one.yaml'])
+        many, many_context = self.dataset.run(files=['one.yaml', 'nested/two.yml'], main='nested/two.yml')
+        self.assertEqual(one.exit_status, 0)
+        self.assertEqual(one_context.main_analysis_path, (self.dataset.root / 'one.yaml').resolve())
+        self.assertEqual(many.exit_status, 0)
+        self.assertEqual(many_context.main_analysis_path, (self.dataset.root / 'nested/two.yml').resolve())
+
+    def test_multiple_requires_included_main(self):
+        self.dataset.yaml('one.yaml', analysis_document())
+        self.dataset.yaml('two.yaml', analysis_document())
+        self.dataset.json(zenodo_document())
+        missing, _ = self.dataset.run(files=['one.yaml', 'two.yaml'])
+        outside, _ = self.dataset.run(files=['one.yaml', 'two.yaml'], main='three.yaml')
+        self.assertTrue(any('require --main-analysis-file' in f.message for f in missing.findings))
+        self.assertTrue(any('must identify one' in f.message for f in outside.findings))
+
+    def test_duplicate_outside_non_file_and_wrong_extension(self):
+        self.dataset.valid()
+        self.dataset.text('directory.yaml/child', 'x')
+        self.dataset.text('analysis.txt', 'x')
+        outside = self.dataset.root.parent / 'outside.yaml'
+        cases = [
+            (['analysis.yaml', './analysis.yaml'], 'duplicated'),
+            ([outside], 'outside'),
+            (['directory.yaml'], 'regular file'),
+            (['analysis.txt'], '.yaml or .yml'),
+        ]
+        for paths, message in cases:
+            with self.subTest(paths=paths):
+                result, _ = self.dataset.run(files=paths)
+                self.assertEqual(result.exit_status, 1)
+                self.assertTrue(any(message in finding.message for finding in result.findings))
+
+    def test_conflicting_main_for_single_file(self):
+        self.dataset.valid()
+        self.dataset.yaml('other.yaml', analysis_document())
+        result, _ = self.dataset.run(files=['analysis.yaml'], main='other.yaml')
+        self.assertTrue(any('conflicts' in finding.message for finding in result.findings))
+
+
+class AnalysisMetadataTests(DatasetTestCase):
+    def test_empty_malformed_and_non_mapping_yaml(self):
+        self.dataset.json(zenodo_document())
+        for text, message in [('', 'top-level mapping'), ('metadata: [', 'Cannot parse YAML'), ('- item\n', 'top-level mapping')]:
+            with self.subTest(text=text):
+                self.dataset.text('analysis.yaml', text)
+                result, _ = self.dataset.run()
+                self.assertTrue(any(message in finding.message for finding in result.findings))
+                self.assertTrue(any('Skipped' in finding.message for finding in result.findings))
+
+    def test_absent_and_malformed_metadata_fields(self):
+        self.dataset.json(zenodo_document())
+        documents = [
+            ({}, 'metadata must be a mapping'),
+            ({'metadata': {'authors': [{'name': 'Jane Doe'}]}}, 'metadata.id'),
+            ({'metadata': {'id': '2026-01', 'authors': 'Jane Doe'}}, 'authors must be a list'),
+            ({'metadata': {'id': '2026-01', 'authors': [{}]}}, 'authors[0].name'),
+            (analysis_document(title=''), 'metadata.title'),
+            (analysis_document(description=' '), 'metadata.description'),
+        ]
+        for document, message in documents:
+            with self.subTest(message=message):
+                self.dataset.yaml('analysis.yaml', document)
+                result, _ = self.dataset.run()
+                self.assertEqual(result.exit_status, 1)
+                self.assertTrue(any(message in finding.message for finding in result.findings))
+
+    def test_author_entries_match_runtime_metadata_schema(self):
+        self.dataset.json(zenodo_document())
+        invalid_authors = [
+            ({'name': 'Jane Doe', 'orcid': '0000-0000-0000-0000'}, "Unknown key 'orcid'"),
+            ({'name': 'Jane Doe', 'affiliation': 7}, 'affiliation must be a string'),
+            ({'name': 'Jane Doe', 'email': []}, 'email must be a string'),
+        ]
+        for author, expected in invalid_authors:
+            with self.subTest(author=author):
+                document = analysis_document()
+                document['metadata']['authors'] = [author]
+                self.dataset.yaml('analysis.yaml', document)
+                result, _ = self.dataset.run()
+                self.assertEqual(result.exit_status, 1)
+                self.assertTrue(any(expected in finding.message for finding in result.findings))
+
+    def test_analysis_id_boundaries_and_revisions(self):
+        for analysis_id, valid in [('0000-00', True), ('9999-99', True), ('2026-01v2', False), ('26-01', False), ('2026-1', False)]:
+            with self.subTest(analysis_id=analysis_id):
+                self.dataset.valid(analysis_id=analysis_id)
+                result, _ = self.dataset.run()
+                self.assertEqual(result.exit_status == 0, valid)
+
+    def test_inconsistent_ids_and_author_sets(self):
+        self.dataset.yaml('one.yaml', analysis_document(authors=['Jane Doe', 'John Roe']))
+        self.dataset.yaml('two.yaml', analysis_document(analysis_id='2026-02', authors=['Jane Doe']))
+        self.dataset.json(zenodo_document(creators=['Jane Doe', 'John Roe']))
+        result, _ = self.dataset.run(files=['one.yaml', 'two.yaml'], main='one.yaml')
+        messages = [finding.message for finding in result.findings]
+        self.assertTrue(any('differs from common ID' in message for message in messages))
+        self.assertTrue(any('author set differs' in message for message in messages))
+
+    def test_author_order_is_ignored_but_duplicates_and_ambiguity_are_errors(self):
+        self.dataset.json(zenodo_document(creators=['Jane Doe', 'John Roe']))
+        self.dataset.yaml('one.yaml', analysis_document(authors=['Jane Doe', 'John Roe']))
+        self.dataset.yaml('two.yaml', analysis_document(authors=['John Roe', 'Jane Doe']))
+        result, _ = self.dataset.run(files=['one.yaml', 'two.yaml'], main='one.yaml')
+        self.assertEqual(result.exit_status, 0)
+        self.dataset.yaml('two.yaml', analysis_document(authors=['Jane Doe', 'Jane-Doe']))
+        duplicate, _ = self.dataset.run(files=['one.yaml', 'two.yaml'], main='one.yaml')
+        self.assertEqual(duplicate.exit_status, 1)
+        self.dataset.yaml('two.yaml', analysis_document(authors=['J. Doe', 'John Roe']))
+        ambiguous, _ = self.dataset.run(files=['one.yaml', 'two.yaml'], main='one.yaml')
+        self.assertEqual(ambiguous.exit_status, 1)
+
+
+class ZenodoTests(DatasetTestCase):
+    def test_missing_malformed_and_non_object_json(self):
+        self.dataset.yaml('analysis.yaml', analysis_document())
+        missing, _ = self.dataset.run()
+        self.assertTrue(any('missing' in finding.message for finding in missing.findings))
+        self.dataset.text('.zenodo.json', '{')
+        malformed, _ = self.dataset.run()
+        self.assertTrue(any('Cannot parse JSON' in finding.message for finding in malformed.findings))
+        self.dataset.json([])
+        non_object, _ = self.dataset.run()
+        self.assertTrue(any('JSON object' in finding.message for finding in non_object.findings))
+
+    def test_initial_and_revision_dataset_ids(self):
+        self.dataset.yaml('analysis.yaml', analysis_document())
+        for dataset_id, valid in [('2026-01', True), ('2026-01v2', True), ('2026-01v19', True), ('2026-01v1', False), ('2026-1', False)]:
+            with self.subTest(dataset_id=dataset_id):
+                self.dataset.json(zenodo_document(dataset_id=dataset_id))
+                result, _ = self.dataset.run()
+                self.assertEqual(result.exit_status == 0, valid)
+
+    def test_title_wrapper_and_embedded_analysis_id(self):
+        self.dataset.valid()
+        document = zenodo_document()
+        document['title'] = 'EOS/DATA-2026-01 - Supplementary material for EOS/ANALYSIS-2026-01'
+        self.dataset.json(document)
+        wrapper, _ = self.dataset.run()
+        self.assertTrue(any('exactly match' in finding.message for finding in wrapper.findings))
+        self.dataset.json(zenodo_document(analysis_id='2026-02'))
+        mismatch, _ = self.dataset.run()
+        self.assertTrue(any("expected '2026-01'" in finding.message for finding in mismatch.findings))
+
+    def test_description_equality_is_exact(self):
+        self.dataset.valid(description='Line one\nLine two')
+        equal, _ = self.dataset.run()
+        self.assertEqual(equal.exit_status, 0)
+        self.dataset.json(zenodo_document(description='Line one\nLine two '))
+        different, _ = self.dataset.run()
+        self.assertTrue(any('does not exactly equal' in finding.message for finding in different.findings))
+
+    def test_missing_or_invalid_creators(self):
+        self.dataset.yaml('analysis.yaml', analysis_document())
+        for creators in [None, [], [{}], [{'name': '---'}]]:
+            document = zenodo_document()
+            document['creators'] = creators
+            self.dataset.json(document)
+            result, _ = self.dataset.run()
+            self.assertTrue(any('creators' in finding.message for finding in result.findings))
+
+
+class CreatorConsistencyTests(DatasetTestCase):
+    def test_normalized_names_are_reused_between_checks(self):
+        self.dataset.valid()
+        with mock.patch(
+            'eos.cli.data_checks._normalize_name',
+            wraps=_normalize_name,
+        ) as normalize:
+            result, _ = self.dataset.run()
+        self.assertEqual(result.exit_status, 0)
+        self.assertEqual(normalize.call_count, 2)
+
+    def test_exact_family_given_case_whitespace_punctuation_and_unicode(self):
+        authors = ['Jane Mary Doe', 'Alice \N{LATIN SMALL LETTER O WITH DIAERESIS}zil']
+        self.dataset.valid(authors=authors)
+        self.dataset.json(zenodo_document(creators=['DOE, jane-mary', '  Alice  O\N{COMBINING DIAERESIS}zil ']))
+        result, _ = self.dataset.run()
+        self.assertEqual(result.exit_status, 0)
+
+    def test_diacritics_initials_order_and_compound_surnames_are_ambiguous(self):
+        cases = [
+            ('Jos\N{LATIN SMALL LETTER E WITH ACUTE} Perez', 'Jose Perez'),
+            ('Jane Doe', 'J Doe'),
+            ('Jane Mary Doe', 'Doe Jane Mary'),
+            ('Jean Van Dyke', 'J Van Dyke'),
+        ]
+        for author, creator in cases:
+            with self.subTest(author=author, creator=creator):
+                self.dataset.valid(authors=[author])
+                self.dataset.json(zenodo_document(creators=[creator]))
+                result, _ = self.dataset.run()
+                warnings = [finding for finding in result.findings if finding.severity is Severity.WARNING]
+                self.assertEqual(result.exit_status, 0)
+                self.assertTrue(warnings)
+                self.assertIsNotNone(warnings[0].question)
+
+    def test_non_unique_ambiguous_candidates_remain_warnings(self):
+        self.dataset.valid(authors=['Jane Doe', 'Janet Doe'])
+        self.dataset.json(zenodo_document(creators=['J Doe']))
+        result, _ = self.dataset.run()
+        warnings = [finding for finding in result.findings if finding.severity is Severity.WARNING]
+        self.assertEqual(len(warnings), 2)
+        self.assertEqual(result.exit_status, 0)
+
+    def test_definite_missing_and_additional_creators(self):
+        self.dataset.valid(authors=['Jane Doe', 'John Roe'])
+        self.dataset.json(zenodo_document(creators=['Jane Doe', 'Alice Poe']))
+        result, _ = self.dataset.run()
+        errors = [finding.message for finding in result.findings if finding.severity is Severity.ERROR]
+        self.assertTrue(any('missing from Zenodo' in message for message in errors))
+        self.assertTrue(any('not an analysis author' in message for message in errors))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/eos/cli/data_checks_dataset.py
+++ b/python/eos/cli/data_checks_dataset.py
@@ -1,0 +1,569 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+import html
+import inspect
+import os
+from pathlib import Path, PurePosixPath
+import re
+import string
+from typing import Any
+from urllib.parse import unquote, urlsplit
+
+import yaml
+
+from ..diagnostic import Severity
+from .data_checks import (
+    CacheKey, CheckContext, CheckFactory, CheckScope, Finding,
+    _finding, _relative_path, _usable_string,
+)
+
+
+MAX_FILE_SIZE = 100 * 1024 * 1024
+MAX_DATASET_SIZE = 1024 * 1024 * 1024
+_ORCID = re.compile(r'^(\d{4})-(\d{4})-(\d{4})-(\d{3}[\dX])$')
+_MARKDOWN_TARGET = re.compile(r'!?\[[^\]]*\]\((?:<([^>]+)>|([^\s)]+))(?:\s+[^)]*)?\)')
+_HTML_TARGET = re.compile(r'''(?:href|src)\s*=\s*["']([^"']+)["']''', re.IGNORECASE)
+_RECOGNIZED_OUTPUT_TYPES = frozenset({
+    'DynestyResults', 'ImportanceSamples', 'MarkovChain', 'MixtureDensity', 'Mode',
+    'NabuLikelihood', 'PMCSampler', 'Prediction', 'SampleMask',
+})
+
+
+@dataclass(frozen=True)
+class FileInventoryEntry:
+    path: Path
+    size: int
+
+
+def _inventory(context: CheckContext) -> tuple[FileInventoryEntry, ...]:
+    cached = context.cache.get(CacheKey.FILE_INVENTORY)
+    if cached is not None:
+        return tuple(cached)
+
+    root = context.dataset_root
+    entries: list[FileInventoryEntry] = []
+    for current, directories, files in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        directories[:] = sorted(
+            directory for directory in directories
+            if not (current_path == root and directory == '.git')
+            and not (current_path / directory).is_symlink()
+        )
+        for filename in sorted(files):
+            path = current_path / filename
+            try:
+                if not path.is_symlink() and path.is_file():
+                    entries.append(FileInventoryEntry(path.relative_to(root), path.stat().st_size))
+            except OSError:
+                continue
+    result = tuple(sorted(entries, key=lambda entry: entry.path.as_posix()))
+    context.cache[CacheKey.FILE_INVENTORY] = result
+    return result
+
+
+def _valid_orcid(value: str) -> bool:
+    match = _ORCID.fullmatch(value)
+    if match is None:
+        return False
+    digits = ''.join(match.groups())
+    total = 0
+    for digit in digits[:15]:
+        total = (total + int(digit)) * 2
+    remainder = (12 - total % 11) % 11
+    expected = 'X' if remainder == 10 else str(remainder)
+    return digits[-1] == expected
+
+
+def check_zenodo_completeness(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'zenodo-metadata.completeness'
+    document = context.cache.get(CacheKey.ZENODO_METADATA)
+    if not isinstance(document, Mapping):
+        yield _finding(check_id, Severity.INFO, 'Skipped because Zenodo metadata is invalid.')
+        return
+    path = context.dataset_root / '.zenodo.json'
+    if document.get('upload_type') != 'dataset':
+        yield _finding(
+            check_id, Severity.ERROR, 'upload_type must be exactly "dataset".',
+            path=path, details={'field': 'upload_type'},
+        )
+    for field_name in ('title', 'description', 'license'):
+        if not _usable_string(document.get(field_name)):
+            yield _finding(
+                check_id, Severity.ERROR, f'{field_name} must be a nonempty string.',
+                path=path, details={'field': field_name},
+            )
+
+    creators = document.get('creators')
+    if isinstance(creators, list):
+        for index, creator in enumerate(creators):
+            if not isinstance(creator, Mapping):
+                continue
+            if not _usable_string(creator.get('affiliation')):
+                yield _finding(
+                    check_id, Severity.ERROR,
+                    f'creators[{index}].affiliation must be a nonempty string.',
+                    path=path, details={'field': f'creators[{index}].affiliation'},
+                )
+            if 'orcid' in creator and (not isinstance(creator['orcid'], str) or not _valid_orcid(creator['orcid'])):
+                yield _finding(
+                    check_id, Severity.ERROR, f'creators[{index}].orcid must be a valid ORCID.',
+                    path=path,
+                    details={
+                        'field': f'creators[{index}].orcid', 'value': creator.get('orcid'),
+                    },
+                )
+
+    grants = document.get('grants')
+    if not isinstance(grants, list):
+        yield _finding(
+            check_id, Severity.ERROR, 'grants must be a list (an empty list is permitted).',
+            path=path, details={'field': 'grants'},
+        )
+        return
+    grant_ids: list[str] = []
+    malformed = False
+    for index, grant in enumerate(grants):
+        if not isinstance(grant, Mapping) or not _usable_string(grant.get('id')):
+            malformed = True
+            yield _finding(
+                check_id, Severity.ERROR, f'grants[{index}].id must be a nonempty string.',
+                path=path, details={'field': f'grants[{index}].id'},
+            )
+        else:
+            grant_ids.append(grant['id'].strip())
+    if not malformed:
+        yield _finding(
+            check_id, Severity.WARNING, 'Grant completeness has not been confirmed.',
+            path=path, details={'grant_ids': tuple(grant_ids)},
+        )
+
+
+def _figure_files(context: CheckContext) -> dict[PurePosixPath, list[str]]:
+    figures: dict[PurePosixPath, list[str]] = defaultdict(list)
+    for entry in _inventory(context):
+        parts = entry.path.parts
+        if len(parts) < 2 or parts[0] != 'figures':
+            continue
+        suffix = entry.path.suffix.lower()
+        if not suffix:
+            continue
+        figures[PurePosixPath(entry.path.with_suffix('').as_posix())].append(suffix)
+    return dict(sorted(figures.items(), key=lambda item: item[0].as_posix()))
+
+
+def _readme_targets(text: str) -> list[str]:
+    markdown = [first or second for first, second in _MARKDOWN_TARGET.findall(text)]
+    return markdown + _HTML_TARGET.findall(text)
+
+
+def _local_target(value: str) -> tuple[PurePosixPath | None, bool]:
+    value = html.unescape(value.strip())
+    split = urlsplit(value)
+    if split.scheme or split.netloc or not split.path:
+        return None, False
+    raw = unquote(split.path).replace('\\', '/')
+    path = PurePosixPath(raw.lstrip('/'))
+    normalized: list[str] = []
+    for part in path.parts:
+        if part in ('', '.'):
+            continue
+        if part == '..':
+            if not normalized:
+                return None, True
+            normalized.pop()
+        else:
+            normalized.append(part)
+    return PurePosixPath(*normalized), False
+
+
+def check_readme_figures(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'figures.readme'
+    path = context.dataset_root / 'README.md'
+    figures = _figure_files(context)
+    if not path.is_file() or path.is_symlink():
+        yield _finding(check_id, Severity.ERROR, 'Required root README.md is missing.', path=path)
+        targets: list[str] = []
+    else:
+        try:
+            targets = _readme_targets(path.read_text(encoding='utf-8'))
+        except (OSError, UnicodeError) as error:
+            yield _finding(check_id, Severity.ERROR, f'Cannot read README.md: {error}', path=path)
+            targets = []
+
+    references: Counter[tuple[PurePosixPath, str]] = Counter()
+    for target in targets:
+        local, traversal = _local_target(target)
+        if traversal:
+            yield _finding(
+                check_id, Severity.ERROR,
+                f'README reference traverses outside the dataset root: {target}',
+                path=Path('README.md'), details={'target': target},
+            )
+            continue
+        if local is None or len(local.parts) < 2 or local.parts[0] != 'figures' or not local.suffix:
+            continue
+        references[(local.with_suffix(''), local.suffix.lower())] += 1
+
+    for stem, suffixes in figures.items():
+        suffix_set = set(suffixes)
+        if '.pdf' not in suffix_set:
+            yield _finding(
+                check_id, Severity.ERROR, 'Physical figure has no PDF representation.',
+                path=Path(stem.as_posix()), details={'figure': stem.as_posix()},
+            )
+        if '.png' not in suffix_set:
+            yield _finding(
+                check_id, Severity.WARNING, 'Physical figure has no PNG representation.',
+                path=Path(stem.as_posix()), details={'figure': stem.as_posix()},
+            )
+        for suffix in sorted(suffix_set - {'.pdf', '.png'}):
+            yield _finding(
+                check_id, Severity.WARNING, f'Physical figure uses additional format {suffix}.',
+                path=Path(stem.as_posix() + suffix),
+                details={'figure': stem.as_posix(), 'format': suffix},
+            )
+        if not any(reference_stem == stem for reference_stem, _suffix in references):
+            yield _finding(
+                check_id, Severity.ERROR, 'Physical figure is not listed in README.md.',
+                path=Path(stem.as_posix()), details={'figure': stem.as_posix()},
+            )
+        duplicate_count = sum(
+            max(0, count - 1)
+            for (reference_stem, _suffix), count in references.items()
+            if reference_stem == stem
+        )
+        if duplicate_count:
+            yield _finding(
+                check_id, Severity.WARNING,
+                'Logical figure is listed redundantly in README.md.', path=Path('README.md'),
+                details={'figure': stem.as_posix(), 'duplicate_count': duplicate_count},
+            )
+
+
+def check_analysis_figures(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'figures.analysis-declarations'
+    if (
+        not context.cache.get(CacheKey.ANALYSIS_METADATA_VALID, False)
+        or not context.cache.get(CacheKey.ANALYSIS_CONSISTENCY_VALID, False)
+    ):
+        yield _finding(
+            check_id, Severity.INFO,
+            'Skipped because not all selected analysis files passed validation.',
+        )
+        return
+    documents = context.cache.get(CacheKey.ANALYSIS_DOCUMENTS)
+    if not isinstance(documents, Mapping):
+        yield _finding(check_id, Severity.INFO, 'Skipped because analysis documents are invalid.')
+        return
+    available = {entry.path.as_posix() for entry in _inventory(context)}
+    for analysis_path in context.analysis_paths:
+        document = documents[analysis_path]
+        figures = document.get('figures', [])
+        if not isinstance(figures, list):
+            yield _finding(
+                check_id, Severity.ERROR, 'figures must be a list.',
+                path=_relative_path(context.dataset_root, analysis_path),
+                details={'field': 'figures'},
+            )
+            continue
+        for index, figure in enumerate(figures):
+            name = figure.get('name') if isinstance(figure, Mapping) else None
+            if not _usable_string(name):
+                yield _finding(
+                    check_id, Severity.ERROR,
+                    f'figures[{index}].name must be a nonempty string.',
+                    path=_relative_path(context.dataset_root, analysis_path),
+                    details={'field': f'figures[{index}].name'},
+                )
+                continue
+            stem, traversal = _local_target(f'figures/{name}')
+            details = {'analysis_path': _relative_path(context.dataset_root, analysis_path).as_posix(), 'figure': name}
+            if traversal or stem is None or stem.parts[0] != 'figures':
+                yield _finding(
+                    check_id, Severity.ERROR, f'Invalid declared figure name: {name}',
+                    path=_relative_path(context.dataset_root, analysis_path), details=details,
+                )
+                continue
+            for suffix, severity in (('.pdf', Severity.ERROR), ('.png', Severity.WARNING)):
+                expected = stem.as_posix() + suffix
+                if expected not in available:
+                    yield _finding(
+                        check_id, severity,
+                        f'Declared figure is missing its {suffix[1:].upper()} file.',
+                        path=Path(expected), details={**details, 'output_path': expected},
+                    )
+
+
+def check_dataset_sizes(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'dataset.size'
+    inventory = _inventory(context)
+    total = sum(entry.size for entry in inventory)
+    for entry in inventory:
+        if entry.size > MAX_FILE_SIZE:
+            yield _finding(
+                check_id, Severity.ERROR, f'File exceeds 100 MiB ({entry.size} bytes).',
+                path=entry.path,
+                details={'size_bytes': entry.size, 'limit_bytes': MAX_FILE_SIZE},
+            )
+    yield _finding(check_id, Severity.INFO, f'Dataset contains exactly {total} bytes.', details={'total_bytes': total})
+    if total > MAX_DATASET_SIZE:
+        yield _finding(
+            check_id, Severity.WARNING,
+            'Dataset exceeds 1 GiB; remove unnecessary importance samples and posterior predictions.',
+            details={'total_bytes': total, 'limit_bytes': MAX_DATASET_SIZE},
+        )
+
+
+def _normalize_output_path(template: str, arguments: Mapping[str, Any]) -> tuple[PurePosixPath | None, str | None]:
+    try:
+        fields = [field for _literal, field, _spec, _conversion in string.Formatter().parse(template) if field]
+        if any('.' in field or '[' in field for field in fields):
+            return None, 'attribute and item access are not permitted in output templates'
+        rendered = template.format(**arguments).replace('\\', '/')
+    except (KeyError, ValueError, TypeError, IndexError) as error:
+        return None, str(error)
+    path = PurePosixPath(rendered)
+    if path.is_absolute() or any(part in ('', '..') for part in path.parts):
+        return None, 'output path is absolute or traverses outside the dataset root'
+    return path, None
+
+
+def _output_template_patterns(templates: Mapping[str, str]) -> tuple[re.Pattern, ...]:
+    patterns = []
+    for template in templates.values():
+        if not template.startswith('data/'):
+            continue
+        try:
+            parts = string.Formatter().parse(template)
+            expression = ''.join(
+                re.escape(literal) + ('[^/]+' if field is not None else '')
+                for literal, field, _spec, _conversion in parts
+            )
+        except ValueError:
+            continue
+        patterns.append(re.compile(f'^{expression}$'))
+    return tuple(patterns)
+
+
+def _recognized_outputs(
+    context: CheckContext,
+    templates: Mapping[str, str],
+) -> tuple[PurePosixPath, ...]:
+    results: list[PurePosixPath] = []
+    layout_patterns = _output_template_patterns(templates)
+    for entry in _inventory(context):
+        if entry.path.name != 'description.yaml' or not entry.path.parts or entry.path.parts[0] != 'data':
+            continue
+        try:
+            document = yaml.safe_load((context.dataset_root / entry.path).read_text(encoding='utf-8'))
+        except (OSError, UnicodeError, yaml.YAMLError):
+            continue
+        if not isinstance(document, Mapping):
+            continue
+        output = PurePosixPath(entry.path.parent.as_posix())
+        if (
+            document.get('type') in _RECOGNIZED_OUTPUT_TYPES
+            or any(pattern.fullmatch(output.as_posix()) for pattern in layout_patterns)
+        ):
+            results.append(output)
+    return tuple(sorted(set(results), key=lambda path: path.as_posix()))
+
+
+def check_reproducible_outputs(context: CheckContext) -> Iterable[Finding]:
+    check_id = 'outputs.reproducibility'
+    if (
+        not context.cache.get(CacheKey.ANALYSIS_METADATA_VALID, False)
+        or not context.cache.get(CacheKey.ANALYSIS_CONSISTENCY_VALID, False)
+    ):
+        yield _finding(
+            check_id, Severity.INFO,
+            'Skipped because not all selected analysis files passed validation.',
+        )
+        return
+    documents = context.cache.get(CacheKey.ANALYSIS_DOCUMENTS)
+    if not isinstance(documents, Mapping):
+        yield _finding(check_id, Severity.INFO, 'Skipped because analysis documents are invalid.')
+        return
+    from .. import tasks as task_registry
+    from ..analysis_file_description import InvalidComponent, TaskComponent
+
+    templates = task_registry.task_output_templates()
+    available_files = {entry.path.as_posix() for entry in _inventory(context)}
+    available_directories = {
+        PurePosixPath(*PurePosixPath(path).parts[:index]).as_posix()
+        for path in available_files
+        for index in range(1, len(PurePosixPath(path).parts))
+    }
+    claims: dict[PurePosixPath, list[dict[str, str]]] = defaultdict(list)
+    for analysis_path in context.analysis_paths:
+        document = documents[analysis_path]
+        steps = document.get('steps', [])
+        if steps is None:
+            steps = []
+        if not isinstance(steps, list):
+            yield _finding(
+                check_id, Severity.ERROR, 'steps must be a list.',
+                path=_relative_path(context.dataset_root, analysis_path),
+                details={'field': 'steps'},
+            )
+            continue
+        for step_index, step in enumerate(steps):
+            if not isinstance(step, Mapping):
+                yield _finding(
+                    check_id, Severity.ERROR, f'steps[{step_index}] must be a mapping.',
+                    path=_relative_path(context.dataset_root, analysis_path),
+                )
+                continue
+            step_id = step.get('id', str(step_index))
+            defaults = step.get('default_arguments', {})
+            task_entries = step.get('tasks', [])
+            if not isinstance(defaults, Mapping) or not isinstance(task_entries, list):
+                yield _finding(
+                    check_id, Severity.ERROR,
+                    f'Step {step_id} has malformed defaults or tasks.',
+                    path=_relative_path(context.dataset_root, analysis_path),
+                    details={'step': step_id},
+                )
+                continue
+            for task in task_entries:
+                if not isinstance(task, Mapping):
+                    yield _finding(
+                        check_id, Severity.ERROR, 'Task invocation must be a mapping.',
+                        path=_relative_path(context.dataset_root, analysis_path),
+                        details={'analysis_path': _relative_path(
+                            context.dataset_root, analysis_path,
+                        ).as_posix(), 'step': str(step_id)},
+                    )
+                    continue
+                raw_task_name = task.get('task')
+                raw_arguments = task.get('arguments', {})
+                if (
+                    not isinstance(raw_task_name, str)
+                    or not isinstance(raw_arguments, Mapping)
+                    or not all(isinstance(key, str) for key in raw_arguments)
+                ):
+                    yield _finding(
+                        check_id, Severity.ERROR, 'Task name or arguments are malformed.',
+                        path=_relative_path(context.dataset_root, analysis_path),
+                        details={'analysis_path': _relative_path(
+                            context.dataset_root, analysis_path,
+                        ).as_posix(), 'step': str(step_id)},
+                    )
+                    continue
+                task_component = TaskComponent.from_dict(**task)
+                task_name = getattr(task_component, 'task', None)
+                details = {
+                    'analysis_path': _relative_path(
+                        context.dataset_root, analysis_path,
+                    ).as_posix(),
+                    'step': str(step_id),
+                    'task': str(task_name),
+                }
+                if task_name not in templates:
+                    yield _finding(
+                        check_id, Severity.ERROR, f'Unknown task {task_name!r}.',
+                        path=_relative_path(context.dataset_root, analysis_path),
+                        details=details,
+                    )
+                    continue
+                template = templates[task_name]
+                if not template or not template.startswith('data/'):
+                    continue
+                function = task_registry._tasks[task_name]
+                arguments = {
+                    name: parameter.default
+                    for name, parameter in inspect.signature(function).parameters.items()
+                    if parameter.default is not inspect.Parameter.empty
+                }
+                task_defaults = defaults.get(task_name, {})
+                task_arguments = getattr(task_component, 'arguments', {})
+                if isinstance(task_component, InvalidComponent):
+                    task_arguments = {}
+                if (
+                    not isinstance(task_defaults, Mapping)
+                    or not all(isinstance(key, str) for key in task_defaults)
+                    or not isinstance(task_arguments, Mapping)
+                ):
+                    yield _finding(
+                        check_id, Severity.ERROR,
+                        f'Task {task_name!r} has malformed arguments.',
+                        path=_relative_path(context.dataset_root, analysis_path), details=details,
+                    )
+                    continue
+                default_component = TaskComponent.from_dict(
+                    task=task_name, arguments=dict(task_defaults),
+                )
+                if isinstance(default_component, InvalidComponent):
+                    yield _finding(
+                        check_id, Severity.ERROR,
+                        f'Task {task_name!r} has malformed default arguments.',
+                        path=_relative_path(context.dataset_root, analysis_path), details=details,
+                    )
+                    continue
+                task_defaults = default_component.arguments
+                arguments.update(task_defaults)
+                arguments.update(task_arguments)
+                output, error = _normalize_output_path(template, arguments)
+                if error is not None:
+                    yield _finding(
+                        check_id, Severity.ERROR,
+                        f'Cannot expand output template for task {task_name!r}: {error}.',
+                        path=_relative_path(context.dataset_root, analysis_path),
+                        details={**details, 'template': template},
+                    )
+                    continue
+                details['output_path'] = output.as_posix()
+                claims[output].append(details)
+                if output.as_posix() not in available_directories and output.as_posix() not in available_files:
+                    yield _finding(
+                        check_id, Severity.ERROR, 'Expected task output is absent.',
+                        path=Path(output.as_posix()), details=details,
+                    )
+
+    for output, output_claims in sorted(claims.items(), key=lambda item: item[0].as_posix()):
+        analysis_paths = {claim['analysis_path'] for claim in output_claims}
+        if len(analysis_paths) > 1:
+            yield _finding(
+                check_id, Severity.ERROR, 'Separate analysis files claim the same output.',
+                path=Path(output.as_posix()),
+                details={'output_path': output.as_posix(), 'claims': tuple(output_claims)},
+            )
+    claimed = set(claims)
+    for output in _recognized_outputs(context, templates):
+        if output not in claimed:
+            yield _finding(
+                check_id, Severity.ERROR,
+                'Recognized EOS output object is not claimed by any analysis step.',
+                path=Path(output.as_posix()), details={'output_path': output.as_posix()},
+            )
+
+
+def register_dataset_checks(factory: CheckFactory) -> None:
+    checks = (
+        ('zenodo-metadata.completeness', ('zenodo-metadata.basic',), check_zenodo_completeness),
+        ('figures.readme', ('analysis-files.selection',), check_readme_figures),
+        ('figures.analysis-declarations', ('analysis-metadata.parse',), check_analysis_figures),
+        ('dataset.size', ('analysis-files.selection',), check_dataset_sizes),
+        ('outputs.reproducibility', ('analysis-metadata.parse',), check_reproducible_outputs),
+    )
+    for name, needs, function in checks:
+        factory.declare(name, scope=CheckScope.COMPLETE, needs=needs)
+        factory.register(name, function)

--- a/python/eos/cli/data_checks_dataset_TEST.py
+++ b/python/eos/cli/data_checks_dataset_TEST.py
@@ -1,0 +1,366 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import yaml
+
+from eos.cli.data import create_check_factory
+from eos.cli.data_checks import CacheKey, CheckContext, CheckScope, Severity, run_checks
+from eos.cli.data_checks_dataset import (
+    FileInventoryEntry,
+    MAX_DATASET_SIZE,
+    MAX_FILE_SIZE,
+    _valid_orcid,
+    check_dataset_sizes,
+)
+from eos.tasks import task_output_templates
+
+
+def analysis_document(*, figures=None, steps=None):
+    result = {
+        'metadata': {
+            'id': '2026-01',
+            'title': 'Title',
+            'description': 'Description',
+            'authors': [{'name': 'Jane Doe'}],
+        },
+    }
+    if figures is not None:
+        result['figures'] = figures
+    if steps is not None:
+        result['steps'] = steps
+    return result
+
+
+def zenodo_document(**updates):
+    result = {
+        'title': 'EOS/DATA-2026-01: Supplementary material for EOS/ANALYSIS-2026-01',
+        'description': 'Description',
+        'upload_type': 'dataset',
+        'license': 'CC-BY-4.0',
+        'creators': [{'name': 'Jane Doe', 'affiliation': 'Example University'}],
+        'grants': [],
+    }
+    result.update(updates)
+    return result
+
+
+class Dataset:
+    def __init__(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def close(self):
+        self.temporary.cleanup()
+
+    def write(self, relative, content=''):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding='utf-8')
+        return path
+
+    def yaml(self, relative, document):
+        return self.write(relative, yaml.safe_dump(document, sort_keys=False))
+
+    def valid(self, *, analysis=None, zenodo=None, readme='# Dataset\n'):
+        self.yaml('analysis.yaml', analysis or analysis_document())
+        self.write('.zenodo.json', json.dumps(zenodo or zenodo_document()))
+        self.write('README.md', readme)
+
+    def run(self, *, paths=(), main=None):
+        context = CheckContext(
+            self.root,
+            tuple(Path(path) for path in paths),
+            Path(main) if main else None,
+        )
+        return run_checks(create_check_factory(), context, scope=CheckScope.COMPLETE), context
+
+
+class DatasetCheckTestCase(unittest.TestCase):
+    def setUp(self):
+        self.dataset = Dataset()
+
+    def tearDown(self):
+        self.dataset.close()
+
+
+class ZenodoCompletenessTests(DatasetCheckTestCase):
+    def test_complete_metadata_warns_only_for_unconfirmed_grants(self):
+        self.dataset.valid(zenodo=zenodo_document(grants=[{'id': 'EU-123'}], extra='kept'))
+        result, _ = self.dataset.run()
+        warnings = [finding for finding in result.findings if finding.check_id == 'zenodo-metadata.completeness']
+        self.assertEqual(result.exit_status, 0)
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0].severity, Severity.WARNING)
+        self.assertEqual(warnings[0].details['grant_ids'], ('EU-123',))
+
+    def test_required_fields_affiliation_and_grant_structure(self):
+        documents = (
+            (zenodo_document(upload_type='publication'), 'upload_type'),
+            (zenodo_document(license=' '), 'license'),
+            (zenodo_document(creators=[{'name': 'Jane Doe'}]), 'affiliation'),
+            (zenodo_document(grants={}), 'grants must be a list'),
+            (zenodo_document(grants=[{}]), 'grants[0].id'),
+        )
+        for document, expected in documents:
+            with self.subTest(expected=expected):
+                self.dataset.valid(zenodo=document)
+                result, _ = self.dataset.run()
+                self.assertEqual(result.exit_status, 1)
+                self.assertTrue(any(expected in finding.message for finding in result.findings))
+
+    def test_orcid_shape_checksum_and_final_x(self):
+        self.assertTrue(_valid_orcid('0000-0002-1825-0097'))
+        self.assertTrue(_valid_orcid('0000-0002-1694-233X'))
+        self.assertFalse(_valid_orcid('0000-0002-1825-0098'))
+        self.assertFalse(_valid_orcid('0000000218250097'))
+        for orcid, valid in (
+            ('0000-0002-1825-0097', True),
+            ('0000-0002-1694-233X', True),
+            ('0000-0002-1825-0098', False),
+            ('bad', False),
+        ):
+            document = zenodo_document(creators=[{
+                'name': 'Jane Doe', 'affiliation': 'Institute', 'orcid': orcid,
+            }])
+            self.dataset.valid(zenodo=document)
+            result, _ = self.dataset.run()
+            self.assertEqual(not any('orcid' in finding.message for finding in result.findings), valid)
+
+
+class ReadmeFigureTests(DatasetCheckTestCase):
+    def test_markdown_html_nested_query_fragment_and_external_references(self):
+        readme = '''
+![one](figures/nested/one.pdf?download=1)
+<img src="/figures/nested/one.png#preview">
+[external](https://example.test/figures/ignored.pdf)
+'''
+        self.dataset.valid(readme=readme)
+        self.dataset.write('figures/nested/one.pdf')
+        self.dataset.write('figures/nested/one.png')
+        result, _ = self.dataset.run()
+        messages = [finding.message for finding in result.findings if finding.check_id == 'figures.readme']
+        self.assertFalse(any('not listed' in message for message in messages))
+        self.assertFalse(any('redundantly' in message for message in messages))
+
+    def test_missing_readme_pdf_png_other_format_duplicates_and_traversal(self):
+        self.dataset.valid(readme='![one](figures/one.pdf)\n![again](figures/one.pdf)\n[x](../outside.pdf)')
+        self.dataset.write('figures/one.png')
+        self.dataset.write('figures/one.svg')
+        result, _ = self.dataset.run()
+        messages = [finding.message for finding in result.findings if finding.check_id == 'figures.readme']
+        for expected in ('no PDF', 'additional format', 'redundantly', 'traverses outside'):
+            self.assertTrue(any(expected in message for message in messages), expected)
+        (self.dataset.root / 'README.md').unlink()
+        missing, _ = self.dataset.run()
+        self.assertTrue(any('README.md is missing' in finding.message for finding in missing.findings))
+
+    def test_unlisted_and_missing_png(self):
+        self.dataset.valid()
+        self.dataset.write('figures/one.pdf')
+        result, _ = self.dataset.run()
+        messages = [finding.message for finding in result.findings if finding.check_id == 'figures.readme']
+        self.assertTrue(any('no PNG' in message for message in messages))
+        self.assertTrue(any('not listed' in message for message in messages))
+
+    def test_declared_figures_across_selected_analysis_files(self):
+        one = analysis_document(figures=[{'name': 'one'}])
+        two = analysis_document(figures=[{'name': 'nested/two'}])
+        self.dataset.valid(analysis=one, readme='![one](figures/one.pdf)\n![two](figures/nested/two.pdf)')
+        self.dataset.yaml('two.yaml', two)
+        self.dataset.write('figures/one.pdf')
+        self.dataset.write('figures/one.png')
+        self.dataset.write('figures/nested/two.pdf')
+        result, _ = self.dataset.run(paths=('analysis.yaml', 'two.yaml'), main='analysis.yaml')
+        findings = [finding for finding in result.findings if finding.check_id == 'figures.analysis-declarations']
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].severity, Severity.WARNING)
+        self.assertEqual(findings[0].details['analysis_path'], 'two.yaml')
+        self.assertEqual(findings[0].details['output_path'], 'figures/nested/two.png')
+
+
+class SizeTests(unittest.TestCase):
+    def result(self, sizes):
+        context = CheckContext(Path('.'))
+        context.cache[CacheKey.FILE_INVENTORY] = tuple(
+            FileInventoryEntry(Path(f'file-{index}'), size)
+            for index, size in enumerate(sizes)
+        )
+        return tuple(check_dataset_sizes(context))
+
+    def test_file_threshold_boundaries(self):
+        for size, error in ((MAX_FILE_SIZE - 1, False), (MAX_FILE_SIZE, False), (MAX_FILE_SIZE + 1, True)):
+            with self.subTest(size=size):
+                findings = self.result((size,))
+                self.assertEqual(any(finding.severity is Severity.ERROR for finding in findings), error)
+
+    def test_total_threshold_boundaries_and_exact_info(self):
+        for total, warning in ((MAX_DATASET_SIZE - 1, False), (MAX_DATASET_SIZE, False), (MAX_DATASET_SIZE + 1, True)):
+            with self.subTest(total=total):
+                findings = self.result((MAX_FILE_SIZE,) * (total // MAX_FILE_SIZE) + (total % MAX_FILE_SIZE,))
+                total_finding = next(finding for finding in findings if finding.severity is Severity.INFO)
+                self.assertEqual(total_finding.details['total_bytes'], total)
+                oversized = [finding for finding in findings if finding.severity is Severity.WARNING]
+                self.assertEqual(bool(oversized), warning)
+                if oversized:
+                    self.assertIn('importance samples and posterior predictions', oversized[0].message)
+
+
+class ReproducibleOutputTests(DatasetCheckTestCase):
+    def output(self, relative, output_type='MarkovChain'):
+        self.dataset.yaml(f'{relative}/description.yaml', {'type': output_type})
+
+    def step(self, task='sample-mcmc', arguments=None, defaults=None, step_id='sample'):
+        return {
+            'title': 'Sample', 'id': step_id,
+            'default_arguments': defaults or {},
+            'tasks': [{'task': task, 'arguments': arguments or {}}],
+        }
+
+    def test_task_templates_are_introspected_from_decorator_registry(self):
+        templates = task_output_templates()
+        self.assertEqual(templates['sample-mcmc'], 'data/{posterior}/mcmc-{chain:04}')
+        self.assertEqual(templates['predict-observables'], 'data/{posterior}/pred-{prediction}')
+
+    def test_valid_claimed_output_and_step_defaults(self):
+        step = self.step(arguments={'posterior': 'p'}, defaults={'sample-mcmc': {'chain': 7}})
+        self.dataset.valid(analysis=analysis_document(steps=[step]))
+        self.output('data/p/mcmc-0007')
+        result, _ = self.dataset.run()
+        findings = [finding for finding in result.findings if finding.check_id == 'outputs.reproducibility']
+        self.assertEqual(findings, [])
+
+    def test_missing_expected_unclaimed_and_missing_steps(self):
+        self.dataset.valid(analysis=analysis_document(steps=[self.step(arguments={'posterior': 'p', 'chain': 1})]))
+        self.output('data/p/mcmc-0002')
+        result, _ = self.dataset.run()
+        messages = [finding.message for finding in result.findings if finding.check_id == 'outputs.reproducibility']
+        self.assertTrue(any('Expected task output is absent' in message for message in messages))
+        self.assertTrue(any('not claimed' in message for message in messages))
+        self.dataset.valid(analysis=analysis_document())
+        missing_steps, _ = self.dataset.run()
+        self.assertTrue(any('not claimed' in finding.message for finding in missing_steps.findings))
+
+    def test_unexpandable_template_and_cross_analysis_collision(self):
+        self.dataset.valid(analysis=analysis_document(steps=[self.step(arguments={'posterior': 'p'})]))
+        invalid, _ = self.dataset.run()
+        self.assertTrue(any('Cannot expand output template' in finding.message for finding in invalid.findings))
+
+        with mock.patch('eos.tasks.task_output_templates', return_value={'sample-mcmc': 'data/{posterior!bad}'}):
+            malformed, _ = self.dataset.run()
+        self.assertTrue(any('Cannot expand output template' in finding.message for finding in malformed.findings))
+
+        shared_step = self.step(arguments={'posterior': 'p', 'chain': 1})
+        self.dataset.yaml('analysis.yaml', analysis_document(steps=[shared_step]))
+        self.dataset.yaml('two.yaml', analysis_document(steps=[shared_step]))
+        self.output('data/p/mcmc-0001')
+        collision, _ = self.dataset.run(paths=('analysis.yaml', 'two.yaml'), main='analysis.yaml')
+        finding = next(finding for finding in collision.findings if 'claim the same output' in finding.message)
+        self.assertEqual(finding.details['output_path'], 'data/p/mcmc-0001')
+
+    def test_legacy_argument_alias_and_description_without_type(self):
+        step = self.step(arguments={'posterior': 'p', 'CHAIN-IDX': 3})
+        self.dataset.valid(analysis=analysis_document(steps=[step]))
+        self.dataset.yaml('data/p/mcmc-0003/description.yaml', {'parameters': []})
+        result, _ = self.dataset.run()
+        findings = [finding for finding in result.findings if finding.check_id == 'outputs.reproducibility']
+        self.assertEqual(findings, [])
+
+    def test_step_default_argument_alias_is_normalized(self):
+        step = self.step(
+            arguments={'posterior': 'p'},
+            defaults={'sample-mcmc': {'CHAIN-IDX': 4}},
+        )
+        self.dataset.valid(analysis=analysis_document(steps=[step]))
+        self.dataset.yaml('data/p/mcmc-0004/description.yaml', {'type': 'MarkovChain'})
+        result, _ = self.dataset.run()
+        findings = [
+            finding for finding in result.findings
+            if finding.check_id == 'outputs.reproducibility'
+        ]
+        self.assertEqual(findings, [])
+
+
+class IntegrationTests(DatasetCheckTestCase):
+    def test_analysis_dependent_checks_skip_when_any_selected_file_is_invalid(self):
+        self.dataset.valid()
+        self.dataset.write('broken.yaml', 'metadata: [')
+        result, _ = self.dataset.run(
+            paths=('analysis.yaml', 'broken.yaml'), main='analysis.yaml',
+        )
+        self.assertEqual(result.exit_status, 1)
+        self.assertIsNone(result.failure)
+        skipped = {
+            finding.check_id: finding
+            for finding in result.findings
+            if finding.check_id in (
+                'figures.analysis-declarations', 'outputs.reproducibility',
+            )
+        }
+        self.assertEqual(set(skipped), {
+            'figures.analysis-declarations', 'outputs.reproducibility',
+        })
+        self.assertTrue(all(finding.severity is Severity.INFO for finding in skipped.values()))
+
+        inconsistent = analysis_document()
+        inconsistent['metadata']['authors'] = [{'name': 'John Roe'}]
+        self.dataset.yaml('broken.yaml', inconsistent)
+        result, _ = self.dataset.run(
+            paths=('analysis.yaml', 'broken.yaml'), main='analysis.yaml',
+        )
+        self.assertEqual(result.exit_status, 1)
+        self.assertIsNone(result.failure)
+        skipped_ids = {
+            finding.check_id for finding in result.findings
+            if 'not all selected analysis files passed validation' in finding.message
+        }
+        self.assertEqual(skipped_ids, {
+            'figures.analysis-declarations', 'outputs.reproducibility',
+        })
+
+    def test_registered_order_warning_exit_and_no_mutation(self):
+        self.dataset.valid()
+        before = {path.relative_to(self.dataset.root): path.read_bytes() for path in self.dataset.root.rglob('*') if path.is_file()}
+        result, _ = self.dataset.run()
+        after = {path.relative_to(self.dataset.root): path.read_bytes() for path in self.dataset.root.rglob('*') if path.is_file()}
+        self.assertEqual(result.exit_status, 0)
+        self.assertEqual(before, after)
+        ids = [registered.declaration.name for registered in create_check_factory().checks(scope=CheckScope.COMPLETE)]
+        self.assertLess(ids.index('zenodo-metadata.completeness'), ids.index('figures.readme'))
+        self.assertLess(ids.index('figures.readme'), ids.index('dataset.size'))
+        self.assertTrue(any(finding.severity is Severity.WARNING for finding in result.findings))
+
+    def test_inventory_does_not_follow_symlinks_or_count_git(self):
+        self.dataset.valid()
+        self.dataset.write('.git/large', 'x')
+        outside = self.dataset.root.parent / 'outside-dataset-checks'
+        outside.write_text('secret', encoding='utf-8')
+        try:
+            (self.dataset.root / 'linked').symlink_to(outside)
+            result, _ = self.dataset.run()
+            total = next(finding.details['total_bytes'] for finding in result.findings if finding.check_id == 'dataset.size' and finding.severity is Severity.INFO)
+            expected = sum(path.stat().st_size for path in self.dataset.root.iterdir() if path.is_file() and not path.is_symlink())
+            self.assertEqual(total, expected)
+        finally:
+            outside.unlink()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/eos/cli/data_github.py
+++ b/python/eos/cli/data_github.py
@@ -1,0 +1,339 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""A thin, replaceable wrapper around the GitHub CLI for EOS dataset releases."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+
+
+class GitHubError(RuntimeError):
+    """A focused failure while reading GitHub state."""
+
+
+class GitHubCLIUnavailable(GitHubError):
+    pass
+
+
+class GitHubCommandError(GitHubError):
+    pass
+
+
+class GitHubResponseError(GitHubError):
+    pass
+
+
+@dataclass(frozen=True)
+class GitHubRef:
+    name: str
+    object_id: str
+    object_type: str
+
+
+@dataclass(frozen=True)
+class GitHubTag:
+    name: str
+    object_id: str
+    commit_id: str
+    message: str
+
+
+@dataclass(frozen=True)
+class GitHubRelease:
+    tag_name: str
+    url: str
+
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class GitHubClient:
+    """Typed read operations implemented with ``gh`` argument arrays."""
+
+    def __init__(
+        self,
+        repository: str = 'eos/data',
+        *,
+        executable: str | None = None,
+        runner: Runner = subprocess.run,
+        git_runner: Runner = subprocess.run,
+    ) -> None:
+        self.repository = repository
+        self._executable = executable
+        self._runner = runner
+        self._git_runner = git_runner
+
+    def _gh(self) -> str:
+        executable = self._executable or shutil.which('gh')
+        if executable is None:
+            raise GitHubCLIUnavailable(
+                "GitHub CLI 'gh' is required for release planning but was not found on PATH"
+            )
+        return executable
+
+    def _run(self, arguments: Sequence[str]) -> subprocess.CompletedProcess:
+        command = [self._gh(), *arguments]
+        try:
+            result = self._runner(command, capture_output=True, text=True, check=False)
+        except OSError as error:
+            raise GitHubCommandError(f"cannot execute GitHub CLI: {error}") from error
+        if result.returncode != 0:
+            diagnostic = (result.stderr or result.stdout or '').strip()
+            suffix = f': {diagnostic}' if diagnostic else ''
+            raise GitHubCommandError(f"GitHub CLI command failed ({result.returncode}){suffix}")
+        return result
+
+    def _api_json(
+        self,
+        endpoint: str,
+        *,
+        allow_missing: bool = False,
+        paginate: bool = False,
+        method: str | None = None,
+        fields: Mapping[str, Any] | None = None,
+    ) -> Any:
+        command = [self._gh(), 'api', endpoint]
+        if method is not None:
+            command.extend(('--method', method))
+        if paginate:
+            command.extend(('--paginate', '--slurp'))
+        for key, value in (fields or {}).items():
+            option = '-F' if isinstance(value, (bool, int)) else '-f'
+            rendered = str(value).lower() if isinstance(value, bool) else str(value)
+            command.extend((option, f'{key}={rendered}'))
+        try:
+            result = self._runner(command, capture_output=True, text=True, check=False)
+        except OSError as error:
+            raise GitHubCommandError(f"cannot execute GitHub CLI: {error}") from error
+        if allow_missing and result.returncode == 1 and '404' in (result.stderr or ''):
+            return None
+        if result.returncode != 0:
+            diagnostic = (result.stderr or result.stdout or '').strip()
+            suffix = f': {diagnostic}' if diagnostic else ''
+            raise GitHubCommandError(f"GitHub API read failed ({result.returncode}){suffix}")
+        try:
+            return json.loads(result.stdout)
+        except (TypeError, json.JSONDecodeError) as error:
+            raise GitHubResponseError(f'malformed JSON from GitHub for {endpoint}: {error}') from error
+
+    @staticmethod
+    def _mapping(value: Any, description: str) -> Mapping[str, Any]:
+        if not isinstance(value, Mapping):
+            raise GitHubResponseError(f'unexpected GitHub response for {description}: expected object')
+        return value
+
+    @staticmethod
+    def _string(mapping: Mapping[str, Any], field: str, description: str) -> str:
+        value = mapping.get(field)
+        if not isinstance(value, str) or not value:
+            raise GitHubResponseError(
+                f'unexpected GitHub response for {description}: '
+                f'{field} must be a nonempty string'
+            )
+        return value
+
+    def list_tag_refs(self) -> tuple[GitHubRef, ...]:
+        document = self._api_json(
+            f'repos/{self.repository}/git/matching-refs/tags/', paginate=True,
+        )
+        if not isinstance(document, list):
+            raise GitHubResponseError('unexpected paginated GitHub tag-ref response: expected list')
+        refs = []
+        for page in document:
+            if not isinstance(page, list):
+                raise GitHubResponseError(
+                    'unexpected paginated GitHub tag-ref response: expected each page to be a list'
+                )
+            for item in page:
+                entry = self._mapping(item, 'tag ref')
+                target = self._mapping(entry.get('object'), 'tag ref object')
+                full_name = self._string(entry, 'ref', 'tag ref')
+                object_id = self._string(target, 'sha', 'tag ref object')
+                object_type = self._string(target, 'type', 'tag ref object')
+                if not full_name.startswith('refs/tags/') or full_name == 'refs/tags/':
+                    raise GitHubResponseError(
+                        f"unexpected GitHub tag ref name: '{full_name}'"
+                    )
+                refs.append(GitHubRef(
+                    full_name.removeprefix('refs/tags/'),
+                    object_id,
+                    object_type,
+                ))
+        return tuple(sorted(refs, key=lambda ref: ref.name))
+
+    def get_tag(self, ref: GitHubRef) -> GitHubTag:
+        if ref.object_type != 'tag':
+            raise GitHubResponseError(
+                f"tag '{ref.name}' is lightweight or has unexpected type '{ref.object_type}'"
+            )
+        document = self._mapping(
+            self._api_json(f'repos/{self.repository}/git/tags/{ref.object_id}'),
+            'annotated tag',
+        )
+        target = self._mapping(document.get('object'), 'annotated tag target')
+        if target.get('type') != 'commit':
+            raise GitHubResponseError(f"annotated tag '{ref.name}' does not point to a commit")
+        commit_id = self._string(target, 'sha', 'annotated tag target')
+        message = document.get('message')
+        if not isinstance(message, str):
+            raise GitHubResponseError('annotated-tag response is missing a string message')
+        return GitHubTag(ref.name, ref.object_id, commit_id, message)
+
+    def get_release(self, tag_name: str) -> GitHubRelease | None:
+        document = self._api_json(f'repos/{self.repository}/releases/tags/{tag_name}', allow_missing=True)
+        if document is None:
+            return None
+        entry = self._mapping(document, 'release')
+        actual_tag = entry.get('tag_name')
+        url = entry.get('html_url')
+        if actual_tag != tag_name or not isinstance(url, str):
+            raise GitHubResponseError(f"unexpected release response for tag '{tag_name}'")
+        return GitHubRelease(tag_name, url)
+
+    def get_branch(self, branch_name: str) -> str | None:
+        document = self._api_json(
+            f'repos/{self.repository}/git/ref/heads/{branch_name}', allow_missing=True,
+        )
+        if document is None:
+            return None
+        entry = self._mapping(document, 'branch ref')
+        target = self._mapping(entry.get('object'), 'branch ref object')
+        if target.get('type') != 'commit' or not isinstance(target.get('sha'), str):
+            raise GitHubResponseError(f"unexpected branch response for '{branch_name}'")
+        return target['sha']
+
+    def commit_parents(self, commit_id: str) -> tuple[str, ...]:
+        document = self._mapping(self._api_json(f'repos/{self.repository}/git/commits/{commit_id}'), 'commit')
+        parents = document.get('parents')
+        if not isinstance(parents, list):
+            raise GitHubResponseError(f"commit response for '{commit_id}' has no parent list")
+        result = []
+        for parent in parents:
+            entry = self._mapping(parent, 'commit parent')
+            if not isinstance(entry.get('sha'), str):
+                raise GitHubResponseError('commit parent is missing sha')
+            result.append(entry['sha'])
+        return tuple(result)
+
+    def is_ancestor(self, ancestor: str, descendant: str) -> bool:
+        document = self._mapping(
+            self._api_json(f'repos/{self.repository}/compare/{ancestor}...{descendant}'),
+            'commit comparison',
+        )
+        status = document.get('status')
+        if status not in ('ahead', 'identical', 'behind', 'diverged'):
+            raise GitHubResponseError('commit-comparison response has an unexpected status')
+        return status in ('ahead', 'identical')
+
+    @contextmanager
+    def checkout_tree(self, commit_id: str):
+        """Check out a remote committed tree using read-only ``gh repo clone``."""
+        temporary = Path(tempfile.mkdtemp(prefix='eos-data-publish-'))
+        try:
+            self._run(['repo', 'clone', self.repository, str(temporary), '--', '--no-checkout'])
+            try:
+                result = self._runner(
+                    ['git', 'checkout', '--detach', commit_id], cwd=temporary,
+                    capture_output=True, text=True, check=False,
+                )
+            except OSError as error:
+                raise GitHubCommandError(f'cannot execute Git while checking out tag: {error}') from error
+            if result.returncode != 0:
+                diagnostic = (result.stderr or result.stdout or '').strip()
+                raise GitHubCommandError(f'cannot check out tagged commit {commit_id}: {diagnostic}')
+            yield temporary
+        finally:
+            shutil.rmtree(temporary, ignore_errors=True)
+
+    def transfer_local_tag(
+        self,
+        root: Path,
+        remote_name: str,
+        tag_name: str,
+        expected_old: str | None,
+    ) -> None:
+        arguments = ['git', 'push', '--porcelain']
+        if expected_old is not None:
+            arguments.append(f'--force-with-lease=refs/tags/{tag_name}:{expected_old}')
+        arguments.extend((remote_name, f'refs/tags/{tag_name}:refs/tags/{tag_name}'))
+        try:
+            result = self._git_runner(
+                arguments, cwd=root, capture_output=True, text=True, check=False,
+            )
+        except OSError as error:
+            raise GitHubCommandError(f'cannot execute Git while transferring tag: {error}') from error
+        if result.returncode != 0:
+            diagnostic = (result.stderr or result.stdout or '').strip()
+            suffix = f': {diagnostic}' if diagnostic else ''
+            raise GitHubCommandError(f'tag transfer failed ({result.returncode}){suffix}')
+
+    def create_release(self, tag_name: str, title: str, notes: str) -> GitHubRelease:
+        document = self._mapping(self._api_json(
+            f'repos/{self.repository}/releases',
+            method='POST',
+            fields={'tag_name': tag_name, 'name': title, 'body': notes},
+        ), 'created release')
+        actual_tag = document.get('tag_name')
+        url = document.get('html_url')
+        if actual_tag != tag_name or not isinstance(url, str) or not url:
+            raise GitHubResponseError('created release does not target the requested tag')
+        return GitHubRelease(tag_name, url)
+
+    def create_branch(self, branch_name: str, commit_id: str) -> None:
+        self._create_ref(f'refs/heads/{branch_name}', commit_id)
+
+    def update_branch(self, branch_name: str, commit_id: str, expected_old: str) -> None:
+        temporary = Path(tempfile.mkdtemp(prefix='eos-data-publish-branch-'))
+        try:
+            self._run(['repo', 'clone', self.repository, str(temporary), '--', '--no-checkout'])
+            command = [
+                'git', 'push', '--porcelain',
+                f'--force-with-lease=refs/heads/{branch_name}:{expected_old}',
+                'origin', f'{commit_id}:refs/heads/{branch_name}',
+            ]
+            try:
+                result = self._git_runner(
+                    command, cwd=temporary, capture_output=True, text=True, check=False,
+                )
+            except OSError as error:
+                raise GitHubCommandError(
+                    f'cannot execute Git while advancing branch: {error}'
+                ) from error
+            if result.returncode != 0:
+                diagnostic = (result.stderr or result.stdout or '').strip()
+                suffix = f': {diagnostic}' if diagnostic else ''
+                raise GitHubCommandError(
+                    f'guarded branch update failed ({result.returncode}){suffix}'
+                )
+        finally:
+            shutil.rmtree(temporary, ignore_errors=True)
+
+    def _create_ref(self, ref_name: str, object_id: str) -> None:
+        document = self._mapping(self._api_json(
+            f'repos/{self.repository}/git/refs',
+            method='POST', fields={'ref': ref_name, 'sha': object_id},
+        ), 'created ref')
+        target = self._mapping(document.get('object'), 'created ref object')
+        if document.get('ref') != ref_name or target.get('sha') != object_id:
+            raise GitHubResponseError(f"created ref '{ref_name}' has an unexpected target")

--- a/python/eos/cli/data_github.py
+++ b/python/eos/cli/data_github.py
@@ -329,6 +329,41 @@ class GitHubClient:
         finally:
             shutil.rmtree(temporary, ignore_errors=True)
 
+    def transfer_local_branch(
+        self,
+        root: Path,
+        branch_name: str,
+        commit_id: str,
+        main_commit_id: str,
+        tag_name: str,
+        tag_object_id: str,
+    ) -> None:
+        """Atomically push a new branch after confirming the main and tag refs are unchanged."""
+        command = [
+            'git', 'push', '--porcelain', '--atomic',
+            f'--force-with-lease=refs/heads/main:{main_commit_id}',
+            f'--force-with-lease=refs/tags/{tag_name}:{tag_object_id}',
+            f'--force-with-lease=refs/heads/{branch_name}:',
+            'origin',
+            f'{main_commit_id}:refs/heads/main',
+            f'{tag_object_id}:refs/tags/{tag_name}',
+            f'{commit_id}:refs/heads/{branch_name}',
+        ]
+        try:
+            result = self._git_runner(
+                command, cwd=root, capture_output=True, text=True, check=False,
+            )
+        except OSError as error:
+            raise GitHubCommandError(
+                f'cannot execute Git while transferring registration branch: {error}'
+            ) from error
+        if result.returncode != 0:
+            diagnostic = (result.stderr or result.stdout or '').strip()
+            suffix = f': {diagnostic}' if diagnostic else ''
+            raise GitHubCommandError(
+                f'registration branch transfer failed ({result.returncode}){suffix}'
+            )
+
     def _create_ref(self, ref_name: str, object_id: str) -> None:
         document = self._mapping(self._api_json(
             f'repos/{self.repository}/git/refs',

--- a/python/eos/cli/data_register.py
+++ b/python/eos/cli/data_register.py
@@ -1,0 +1,420 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Planning and execution for ``eos-data register``."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import difflib
+from pathlib import Path, PurePosixPath
+import re
+from typing import Any, Protocol
+
+import yaml
+
+from ..datasets_file_description import DataSetDescription, PublicLikelihoodDescription
+from .data_checks import CacheKey
+from .data_github import GitHubRef, GitHubRelease, GitHubTag
+from .data_release import (
+    LocalGitClient, ReleasePlanningError, TagAnnotation, parse_annotation,
+    parse_data_id, validate_annotation_documents, _run_source_checks,
+)
+
+
+_DOI = re.compile(r'^10\.5281/zenodo\.[0-9]+$')
+_REPOSITORY = re.compile(r'^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')
+
+
+class _RegistryDumper(yaml.SafeDumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False):
+        return super().increase_indent(flow, False)
+
+
+class RegistrationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    data_id: str
+    authors: tuple[str, ...]
+    title: str
+    doi: str
+    likelihoods: tuple[tuple[str, str, str], ...]
+    keywords: tuple[str, ...]
+    eos_version: str
+
+    def as_mapping(self) -> dict[str, Any]:
+        return {
+            'authors': list(self.authors),
+            'title': self.title,
+            'doi': self.doi,
+            'likelihoods': {
+                name: {'filename': filename, 'filetype': filetype}
+                for name, filename, filetype in self.likelihoods
+            },
+            'keywords': list(self.keywords),
+            'eos_version': self.eos_version,
+        }
+
+
+@dataclass(frozen=True)
+class RegisterPlan:
+    repository: str
+    data_id: str
+    tag_object_id: str
+    tag_commit_id: str
+    annotation: TagAnnotation
+    release_url: str
+    main_commit_id: str
+    branch_name: str
+    commit_message: str
+    entry: RegistryEntry
+    original_registry: str
+    updated_registry: str
+    diff: str
+    operations: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RegisterResult:
+    data_id: str
+    branch_name: str
+    commit_id: str
+    completed: tuple[str, ...]
+
+
+class RegisterGitHub(Protocol):
+    def list_tag_refs(self) -> tuple[GitHubRef, ...]: ...
+    def get_tag(self, ref: GitHubRef) -> GitHubTag: ...
+    def get_release(self, tag_name: str) -> GitHubRelease | None: ...
+    def get_branch(self, branch_name: str) -> str | None: ...
+    def checkout_tree(self, commit_id: str): ...
+    def transfer_local_branch(
+        self, root: Path, branch_name: str, commit_id: str, main_commit_id: str,
+        tag_name: str, tag_object_id: str,
+    ) -> None: ...
+
+
+def parse_repository(value: str) -> str:
+    if _REPOSITORY.fullmatch(value) is None:
+        raise RegistrationError("repository must have 'OWNER/REPO' form")
+    return value
+
+
+def parse_doi(value: str) -> str:
+    if _DOI.fullmatch(value) is None:
+        raise RegistrationError("DOI must have '10.5281/zenodo.<record>' form")
+    return value
+
+
+def parse_keywords(values: Sequence[str]) -> tuple[str, ...]:
+    keywords = tuple(value.strip() for value in values)
+    if not keywords or any(not value for value in keywords):
+        raise RegistrationError('at least one nonempty keyword is required')
+    if len(set(keywords)) != len(keywords):
+        raise RegistrationError('keywords must not contain duplicates')
+    return keywords
+
+
+def parse_eos_version(value: str) -> str:
+    result = value.strip()
+    if not result or any(character.isspace() for character in result):
+        raise RegistrationError('EOS version must be a nonempty value without whitespace')
+    return result
+
+
+def parse_likelihoods(values: Sequence[str]) -> tuple[tuple[str, str, str], ...]:
+    result = []
+    names = set()
+    for value in values:
+        fields = value.split(':')
+        if len(fields) != 3 or any(not field.strip() for field in fields):
+            raise RegistrationError(
+                "likelihood must have nonempty 'NAME:FILENAME:FILETYPE' fields"
+            )
+        name, filename, filetype = (field.strip() for field in fields)
+        if name in names:
+            raise RegistrationError(f"duplicate likelihood name '{name}'")
+        try:
+            PublicLikelihoodDescription(filename, filetype)
+        except ValueError as error:
+            raise RegistrationError(str(error)) from error
+        names.add(name)
+        result.append((name, filename, filetype))
+    return tuple(result)
+
+
+def _validate_registry(text: str) -> Mapping[str, Any]:
+    try:
+        document = yaml.safe_load(text)
+    except yaml.YAMLError as error:
+        raise RegistrationError(f'cannot parse remote datasets.yaml: {error}') from error
+    if not isinstance(document, Mapping) or not all(isinstance(key, str) for key in document):
+        raise RegistrationError('remote datasets.yaml must contain a string-keyed mapping')
+    for data_id, raw in document.items():
+        try:
+            parse_data_id(data_id)
+        except ReleasePlanningError as error:
+            raise RegistrationError(f"registry entry ID '{data_id}' is malformed") from error
+        if not isinstance(raw, Mapping):
+            raise RegistrationError(f"registry entry '{data_id}' must be a mapping")
+        required = {'authors', 'title', 'keywords', 'likelihoods'}
+        missing = required - raw.keys()
+        if missing:
+            raise RegistrationError(
+                f"registry entry '{data_id}' is missing {', '.join(sorted(missing))}"
+            )
+        authors = raw['authors']
+        keywords = raw['keywords']
+        likelihoods = raw['likelihoods']
+        if (
+            not isinstance(authors, list) or not authors
+            or not all(isinstance(author, str) and author.strip() for author in authors)
+        ):
+            raise RegistrationError(f"registry entry '{data_id}' has invalid authors")
+        if not isinstance(raw['title'], str) or not raw['title'].strip():
+            raise RegistrationError(f"registry entry '{data_id}' has invalid title")
+        if not isinstance(keywords, list) or not all(
+            isinstance(keyword, str) and keyword.strip() for keyword in keywords
+        ):
+            raise RegistrationError(f"registry entry '{data_id}' has invalid keywords")
+        if not isinstance(likelihoods, Mapping) or not all(
+            isinstance(name, str) and name and isinstance(value, Mapping)
+            for name, value in likelihoods.items()
+        ):
+            raise RegistrationError(f"registry entry '{data_id}' has invalid likelihoods")
+        try:
+            for value in likelihoods.values():
+                PublicLikelihoodDescription.from_dict(**value)
+        except (TypeError, ValueError) as error:
+            raise RegistrationError(f"invalid registry entry '{data_id}': {error}") from error
+        if 'doi' in raw:
+            try:
+                parse_doi(raw['doi'])
+            except (TypeError, RegistrationError) as error:
+                raise RegistrationError(f"invalid registry entry '{data_id}': {error}") from error
+        if 'eos_version' in raw:
+            try:
+                parse_eos_version(raw['eos_version'])
+            except (AttributeError, RegistrationError) as error:
+                raise RegistrationError(f"invalid registry entry '{data_id}': {error}") from error
+        known = {key: raw[key] for key in DataSetDescription.__dataclass_fields__ if key in raw}
+        if 'eos_version' in known:
+            try:
+                DataSetDescription.from_dict(**known)
+            except (TypeError, ValueError) as error:
+                raise RegistrationError(f"invalid registry entry '{data_id}': {error}") from error
+    return document
+
+
+def _updated_registry(text: str, entry: RegistryEntry) -> tuple[str, str]:
+    document = _validate_registry(text)
+    if entry.data_id in document:
+        adjective = 'identical' if document[entry.data_id] == entry.as_mapping() else 'conflicting'
+        raise RegistrationError(f"registry already contains {adjective} ID '{entry.data_id}'")
+    rendered = yaml.dump(
+        {entry.data_id: entry.as_mapping()}, Dumper=_RegistryDumper,
+        sort_keys=False, allow_unicode=True, width=4096,
+    )
+    updated = rendered + ('\n' if text and not text.startswith('\n') else '') + text
+    difference = ''.join(difflib.unified_diff(
+        text.splitlines(keepends=True), updated.splitlines(keepends=True),
+        fromfile='main/datasets.yaml', tofile=f'register-{entry.data_id}/datasets.yaml',
+    ))
+    return updated, difference
+
+
+def _exact_tag(github: RegisterGitHub, data_id: str) -> GitHubTag:
+    refs = [ref for ref in github.list_tag_refs() if ref.name == data_id]
+    if len(refs) != 1:
+        raise RegistrationError(f"exact remote tag '{data_id}' does not exist")
+    if refs[0].object_type != 'tag':
+        raise RegistrationError(f"remote tag '{data_id}' is lightweight")
+    tag = github.get_tag(refs[0])
+    if (
+        tag.name != data_id or tag.object_id != refs[0].object_id
+        or not tag.commit_id or not isinstance(tag.message, str)
+    ):
+        raise RegistrationError(f"remote annotated tag '{data_id}' has inconsistent metadata")
+    return tag
+
+
+def plan_register(
+    data_id: str,
+    *,
+    doi: str,
+    keywords: Sequence[str],
+    eos_version: str,
+    likelihoods: Sequence[str] = (),
+    repository: str = 'eos/data',
+    github: RegisterGitHub,
+    check_factory,
+) -> RegisterPlan:
+    parse_data_id(data_id)
+    repository = parse_repository(repository)
+    doi = parse_doi(doi)
+    keywords = parse_keywords(keywords)
+    eos_version = parse_eos_version(eos_version)
+    likelihoods = parse_likelihoods(likelihoods)
+    tag = _exact_tag(github, data_id)
+    annotation = parse_annotation(tag.message, expected_data_id=data_id)
+    release = github.get_release(data_id)
+    if release is None or release.tag_name != data_id:
+        raise RegistrationError(f"GitHub release for exact tag '{data_id}' does not exist")
+
+    with github.checkout_tree(tag.commit_id) as root:
+        validate_annotation_documents(annotation, root)
+        _result, context = _run_source_checks(
+            root, annotation.analysis_files, annotation.main_analysis_file, check_factory,
+        )
+        metadata = context.cache[CacheKey.ANALYSIS_METADATA][context.main_analysis_path]
+        authors = context.cache[CacheKey.ANALYSIS_AUTHOR_NAMES][context.main_analysis_path]
+        title = metadata['title']
+
+    main_commit = github.get_branch('main')
+    if main_commit is None:
+        raise RegistrationError("remote branch 'main' does not exist")
+    branch_name = f'register-{data_id}'
+    if github.get_branch(branch_name) is not None:
+        raise RegistrationError(f"remote branch '{branch_name}' already exists")
+    with github.checkout_tree(main_commit) as root:
+        registry_path = root / 'datasets.yaml'
+        try:
+            original = registry_path.read_text(encoding='utf-8')
+        except (OSError, UnicodeError) as error:
+            raise RegistrationError(f'cannot read remote main datasets.yaml: {error}') from error
+    entry = RegistryEntry(
+        data_id, tuple(authors), title, doi, tuple(likelihoods), tuple(keywords), eos_version,
+    )
+    updated, difference = _updated_registry(original, entry)
+    message = f'Add {data_id}'
+    return RegisterPlan(
+        repository, data_id, tag.object_id, tag.commit_id, annotation, release.url,
+        main_commit, branch_name, message, entry, original, updated, difference,
+        ('checkout-remote-main', 'create-local-branch', 'update-datasets.yaml',
+         'create-single-commit', 'push-new-branch', 'verify-remote-branch'),
+    )
+
+
+def render_register_plan(plan: RegisterPlan) -> str:
+    entry = yaml.dump(
+        {plan.data_id: plan.entry.as_mapping()}, Dumper=_RegistryDumper,
+        sort_keys=False, allow_unicode=True, width=4096,
+    ).rstrip()
+    lines = [
+        'Register dataset plan (read-only)',
+        f'Repository: {plan.repository}',
+        f'Tag: {plan.data_id}',
+        f'Tag object: {plan.tag_object_id}',
+        f'Tag commit: {plan.tag_commit_id}',
+        f'GitHub release: {plan.release_url}',
+        f'Source main commit: {plan.main_commit_id}',
+        f'Branch: {plan.branch_name}',
+        f'Commit message: {plan.commit_message}',
+        'Prospective registry entry:', entry,
+        'YAML diff:', plan.diff.rstrip(),
+        'Operations:',
+    ]
+    lines.extend(f'{index}. {operation}' for index, operation in enumerate(plan.operations, 1))
+    return '\n'.join(lines) + '\n'
+
+
+def _signature(plan: RegisterPlan) -> tuple[Any, ...]:
+    return (
+        plan.repository, plan.data_id, plan.tag_object_id, plan.tag_commit_id,
+        plan.annotation, plan.release_url, plan.main_commit_id, plan.branch_name,
+        plan.commit_message, plan.entry, plan.original_registry, plan.updated_registry,
+        plan.diff, plan.operations,
+    )
+
+
+def execute_register(
+    plan: RegisterPlan,
+    *,
+    git: LocalGitClient,
+    github: RegisterGitHub,
+    check_factory,
+) -> RegisterResult:
+    fresh = plan_register(
+        plan.data_id, doi=plan.entry.doi, keywords=plan.entry.keywords,
+        eos_version=plan.entry.eos_version,
+        likelihoods=tuple(':'.join(value) for value in plan.entry.likelihoods),
+        repository=plan.repository, github=github, check_factory=check_factory,
+    )
+    if _signature(fresh) != _signature(plan):
+        raise RegistrationError('registration preconditions changed; no writes performed')
+    completed = []
+    try:
+        with github.checkout_tree(plan.main_commit_id) as root:
+            completed.append(f'checkout-main:{plan.main_commit_id}')
+            if github.get_branch('main') != plan.main_commit_id:
+                raise RegistrationError('remote main advanced before registration commit creation')
+            commit_id = git.create_registration_commit(
+                root, plan.branch_name, plan.main_commit_id,
+                plan.updated_registry, plan.commit_message,
+            )
+            completed.append(f'create-commit:{commit_id}')
+            observed_tag = _exact_tag(github, plan.data_id)
+            observed_release = github.get_release(plan.data_id)
+            if (
+                observed_tag.object_id != plan.tag_object_id
+                or observed_tag.commit_id != plan.tag_commit_id
+                or observed_tag.message.rstrip('\n') != plan.annotation.serialize()
+                or observed_release is None
+                or observed_release.tag_name != plan.data_id
+                or observed_release.url != plan.release_url
+            ):
+                raise RegistrationError('published tag or release changed before branch transfer')
+            if github.get_branch('main') != plan.main_commit_id:
+                raise RegistrationError('remote main advanced before registration branch transfer')
+            if github.get_branch(plan.branch_name) is not None:
+                raise RegistrationError(f"remote branch '{plan.branch_name}' appeared before transfer")
+            github.transfer_local_branch(
+                root, plan.branch_name, commit_id, plan.main_commit_id,
+                plan.data_id, plan.tag_object_id,
+            )
+            completed.append(f'push-branch:{plan.branch_name}:{commit_id}')
+        observed_main = github.get_branch('main')
+        observed_tag = _exact_tag(github, plan.data_id)
+        observed_release = github.get_release(plan.data_id)
+        observed_branch = github.get_branch(plan.branch_name)
+        if (
+            observed_main != plan.main_commit_id
+            or observed_tag.object_id != plan.tag_object_id
+            or observed_tag.commit_id != plan.tag_commit_id
+            or observed_tag.message.rstrip('\n') != plan.annotation.serialize()
+            or observed_release is None
+            or observed_release.tag_name != plan.data_id
+            or observed_release.url != plan.release_url
+            or observed_branch != commit_id
+        ):
+            raise RegistrationError(
+                'post-push publication verification failed: '
+                f'main={observed_main or "absent"}, tag={observed_tag.object_id}, '
+                f'release={observed_release.url if observed_release else "absent"}, '
+                f'branch={observed_branch or "absent"}'
+            )
+        completed.append(f'verify-branch:{plan.branch_name}:{commit_id}')
+        return RegisterResult(plan.data_id, plan.branch_name, commit_id, tuple(completed))
+    except Exception as error:
+        state = ', '.join(completed) if completed else 'none'
+        raise RegistrationError(
+            f'registration execution failed: {error}. Completed operations: {state}. '
+            f"Safe recovery: inspect remote branch '{plan.branch_name}' and rerun only after "
+            'reconciling its target; do not delete published release or tag state.'
+        ) from error

--- a/python/eos/cli/data_register_TEST.py
+++ b/python/eos/cli/data_register_TEST.py
@@ -1,0 +1,474 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from contextlib import contextmanager
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from eos.cli import data
+from eos.cli.data_github import (
+    GitHubClient, GitHubCommandError, GitHubRef, GitHubRelease, GitHubTag,
+)
+from eos.cli.data_register import (
+    RegistrationError, execute_register, parse_doi, parse_eos_version,
+    parse_keywords, parse_likelihoods, parse_repository, plan_register,
+    render_register_plan,
+)
+from eos.cli.data_release import LocalGitClient, SourceCheckError, make_annotation
+
+
+def _dataset(root: Path, *, authors=('Jane Doe', 'John Roe')):
+    (root / 'README.md').write_text('# Dataset\n', encoding='utf-8')
+    author_yaml = ''.join(f'    - name: {author}\n' for author in authors)
+    (root / 'analysis.yaml').write_text(
+        'metadata:\n  id: 2025-03\n  title: Main title\n'
+        '  description: Release notes.\n  authors:\n' + author_yaml,
+        encoding='utf-8',
+    )
+    (root / '.zenodo.json').write_text(json.dumps({
+        'title': 'EOS/DATA-2026-01: Supplementary material for EOS/ANALYSIS-2025-03',
+        'description': 'Release notes.',
+        'creators': [
+            {'name': author, 'affiliation': 'Lab'} for author in authors
+        ],
+        'upload_type': 'dataset', 'license': 'CC-BY-4.0', 'grants': [],
+    }), encoding='utf-8')
+
+
+REGISTRY = """2025-01:
+  authors:
+  - Existing Author
+  title: Existing title
+  likelihoods: {}
+  keywords:
+  - existing
+  eos_version: 1.0.0
+  future-field: retained
+"""
+
+
+class FakeGitHub:
+    def __init__(self, tagged: Path, main: Path):
+        annotation = make_annotation('2026-01', '2025-03', ('analysis.yaml',), 'analysis.yaml')
+        self.tag = GitHubTag('2026-01', 'tag-object', 'tag-commit', annotation.serialize())
+        self.roots = {'tag-commit': tagged, 'main-commit': main}
+        self.branches = {'main': 'main-commit'}
+        self.release_url = 'https://example.invalid/release'
+        self.before_push = None
+        self.after_push = None
+        self.calls = []
+
+    def list_tag_refs(self):
+        self.calls.append(('list-tag-refs',))
+        return (GitHubRef('2026-01', 'tag-object', 'tag'),)
+
+    def get_tag(self, ref):
+        self.calls.append(('get-tag', ref.name))
+        return self.tag
+
+    def get_release(self, name):
+        self.calls.append(('get-release', name))
+        return GitHubRelease(name, self.release_url)
+
+    def get_branch(self, name):
+        self.calls.append(('get-branch', name))
+        return self.branches.get(name)
+
+    @contextmanager
+    def checkout_tree(self, commit):
+        self.calls.append(('checkout', commit))
+        yield self.roots[commit]
+
+    def transfer_local_branch(self, root, branch, commit, main, tag_name, tag_object):
+        self.calls.append(('push-branch', branch, commit, main, tag_name, tag_object))
+        if self.before_push is not None:
+            self.before_push()
+        if (
+            branch in self.branches or self.branches.get('main') != main
+            or self.tag.name != tag_name or self.tag.object_id != tag_object
+        ):
+            raise RuntimeError('atomic ref lease rejected')
+        self.branches[branch] = commit
+        if self.after_push is not None:
+            self.after_push()
+
+
+class FakeGit:
+    def __init__(self):
+        self.calls = []
+
+    def create_registration_commit(self, root, branch, parent, text, message):
+        self.calls.append(('create-commit', branch, parent, message, text))
+        return 'registration-commit'
+
+
+class RegisterTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        base = Path(temporary.name)
+        self.tagged, self.main = base / 'tagged', base / 'main'
+        self.tagged.mkdir()
+        self.main.mkdir()
+        _dataset(self.tagged)
+        (self.main / 'datasets.yaml').write_text(REGISTRY, encoding='utf-8')
+        self.github = FakeGitHub(self.tagged, self.main)
+
+    def plan(self, **kwargs):
+        values = {
+            'doi': '10.5281/zenodo.12345', 'keywords': ('flavour', 'fits'),
+            'eos_version': '1.0.20', 'github': self.github,
+            'check_factory': data.create_check_factory(),
+        }
+        values.update(kwargs)
+        return plan_register('2026-01', **values)
+
+    def test_input_parsing(self):
+        self.assertEqual(parse_doi('10.5281/zenodo.123'), '10.5281/zenodo.123')
+        self.assertEqual(parse_keywords(('one', 'two')), ('one', 'two'))
+        self.assertEqual(parse_eos_version('1.0.20'), '1.0.20')
+        self.assertEqual(parse_repository('other/data'), 'other/data')
+        self.assertEqual(
+            parse_likelihoods(('fit:path/to/file:MixtureDensity',)),
+            (('fit', 'path/to/file', 'MixtureDensity'),),
+        )
+        for function, value in (
+            (parse_doi, 'https://doi.org/10.5281/zenodo.1'),
+            (parse_keywords, ('one', 'one')),
+            (parse_eos_version, ' '),
+            (parse_repository, 'data'),
+            (parse_likelihoods, ('fit:file',)),
+            (parse_likelihoods, ('fit:a:MixtureDensity', 'fit:b:NabuLikelihood')),
+        ):
+            with self.subTest(value=value), self.assertRaises(RegistrationError):
+                function(value)
+        self.assertEqual(parse_likelihoods(()), ())
+
+    def test_cli_parser_requires_registry_fields_and_accepts_repeats(self):
+        arguments = [
+            'register', '2026-01', '--doi', '10.5281/zenodo.123',
+            '--keyword', 'one', '--keyword', 'two', '--eos-version', '1.2.3',
+            '--likelihood', 'fit:file:MixtureDensity', '--repo', 'other/data', '--dry-run',
+        ]
+        parsed = data._parser().parse_args(arguments)
+        self.assertEqual(parsed.keyword, ['one', 'two'])
+        self.assertEqual(parsed.likelihood, ['fit:file:MixtureDensity'])
+        self.assertEqual(parsed.repo, 'other/data')
+        self.assertTrue(parsed.dry_run)
+        for missing in ('--doi', '--keyword', '--eos-version'):
+            reduced = [
+                'register', '2026-01', '--doi', '10.5281/zenodo.123',
+                '--keyword', 'one', '--eos-version', '1.2.3',
+            ]
+            index = reduced.index(missing)
+            del reduced[index:index + 2]
+            self.assertEqual(data.main(reduced, stderr=io.StringIO()), 2)
+
+    def test_plan_derives_metadata_and_preserves_registry_bytes(self):
+        plan = self.plan(likelihoods=('fit:result.yaml:MixtureDensity',))
+        self.assertEqual(plan.entry.authors, ('Jane Doe', 'John Roe'))
+        self.assertEqual(plan.entry.title, 'Main title')
+        self.assertEqual(plan.branch_name, 'register-2026-01')
+        self.assertEqual(plan.commit_message, 'Add 2026-01')
+        self.assertTrue(plan.updated_registry.endswith(REGISTRY))
+        self.assertIn('future-field: retained', plan.updated_registry)
+        rendered = render_register_plan(plan)
+        for expected in ('Source main commit: main-commit', 'Prospective registry entry:',
+                         'YAML diff:', 'push-new-branch'):
+            self.assertIn(expected, rendered)
+
+    def test_common_author_set_uses_main_file_order(self):
+        (self.tagged / 'secondary.yaml').write_text(
+            'metadata:\n  id: 2025-03\n  title: Secondary\n'
+            '  description: Release notes.\n  authors:\n'
+            '    - name: John Roe\n    - name: Jane Doe\n',
+            encoding='utf-8',
+        )
+        annotation = make_annotation(
+            '2026-01', '2025-03', ('secondary.yaml', 'analysis.yaml'), 'analysis.yaml',
+        )
+        self.github.tag = GitHubTag('2026-01', 'tag-object', 'tag-commit', annotation.serialize())
+        self.assertEqual(self.plan().entry.authors, ('Jane Doe', 'John Roe'))
+        (self.tagged / 'secondary.yaml').write_text(
+            'metadata:\n  id: 2025-03\n  title: Secondary\n'
+            '  description: Release notes.\n  authors:\n    - name: Jane Doe\n',
+            encoding='utf-8',
+        )
+        with self.assertRaises(SourceCheckError):
+            self.plan()
+
+    def test_rejects_existing_id_malformed_registry_and_branch_conflict(self):
+        valid = self.plan()
+        for contents, message in (
+            (valid.updated_registry, 'already contains'),
+            ('- not-a-mapping\n', 'string-keyed mapping'),
+        ):
+            self.main.joinpath('datasets.yaml').write_text(contents, encoding='utf-8')
+            with self.assertRaisesRegex(RegistrationError, message):
+                self.plan()
+        self.main.joinpath('datasets.yaml').write_text(REGISTRY, encoding='utf-8')
+        self.github.branches['register-2026-01'] = 'other'
+        with self.assertRaisesRegex(RegistrationError, 'already exists'):
+            self.plan()
+
+    def test_release_and_tag_are_mandatory(self):
+        with mock.patch.object(self.github, 'get_release', return_value=None):
+            with self.assertRaisesRegex(RegistrationError, 'release'):
+                self.plan()
+        with mock.patch.object(
+            self.github, 'list_tag_refs',
+            return_value=(GitHubRef('2026-01', 'commit', 'commit'),),
+        ):
+            with self.assertRaisesRegex(RegistrationError, 'lightweight'):
+                self.plan()
+
+    def test_execute_replans_commits_once_pushes_and_verifies(self):
+        plan = self.plan()
+        git = FakeGit()
+        result = execute_register(
+            plan, git=git, github=self.github, check_factory=data.create_check_factory(),
+        )
+        self.assertEqual(result.commit_id, 'registration-commit')
+        self.assertEqual(len(git.calls), 1)
+        writes = [call[0] for call in self.github.calls if call[0] == 'push-branch']
+        self.assertEqual(writes, ['push-branch'])
+        self.assertEqual(self.github.branches['register-2026-01'], 'registration-commit')
+
+    def test_execute_rejects_stale_main_and_branch_race_without_push(self):
+        plan = self.plan()
+        git = FakeGit()
+        self.github.roots['advanced-main'] = self.main
+        self.github.branches['main'] = 'advanced-main'
+        with self.assertRaisesRegex(RegistrationError, 'preconditions changed'):
+            execute_register(
+                plan, git=git, github=self.github, check_factory=data.create_check_factory(),
+            )
+        self.assertEqual(git.calls, [])
+        self.github.branches['main'] = 'main-commit'
+        original = git.create_registration_commit
+        def raced(*arguments):
+            commit = original(*arguments)
+            self.github.branches['register-2026-01'] = 'racing-commit'
+            return commit
+        git.create_registration_commit = raced
+        with self.assertRaisesRegex(RegistrationError, 'appeared before transfer'):
+            execute_register(
+                plan, git=git, github=self.github, check_factory=data.create_check_factory(),
+            )
+        self.assertNotIn('push-branch', [call[0] for call in self.github.calls])
+
+    def test_atomic_push_rejects_main_or_tag_race_after_final_validation(self):
+        for kind in ('main', 'tag'):
+            with self.subTest(kind=kind):
+                self.setUp()
+                plan = self.plan()
+                if kind == 'main':
+                    self.github.before_push = lambda: self.github.branches.__setitem__(
+                        'main', 'racing-main',
+                    )
+                else:
+                    def move_tag():
+                        self.github.tag = GitHubTag(
+                            '2026-01', 'racing-tag', 'tag-commit', self.github.tag.message,
+                        )
+                    self.github.before_push = move_tag
+                with self.assertRaisesRegex(RegistrationError, 'atomic ref lease rejected'):
+                    execute_register(
+                        plan, git=FakeGit(), github=self.github,
+                        check_factory=data.create_check_factory(),
+                    )
+                self.assertNotIn('register-2026-01', self.github.branches)
+
+    def test_post_push_release_race_is_reported_as_partial_failure(self):
+        plan = self.plan()
+        self.github.after_push = lambda: setattr(
+            self.github, 'release_url', 'https://example.invalid/changed-release',
+        )
+        with self.assertRaisesRegex(
+            RegistrationError, 'post-push publication verification failed',
+        ) as caught:
+            execute_register(
+                plan, git=FakeGit(), github=self.github,
+                check_factory=data.create_check_factory(),
+            )
+        self.assertEqual(
+            self.github.branches.get('register-2026-01'), 'registration-commit',
+        )
+        self.assertIn('Completed operations:', str(caught.exception))
+
+    def test_local_git_creates_one_commit_changing_only_registry(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        environment = {
+            **os.environ, 'GIT_AUTHOR_NAME': 'Test', 'GIT_AUTHOR_EMAIL': 'test@example.com',
+            'GIT_COMMITTER_NAME': 'Test', 'GIT_COMMITTER_EMAIL': 'test@example.com',
+        }
+        def git(*arguments):
+            return subprocess.run(
+                ['git', *arguments], cwd=root, env=environment, check=True,
+                capture_output=True, text=True,
+            ).stdout.strip()
+        git('init', '-q')
+        git('config', 'user.name', 'Test')
+        git('config', 'user.email', 'test@example.com')
+        (root / 'datasets.yaml').write_text(REGISTRY, encoding='utf-8')
+        (root / 'untouched').write_text('same\n', encoding='utf-8')
+        git('add', 'datasets.yaml', 'untouched')
+        git('commit', '-q', '-m', 'main')
+        parent = git('rev-parse', 'HEAD')
+        commit = LocalGitClient().create_registration_commit(
+            root, 'register-2026-01', parent, 'new registry\n', 'Add 2026-01',
+        )
+        self.assertEqual(git('show', '-s', '--format=%P', commit), parent)
+        self.assertEqual(git('show', '-s', '--format=%s', commit), 'Add 2026-01')
+        self.assertEqual(git('diff-tree', '--no-commit-id', '--name-only', '-r', commit), 'datasets.yaml')
+
+    def test_cli_dry_run_is_read_only_and_real_run_prints_pr_reminder(self):
+        arguments = [
+            'register', '2026-01', '--doi', '10.5281/zenodo.12345',
+            '--keyword', 'flavour', '--eos-version', '1.0.20',
+        ]
+        git = FakeGit()
+        output = io.StringIO()
+        files_before = self.main.joinpath('datasets.yaml').read_bytes()
+        refs_before = dict(self.github.branches)
+        self.assertEqual(data.main(
+            [*arguments, '--dry-run'], stdout=output, stderr=io.StringIO(),
+            git_client=git, github_client=self.github,
+        ), 0)
+        self.assertEqual(git.calls, [])
+        self.assertNotIn('push-branch', [call[0] for call in self.github.calls])
+        self.assertEqual(self.main.joinpath('datasets.yaml').read_bytes(), files_before)
+        self.assertEqual(self.github.branches, refs_before)
+        output = io.StringIO()
+        self.assertEqual(data.main(
+            arguments, stdout=output, stderr=io.StringIO(),
+            git_client=git, github_client=self.github,
+        ), 0)
+        self.assertIn('Create a pull request', output.getvalue())
+
+    def test_no_pr_capability_exists(self):
+        self.assertFalse(hasattr(self.github, 'create_pull_request'))
+        source = Path(data.__file__).with_name('data_register.py').read_text(encoding='utf-8')
+        self.assertNotIn('gh pr', source)
+        self.assertNotIn('create_pull_request', source)
+
+    def test_github_branch_transfer_uses_guarded_argument_array(self):
+        result = subprocess.CompletedProcess([], 0, stdout='', stderr='')
+        runner = mock.Mock(return_value=result)
+        GitHubClient(executable='unused', git_runner=runner).transfer_local_branch(
+            Path('/checkout'), 'register-2026-01', 'commit-id', 'main-id',
+            '2026-01', 'tag-id',
+        )
+        command = runner.call_args.args[0]
+        self.assertEqual(command[:4], ['git', 'push', '--porcelain', '--atomic'])
+        self.assertIn('--force-with-lease=refs/heads/main:main-id', command)
+        self.assertIn('--force-with-lease=refs/tags/2026-01:tag-id', command)
+        self.assertIn('--force-with-lease=refs/heads/register-2026-01:', command)
+        self.assertEqual(command[-4:], [
+            'origin', 'main-id:refs/heads/main', 'tag-id:refs/tags/2026-01',
+            'commit-id:refs/heads/register-2026-01',
+        ])
+
+    def test_real_atomic_push_does_not_create_branch_after_main_or_tag_race(self):
+        environment = {
+            **os.environ, 'GIT_AUTHOR_NAME': 'Test', 'GIT_AUTHOR_EMAIL': 'test@example.com',
+            'GIT_COMMITTER_NAME': 'Test', 'GIT_COMMITTER_EMAIL': 'test@example.com',
+        }
+        for raced_ref in ('main', 'tag'):
+            with self.subTest(raced_ref=raced_ref):
+                temporary = tempfile.TemporaryDirectory()
+                self.addCleanup(temporary.cleanup)
+                base = Path(temporary.name)
+                remote, seed, client, racer = (
+                    base / 'remote.git', base / 'seed', base / 'client', base / 'racer',
+                )
+                def run(root, *arguments):
+                    return subprocess.run(
+                        ['git', *arguments], cwd=root, env=environment, check=True,
+                        capture_output=True, text=True,
+                    ).stdout.strip()
+                subprocess.run(
+                    ['git', 'init', '--bare', '-q', str(remote)], check=True,
+                    capture_output=True, text=True,
+                )
+                seed.mkdir()
+                run(seed, 'init', '-q')
+                run(seed, 'config', 'user.name', 'Test')
+                run(seed, 'config', 'user.email', 'test@example.com')
+                seed.joinpath('datasets.yaml').write_text(REGISTRY, encoding='utf-8')
+                run(seed, 'add', 'datasets.yaml')
+                run(seed, 'commit', '-q', '-m', 'main')
+                run(seed, 'branch', '-M', 'main')
+                run(seed, 'tag', '-a', '2026-01', '-m', 'dataset')
+                run(seed, 'remote', 'add', 'origin', str(remote))
+                run(seed, 'push', '-q', 'origin', 'main', 'refs/tags/2026-01')
+                subprocess.run(
+                    ['git', 'clone', '-q', '-b', 'main', str(remote), str(client)],
+                    check=True, capture_output=True, text=True,
+                )
+                subprocess.run(
+                    ['git', 'clone', '-q', '-b', 'main', str(remote), str(racer)],
+                    check=True, capture_output=True, text=True,
+                )
+                for checkout in (client, racer):
+                    run(checkout, 'config', 'user.name', 'Test')
+                    run(checkout, 'config', 'user.email', 'test@example.com')
+                expected_main = run(client, 'rev-parse', 'origin/main^{commit}')
+                expected_tag = run(client, 'rev-parse', 'refs/tags/2026-01^{tag}')
+                run(client, 'checkout', '-q', '-b', 'register-2026-01')
+                client.joinpath('datasets.yaml').write_text('registration\n', encoding='utf-8')
+                run(client, 'add', 'datasets.yaml')
+                run(client, 'commit', '-q', '-m', 'Add 2026-01')
+                registration_commit = run(client, 'rev-parse', 'HEAD^{commit}')
+                if raced_ref == 'main':
+                    racer.joinpath('race').write_text('main moved\n', encoding='utf-8')
+                    run(racer, 'add', 'race')
+                    run(racer, 'commit', '-q', '-m', 'race main')
+                    run(racer, 'push', '-q', 'origin', 'HEAD:refs/heads/main')
+                else:
+                    run(racer, 'tag', '-f', '-a', '2026-01', '-m', 'moved dataset')
+                    run(racer, 'push', '-q', '--force', 'origin', 'refs/tags/2026-01')
+                with self.assertRaises(GitHubCommandError):
+                    GitHubClient(executable='unused').transfer_local_branch(
+                        client, 'register-2026-01', registration_commit,
+                        expected_main, '2026-01', expected_tag,
+                    )
+                refs = subprocess.run(
+                    ['git', 'ls-remote', '--heads', str(remote), 'register-2026-01'],
+                    check=True, capture_output=True, text=True,
+                ).stdout
+                self.assertEqual(refs, '')
+
+    def test_missing_gh_is_focused_register_failure(self):
+        arguments = [
+            'register', '2026-01', '--doi', '10.5281/zenodo.12345',
+            '--keyword', 'flavour', '--eos-version', '1.0.20', '--dry-run',
+        ]
+        error = io.StringIO()
+        with mock.patch('shutil.which', return_value=None):
+            self.assertEqual(data.main(arguments, stderr=error), 2)
+        self.assertIn("GitHub CLI 'gh' is required", error.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=5)

--- a/python/eos/cli/data_release.py
+++ b/python/eos/cli/data_release.py
@@ -1,0 +1,880 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Pure release planning for ``eos-data create`` and ``publish``."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import subprocess
+import tempfile
+from types import MappingProxyType
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+import yaml
+
+from .data_checks import (
+    CacheKey, CheckContext, CheckResult, CheckScope, ExitStatus, PlainTextRenderer, run_checks,
+)
+from .data_github import GitHubRef, GitHubRelease, GitHubTag
+
+
+_BASE_ID = re.compile(r'^[0-9]{4}-[0-9]{2}$')
+_DATA_ID = re.compile(r'^(?P<base>[0-9]{4}-[0-9]{2})(?:v(?P<revision>[1-9][0-9]*))?$')
+_SUBJECT = re.compile(
+    r'^EOS/DATA-(?P<data_id>[0-9]{4}-[0-9]{2}(?:v(?:[2-9]|[1-9][0-9]+))?): '
+    r'Supplementary material for EOS/ANALYSIS-(?P<analysis_id>[0-9]{4}-[0-9]{2})$'
+)
+_TRAILER = re.compile(r'^(?P<key>[A-Za-z0-9-]+): (?P<value>.*)$')
+
+
+class ReleasePlanningError(RuntimeError):
+    pass
+
+
+class SourceCheckError(ReleasePlanningError):
+    def __init__(self, result: CheckResult):
+        self.result = result
+        diagnostics = PlainTextRenderer().render(result).strip()
+        super().__init__(
+            f'source dataset check failed with exit status {int(result.exit_status)}:\n{diagnostics}'
+        )
+
+
+class GitError(ReleasePlanningError):
+    pass
+
+
+@dataclass(frozen=True)
+class ResolvedSource:
+    description: str
+    commit_id: str
+    root: Path
+
+
+@dataclass(frozen=True)
+class TargetCheckout:
+    root: Path
+    remote_name: str
+    remote_url: str
+
+
+@dataclass(frozen=True)
+class TagAnnotation:
+    data_id: str
+    analysis_id: str
+    main_analysis_file: PurePosixPath
+    analysis_files: tuple[PurePosixPath, ...]
+    unknown_trailers: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def subject(self) -> str:
+        return (
+            f'EOS/DATA-{self.data_id}: Supplementary material for '
+            f'EOS/ANALYSIS-{self.analysis_id}'
+        )
+
+    def serialize(self) -> str:
+        lines = [
+            self.subject,
+            '',
+            'EOS-Data-Metadata-Version: 1',
+            f'EOS-Analysis-ID: {self.analysis_id}',
+            f'EOS-Main-Analysis-File: {self.main_analysis_file.as_posix()}',
+        ]
+        lines.extend(f'EOS-Analysis-File: {path.as_posix()}' for path in self.analysis_files)
+        lines.extend(f'{key}: {value}' for key, value in self.unknown_trailers)
+        return '\n'.join(lines)
+
+
+@dataclass(frozen=True)
+class FamilyTag:
+    name: str
+    object_id: str
+    commit_id: str
+    parent_commit_id: str | None
+
+
+@dataclass(frozen=True)
+class TagFamily:
+    base_id: str
+    tags: tuple[FamilyTag, ...]
+
+    @property
+    def latest(self) -> FamilyTag | None:
+        return self.tags[-1] if self.tags else None
+
+    @property
+    def next_id(self) -> str:
+        return self.base_id if not self.tags else f'{self.base_id}v{len(self.tags) + 1}'
+
+
+@dataclass(frozen=True)
+class RemoteFamilyState:
+    family: TagFamily
+    remote_tags: tuple[GitHubTag, ...]
+    releases: frozenset[str]
+    branch_commit_id: str | None
+
+
+class OperationType(Enum):
+    PREPARE_LOCAL_BRANCH = 'prepare-local-branch'
+    CREATE_COMMIT = 'create-commit'
+    MOVE_LOCAL_BRANCH = 'move-local-branch'
+    CREATE_ANNOTATED_TAG = 'create-annotated-tag'
+    TRANSFER_TAG = 'transfer-tag'
+    CREATE_RELEASE = 'create-release'
+    CREATE_REMOTE_BRANCH = 'create-remote-branch'
+    ADVANCE_REMOTE_BRANCH = 'advance-remote-branch'
+
+
+@dataclass(frozen=True)
+class PlannedOperation:
+    kind: OperationType
+    ref: str
+    expected_old: str | None = None
+    target: str | None = None
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class CreatePlan:
+    source_description: str
+    source_commit_id: str
+    target: TargetCheckout
+    data_id: str
+    base_branch: str
+    parent_commit_id: str | None
+    analysis_files: tuple[PurePosixPath, ...]
+    main_analysis_file: PurePosixPath
+    commit_message: str
+    annotation: TagAnnotation
+    old_tag_object_id: str | None
+    old_commit_id: str | None
+    check_result: CheckResult
+    operations: tuple[PlannedOperation, ...]
+
+
+@dataclass(frozen=True)
+class PublishPlan:
+    target: TargetCheckout
+    data_id: str
+    base_branch: str
+    tag_object_id: str
+    tag_commit_id: str
+    annotation: TagAnnotation
+    analysis_files: tuple[PurePosixPath, ...]
+    main_analysis_file: PurePosixPath
+    release_title: str
+    release_notes: str
+    branch_commit_id: str | None
+    check_result: CheckResult
+    operations: tuple[PlannedOperation, ...]
+
+
+class GitHubReads(Protocol):
+    def list_tag_refs(self) -> tuple[GitHubRef, ...]: ...
+    def get_tag(self, ref: GitHubRef) -> GitHubTag: ...
+    def get_release(self, tag_name: str) -> GitHubRelease | None: ...
+    def get_branch(self, branch_name: str) -> str | None: ...
+    def commit_parents(self, commit_id: str) -> tuple[str, ...]: ...
+    def is_ancestor(self, ancestor: str, descendant: str) -> bool: ...
+
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class LocalGitClient:
+    """Read-only local Git operations, including temporary checkouts of a source."""
+
+    def __init__(self, *, executable: str = 'git', runner: Runner = subprocess.run) -> None:
+        self.executable = executable
+        self._runner = runner
+
+    def _run(
+        self,
+        arguments: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: Mapping[str, str] | None = None,
+        input_text: str | None = None,
+    ) -> str:
+        command = [self.executable, *arguments]
+        try:
+            keywords = {'cwd': cwd, 'capture_output': True, 'text': True, 'check': False}
+            if env is not None:
+                keywords['env'] = env
+            if input_text is not None:
+                keywords['input'] = input_text
+            result = self._runner(command, **keywords)
+        except OSError as error:
+            raise GitError(f'cannot execute Git: {error}') from error
+        if result.returncode != 0:
+            diagnostic = (result.stderr or result.stdout or '').strip()
+            suffix = f': {diagnostic}' if diagnostic else ''
+            raise GitError(f"Git command failed ({' '.join(arguments[:2])}){suffix}")
+        return result.stdout.strip()
+
+    def target_checkout(self, directory: Path, *, require_clean: bool = True) -> TargetCheckout:
+        requested = directory.resolve()
+        root = Path(self._run(['rev-parse', '--show-toplevel'], cwd=requested)).resolve()
+        if root != requested:
+            raise ReleasePlanningError(f'target must be the Git checkout root: {root}')
+        remotes = self._run(['remote'], cwd=root).splitlines()
+        matches = []
+        for name in remotes:
+            fetch_urls = self._run(['remote', 'get-url', '--all', name], cwd=root).splitlines()
+            push_urls = self._run([
+                'remote', 'get-url', '--push', '--all', name,
+            ], cwd=root).splitlines()
+            if (
+                fetch_urls
+                and push_urls
+                and all(github_repository(url) == 'eos/data' for url in fetch_urls)
+                and all(github_repository(url) == 'eos/data' for url in push_urls)
+            ):
+                matches.append((name, fetch_urls[0]))
+        if not matches:
+            raise ReleasePlanningError("target Git checkout does not identify GitHub repository 'eos/data'")
+        if require_clean and self._run(['status', '--porcelain=v1', '--untracked-files=all'], cwd=root):
+            raise ReleasePlanningError('target Git worktree has modifications or untracked files')
+        name, url = sorted(matches)[0]
+        return TargetCheckout(root, name, url)
+
+    def local_tag_refs(self, target: TargetCheckout) -> Mapping[str, tuple[str, str]]:
+        output = self._run([
+            'for-each-ref', '--format=%(refname) %(objectname) %(*objectname)',
+        ], cwd=target.root)
+        result = {}
+        for line in output.splitlines():
+            fields = line.split()
+            if not fields or not fields[0].startswith('refs/tags/'):
+                continue
+            fields[0] = fields[0].removeprefix('refs/tags/')
+            if len(fields) == 2:
+                result[fields[0]] = (fields[1], '')
+                continue
+            if len(fields) != 3:
+                raise ReleasePlanningError(f'unexpected local tag response: {line}')
+            result[fields[0]] = (fields[1], fields[2])
+        return MappingProxyType(result)
+
+    def local_branch(self, target: TargetCheckout, branch_name: str) -> str | None:
+        output = self._run([
+            'for-each-ref', '--format=%(objectname)', f'refs/heads/{branch_name}',
+        ], cwd=target.root)
+        lines = output.splitlines()
+        if not lines:
+            return None
+        if len(lines) != 1:
+            raise ReleasePlanningError(f"unexpected local branch state for '{branch_name}'")
+        return lines[0]
+
+    @contextmanager
+    def checkout_source(self, source: str | Path) -> Iterator[ResolvedSource]:
+        value = str(source)
+        local = Path(value).expanduser()
+        if local.exists():
+            source_description = str(local.resolve())
+            repository = source_description
+            commit = self._run(['-C', repository, 'rev-parse', '--verify', 'refs/heads/main^{commit}'])
+        else:
+            source_description = value
+            repository = value
+            commit = ''
+        temporary = Path(tempfile.mkdtemp(prefix='eos-data-source-'))
+        try:
+            self._run(['clone', '--no-checkout', '--', repository, str(temporary)])
+            if not commit:
+                commit = self._run(
+                    ['rev-parse', '--verify', 'refs/remotes/origin/main^{commit}'],
+                    cwd=temporary,
+                )
+            self._run(['checkout', '--detach', commit], cwd=temporary)
+            actual = self._run(['rev-parse', 'HEAD^{commit}'], cwd=temporary)
+            yield ResolvedSource(source_description, actual, temporary)
+        finally:
+            shutil.rmtree(temporary, ignore_errors=True)
+
+    @contextmanager
+    def checkout_commit(self, source: str | Path, commit_id: str) -> Iterator[Path]:
+        value = str(source)
+        local = Path(value).expanduser()
+        repository = str(local.resolve()) if local.exists() else value
+        temporary = Path(tempfile.mkdtemp(prefix='eos-data-source-'))
+        try:
+            self._run(['clone', '--no-checkout', '--', repository, str(temporary)])
+            self._run(['checkout', '--detach', commit_id], cwd=temporary)
+            actual = self._run(['rev-parse', 'HEAD^{commit}'], cwd=temporary)
+            if actual != commit_id:
+                raise ReleasePlanningError(
+                    f'source moved while executing: expected {commit_id}, observed {actual}'
+                )
+            yield temporary
+        finally:
+            shutil.rmtree(temporary, ignore_errors=True)
+
+    def create_dataset_commit(
+        self,
+        target: TargetCheckout,
+        source_root: Path,
+        message: str,
+        parent_commit_id: str | None,
+    ) -> str:
+        import os
+
+        descriptor, index_name = tempfile.mkstemp(prefix='eos-data-index-')
+        os.close(descriptor)
+        Path(index_name).unlink()
+        environment = dict(os.environ)
+        environment['GIT_INDEX_FILE'] = index_name
+        git_dir = self._run(['rev-parse', '--git-dir'], cwd=target.root)
+        git_dir_path = (target.root / git_dir).resolve()
+        prefix = [f'--git-dir={git_dir_path}', f'--work-tree={source_root}']
+        try:
+            self._run([*prefix, 'read-tree', '--empty'], cwd=source_root, env=environment)
+            self._run([*prefix, 'add', '--all'], cwd=source_root, env=environment)
+            tree_id = self._run([*prefix, 'write-tree'], cwd=source_root, env=environment)
+        finally:
+            Path(index_name).unlink(missing_ok=True)
+        arguments = ['commit-tree', tree_id]
+        if parent_commit_id is not None:
+            arguments.extend(('-p', parent_commit_id))
+        arguments.extend(('-m', message))
+        return self._run(arguments, cwd=target.root)
+
+    def prepare_local_branch(
+        self,
+        target: TargetCheckout,
+        branch_name: str,
+        current_commit_id: str | None,
+        parent_commit_id: str | None,
+    ) -> None:
+        if current_commit_id is not None:
+            self._run(['checkout', '--force', branch_name], cwd=target.root)
+        elif parent_commit_id is not None:
+            self._run(['checkout', '--detach', '--force', parent_commit_id], cwd=target.root)
+        else:
+            self._run(['checkout', '--orphan', branch_name], cwd=target.root)
+
+    def commit_parents(self, target: TargetCheckout, commit_id: str) -> tuple[str, ...]:
+        return tuple(self._run(
+            ['show', '-s', '--format=%P', commit_id], cwd=target.root,
+        ).split())
+
+    def update_local_branch(
+        self,
+        target: TargetCheckout,
+        branch_name: str,
+        commit_id: str,
+        expected_old: str | None,
+    ) -> None:
+        arguments = ['update-ref', f'refs/heads/{branch_name}', commit_id]
+        arguments.append(expected_old if expected_old is not None else '0' * 40)
+        self._run(arguments, cwd=target.root)
+        self._run(['checkout', '--force', branch_name], cwd=target.root)
+
+    def create_local_tag(
+        self,
+        target: TargetCheckout,
+        tag_name: str,
+        commit_id: str,
+        message: str,
+        expected_old: str | None,
+    ) -> tuple[str, str]:
+        tagger = self._run(['var', 'GIT_COMMITTER_IDENT'], cwd=target.root)
+        tag_contents = (
+            f'object {commit_id}\n'
+            'type commit\n'
+            f'tag {tag_name}\n'
+            f'tagger {tagger}\n\n'
+            f'{message}\n'
+        )
+        object_id = self._run(
+            ['mktag'], cwd=target.root, input_text=tag_contents,
+        )
+        old_object_id = expected_old if expected_old is not None else '0' * 40
+        self._run([
+            'update-ref', f'refs/tags/{tag_name}', object_id, old_object_id,
+        ], cwd=target.root)
+        result = self.local_tag_refs(target).get(tag_name)
+        if result is None or result != (object_id, commit_id):
+            raise ReleasePlanningError(
+                f"local annotated tag '{tag_name}' failed verification: "
+                f"expected {(object_id, commit_id)}, observed {result}"
+            )
+        actual_message = self._run(['for-each-ref', '--format=%(contents)', f'refs/tags/{tag_name}'], cwd=target.root)
+        if actual_message != message:
+            raise ReleasePlanningError(f"local annotated tag '{tag_name}' has unexpected metadata")
+        return result
+
+
+def github_repository(url: str) -> str | None:
+    """Return ``owner/repository`` for supported GitHub SSH/HTTPS URLs."""
+    value = url.strip()
+    if value.startswith('git@github.com:'):
+        path = value[len('git@github.com:'):]
+    else:
+        parsed = urlparse(value)
+        if parsed.scheme not in ('https', 'ssh') or parsed.hostname != 'github.com':
+            return None
+        if parsed.password is not None:
+            return None
+        if parsed.scheme == 'ssh' and parsed.username not in (None, 'git'):
+            return None
+        if parsed.scheme == 'https' and parsed.username is not None:
+            return None
+        path = parsed.path.lstrip('/')
+    path = path.removesuffix('.git').strip('/')
+    parts = path.split('/')
+    return '/'.join(parts) if len(parts) == 2 and all(parts) else None
+
+
+def parse_base_id(value: str) -> str:
+    if _BASE_ID.fullmatch(value) is None:
+        raise ReleasePlanningError("base ID must have suffix-less 'YYYY-NN' form")
+    return value
+
+
+def parse_data_id(value: str) -> tuple[str, int]:
+    match = _DATA_ID.fullmatch(value)
+    if match is None:
+        raise ReleasePlanningError("data ID must have 'YYYY-NN' or 'YYYY-NNvN' form")
+    revision = int(match.group('revision') or 1)
+    if match.group('revision') is not None and revision < 2:
+        raise ReleasePlanningError('dataset revision v1 is invalid; the initial tag has no suffix')
+    return match.group('base'), revision
+
+
+def _release_path(value: str | Path) -> PurePosixPath:
+    raw = str(value).replace('\\', '/')
+    path = PurePosixPath(raw)
+    if path.is_absolute() or not path.parts or any(part in ('', '.', '..') for part in path.parts):
+        raise ReleasePlanningError(f"analysis path must be normalized and repository-relative: '{value}'")
+    return path
+
+
+def make_annotation(
+    data_id: str,
+    analysis_id: str,
+    analysis_files: Sequence[str | Path],
+    main_analysis_file: str | Path,
+) -> TagAnnotation:
+    parse_data_id(data_id)
+    if _BASE_ID.fullmatch(analysis_id) is None:
+        raise ReleasePlanningError('analysis ID must have YYYY-NN form')
+    files = tuple(sorted((_release_path(path) for path in analysis_files), key=lambda path: path.as_posix()))
+    if len(set(files)) != len(files):
+        raise ReleasePlanningError('annotated-tag analysis paths must be unique')
+    main = _release_path(main_analysis_file)
+    if main not in files:
+        raise ReleasePlanningError('main analysis path is not in the complete analysis selection')
+    return TagAnnotation(data_id, analysis_id, main, files)
+
+
+def parse_annotation(message: str, *, expected_data_id: str | None = None) -> TagAnnotation:
+    lines = message.splitlines()
+    if len(lines) < 6 or lines[1] != '':
+        raise ReleasePlanningError('annotated-tag message must contain a subject and trailer block')
+    subject = _SUBJECT.fullmatch(lines[0])
+    if subject is None:
+        raise ReleasePlanningError('annotated-tag subject is malformed')
+    if expected_data_id is not None and subject.group('data_id') != expected_data_id:
+        raise ReleasePlanningError('annotated-tag subject disagrees with the tag name')
+    trailers: dict[str, list[str]] = {}
+    unknown = []
+    known = {
+        'EOS-Data-Metadata-Version', 'EOS-Analysis-ID',
+        'EOS-Main-Analysis-File', 'EOS-Analysis-File',
+    }
+    for line in lines[2:]:
+        match = _TRAILER.fullmatch(line)
+        if match is None:
+            raise ReleasePlanningError(f'malformed annotated-tag trailer: {line!r}')
+        key, value = match.group('key'), match.group('value')
+        trailers.setdefault(key, []).append(value)
+        if key not in known:
+            unknown.append((key, value))
+    for key in ('EOS-Data-Metadata-Version', 'EOS-Analysis-ID', 'EOS-Main-Analysis-File'):
+        if len(trailers.get(key, ())) != 1:
+            raise ReleasePlanningError(f'annotated-tag trailer {key} must occur exactly once')
+    if trailers['EOS-Data-Metadata-Version'][0] != '1':
+        raise ReleasePlanningError('unsupported EOS data metadata version')
+    if trailers['EOS-Analysis-ID'][0] != subject.group('analysis_id'):
+        raise ReleasePlanningError('analysis ID trailer disagrees with the annotated-tag subject')
+    files = trailers.get('EOS-Analysis-File', [])
+    annotation = make_annotation(
+        subject.group('data_id'), trailers['EOS-Analysis-ID'][0], files,
+        trailers['EOS-Main-Analysis-File'][0],
+    )
+    return TagAnnotation(
+        annotation.data_id, annotation.analysis_id, annotation.main_analysis_file,
+        annotation.analysis_files, tuple(unknown),
+    )
+
+
+def validate_annotation_documents(annotation: TagAnnotation, root: Path) -> None:
+    for path in annotation.analysis_files:
+        candidate = root / Path(path.as_posix())
+        try:
+            document = yaml.safe_load(candidate.read_text(encoding='utf-8'))
+            actual = document['metadata']['id']
+        except (OSError, UnicodeError, yaml.YAMLError, TypeError, KeyError) as error:
+            raise ReleasePlanningError(f"cannot validate tagged analysis '{path}': {error}") from error
+        if actual != annotation.analysis_id:
+            raise ReleasePlanningError(
+                f"tag annotation analysis ID disagrees with tagged file '{path}'"
+            )
+
+
+def validate_family(
+    base_id: str,
+    local_tags: Mapping[str, tuple[str, str]],
+    remote_tags: Sequence[GitHubTag],
+    parent_lookup: Callable[[str], Sequence[str]],
+) -> TagFamily:
+    parse_base_id(base_id)
+    combined: dict[str, tuple[str, str]] = {}
+    prefix = re.compile(rf'^{re.escape(base_id)}(?:v.*)?$')
+    for name, target in local_tags.items():
+        if prefix.fullmatch(name):
+            try:
+                tag_base, _ = parse_data_id(name)
+            except ReleasePlanningError as error:
+                raise ReleasePlanningError(f"malformed member of tag family '{base_id}': {name}") from error
+            if tag_base == base_id:
+                if not target[1]:
+                    raise ReleasePlanningError(
+                        f"local tag '{name}' is lightweight or has an unexpected ref type"
+                    )
+                combined[name] = target
+    for tag in remote_tags:
+        if not prefix.fullmatch(tag.name):
+            continue
+        try:
+            tag_base, _ = parse_data_id(tag.name)
+        except ReleasePlanningError as error:
+            raise ReleasePlanningError(f"malformed member of tag family '{base_id}': {tag.name}") from error
+        if tag_base != base_id:
+            continue
+        target = (tag.object_id, tag.commit_id)
+        if tag.name in combined and combined[tag.name] != target:
+            raise ReleasePlanningError(f"local and remote tag '{tag.name}' have conflicting targets")
+        combined[tag.name] = target
+    revisions = {}
+    for name in combined:
+        _, revision = parse_data_id(name)
+        revisions[revision] = name
+    if revisions and sorted(revisions) != list(range(1, max(revisions) + 1)):
+        raise ReleasePlanningError(f"tag family '{base_id}' has a revision gap")
+    tags = []
+    previous = None
+    for revision in sorted(revisions):
+        name = revisions[revision]
+        object_id, commit_id = combined[name]
+        parents = tuple(parent_lookup(commit_id))
+        if revision == 1:
+            if parents:
+                raise ReleasePlanningError(f"initial tag '{name}' is not an orphan commit")
+            parent = None
+        else:
+            if parents != (previous,):
+                raise ReleasePlanningError(f"tag '{name}' does not directly extend the validated tag lineage")
+            parent = previous
+        tags.append(FamilyTag(name, object_id, commit_id, parent))
+        previous = commit_id
+    return TagFamily(base_id, tuple(tags))
+
+
+def _remote_tags(github: GitHubReads, base_id: str) -> tuple[GitHubTag, ...]:
+    result = []
+    for ref in github.list_tag_refs():
+        if ref.name == base_id or ref.name.startswith(f'{base_id}v'):
+            result.append(github.get_tag(ref))
+    return tuple(result)
+
+
+def read_remote_family(
+    github: GitHubReads,
+    base_id: str,
+    local_tags: Mapping[str, tuple[str, str]],
+) -> RemoteFamilyState:
+    tags = _remote_tags(github, base_id)
+    family = validate_family(base_id, local_tags, tags, github.commit_parents)
+    remote_names = {tag.name for tag in tags}
+    local_family_names = {
+        tag.name for tag in family.tags if tag.name in local_tags
+    }
+    missing_remote = sorted(local_family_names - remote_names)
+    if missing_remote:
+        raise ReleasePlanningError(
+            'local tag family contains tag(s) absent from GitHub: ' + ', '.join(missing_remote)
+        )
+    releases = frozenset(tag.name for tag in family.tags if github.get_release(tag.name) is not None)
+    branch = github.get_branch(base_id)
+    return RemoteFamilyState(family, tags, releases, branch)
+
+
+def _run_source_checks(
+    root: Path,
+    analysis_files: Sequence[str | Path],
+    main_analysis_file: str | Path | None,
+    factory,
+) -> tuple[CheckResult, CheckContext]:
+    context = CheckContext(
+        root,
+        tuple(Path(path) for path in analysis_files),
+        Path(main_analysis_file) if main_analysis_file is not None else None,
+    )
+    result = run_checks(factory, context, scope=CheckScope.COMPLETE)
+    if result.exit_status is not ExitStatus.SUCCESS:
+        raise SourceCheckError(result)
+    return result, context
+
+
+def _exact_zenodo_data_id(context: CheckContext, expected: str) -> None:
+    document = context.cache.get(CacheKey.ZENODO_METADATA)
+    title = document.get('title') if isinstance(document, Mapping) else None
+    prefix = f'EOS/DATA-{expected}: '
+    if not isinstance(title, str) or not title.startswith(prefix):
+        raise ReleasePlanningError(f'Zenodo dataset ID must equal the derived tag ID {expected}')
+
+
+def plan_create(
+    base_id: str,
+    source: str | Path,
+    target_directory: Path,
+    *,
+    analysis_files: Sequence[str | Path] = (),
+    main_analysis_file: str | Path | None = None,
+    revision: bool = False,
+    replace: bool = False,
+    git: LocalGitClient,
+    github: GitHubReads,
+    check_factory,
+) -> CreatePlan:
+    base_id = parse_base_id(base_id)
+    if revision and replace:
+        raise ReleasePlanningError('--revision and --replace are mutually exclusive')
+    target = git.target_checkout(target_directory, require_clean=True)
+
+    with git.checkout_source(source) as resolved:
+        result, context = _run_source_checks(
+            resolved.root, analysis_files, main_analysis_file, check_factory,
+        )
+        analysis_id = context.cache[CacheKey.COMMON_ANALYSIS_ID]
+        selected = tuple(
+            PurePosixPath(path.relative_to(context.dataset_root).as_posix())
+            for path in context.analysis_paths
+        )
+        main = PurePosixPath(context.main_analysis_path.relative_to(context.dataset_root).as_posix())
+        source_description = resolved.description
+        source_commit_id = resolved.commit_id
+
+    local_tags = git.local_tag_refs(target)
+    local_branch = git.local_branch(target, base_id)
+    remote = read_remote_family(github, base_id, local_tags)
+    family = remote.family
+    if not family.tags:
+        if revision or replace:
+            raise ReleasePlanningError('initial creation does not accept --revision or --replace')
+        data_id = base_id
+        mode = 'initial'
+    else:
+        if revision == replace:
+            raise ReleasePlanningError('an existing base tag requires exactly one of --revision or --replace')
+        if replace:
+            if len(family.tags) != 1:
+                raise ReleasePlanningError('replacement is forbidden when revision tags exist')
+            if base_id in remote.releases:
+                raise ReleasePlanningError('replacement is forbidden after GitHub release publication')
+            if remote.branch_commit_id is not None:
+                raise ReleasePlanningError('replacement is forbidden after the remote base branch exists')
+            data_id = base_id
+            mode = 'replacement'
+        else:
+            data_id = family.next_id
+            mode = 'revision'
+    if mode == 'initial':
+        if local_branch is not None:
+            raise ReleasePlanningError(f"local base branch '{base_id}' already exists without a tag family")
+        if remote.branch_commit_id is not None:
+            raise ReleasePlanningError(f"remote base branch '{base_id}' already exists without a tag family")
+    elif mode == 'revision' and local_branch not in (None, family.latest.commit_id):
+        raise ReleasePlanningError(f"local base branch '{base_id}' is not at the latest family commit")
+    elif mode == 'replacement' and local_branch not in (None, family.latest.commit_id):
+        raise ReleasePlanningError(f"local base branch '{base_id}' is inconsistent with the base tag")
+    if mode == 'revision' and remote.branch_commit_id is not None:
+        family_commits = {tag.commit_id for tag in family.tags}
+        if remote.branch_commit_id not in family_commits:
+            raise ReleasePlanningError('remote base branch is outside the validated tag lineage')
+    if data_id in remote.releases:
+        raise ReleasePlanningError(f"GitHub release already exists for '{data_id}'")
+
+    _exact_zenodo_data_id(context, data_id)
+    annotation = make_annotation(data_id, analysis_id, selected, main)
+
+    parent = family.latest.commit_id if mode == 'revision' else None
+    old = family.latest if mode == 'replacement' else None
+    message = annotation.subject
+    operations = [
+        PlannedOperation(OperationType.PREPARE_LOCAL_BRANCH, base_id, old.commit_id if old else None, parent),
+        PlannedOperation(OperationType.CREATE_COMMIT, base_id, parent, source_commit_id),
+        PlannedOperation(
+            OperationType.MOVE_LOCAL_BRANCH,
+            base_id,
+            local_branch,
+            '<new-commit>',
+            mode == 'replacement',
+        ),
+    ]
+    operations.extend((
+        PlannedOperation(
+            OperationType.CREATE_ANNOTATED_TAG,
+            data_id,
+            old.object_id if old else None,
+            '<new-tag-object>',
+            mode == 'replacement',
+        ),
+        PlannedOperation(
+            OperationType.TRANSFER_TAG,
+            f'{target.remote_name}:{data_id}',
+            old.object_id if old else None,
+            '<new-tag-object>',
+            mode == 'replacement',
+        ),
+    ))
+    return CreatePlan(
+        source_description, source_commit_id, target, data_id, base_id, parent,
+        annotation.analysis_files, annotation.main_analysis_file, message, annotation,
+        old.object_id if old else None, old.commit_id if old else None,
+        result, tuple(operations),
+    )
+
+
+def plan_publish(
+    data_id: str,
+    target_directory: Path,
+    *,
+    git: LocalGitClient,
+    github: GitHubReads,
+    check_factory,
+) -> PublishPlan:
+    base_id, _ = parse_data_id(data_id)
+    target = git.target_checkout(target_directory, require_clean=False)
+    local_tags = git.local_tag_refs(target)
+    remote = read_remote_family(github, base_id, local_tags)
+    remote_tag = next((tag for tag in remote.remote_tags if tag.name == data_id), None)
+    if remote_tag is None:
+        raise ReleasePlanningError(f"remote annotated tag '{data_id}' does not exist")
+    if data_id in remote.releases:
+        raise ReleasePlanningError(f"GitHub release already exists for '{data_id}'")
+    annotation = parse_annotation(remote_tag.message, expected_data_id=data_id)
+
+    checkout = getattr(github, 'checkout_tree', None)
+    if not callable(checkout):
+        raise ReleasePlanningError('GitHub read client cannot check out the tagged commit tree')
+    with checkout(remote_tag.commit_id) as root:
+        validate_annotation_documents(annotation, root)
+        result, context = _run_source_checks(
+            root, annotation.analysis_files, annotation.main_analysis_file, check_factory,
+        )
+        if context.cache[CacheKey.COMMON_ANALYSIS_ID] != annotation.analysis_id:
+            raise ReleasePlanningError('tag annotation analysis ID disagrees with tagged analyses')
+        metadata = context.cache[CacheKey.ANALYSIS_METADATA][context.main_analysis_path]
+        title = metadata['title']
+        notes = metadata['description']
+
+    branch = remote.branch_commit_id
+    if branch is not None and not github.is_ancestor(branch, remote_tag.commit_id):
+        raise ReleasePlanningError('remote base branch is not an ancestor of the tag commit')
+    operations = [PlannedOperation(
+        OperationType.CREATE_RELEASE, data_id, None, remote_tag.commit_id,
+    )]
+    if branch is None:
+        operations.append(PlannedOperation(
+            OperationType.CREATE_REMOTE_BRANCH, base_id, None, remote_tag.commit_id,
+        ))
+    elif branch != remote_tag.commit_id:
+        operations.append(PlannedOperation(
+            OperationType.ADVANCE_REMOTE_BRANCH, base_id, branch, remote_tag.commit_id,
+        ))
+    return PublishPlan(
+        target, data_id, base_id, remote_tag.object_id, remote_tag.commit_id, annotation,
+        annotation.analysis_files, annotation.main_analysis_file, title, notes, branch,
+        result, tuple(operations),
+    )
+
+
+def render_create_plan(plan: CreatePlan) -> str:
+    lines = [
+        'Create dataset/tag plan (read-only)',
+        f'Source repository: {plan.source_description}',
+        f'Source commit: {plan.source_commit_id}',
+        f'Target repository: eos/data ({plan.target.remote_name}: {plan.target.remote_url})',
+        f'Derived tag: {plan.data_id}',
+        f'Local base branch: {plan.base_branch}',
+        f'Parent/ancestry: {plan.parent_commit_id or "orphan"}',
+        'Analysis files: ' + ', '.join(path.as_posix() for path in plan.analysis_files),
+        f'Main analysis file: {plan.main_analysis_file}',
+        f'Commit message: {plan.commit_message}',
+        f'Old tag object: {plan.old_tag_object_id or "none"}',
+        f'Old commit: {plan.old_commit_id or "none"}',
+        'Check findings:',
+        PlainTextRenderer().render(plan.check_result).rstrip(),
+        'Annotated tag message:',
+        plan.annotation.serialize(),
+        'Operations:',
+    ]
+    for index, operation in enumerate(plan.operations, 1):
+        lines.append(
+            f'{index}. {operation.kind.value}: {operation.ref}; '
+            f'old={operation.expected_old or "none"}; target={operation.target or "execution-derived"}; '
+            f'force={str(operation.force).lower()}'
+        )
+    return '\n'.join(lines) + '\n'
+
+
+def render_publish_plan(plan: PublishPlan) -> str:
+    lines = [
+        'Publish release plan (read-only)',
+        f'Target repository: eos/data ({plan.target.remote_name}: {plan.target.remote_url})',
+        f'Tag: {plan.data_id}',
+        f'Tag object: {plan.tag_object_id}',
+        f'Tag commit: {plan.tag_commit_id}',
+        f'Base branch: {plan.base_branch}',
+        f'Current branch commit: {plan.branch_commit_id or "absent"}',
+        'Analysis files: ' + ', '.join(path.as_posix() for path in plan.analysis_files),
+        f'Main analysis file: {plan.main_analysis_file}',
+        f'Release title: {plan.release_title}',
+        'Release notes:',
+        plan.release_notes,
+        'Check findings:',
+        PlainTextRenderer().render(plan.check_result).rstrip(),
+        'Operations:',
+    ]
+    for index, operation in enumerate(plan.operations, 1):
+        lines.append(
+            f'{index}. {operation.kind.value}: {operation.ref}; '
+            f'old={operation.expected_old or "none"}; target={operation.target or "none"}'
+        )
+    return '\n'.join(lines) + '\n'

--- a/python/eos/cli/data_release.py
+++ b/python/eos/cli/data_release.py
@@ -427,6 +427,33 @@ class LocalGitClient:
             raise ReleasePlanningError(f"local annotated tag '{tag_name}' has unexpected metadata")
         return result
 
+    def create_registration_commit(
+        self,
+        root: Path,
+        branch_name: str,
+        main_commit_id: str,
+        registry_text: str,
+        message: str,
+    ) -> str:
+        """Create the single registry commit in an isolated local checkout."""
+        if self._run(['rev-parse', 'HEAD^{commit}'], cwd=root) != main_commit_id:
+            raise ReleasePlanningError('materialized main checkout is stale')
+        self._run(['checkout', '-b', branch_name, main_commit_id], cwd=root)
+        (root / 'datasets.yaml').write_text(registry_text, encoding='utf-8')
+        self._run(['add', '--', 'datasets.yaml'], cwd=root)
+        changed = tuple(self._run(
+            ['diff', '--cached', '--name-only'], cwd=root,
+        ).splitlines())
+        if changed != ('datasets.yaml',):
+            raise ReleasePlanningError(
+                f'registration commit must change only datasets.yaml, observed {changed}'
+            )
+        self._run(['commit', '-m', message], cwd=root)
+        commit_id = self._run(['rev-parse', 'HEAD^{commit}'], cwd=root)
+        if self.commit_parents(TargetCheckout(root, 'origin', ''), commit_id) != (main_commit_id,):
+            raise ReleasePlanningError('registration commit has an unexpected parent')
+        return commit_id
+
 
 def github_repository(url: str) -> str | None:
     """Return ``owner/repository`` for supported GitHub SSH/HTTPS URLs."""

--- a/python/eos/cli/data_release_TEST.py
+++ b/python/eos/cli/data_release_TEST.py
@@ -1,0 +1,485 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+from eos.cli.data import create_check_factory
+from eos.cli.data_github import (
+    GitHubCLIUnavailable, GitHubClient, GitHubCommandError, GitHubRef,
+    GitHubRelease, GitHubResponseError, GitHubTag,
+)
+from eos.cli.data_release import (
+    LocalGitClient, OperationType, ReleasePlanningError, ResolvedSource,
+    TargetCheckout, github_repository, make_annotation, parse_annotation,
+    parse_base_id, parse_data_id, plan_create, plan_publish,
+    render_create_plan, render_publish_plan, validate_family,
+)
+
+
+def _run_git(root, *arguments):
+    return subprocess.run(
+        ['git', *arguments], cwd=root, check=True, capture_output=True, text=True,
+        env={**os.environ, 'GIT_AUTHOR_NAME': 'Test', 'GIT_AUTHOR_EMAIL': 'test@example.com',
+             'GIT_COMMITTER_NAME': 'Test', 'GIT_COMMITTER_EMAIL': 'test@example.com'},
+    ).stdout.strip()
+
+
+def _dataset(root: Path, data_id='2026-01'):
+    (root / 'README.md').write_text('# Dataset\n', encoding='utf-8')
+    (root / 'analysis.yaml').write_text(
+        'metadata:\n  id: 2025-03\n  title: Main title\n'
+        '  description: Release notes.\n  authors:\n    - name: Jane Doe\n',
+        encoding='utf-8',
+    )
+    (root / '.zenodo.json').write_text(json.dumps({
+        'title': f'EOS/DATA-{data_id}: Supplementary material for EOS/ANALYSIS-2025-03',
+        'description': 'Release notes.', 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Lab'}],
+        'upload_type': 'dataset', 'license': 'CC-BY-4.0', 'grants': [],
+    }), encoding='utf-8')
+
+
+class FakeGit:
+    def __init__(self, source: Path, local_tags=None, local_branch=None):
+        self.source = source
+        self.tags = local_tags or {}
+        self.branch = local_branch
+
+    def target_checkout(self, directory, *, require_clean=True):
+        return TargetCheckout(Path(directory), 'origin', 'git@github.com:eos/data.git')
+
+    def local_tag_refs(self, target):
+        return self.tags
+
+    def local_branch(self, target, name):
+        return self.branch
+
+    @contextmanager
+    def checkout_source(self, source):
+        yield ResolvedSource(str(source), 'source-commit', self.source)
+
+
+class FakeGitHub:
+    def __init__(self, root: Path, tags=(), releases=(), branch=None, parents=None):
+        self.root = root
+        self.tags = {tag.name: tag for tag in tags}
+        self.releases = set(releases)
+        self.branch = branch
+        self.parents = parents or {}
+        self.calls = []
+
+    def list_tag_refs(self):
+        self.calls.append(('list-tag-refs',))
+        return tuple(GitHubRef(tag.name, tag.object_id, 'tag') for tag in self.tags.values())
+
+    def get_tag(self, ref):
+        self.calls.append(('get-tag', ref.name))
+        return self.tags[ref.name]
+
+    def get_release(self, name):
+        self.calls.append(('get-release', name))
+        return GitHubRelease(name, 'https://example.invalid') if name in self.releases else None
+
+    def get_branch(self, name):
+        self.calls.append(('get-branch', name))
+        return self.branch
+
+    def commit_parents(self, commit):
+        self.calls.append(('parents', commit))
+        return tuple(self.parents.get(commit, ()))
+
+    def is_ancestor(self, ancestor, descendant):
+        self.calls.append(('is-ancestor', ancestor, descendant))
+        return ancestor == descendant or ancestor in self.parents.get(descendant, ())
+
+    @contextmanager
+    def checkout_tree(self, commit):
+        self.calls.append(('checkout', commit))
+        yield self.root
+
+
+def _tag(name, commit, analysis_id='2025-03', files=('analysis.yaml',), main='analysis.yaml'):
+    annotation = make_annotation(name, analysis_id, files, main)
+    return GitHubTag(name, f'tag-{name}', commit, annotation.serialize())
+
+
+class IDAndAnnotationTests(unittest.TestCase):
+    def test_ids(self):
+        self.assertEqual(parse_base_id('2026-01'), '2026-01')
+        self.assertEqual(parse_data_id('2026-01'), ('2026-01', 1))
+        self.assertEqual(parse_data_id('2026-01v10'), ('2026-01', 10))
+        for value in ('2026-1', '2026-01v2'):
+            with self.assertRaises(ReleasePlanningError):
+                parse_base_id(value)
+        for value in ('2026-01v1', '2026-01v01', '2026-01v02', 'x'):
+            with self.assertRaises(ReleasePlanningError):
+                parse_data_id(value)
+
+    def test_annotation_round_trip_is_sorted_and_retains_unknown_trailers(self):
+        value = make_annotation('2026-01v2', '2025-03', ['z.yaml', 'a.yaml'], 'z.yaml')
+        parsed = parse_annotation(value.serialize() + '\nFuture-Key: retained', expected_data_id='2026-01v2')
+        self.assertEqual(parsed.analysis_files, (Path('a.yaml'), Path('z.yaml')))
+        self.assertEqual(parsed.unknown_trailers, (('Future-Key', 'retained'),))
+
+    def test_annotation_rejects_malformed_metadata(self):
+        valid = make_annotation('2026-01', '2025-03', ['analysis.yaml'], 'analysis.yaml').serialize()
+        cases = (
+            valid.replace('Version: 1', 'Version: 2'),
+            valid.replace('EOS-Analysis-ID: 2025-03\n', ''),
+            valid + '\nEOS-Analysis-ID: 2025-03',
+            valid + '\nEOS-Analysis-File: analysis.yaml',
+            valid.replace('analysis.yaml', '../analysis.yaml'),
+            valid.replace('EOS-Main-Analysis-File: analysis.yaml', 'EOS-Main-Analysis-File: other.yaml'),
+            valid.replace('DATA-2026-01', 'DATA-2026-02'),
+            valid + '\nnot a trailer',
+        )
+        for message in cases:
+            with self.subTest(message=message[-50:]), self.assertRaises(ReleasePlanningError):
+                parse_annotation(message, expected_data_id='2026-01')
+
+    def test_supported_github_urls(self):
+        for url in (
+            'git@github.com:eos/data.git', 'ssh://git@github.com/eos/data.git',
+            'ssh://github.com/eos/data', 'https://github.com/eos/data.git',
+        ):
+            self.assertEqual(github_repository(url), 'eos/data')
+        for url in (
+            'https://gitlab.com/eos/data', 'ssh://github/eos/data',
+            'ssh://attacker@github.com/eos/data',
+            'https://attacker@github.com/eos/data',
+            'https://attacker:secret@github.com/eos/data',
+        ):
+            self.assertIsNone(github_repository(url))
+
+
+class FamilyTests(unittest.TestCase):
+    def test_consecutive_lineage(self):
+        remote = (_tag('2026-01', 'c1'), _tag('2026-01v2', 'c2'))
+        family = validate_family('2026-01', {}, remote, lambda commit: {'c1': (), 'c2': ('c1',)}[commit])
+        self.assertEqual(family.next_id, '2026-01v3')
+
+    def test_gaps_malformed_conflicts_and_lineage_fail(self):
+        cases = (
+            ({}, (_tag('2026-01', 'c1'), _tag('2026-01v3', 'c3')), {'c1': (), 'c3': ('c1',)}),
+            ({}, (_tag('2026-01', 'c1'), GitHubTag('2026-01v1', 't1', 'c2', 'x')), {'c1': (), 'c2': ('c1',)}),
+            ({'2026-01': ('different', 'c1')}, (_tag('2026-01', 'c1'),), {'c1': ()}),
+            ({}, (_tag('2026-01', 'c1'), _tag('2026-01v2', 'c2')), {'c1': (), 'c2': ('other',)}),
+        )
+        for local, remote, parents in cases:
+            with self.subTest(remote=[tag.name for tag in remote]), self.assertRaises(ReleasePlanningError):
+                validate_family('2026-01', local, remote, lambda commit: parents[commit])
+
+
+class LocalGitTests(unittest.TestCase):
+    def test_local_source_uses_committed_main_and_excludes_dirty_content(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _run_git(root, 'init', '-b', 'main')
+            (root / 'value').write_text('committed', encoding='utf-8')
+            _run_git(root, 'add', 'value')
+            _run_git(root, 'commit', '-m', 'initial')
+            commit = _run_git(root, 'rev-parse', 'HEAD')
+            (root / 'value').write_text('dirty', encoding='utf-8')
+            (root / 'untracked').write_text('no', encoding='utf-8')
+            client = LocalGitClient()
+            with client.checkout_source(root) as source:
+                self.assertEqual(source.commit_id, commit)
+                self.assertEqual((source.root / 'value').read_text(), 'committed')
+                self.assertFalse((source.root / 'untracked').exists())
+
+    def test_remote_source_resolves_remote_main(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / 'source'
+            root.mkdir()
+            _run_git(root, 'init', '-b', 'main')
+            (root / 'value').write_text('remote committed', encoding='utf-8')
+            _run_git(root, 'add', 'value')
+            _run_git(root, 'commit', '-m', 'initial')
+            commit = _run_git(root, 'rev-parse', 'HEAD')
+            url = root.as_uri()
+            with LocalGitClient().checkout_source(url) as source:
+                self.assertEqual(source.description, url)
+                self.assertEqual(source.commit_id, commit)
+                self.assertEqual((source.root / 'value').read_text(), 'remote committed')
+
+    def test_target_requires_root_identity_and_clean_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _run_git(root, 'init', '-b', 'main')
+            _run_git(root, 'remote', 'add', 'origin', 'https://github.com/eos/data.git')
+            target = LocalGitClient().target_checkout(root)
+            self.assertEqual(target.remote_name, 'origin')
+            child = root / 'child'
+            child.mkdir()
+            with self.assertRaises(ReleasePlanningError):
+                LocalGitClient().target_checkout(child)
+            (root / 'untracked').write_text('unsafe', encoding='utf-8')
+            with self.assertRaises(ReleasePlanningError):
+                LocalGitClient().target_checkout(root)
+
+    def test_target_requires_push_url_to_identify_eos_data(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _run_git(root, 'init', '-b', 'main')
+            _run_git(root, 'remote', 'add', 'origin', 'https://github.com/eos/data.git')
+            _run_git(root, 'remote', 'set-url', '--push', 'origin', 'https://github.com/attacker/data.git')
+            with self.assertRaises(ReleasePlanningError):
+                LocalGitClient().target_checkout(root)
+
+            _run_git(root, 'remote', 'set-url', '--push', 'origin', 'https://github.com/eos/data.git')
+            _run_git(
+                root, 'remote', 'set-url', '--add', '--push', 'origin',
+                'https://github.com/attacker/data.git',
+            )
+            with self.assertRaises(ReleasePlanningError):
+                LocalGitClient().target_checkout(root)
+
+    def test_remote_source_is_terminated_before_user_input(self):
+        runner = mock.Mock(return_value=subprocess.CompletedProcess([], 2, '', 'expected failure'))
+        with self.assertRaises(ReleasePlanningError):
+            with LocalGitClient(runner=runner).checkout_source('-malicious-option'):
+                pass
+        command = runner.call_args.args[0]
+        self.assertEqual(command[1:5], ['clone', '--no-checkout', '--', '-malicious-option'])
+
+
+class PlannerTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        _dataset(self.root)
+        self.factory = create_check_factory()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_initial_plan_is_deterministic_and_read_only(self):
+        github = FakeGitHub(self.root)
+        plan = plan_create(
+            '2026-01', self.root, Path('/target'), git=FakeGit(self.root), github=github,
+            check_factory=self.factory,
+        )
+        self.assertEqual(plan.data_id, '2026-01')
+        self.assertIsNone(plan.parent_commit_id)
+        self.assertEqual([operation.kind for operation in plan.operations], [
+            OperationType.PREPARE_LOCAL_BRANCH, OperationType.CREATE_COMMIT,
+            OperationType.MOVE_LOCAL_BRANCH, OperationType.CREATE_ANNOTATED_TAG,
+            OperationType.TRANSFER_TAG,
+        ])
+        self.assertIsNone(plan.operations[2].expected_old)
+        self.assertEqual(plan.operations[2].target, '<new-commit>')
+        rendered = render_create_plan(plan)
+        for text in ('Create dataset/tag plan', 'Source commit: source-commit', 'Parent/ancestry: orphan',
+                     'Analysis files: analysis.yaml', 'EOS-Data-Metadata-Version: 1'):
+            self.assertIn(text, rendered)
+        self.assertTrue(all(call[0] in {'list-tag-refs', 'get-branch'} for call in github.calls))
+
+    def test_revision_and_replacement_policy(self):
+        base = _tag('2026-01', 'c1')
+        parents = {'c1': ()}
+        github = FakeGitHub(self.root, (base,), parents=parents)
+        _dataset(self.root, '2026-01v2')
+        revision = plan_create(
+            '2026-01', self.root, Path('/target'), revision=True,
+            git=FakeGit(self.root, {'2026-01': ('tag-2026-01', 'c1')}, 'c1'), github=github,
+            check_factory=self.factory,
+        )
+        self.assertEqual((revision.data_id, revision.parent_commit_id), ('2026-01v2', 'c1'))
+
+        _dataset(self.root, '2026-01')
+        replacement = plan_create(
+            '2026-01', self.root, Path('/target'), replace=True,
+            git=FakeGit(self.root, {'2026-01': ('tag-2026-01', 'c1')}, 'c1'), github=github,
+            check_factory=self.factory,
+        )
+        self.assertEqual(replacement.old_tag_object_id, 'tag-2026-01')
+        self.assertTrue(replacement.operations[-1].force)
+
+    def test_replacement_disqualifying_states(self):
+        base = _tag('2026-01', 'c1')
+        revision = _tag('2026-01v2', 'c2')
+        cases = (
+            FakeGitHub(self.root, (base,), releases=('2026-01',), parents={'c1': ()}),
+            FakeGitHub(self.root, (base,), branch='c1', parents={'c1': ()}),
+            FakeGitHub(self.root, (base, revision), parents={'c1': (), 'c2': ('c1',)}),
+        )
+        for github in cases:
+            with self.subTest(calls=github.calls), self.assertRaises(ReleasePlanningError):
+                plan_create(
+                    '2026-01', self.root, Path('/target'), replace=True,
+                    git=FakeGit(self.root), github=github, check_factory=self.factory,
+                )
+
+    def test_publish_recovers_selection_and_orders_release_before_branch(self):
+        tag = _tag('2026-01', 'c1')
+        github = FakeGitHub(self.root, (tag,), parents={'c1': ()})
+        plan = plan_publish(
+            '2026-01', Path('/target'), git=FakeGit(self.root), github=github,
+            check_factory=self.factory,
+        )
+        self.assertEqual((plan.release_title, plan.release_notes), ('Main title', 'Release notes.'))
+        self.assertEqual([operation.kind for operation in plan.operations], [
+            OperationType.CREATE_RELEASE, OperationType.CREATE_REMOTE_BRANCH,
+        ])
+        rendered = render_publish_plan(plan)
+        self.assertLess(rendered.index('create-release'), rendered.index('create-remote-branch'))
+        self.assertEqual(github.calls.count(('list-tag-refs',)), 1)
+        self.assertEqual(github.calls.count(('get-tag', '2026-01')), 1)
+
+    def test_publish_rejects_existing_release_and_unrelated_or_backward_branch(self):
+        base = _tag('2026-01', 'c1')
+        revision = _tag('2026-01v2', 'c2')
+        cases = (
+            ('2026-01', FakeGitHub(
+                self.root, (base,), releases=('2026-01',), parents={'c1': ()},
+            )),
+            ('2026-01', FakeGitHub(
+                self.root, (base,), branch='unrelated', parents={'c1': (), 'unrelated': ()},
+            )),
+            ('2026-01', FakeGitHub(
+                self.root, (base, revision), branch='c2', parents={'c1': (), 'c2': ('c1',)},
+            )),
+        )
+        for data_id, github in cases:
+            with self.subTest(data_id=data_id, branch=github.branch), self.assertRaises(ReleasePlanningError):
+                plan_publish(
+                    data_id, Path('/target'), git=FakeGit(self.root), github=github,
+                    check_factory=self.factory,
+                )
+
+    def test_planning_failure_does_not_mutate(self):
+        _dataset(self.root, '2026-99')
+        github = FakeGitHub(self.root)
+        with self.assertRaises(ReleasePlanningError):
+            plan_create(
+                '2026-01', self.root, Path('/target'), git=FakeGit(self.root), github=github,
+                check_factory=self.factory,
+            )
+        self.assertTrue(all(call[0] in {'list-tag-refs', 'get-branch'} for call in github.calls))
+
+    def test_create_checks_source_before_github_preflight(self):
+        events = []
+
+        class OrderingGit(FakeGit):
+            @contextmanager
+            def checkout_source(inner_self, source):
+                events.append('check-source')
+                yield ResolvedSource(str(source), 'source-commit', inner_self.source)
+
+        class OrderingGitHub(FakeGitHub):
+            def list_tag_refs(inner_self):
+                self.assertEqual(events, ['check-source'])
+                events.append('github-preflight')
+                return super().list_tag_refs()
+
+        plan_create(
+            '2026-01', self.root, Path('/target'), git=OrderingGit(self.root),
+            github=OrderingGitHub(self.root), check_factory=self.factory,
+        )
+        self.assertEqual(events, ['check-source', 'github-preflight'])
+
+
+class GitHubClientTests(unittest.TestCase):
+    def test_missing_gh(self):
+        with mock.patch('shutil.which', return_value=None):
+            with self.assertRaises(GitHubCLIUnavailable):
+                GitHubClient().list_tag_refs()
+
+    def test_lightweight_tag_is_rejected_without_an_api_call(self):
+        client = GitHubClient(executable='gh', runner=mock.Mock())
+        with self.assertRaises(GitHubResponseError):
+            client.get_tag(GitHubRef('2026-01', 'commit-id', 'commit'))
+        client._runner.assert_not_called()
+
+    def test_malformed_json_command_failure_and_unexpected_response(self):
+        def result(returncode=0, stdout='', stderr=''):
+            return subprocess.CompletedProcess([], returncode, stdout, stderr)
+        for response, error in (
+            (result(stdout='not json'), GitHubResponseError),
+            (result(returncode=2, stderr='denied'), GitHubCommandError),
+            (result(stdout='{}'), GitHubResponseError),
+        ):
+            with self.subTest(error=error):
+                client = GitHubClient(executable='gh', runner=mock.Mock(return_value=response))
+                with self.assertRaises(error):
+                    client.list_tag_refs()
+
+    def test_tag_ref_enumeration_paginates_and_flattens_all_pages(self):
+        pages = [[
+            {'ref': 'refs/tags/2026-01', 'object': {'sha': 'tag-1', 'type': 'tag'}},
+        ], [
+            {'ref': 'refs/tags/2026-01v2', 'object': {'sha': 'tag-2', 'type': 'tag'}},
+        ]]
+        runner = mock.Mock(return_value=subprocess.CompletedProcess([], 0, json.dumps(pages), ''))
+        refs = GitHubClient(executable='gh', runner=runner).list_tag_refs()
+        self.assertEqual([ref.name for ref in refs], ['2026-01', '2026-01v2'])
+        self.assertEqual(runner.call_args.args[0][-2:], ['--paginate', '--slurp'])
+
+    def test_tag_ref_response_requires_nonempty_string_fields(self):
+        valid = {'ref': 'refs/tags/2026-01', 'object': {'sha': 'tag-1', 'type': 'tag'}}
+        cases = []
+        for field in ('ref',):
+            for value in (None, ''):
+                item = {**valid, field: value}
+                cases.append(item)
+        for field in ('sha', 'type'):
+            for value in (None, ''):
+                item = {**valid, 'object': {**valid['object'], field: value}}
+                cases.append(item)
+        cases.append({'object': valid['object']})
+        cases.append({'ref': valid['ref'], 'object': {'type': 'tag'}})
+        for item in cases:
+            with self.subTest(item=item):
+                response = subprocess.CompletedProcess([], 0, json.dumps([[item]]), '')
+                client = GitHubClient(executable='gh', runner=mock.Mock(return_value=response))
+                with self.assertRaises(GitHubResponseError):
+                    client.list_tag_refs()
+
+    def test_release_and_guarded_branch_update_use_exact_api_arguments(self):
+        release = {
+            'tag_name': '2026-01', 'html_url': 'https://example.invalid/release',
+        }
+        responses = [
+            subprocess.CompletedProcess([], 0, json.dumps(release), ''),
+            subprocess.CompletedProcess([], 0, '', ''),
+        ]
+        runner = mock.Mock(side_effect=responses)
+        git_runner = mock.Mock(return_value=subprocess.CompletedProcess([], 0, '', ''))
+        client = GitHubClient(executable='gh', runner=runner, git_runner=git_runner)
+        result = client.create_release('2026-01', 'Title', 'Notes')
+        self.assertEqual(result.tag_name, '2026-01')
+        client.update_branch('2026-01', 'new', 'old')
+        release_command = runner.call_args_list[0].args[0]
+        self.assertEqual(release_command[:5], [
+            'gh', 'api', 'repos/eos/data/releases', '--method', 'POST',
+        ])
+        self.assertIn('tag_name=2026-01', release_command)
+        self.assertEqual(runner.call_args_list[1].args[0][:4], [
+            'gh', 'repo', 'clone', 'eos/data',
+        ])
+        update_command = git_runner.call_args.args[0]
+        self.assertEqual(update_command[:3], ['git', 'push', '--porcelain'])
+        self.assertIn('--force-with-lease=refs/heads/2026-01:old', update_command)
+        self.assertIn('new:refs/heads/2026-01', update_command)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/eos/cli/data_release_execution.py
+++ b/python/eos/cli/data_release_execution.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+"""Execution of validated EOS dataset create and publish plans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .data_github import GitHubRef, GitHubRelease, GitHubTag
+from .data_release import (
+    CreatePlan, LocalGitClient, PublishPlan, plan_create, plan_publish,
+)
+
+
+class ReleaseExecutionError(RuntimeError):
+    def __init__(self, message: str, completed: tuple[str, ...] = ()) -> None:
+        self.message = message
+        self.completed = completed
+        suffix = f"\nCompleted operations: {', '.join(completed)}" if completed else ''
+        super().__init__(message + suffix)
+
+
+class PartialPublishError(ReleaseExecutionError):
+    pass
+
+
+@dataclass(frozen=True)
+class CreateExecutionResult:
+    data_id: str
+    commit_id: str
+    local_tag_object_id: str
+    remote_tag_object_id: str
+    old_tag_object_id: str | None
+    old_commit_id: str | None
+    completed: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PublishExecutionResult:
+    data_id: str
+    release_url: str
+    branch_name: str
+    branch_commit_id: str
+    completed: tuple[str, ...]
+
+
+class GitHubWrites(Protocol):
+    def list_tag_refs(self) -> tuple[GitHubRef, ...]: ...
+    def get_tag(self, ref: GitHubRef) -> GitHubTag: ...
+    def get_release(self, tag_name: str) -> GitHubRelease | None: ...
+    def get_branch(self, branch_name: str) -> str | None: ...
+    def commit_parents(self, commit_id: str) -> tuple[str, ...]: ...
+    def is_ancestor(self, ancestor: str, descendant: str) -> bool: ...
+    def transfer_local_tag(self, root, remote_name: str, tag_name: str, expected_old: str | None) -> None: ...
+    def create_release(self, tag_name: str, title: str, notes: str) -> GitHubRelease: ...
+    def create_branch(self, branch_name: str, commit_id: str) -> None: ...
+    def update_branch(self, branch_name: str, commit_id: str, expected_old: str) -> None: ...
+
+
+def _create_signature(plan: CreatePlan) -> tuple:
+    return (
+        plan.source_description, plan.source_commit_id, plan.target, plan.data_id,
+        plan.base_branch, plan.parent_commit_id, plan.analysis_files,
+        plan.main_analysis_file, plan.commit_message, plan.annotation,
+        plan.old_tag_object_id, plan.old_commit_id, plan.operations,
+    )
+
+
+def _publish_signature(plan: PublishPlan) -> tuple:
+    return (
+        plan.target, plan.data_id, plan.base_branch, plan.tag_object_id,
+        plan.tag_commit_id, plan.annotation, plan.analysis_files,
+        plan.main_analysis_file, plan.release_title, plan.release_notes,
+        plan.branch_commit_id, plan.operations,
+    )
+
+
+def execute_create(
+    plan: CreatePlan,
+    *,
+    git: LocalGitClient,
+    github: GitHubWrites,
+    check_factory,
+) -> CreateExecutionResult:
+    """Revalidate and execute one create plan, recording every completed write."""
+    revision = plan.data_id != plan.base_branch
+    replace = plan.old_tag_object_id is not None
+    fresh = plan_create(
+        plan.base_branch,
+        plan.source_description,
+        plan.target.root,
+        analysis_files=plan.analysis_files,
+        main_analysis_file=plan.main_analysis_file,
+        revision=revision,
+        replace=replace,
+        git=git,
+        github=github,
+        check_factory=check_factory,
+    )
+    if _create_signature(fresh) != _create_signature(plan):
+        raise ReleaseExecutionError('create preconditions changed after planning; no writes performed')
+
+    completed: list[str] = []
+    try:
+        current_branch = git.local_branch(plan.target, plan.base_branch)
+        git.prepare_local_branch(
+            plan.target, plan.base_branch, current_branch, plan.parent_commit_id,
+        )
+        completed.append(f'prepare-local-branch:{plan.base_branch}')
+        with git.checkout_commit(plan.source_description, plan.source_commit_id) as source_root:
+            commit_id = git.create_dataset_commit(
+                plan.target, source_root, plan.commit_message, plan.parent_commit_id,
+            )
+        parents = git.commit_parents(plan.target, commit_id)
+        expected_parents = () if plan.parent_commit_id is None else (plan.parent_commit_id,)
+        if parents != expected_parents:
+            raise ReleaseExecutionError(
+                f'new commit {commit_id} has parents {parents}, expected {expected_parents}',
+                tuple(completed),
+            )
+        completed.append(f'create-commit:{commit_id}')
+
+        git.update_local_branch(
+            plan.target, plan.base_branch, commit_id, current_branch,
+        )
+        if git.local_branch(plan.target, plan.base_branch) != commit_id:
+            raise ReleaseExecutionError('local base branch failed postcondition verification', tuple(completed))
+        completed.append(f'move-local-branch:{plan.base_branch}:{commit_id}')
+
+        local_object, peeled = git.create_local_tag(
+            plan.target, plan.data_id, commit_id, plan.annotation.serialize(),
+            plan.old_tag_object_id,
+        )
+        if peeled != commit_id:
+            raise ReleaseExecutionError('local tag peeled commit failed verification', tuple(completed))
+        completed.append(f'create-annotated-tag:{plan.data_id}:{local_object}')
+
+        github.transfer_local_tag(
+            plan.target.root, plan.target.remote_name, plan.data_id, plan.old_tag_object_id,
+        )
+        remote_ref = next(
+            (ref for ref in github.list_tag_refs() if ref.name == plan.data_id), None,
+        )
+        if remote_ref is None or remote_ref.object_type != 'tag' or remote_ref.object_id != local_object:
+            raise ReleaseExecutionError('remote tag ref failed postcondition verification', tuple(completed))
+        remote_tag = github.get_tag(remote_ref)
+        if (
+            remote_tag.commit_id != commit_id
+            or remote_tag.message.rstrip('\n') != plan.annotation.serialize()
+        ):
+            raise ReleaseExecutionError('remote annotated tag failed postcondition verification', tuple(completed))
+        if tuple(github.commit_parents(commit_id)) != expected_parents:
+            raise ReleaseExecutionError('remote tag lineage failed postcondition verification', tuple(completed))
+        completed.append(f'transfer-tag:{plan.data_id}:{remote_ref.object_id}')
+        return CreateExecutionResult(
+            plan.data_id, commit_id, local_object, remote_ref.object_id,
+            plan.old_tag_object_id, plan.old_commit_id, tuple(completed),
+        )
+    except Exception as error:
+        done = error.completed if isinstance(error, ReleaseExecutionError) else tuple(completed)
+        cause = error.message if isinstance(error, ReleaseExecutionError) else str(error)
+        try:
+            local_branch = git.local_branch(plan.target, plan.base_branch) or 'absent'
+            local_tag = git.local_tag_refs(plan.target).get(plan.data_id)
+        except Exception as observation_error:
+            local_branch = f'unavailable ({observation_error})'
+            local_tag = 'unavailable'
+        try:
+            remote_ref = next(
+                (ref for ref in github.list_tag_refs() if ref.name == plan.data_id), None,
+            )
+            remote_tag = remote_ref.object_id if remote_ref is not None else 'absent'
+        except Exception as observation_error:
+            remote_tag = f'unavailable ({observation_error})'
+        state = (
+            f'Observed local branch={local_branch}, local tag={local_tag or "absent"}, '
+            f'remote tag={remote_tag}. Safe recovery: inspect these refs and the completed '
+            'operations, reconcile any race, then run create again; do not delete a published object.'
+        )
+        raise ReleaseExecutionError(f'create execution failed: {cause}. {state}', done) from error
+
+
+def execute_publish(
+    plan: PublishPlan,
+    *,
+    git: LocalGitClient,
+    github: GitHubWrites,
+    check_factory,
+) -> PublishExecutionResult:
+    """Revalidate and publish a tag before creating or advancing its branch."""
+    fresh = plan_publish(
+        plan.data_id, plan.target.root, git=git, github=github, check_factory=check_factory,
+    )
+    if _publish_signature(fresh) != _publish_signature(plan):
+        raise ReleaseExecutionError('publish preconditions changed after planning; no writes performed')
+
+    completed: list[str] = []
+    try:
+        release = github.create_release(plan.data_id, plan.release_title, plan.release_notes)
+        completed.append(f'create-release:{plan.data_id}')
+    except Exception as error:
+        raise ReleaseExecutionError(
+            f'release creation failed; remote branch was not touched: {error}', tuple(completed),
+        ) from error
+
+    try:
+        verified_release = github.get_release(plan.data_id)
+        if verified_release is None or verified_release.tag_name != plan.data_id:
+            raise RuntimeError('GitHub release failed postcondition verification')
+        tag_ref = next(
+            (ref for ref in github.list_tag_refs() if ref.name == plan.data_id), None,
+        )
+        if (
+            tag_ref is None
+            or tag_ref.object_type != 'tag'
+            or tag_ref.object_id != plan.tag_object_id
+        ):
+            observed = 'absent' if tag_ref is None else (
+                f'{tag_ref.object_type} {tag_ref.object_id}'
+            )
+            raise RuntimeError(
+                f'post-release tag ref mismatch: expected tag {plan.tag_object_id}, observed {observed}'
+            )
+        verified_tag = github.get_tag(tag_ref)
+        if (
+            verified_tag.commit_id != plan.tag_commit_id
+            or verified_tag.message.rstrip('\n') != plan.annotation.serialize()
+        ):
+            raise RuntimeError(
+                'post-release annotated tag object, peeled commit, or metadata changed'
+            )
+        completed.append(f'verify-release:{plan.data_id}')
+    except Exception as error:
+        raise PartialPublishError(
+            f"release '{plan.data_id}' exists, but its exact tag failed post-release "
+            f'verification and the remote branch was not touched. Inspect release and tag '
+            f'{plan.data_id} before any ref update. Verification failure: {error}',
+            tuple(completed),
+        ) from error
+
+    try:
+        if plan.branch_commit_id is None:
+            github.create_branch(plan.base_branch, plan.tag_commit_id)
+            completed.append(f'create-remote-branch:{plan.base_branch}:{plan.tag_commit_id}')
+        elif plan.branch_commit_id != plan.tag_commit_id:
+            if not github.is_ancestor(plan.branch_commit_id, plan.tag_commit_id):
+                raise ReleaseExecutionError('remote branch is no longer an ancestor of the tag commit')
+            github.update_branch(plan.base_branch, plan.tag_commit_id, plan.branch_commit_id)
+            completed.append(f'advance-remote-branch:{plan.base_branch}:{plan.tag_commit_id}')
+        observed = github.get_branch(plan.base_branch)
+        if observed != plan.tag_commit_id:
+            raise ReleaseExecutionError(
+                f'remote branch postcondition failed: observed {observed or "absent"}', tuple(completed),
+            )
+    except Exception as error:
+        try:
+            observed = github.get_branch(plan.base_branch)
+        except Exception as observation_error:
+            observed = f'unavailable ({observation_error})'
+        recovery = (
+            f"release '{plan.data_id}' exists, but branch 'refs/heads/{plan.base_branch}' "
+            f"must target {plan.tag_commit_id}; observed {observed or 'absent'}. "
+            f"After verifying ancestry, set that ref explicitly to {plan.tag_commit_id}."
+        )
+        raise PartialPublishError(f'{recovery} Branch failure: {error}', tuple(completed)) from error
+
+    return PublishExecutionResult(
+        plan.data_id, release.url, plan.base_branch, plan.tag_commit_id, tuple(completed),
+    )

--- a/python/eos/cli/data_release_execution_TEST.py
+++ b/python/eos/cli/data_release_execution_TEST.py
@@ -1,0 +1,432 @@
+# Copyright (c) 2026 Danny van Dyk
+#
+# This file is part of the EOS project. EOS is free software;
+# you can redistribute it and/or modify it under the terms of the GNU General
+# Public License version 2, as published by the Free Software Foundation.
+#
+# EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from eos.cli.data import create_check_factory
+from eos.cli.data_github import GitHubClient, GitHubCommandError, GitHubRef, GitHubRelease, GitHubTag
+from eos.cli.data_release import (
+    LocalGitClient, ReleasePlanningError, ResolvedSource, TargetCheckout,
+    make_annotation, plan_create, plan_publish, render_create_plan, render_publish_plan,
+)
+from eos.cli.data_release_execution import (
+    PartialPublishError, ReleaseExecutionError, execute_create, execute_publish,
+)
+
+
+def _dataset(root: Path, data_id: str) -> None:
+    (root / 'README.md').write_text('# Dataset\n', encoding='utf-8')
+    (root / 'analysis.yaml').write_text(
+        'metadata:\n  id: 2025-03\n  title: Main title\n'
+        '  description: Release notes.\n  authors:\n    - name: Jane Doe\n',
+        encoding='utf-8',
+    )
+    (root / '.zenodo.json').write_text(json.dumps({
+        'title': f'EOS/DATA-{data_id}: Supplementary material for EOS/ANALYSIS-2025-03',
+        'description': 'Release notes.',
+        'creators': [{'name': 'Doe, Jane', 'affiliation': 'Lab'}],
+        'upload_type': 'dataset', 'license': 'CC-BY-4.0', 'grants': [],
+    }), encoding='utf-8')
+
+
+def _tag(name: str, commit: str) -> GitHubTag:
+    annotation = make_annotation(name, '2025-03', ('analysis.yaml',), 'analysis.yaml')
+    return GitHubTag(name, f'tag-{name}', commit, annotation.serialize())
+
+
+def _git(root: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ['git', *arguments], cwd=root, check=True, capture_output=True, text=True,
+        env={
+            **os.environ,
+            'GIT_AUTHOR_NAME': 'Test', 'GIT_AUTHOR_EMAIL': 'test@example.com',
+            'GIT_COMMITTER_NAME': 'Test', 'GIT_COMMITTER_EMAIL': 'test@example.com',
+        },
+    ).stdout.strip()
+
+
+class ScriptedGit:
+    def __init__(self, root: Path, tags=(), branch=None):
+        self.root = root
+        self.tags = {tag.name: (tag.object_id, tag.commit_id) for tag in tags}
+        self.messages = {tag.name: tag.message for tag in tags}
+        self.branch = branch
+        self.parents = {tag.commit_id: (() if index == 0 else (tags[index - 1].commit_id,))
+                        for index, tag in enumerate(tags)}
+        self.calls = []
+        self.next_commit = 'new-commit'
+
+    def target_checkout(self, directory, *, require_clean=True):
+        self.calls.append(('target', require_clean))
+        return TargetCheckout(Path(directory), 'origin', 'git@github.com:eos/data.git')
+
+    def local_tag_refs(self, target):
+        self.calls.append(('local-tags',))
+        return dict(self.tags)
+
+    def local_branch(self, target, name):
+        self.calls.append(('local-branch', name))
+        return self.branch
+
+    @contextmanager
+    def checkout_source(self, source):
+        self.calls.append(('check-source', str(source)))
+        yield ResolvedSource(str(source), 'source-commit', self.root)
+
+    @contextmanager
+    def checkout_commit(self, source, commit):
+        self.calls.append(('checkout-commit', str(source), commit))
+        yield self.root
+
+    def create_dataset_commit(self, target, source, message, parent):
+        self.calls.append(('create-commit', message, parent))
+        self.parents[self.next_commit] = () if parent is None else (parent,)
+        return self.next_commit
+
+    def prepare_local_branch(self, target, name, current, parent):
+        self.calls.append(('prepare-branch', name, current, parent))
+
+    def commit_parents(self, target, commit):
+        self.calls.append(('local-parents', commit))
+        return self.parents[commit]
+
+    def update_local_branch(self, target, name, commit, expected_old):
+        self.calls.append(('move-branch', name, commit, expected_old))
+        if self.branch != expected_old:
+            raise RuntimeError('local branch race')
+        self.branch = commit
+
+    def create_local_tag(self, target, name, commit, message, expected_old):
+        self.calls.append(('create-tag', name, commit, expected_old))
+        current = self.tags.get(name)
+        if (current[0] if current else None) != expected_old:
+            raise RuntimeError('local tag race')
+        object_id = f'new-tag-{name}'
+        self.tags[name] = (object_id, commit)
+        self.messages[name] = message
+        return self.tags[name]
+
+
+class ScriptedGitHub:
+    def __init__(self, root: Path, tags=(), releases=(), branch=None, parents=None):
+        self.root = root
+        self.tags = {tag.name: tag for tag in tags}
+        self.releases = set(releases)
+        self.branch = branch
+        self.parents = dict(parents or {})
+        self.calls = []
+        self.git = None
+        self.fail_release = False
+        self.fail_branch = False
+        self.wrong_transfer = False
+        self.move_tag_after_release = False
+
+    def list_tag_refs(self):
+        self.calls.append(('list-tags',))
+        return tuple(GitHubRef(tag.name, tag.object_id, 'tag') for tag in self.tags.values())
+
+    def get_tag(self, ref):
+        self.calls.append(('get-tag', ref.name))
+        return self.tags[ref.name]
+
+    def get_release(self, name):
+        self.calls.append(('get-release', name))
+        return GitHubRelease(name, f'https://example.invalid/{name}') if name in self.releases else None
+
+    def get_branch(self, name):
+        self.calls.append(('get-branch', name))
+        return self.branch
+
+    def commit_parents(self, commit):
+        self.calls.append(('parents', commit))
+        return tuple(self.parents.get(commit, ()))
+
+    def is_ancestor(self, ancestor, descendant):
+        self.calls.append(('ancestor', ancestor, descendant))
+        current = descendant
+        while self.parents.get(current):
+            current = self.parents[current][0]
+            if current == ancestor:
+                return True
+        return ancestor == descendant
+
+    @contextmanager
+    def checkout_tree(self, commit):
+        self.calls.append(('checkout-tree', commit))
+        yield self.root
+
+    def transfer_local_tag(self, root, remote, name, expected_old):
+        self.calls.append(('transfer-tag', remote, name, expected_old))
+        current = self.tags.get(name)
+        if (current.object_id if current else None) != expected_old:
+            raise GitHubCommandError('remote tag race')
+        object_id, commit_id = self.git.tags[name]
+        if self.wrong_transfer:
+            object_id = 'wrong-object'
+        self.tags[name] = GitHubTag(name, object_id, commit_id, self.git.messages[name])
+        self.parents[commit_id] = self.git.parents[commit_id]
+
+    def create_release(self, name, title, notes):
+        self.calls.append(('create-release', name, title, notes))
+        if self.fail_release:
+            raise GitHubCommandError('scripted release failure')
+        self.releases.add(name)
+        if self.move_tag_after_release:
+            tag = self.tags[name]
+            self.tags[name] = GitHubTag(name, 'moved-tag-object', 'moved-commit', tag.message)
+        return GitHubRelease(name, f'https://example.invalid/{name}')
+
+    def create_branch(self, name, commit):
+        self.calls.append(('create-branch', name, commit))
+        if self.fail_branch:
+            raise GitHubCommandError('scripted branch failure')
+        self.branch = commit
+
+    def update_branch(self, name, commit, expected_old):
+        self.calls.append(('update-branch', name, commit, expected_old))
+        if self.fail_branch or self.branch != expected_old:
+            raise GitHubCommandError('scripted guarded branch failure')
+        self.branch = commit
+
+
+class CreateExecutionTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        _dataset(self.root, '2026-01')
+        self.factory = create_check_factory()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def _execute(self, git, github, **options):
+        github.git = git
+        plan = plan_create(
+            '2026-01', self.root, Path('/target'), git=git, github=github,
+            check_factory=self.factory, **options,
+        )
+        before = (dict(git.tags), git.branch, dict(github.tags), github.branch)
+        self.assertIn('read-only', render_create_plan(plan))
+        self.assertEqual(before, (dict(git.tags), git.branch, dict(github.tags), github.branch))
+        result = execute_create(plan, git=git, github=github, check_factory=self.factory)
+        return result
+
+    def test_initial_creation_exact_write_order(self):
+        git, github = ScriptedGit(self.root), ScriptedGitHub(self.root)
+        result = self._execute(git, github)
+        self.assertEqual(result.commit_id, 'new-commit')
+        writes = [call[0] for call in git.calls + github.calls if call[0] in {
+            'prepare-branch', 'create-commit', 'move-branch', 'create-tag', 'transfer-tag',
+        }]
+        self.assertEqual(writes, [
+            'prepare-branch', 'create-commit', 'move-branch', 'create-tag', 'transfer-tag',
+        ])
+        self.assertIn('move-local-branch:2026-01:new-commit', result.completed)
+
+    def test_replacement_uses_old_ids_and_guarded_transfer(self):
+        base = _tag('2026-01', 'c1')
+        git = ScriptedGit(self.root, (base,), 'c1')
+        github = ScriptedGitHub(self.root, (base,), parents={'c1': ()})
+        result = self._execute(git, github, replace=True)
+        self.assertEqual((result.old_tag_object_id, result.old_commit_id), ('tag-2026-01', 'c1'))
+        self.assertIn(('move-branch', '2026-01', 'new-commit', 'c1'), git.calls)
+        self.assertIn(('transfer-tag', 'origin', '2026-01', 'tag-2026-01'), github.calls)
+
+    def test_v2_and_v3_extend_latest_commit(self):
+        for tags, expected_id, parent in (
+            ((_tag('2026-01', 'c1'),), '2026-01v2', 'c1'),
+            ((_tag('2026-01', 'c1'), _tag('2026-01v2', 'c2')), '2026-01v3', 'c2'),
+        ):
+            with self.subTest(expected_id=expected_id):
+                _dataset(self.root, expected_id)
+                parents = {'c1': (), 'c2': ('c1',)}
+                git = ScriptedGit(self.root, tags, parent)
+                github = ScriptedGitHub(self.root, tags, parents=parents)
+                result = self._execute(git, github, revision=True)
+                self.assertEqual(result.data_id, expected_id)
+                subject = make_annotation(
+                    expected_id, '2025-03', ('analysis.yaml',), 'analysis.yaml',
+                ).subject
+                self.assertIn(('create-commit', subject, parent), git.calls)
+
+    def test_wrong_remote_object_is_reported_with_completed_state(self):
+        git, github = ScriptedGit(self.root), ScriptedGitHub(self.root)
+        github.wrong_transfer = True
+        github.git = git
+        plan = plan_create('2026-01', self.root, Path('/target'), git=git, github=github,
+                           check_factory=self.factory)
+        with self.assertRaises(ReleaseExecutionError) as caught:
+            execute_create(plan, git=git, github=github, check_factory=self.factory)
+        self.assertIn('remote tag ref failed', str(caught.exception))
+        self.assertIn('move-local-branch:2026-01:new-commit', str(caught.exception))
+        self.assertIn('create-annotated-tag', str(caught.exception))
+
+
+class LocalMutationTests(unittest.TestCase):
+    def test_commit_branch_and_annotated_tag_have_exact_tree_and_parent(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target_root, source_root = root / 'target', root / 'source'
+            remote_root = root / 'remote.git'
+            target_root.mkdir()
+            source_root.mkdir()
+            _git(root, 'init', '--bare', str(remote_root))
+            _git(target_root, 'init', '-b', 'main')
+            _git(target_root, 'config', 'user.name', 'Test')
+            _git(target_root, 'config', 'user.email', 'test@example.com')
+            (target_root / 'old').write_text('old', encoding='utf-8')
+            _git(target_root, 'add', 'old')
+            _git(target_root, 'commit', '-m', 'unrelated main')
+            _git(target_root, 'remote', 'add', 'origin', str(remote_root))
+            _git(source_root, 'init', '-b', 'main')
+            (source_root / 'new').write_text('new', encoding='utf-8')
+            _git(source_root, 'add', 'new')
+            _git(source_root, 'commit', '-m', 'source')
+            source_commit = _git(source_root, 'rev-parse', 'HEAD')
+
+            client = LocalGitClient()
+            target = TargetCheckout(target_root, 'origin', 'git@github.com:eos/data.git')
+            client.prepare_local_branch(target, '2026-01', None, None)
+            with client.checkout_commit(source_root, source_commit) as checked_out:
+                commit = client.create_dataset_commit(target, checked_out, 'dataset', None)
+            self.assertEqual(client.commit_parents(target, commit), ())
+            self.assertEqual(
+                _git(target_root, 'rev-parse', f'{commit}^{{tree}}'),
+                _git(source_root, 'rev-parse', f'{source_commit}^{{tree}}'),
+            )
+            client.update_local_branch(target, '2026-01', commit, None)
+            self.assertEqual(sorted(path.name for path in target_root.iterdir() if path.name != '.git'), ['new'])
+            message = make_annotation(
+                '2026-01', '2025-03', ('analysis.yaml',), 'analysis.yaml',
+            ).serialize()
+            object_id, peeled = client.create_local_tag(target, '2026-01', commit, message, None)
+            self.assertEqual(peeled, commit)
+            GitHubClient(executable='unused').transfer_local_tag(
+                target_root, 'origin', '2026-01', None,
+            )
+            self.assertEqual(
+                _git(remote_root, 'rev-parse', 'refs/tags/2026-01'), object_id,
+            )
+            self.assertEqual(_git(remote_root, 'for-each-ref', '--format=%(refname)', 'refs/heads'), '')
+
+    def test_local_tag_compare_and_swap_does_not_overwrite_a_race(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _git(root, 'init', '-b', 'main')
+            _git(root, 'config', 'user.name', 'Test')
+            _git(root, 'config', 'user.email', 'test@example.com')
+            (root / 'value').write_text('one', encoding='utf-8')
+            _git(root, 'add', 'value')
+            _git(root, 'commit', '-m', 'one')
+            first = _git(root, 'rev-parse', 'HEAD')
+            (root / 'value').write_text('two', encoding='utf-8')
+            _git(root, 'commit', '-am', 'two')
+            second = _git(root, 'rev-parse', 'HEAD')
+            _git(root, 'tag', '-a', '-m', 'old', '2026-01', first)
+            old_object = _git(root, 'rev-parse', 'refs/tags/2026-01')
+
+            class RacingGit(LocalGitClient):
+                injected = False
+
+                def _run(inner_self, arguments, **kwargs):
+                    if (
+                        arguments[:2] == ['update-ref', 'refs/tags/2026-01']
+                        and not inner_self.injected
+                    ):
+                        inner_self.injected = True
+                        _git(root, 'update-ref', 'refs/tags/2026-01', second, old_object)
+                    return super()._run(arguments, **kwargs)
+
+            target = TargetCheckout(root, 'origin', 'git@github.com:eos/data.git')
+            with self.assertRaises(ReleasePlanningError):
+                RacingGit().create_local_tag(
+                    target, '2026-01', second, 'replacement metadata', old_object,
+                )
+            self.assertEqual(_git(root, 'rev-parse', 'refs/tags/2026-01'), second)
+
+
+class PublishExecutionTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        _dataset(self.root, '2026-01')
+        self.factory = create_check_factory()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def _plan(self, tags, *, data_id='2026-01', branch=None, parents=None):
+        if isinstance(tags, GitHubTag):
+            tags = (tags,)
+        git = ScriptedGit(self.root)
+        github = ScriptedGitHub(self.root, tags, branch=branch, parents=parents)
+        plan = plan_publish(data_id, Path('/target'), git=git, github=github,
+                            check_factory=self.factory)
+        before = (set(github.releases), github.branch, list(github.calls))
+        self.assertIn('read-only', render_publish_plan(plan))
+        self.assertEqual((set(github.releases), github.branch), before[:2])
+        return git, github, plan
+
+    def test_first_publish_releases_verifies_then_creates_branch(self):
+        git, github, plan = self._plan(_tag('2026-01', 'c1'), parents={'c1': ()})
+        result = execute_publish(plan, git=git, github=github, check_factory=self.factory)
+        writes = [call[0] for call in github.calls if call[0] in {'create-release', 'create-branch'}]
+        self.assertEqual(writes, ['create-release', 'create-branch'])
+        self.assertEqual(result.branch_commit_id, 'c1')
+
+    def test_later_publish_advances_only_an_ancestor_branch(self):
+        tags = (_tag('2026-01', 'c1'), _tag('2026-01v2', 'c2'))
+        git, github, plan = self._plan(
+            tags, data_id='2026-01v2', branch='c1', parents={'c1': (), 'c2': ('c1',)},
+        )
+        execute_publish(plan, git=git, github=github, check_factory=self.factory)
+        self.assertIn(('update-branch', '2026-01', 'c2', 'c1'), github.calls)
+
+    def test_release_failure_never_calls_branch_write(self):
+        git, github, plan = self._plan(_tag('2026-01', 'c1'), parents={'c1': ()})
+        github.fail_release = True
+        with self.assertRaises(ReleaseExecutionError) as caught:
+            execute_publish(plan, git=git, github=github, check_factory=self.factory)
+        self.assertIn('branch was not touched', str(caught.exception))
+        self.assertFalse(any(call[0] in {'create-branch', 'update-branch'} for call in github.calls))
+
+    def test_post_release_tag_movement_is_partial_failure_without_branch_write(self):
+        git, github, plan = self._plan(_tag('2026-01', 'c1'), parents={'c1': ()})
+        github.move_tag_after_release = True
+        with self.assertRaises(PartialPublishError) as caught:
+            execute_publish(plan, git=git, github=github, check_factory=self.factory)
+        self.assertIn("release '2026-01' exists", str(caught.exception))
+        self.assertIn('tag ref mismatch', str(caught.exception))
+        self.assertFalse(any(call[0] in {'create-branch', 'update-branch'} for call in github.calls))
+
+    def test_branch_failure_reports_release_observed_target_and_recovery(self):
+        git, github, plan = self._plan(_tag('2026-01', 'c1'), parents={'c1': ()})
+        github.fail_branch = True
+        with self.assertRaises(PartialPublishError) as caught:
+            execute_publish(plan, git=git, github=github, check_factory=self.factory)
+        message = str(caught.exception)
+        for text in ("release '2026-01' exists", 'refs/heads/2026-01', 'c1', 'observed absent',
+                     'set that ref explicitly'):
+            self.assertIn(text, message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/eos/deserializable.py
+++ b/python/eos/deserializable.py
@@ -21,6 +21,11 @@ from dataclasses import MISSING, dataclass, fields
 from .diagnostic import Diagnostic, Severity
 
 
+def load_yaml_file(path):
+    with open(path, encoding='utf-8') as stream:
+        return _yaml.safe_load(stream)
+
+
 @dataclass
 class InvalidComponent:
     diagnostics: list
@@ -58,8 +63,7 @@ class Deserializable:
         """
         if not _os.path.exists(path) or not _os.path.isfile(path):
             raise RuntimeError(f'Description file {path} does not exist or is not a file')
-        with open(path) as f:
-            data = _yaml.safe_load(f)
+        data = load_yaml_file(path)
         if not isinstance(data, dict):
             raise RuntimeError(f'Description file {path} does not contain a YAML mapping')
         return cls.from_dict(**data)

--- a/python/eos/diagnostic.py
+++ b/python/eos/diagnostic.py
@@ -23,6 +23,7 @@ import enum
 class Severity(enum.Enum):
     ERROR = 'error'
     WARNING = 'warning'
+    INFO = 'info'
 
 
 @dataclass(frozen=True)

--- a/python/eos/tasks.py
+++ b/python/eos/tasks.py
@@ -68,6 +68,12 @@ class LogfileHandler:
 
 
 _tasks = {}
+_task_outputs = {}
+
+
+def task_output_templates():
+    """Return the registered task output templates without executing any task."""
+    return dict(_task_outputs)
 
 def task(name, output, mode=lambda **kwargs: 'w', modules=None, logfile=True, load_analysis_file=True):
     """Decorator that registers a function as a named EOS task.
@@ -150,6 +156,7 @@ def task(name, output, mode=lambda **kwargs: 'w', modules=None, logfile=True, lo
                         iaccordion.selected_index = None
                     return result
         _tasks[name] = task_wrapper
+        _task_outputs[name] = output
         return task_wrapper
     return _task
 


### PR DESCRIPTION
The proposed workflow begins by checking an analysis repository for consistent analysis metadata, Zenodo metadata, authors, figures, file sizes, and reproducible outputs. The ``create`` command then imports the committed ``main`` tree into ``eos/data``, creates an annotated dataset tag, and transfers only that tag to GitHub, allowing a preprint to cite it without creating a Zenodo release.

Once the associated manuscript is ready for publication, ``publish`` creates and verifies the GitHub release before creating or advancing the dataset branch, which triggers the Zenodo workflow. After Zenodo supplies a DOI, ``register`` prepares and pushes a guarded ``register-{ID}`` branch containing the new ``datasets.yaml`` entry, leaving the user to open the pull request; all three mutating commands support read-only dry runs.

- ce706370 [python] Add informational diagnostic severity.  This distinguishes explanatory findings from warnings and errors.
- adae094a [python] Validate analysis metadata author fields. This requires every author entry to provide a usable name.
- 4372513a [python] Convert ``eos-data`` into a shim and introduce ``eos.cli`` package.
- cdac7ef7 [python] Add ``eos-data check`` infrastructure. This introduces the check registry, runner, renderer, exit statuses, and importable command implementation while preserving the existing commands.
- 24050d95 [python] Add analysis and Zenodo metadata checks for ``eos-data``. This checks analysis selection and consistency, Zenodo title and description, and exact author/creator agreement.
- 29a395c6 [python] Add ``eos-data check`` coverage. This adds permanent fixtures and tests for metadata validation, command behavior, and failure reporting.
- e55d3547 [python] Extend ``eos-data`` checks. This adds checks for Zenodo completeness, README figures, file sizes, and reproducible task outputs.
- d9048f1a [python] Implement ``eos-data create`` and ``eos-data publish`` commands.
- 1e4c9caa [python] Implement ``eos-data register`` command.
- d6fd04b9 [eos] Update changelog for PR #1222.