### PR TITLE
Convert baryon form factors to use parametric masses and thresholds (where applicable)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,8 @@
 - Add the ``SSE`` (Simplified Series Expansion) form factor parametrization for pseudoscalar-to-pseudoscalar, pseudoscalar-to-vector, and 1/2^+ -> 1/2^+ transitions (D. van Dyk)
 - Add the ``M:2017A`` reference and its constraints on the ``Lambda_c->proton`` and ``Lambda_c->neutron`` form factors (D. van Dyk)
 - Add the ``mass::D_u,0@HME`` and ``mass::D_u,1@HME`` parameters (D. van Dyk)
+- Add the ``mass::Lambda_c(2595)@HME``, ``mass::Lambda_c(2625)@HME``, and ``mass::Lambda(1520)@HME`` parameters (D. van Dyk)
+- Add the ``Lambda_b->Lambda(1520)::tp_v@SE``, ``Lambda_b->Lambda(1520)::tp_a@SE``, and ``Lambda_b->Lambda(1520)::t0@SE`` parameters (D. van Dyk)
 
 ### Deprecated
 
@@ -30,6 +32,7 @@
 ### Fixed
 
 - Correct the ``Lambda_c`` mass entering the ``Lambda_b->Lambda_c``, ``Lambda_c->Lambda``, ``Lambda_c->proton``, and ``Lambda_c->neutron`` unitarity-bound thresholds to match the canonical ``mass::Lambda_c`` parameter (D. van Dyk)
+- Convert the ``Lambda_b->Lambda_c::DKMR2017``, ``Lambda_b->Lambda::DM2016``, ``Lambda_b->Lambda_c(2595)::HQET``, ``Lambda_b->Lambda_c(2625)::HQET``, and ``Lambda_b->Lambda(1520)::SE`` form factors to read their initial- and final-state masses from ``Parameters`` in lieu of hardcoded compile-time constants that could silently drift from the corresponding ``@HME`` parameter values (D. van Dyk)
 
 
 ## [v1.0.21] - 2026-08-05

--- a/eos/form-factors/baryonic-processes.hh
+++ b/eos/form-factors/baryonic-processes.hh
@@ -33,10 +33,6 @@ namespace eos
         static constexpr const char * name_1 = "mass::Lambda_b";
         static constexpr const char * name_2 = "mass::Lambda";
         static constexpr const std::tuple<QuarkFlavor, QuarkFlavor> partonic_transition = std::make_tuple(QuarkFlavor::bottom, QuarkFlavor::strange);
-        // initial state mass
-        static constexpr double m1 = 5.61951;
-        // final state mass
-        static constexpr double m2 = 1.115683;
         // OPE results for the unitarity bounds
         static constexpr double chi_0m = 1.57e-2;
         static constexpr double chi_0p = 1.42e-2;

--- a/eos/form-factors/baryonic-processes.hh
+++ b/eos/form-factors/baryonic-processes.hh
@@ -149,13 +149,6 @@ namespace eos
         static constexpr const char * label = "Lambda_b->Lambda(1520)";
         static constexpr const char * name_1 = "mass::Lambda_b";
         static constexpr const char * name_2 = "mass::Lambda(1520)";
-        // scalar pair production threshold: B + K
-        static constexpr double tp = (5.279 + 0.494) * (5.279 + 0.494);
-        // // vector pair production threshold: B + K*
-        // static constexpr double tpv = (5.279 + 0.896) * (5.279 + 0.896);
-        // zero of the conformal mapping: z(t0, t0) = 0.0
-        // This optimal value follows from z(0, t0) = - z(tm, t0)
-        static constexpr double t0 = 9.865;
         // first resonances sorted by spin/parity
         static constexpr double mR2_0m = 5.367 * 5.367;
         static constexpr double mR2_0p = 5.711 * 5.711;

--- a/eos/form-factors/baryonic-processes.hh
+++ b/eos/form-factors/baryonic-processes.hh
@@ -117,14 +117,8 @@ namespace eos
 
     struct LambdaBToLambdaC2595 {
         static constexpr const char * label = "Lambda_b->Lambda_c(2595)";
-        // initial state mass
-        static constexpr double m1 = 5.61951;
-        // final state mass
-        static constexpr double m2 = 2.59225;
-        // semileptonic kinematic endpoint
-        static constexpr double tm = (m1 - m2) * (m1 - m2);
-        // pair production threshold: Lambda_b + Lambda_c(2625)
-        static constexpr double tp = (m1 + m2) * (m1 + m2);
+        static constexpr const char * name_1 = "mass::Lambda_b";
+        static constexpr const char * name_2 = "mass::Lambda_c(2595)";
         // first resonances sorted by spin/parity
         // we use the shifts from [DLM:2015A], table VII.
         static constexpr double mBc = 6.2751;
@@ -140,14 +134,8 @@ namespace eos
 
     struct LambdaBToLambdaC2625 {
         static constexpr const char * label = "Lambda_b->Lambda_c(2625)";
-        // initial state mass
-        static constexpr double m1 = 5.61951;
-        // final state mass
-        static constexpr double m2 = 2.62811;
-        // semileptonic kinematic endpoint
-        static constexpr double tm = (m1 - m2) * (m1 - m2);
-        // pair production threshold: Lambda_b + Lambda_c(2625)
-        static constexpr double tp = (m1 + m2) * (m1 + m2);
+        static constexpr const char * name_1 = "mass::Lambda_b";
+        static constexpr const char * name_2 = "mass::Lambda_c(2625)";
         // first resonances sorted by spin/parity
         // we use the shifts from [DLM:2015A], table VII.
         static constexpr double mBc = 6.2751;

--- a/eos/form-factors/baryonic-processes.hh
+++ b/eos/form-factors/baryonic-processes.hh
@@ -48,10 +48,8 @@ namespace eos
 
     struct LambdaBToLambdaC {
         static constexpr const char * label = "Lambda_b->Lambda_c";
-        // initial state mass
-        static constexpr double m1 = 5.61951;
-        // final state mass
-        static constexpr double m2 = 2.28646;
+        static constexpr const char * name_1 = "mass::Lambda_b";
+        static constexpr const char * name_2 = "mass::Lambda_c";
         static constexpr const std::tuple<QuarkFlavor, QuarkFlavor> partonic_transition = std::make_tuple(QuarkFlavor::bottom, QuarkFlavor::charm);
     };
 

--- a/eos/form-factors/baryonic-processes.hh
+++ b/eos/form-factors/baryonic-processes.hh
@@ -147,12 +147,8 @@ namespace eos
 
     struct LambdaBToLambda1520 {
         static constexpr const char * label = "Lambda_b->Lambda(1520)";
-        // initial state mass
-        static constexpr double m1 = 5.620;
-        // final state mass
-        static constexpr double m2 = 1.520;
-        // semileptonic kinematic endpoint
-        static constexpr double tm = (m1 - m2) * (m1 - m2);
+        static constexpr const char * name_1 = "mass::Lambda_b";
+        static constexpr const char * name_2 = "mass::Lambda(1520)";
         // scalar pair production threshold: B + K
         static constexpr double tp = (5.279 + 0.494) * (5.279 + 0.494);
         // // vector pair production threshold: B + K*

--- a/eos/form-factors/parametric-bbgorvd2018-impl.hh
+++ b/eos/form-factors/parametric-bbgorvd2018-impl.hh
@@ -1,10 +1,10 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2014, 2015, 2016, 2017 Danny van Dyk
- * Copyright (c) 2017 Elena Graverini
- * Copyright (c) 2017, 2018 Marzia Bordone
- * Copyright (c) 2018 Ahmet Kokulu
+ * Copyright (c) 2014-2026 Danny van Dyk
+ * Copyright (c) 2017      Elena Graverini
+ * Copyright (c) 2017-2018 Marzia Bordone
+ * Copyright (c) 2018      Ahmet Kokulu
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -37,7 +37,9 @@ namespace eos
         _zeta_max(p["Lambda_b->Lambda_c^*::zeta(q^2_max)@HQET"], *this),
         _rho(p["Lambda_b->Lambda_c^*::rho@HQET"], *this),
         _delta_3b(p["Lambda_b->Lambda_c^*::delta_3b@HQET"], *this),
-        _rho_3b(p["Lambda_b->Lambda_c^*::rho_3b@HQET"], *this)
+        _rho_3b(p["Lambda_b->Lambda_c^*::rho_3b@HQET"], *this),
+        mLb(UsedParameter(p[std::string(Process_::name_1) + "@HME"], *this)),
+        mLcs(UsedParameter(p[std::string(Process_::name_2) + "@HME"], *this))
     {
         uses(_b_to_c);
     }
@@ -67,8 +69,8 @@ namespace eos
 
         // leading-power IWF
         double result = C_1 * sp;
-        result += (mLb + mLcs) / (mLb - mLcs) * (mLb2 - mLcs2 + s) / (2.0 * mLb ) * (lambdabar      + C_2 * sp / (mLb + mLcs));
-        result -= (mLb + mLcs) / (mLb - mLcs) * (mLb2 - mLcs2 - s) / (2.0 * mLcs) * (lambdabarprime - C_3 * sp / (mLb + mLcs));
+        result += (mLb + mLcs) / (mLb - mLcs) * (mLb2() - mLcs2() + s) / (2.0 * mLb ) * (lambdabar()      + C_2 * sp / (mLb + mLcs));
+        result -= (mLb + mLcs) / (mLb - mLcs) * (mLb2() - mLcs2() - s) / (2.0 * mLcs) * (lambdabarprime() - C_3 * sp / (mLb + mLcs));
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -95,7 +97,7 @@ namespace eos
         // leading-power IWF
         double result = C_1 + sp * (C_2 * mLcs + C_3 * mLb) / (2.0 * mLb * mLcs * (mLb + mLcs));
         result *= sm;
-        result += (mLb - mLcs) / (mLb + mLcs) * ((mLb2 - mLcs2 + s) / (2.0 * mLb) * lambdabar - (mLb2 - mLcs2 - s) / (2.0 * mLcs) * lambdabarprime);
+        result += (mLb - mLcs) / (mLb + mLcs) * ((mLb2() - mLcs2() + s) / (2.0 * mLb) * lambdabar() - (mLb2() - mLcs2() - s) / (2.0 * mLcs) * lambdabarprime());
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -118,7 +120,7 @@ namespace eos
         const double C_1 = _b_to_c.c_1_vector(omegabar);
 
         // leading-power IWF
-        double result = C_1 * sm + (3.0 * mLb2 + mLcs2 - s) / (2.0 * mLb) * lambdabar - (mLb2 + 3.0 * mLcs2 - s) / (2.0 * mLcs) * lambdabarprime;
+        double result = C_1 * sm + (3.0 * mLb2() + mLcs2() - s) / (2.0 * mLb) * lambdabar() - (mLb2() + 3.0 * mLcs2() - s) / (2.0 * mLcs) * lambdabarprime();
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -145,8 +147,8 @@ namespace eos
 
         // leading-power IWF
         double result = C_1 * sm;
-        result += (mLb - mLcs) / (mLb + mLcs) * (mLb2 - mLcs2 + s) / (2.0 * mLb ) * (lambdabar      - C_2 * sm / (mLb - mLcs));
-        result -= (mLb - mLcs) / (mLb + mLcs) * (mLb2 - mLcs2 - s) / (2.0 * mLcs) * (lambdabarprime + C_3 * sm / (mLb - mLcs));
+        result += (mLb - mLcs) / (mLb + mLcs) * (mLb2() - mLcs2() + s) / (2.0 * mLb ) * (lambdabar()      - C_2 * sm / (mLb - mLcs));
+        result -= (mLb - mLcs) / (mLb + mLcs) * (mLb2() - mLcs2() - s) / (2.0 * mLcs) * (lambdabarprime() + C_3 * sm / (mLb - mLcs));
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -173,7 +175,7 @@ namespace eos
         // leading-power IWF
         double result = C_1 - sm * (C_2 * mLcs + C_3 * mLb) / (2.0 * mLb * mLcs * (mLb - mLcs));
         result *= sp;
-        result += (mLb + mLcs) / (mLb - mLcs) * ((mLb2 - mLcs2 + s) / (2.0 * mLb) * lambdabar - (mLb2 - mLcs2 - s) / (2.0 * mLcs) * lambdabarprime);
+        result += (mLb + mLcs) / (mLb - mLcs) * ((mLb2() - mLcs2() + s) / (2.0 * mLb) * lambdabar() - (mLb2() - mLcs2() - s) / (2.0 * mLcs) * lambdabarprime());
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -196,7 +198,7 @@ namespace eos
         const double C_1 = _b_to_c.c_1_axialvector(omegabar);
 
         // leading-power IWF
-        double result = C_1 * sp + (3.0 * mLb2 + mLcs2 - s) / (2.0 * mLb) * lambdabar - (mLb2 + 3.0 * mLcs2 - s) / (2.0 * mLcs) * lambdabarprime;
+        double result = C_1 * sp + (3.0 * mLb2() + mLcs2() - s) / (2.0 * mLb) * lambdabar() - (mLb2() + 3.0 * mLcs2() - s) / (2.0 * mLcs) * lambdabarprime();
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -214,9 +216,9 @@ namespace eos
     {
         Diagnostics results;
 
-        // s = s_max
+        // s = s_max()
         {
-            const double s        = s_max;
+            const double s        = s_max();
             const double omega    = this->omega(s);
             const double omegabar = this->omegabar(s);
             const double C_1_v    = _b_to_c.c_1_vector(omegabar);
@@ -236,8 +238,8 @@ namespace eos
             results.add({ C_1_a,          "C_1_a(s_max)"    });
             results.add({ C_2_a,          "C_2_a(s_max)"    });
             results.add({ C_3_a,          "C_3_a(s_max)"    });
-            results.add({ lambdabar,      "LambdaBar"       });
-            results.add({ lambdabarprime, "LambdaBar'"      });
+            results.add({ lambdabar(),      "LambdaBar"     });
+            results.add({ lambdabarprime(), "LambdaBar'"    });
             results.add({ f_time_v(s),    "f_{time}"        });
             results.add({ f_long_v(s),    "f_{long}"        });
             results.add({ f_perp_v(s),    "f_{perp}"        });
@@ -246,9 +248,9 @@ namespace eos
             results.add({ f_perp_a(s),    "g_{perp}"        });
         }
 
-        // s = s_max - 3.0
+        // s = s_max() - 3.0
         {
-            const double s        = s_max - 3.0;
+            const double s        = s_max() - 3.0;
             const double omega    = this->omega(s);
             const double omegabar = this->omegabar(s);
             const double C_1_v    = _b_to_c.c_1_vector(omegabar);
@@ -268,8 +270,8 @@ namespace eos
             results.add({ C_1_a,          "C_1_a(s_max)"    });
             results.add({ C_2_a,          "C_2_a(s_max)"    });
             results.add({ C_3_a,          "C_3_a(s_max)"    });
-            results.add({ lambdabar,      "LambdaBar"       });
-            results.add({ lambdabarprime , "LambdaBar'"      });
+            results.add({ lambdabar(),      "LambdaBar"     });
+            results.add({ lambdabarprime(), "LambdaBar'"    });
             results.add({ f_time_v(s),    "f_{time}"        });
             results.add({ f_long_v(s),    "f_{long}"        });
             results.add({ f_perp_v(s),    "f_{perp}"        });
@@ -291,7 +293,9 @@ namespace eos
         _zeta_max(p["Lambda_b->Lambda_c^*::zeta(q^2_max)@HQET"], *this),
         _rho(p["Lambda_b->Lambda_c^*::rho@HQET"], *this),
         _delta_3b(p["Lambda_b->Lambda_c^*::delta_3b@HQET"], *this),
-        _rho_3b(p["Lambda_b->Lambda_c^*::rho_3b@HQET"], *this)
+        _rho_3b(p["Lambda_b->Lambda_c^*::rho_3b@HQET"], *this),
+        mLb(UsedParameter(p[std::string(Process_::name_1) + "@HME"], *this)),
+        mLcs(UsedParameter(p[std::string(Process_::name_2) + "@HME"], *this))
     {
         uses(_b_to_c);
     }
@@ -321,8 +325,8 @@ namespace eos
 
         // leading-power IWF
         double result = C_1 * sp;
-        result += (mLb + mLcs) / (mLb - mLcs) * (mLb2 - mLcs2 + s) / (2.0 * mLb ) * (lambdabar      + C_2 * sp / (mLb + mLcs));
-        result -= (mLb + mLcs) / (mLb - mLcs) * (mLb2 - mLcs2 - s) / (2.0 * mLcs) * (lambdabarprime - C_3 * sp / (mLb + mLcs));
+        result += (mLb + mLcs) / (mLb - mLcs) * (mLb2() - mLcs2() + s) / (2.0 * mLb ) * (lambdabar()      + C_2 * sp / (mLb + mLcs));
+        result -= (mLb + mLcs) / (mLb - mLcs) * (mLb2() - mLcs2() - s) / (2.0 * mLcs) * (lambdabarprime() - C_3 * sp / (mLb + mLcs));
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -349,7 +353,7 @@ namespace eos
         // leading-power IWF
         double result = C_1 + sp * (C_2 * mLcs + C_3 * mLb) / (2.0 * mLb * mLcs * (mLb + mLcs));
         result *= sm;
-        result += (mLb - mLcs) / (mLb + mLcs) * ((mLb2 - mLcs2 + s) / (2.0 * mLb) * lambdabar - (mLb2 - mLcs2 - s) / (2.0 * mLcs) * lambdabarprime);
+        result += (mLb - mLcs) / (mLb + mLcs) * ((mLb2() - mLcs2() + s) / (2.0 * mLb) * lambdabar() - (mLb2() - mLcs2() - s) / (2.0 * mLcs) * lambdabarprime());
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -372,7 +376,7 @@ namespace eos
         const double C_1 = _b_to_c.c_1_vector(omegabar);
 
         // leading-power IWF
-        double result = C_1 * sm + (3.0 * mLb2 + mLcs2 - s) / (2.0 * mLb) * lambdabar - (mLb2 + 3.0 * mLcs2 - s) / (2.0 * mLcs) * lambdabarprime;
+        double result = C_1 * sm + (3.0 * mLb2() + mLcs2() - s) / (2.0 * mLb) * lambdabar() - (mLb2() + 3.0 * mLcs2() - s) / (2.0 * mLcs) * lambdabarprime();
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -411,8 +415,8 @@ namespace eos
 
         // leading-power IWF
         double result = C_1 * sm;
-        result += (mLb - mLcs) / (mLb + mLcs) * (mLb2 - mLcs2 + s) / (2.0 * mLb ) * (lambdabar      - C_2 * sm / (mLb - mLcs));
-        result -= (mLb - mLcs) / (mLb + mLcs) * (mLb2 - mLcs2 - s) / (2.0 * mLcs) * (lambdabarprime + C_3 * sm / (mLb - mLcs));
+        result += (mLb - mLcs) / (mLb + mLcs) * (mLb2() - mLcs2() + s) / (2.0 * mLb ) * (lambdabar()      - C_2 * sm / (mLb - mLcs));
+        result -= (mLb - mLcs) / (mLb + mLcs) * (mLb2() - mLcs2() - s) / (2.0 * mLcs) * (lambdabarprime() + C_3 * sm / (mLb - mLcs));
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -439,7 +443,7 @@ namespace eos
         // leading-power IWF
         double result = C_1 - sm * (C_2 * mLcs + C_3 * mLb) / (2.0 * mLb * mLcs * (mLb - mLcs));
         result *= sp;
-        result += (mLb + mLcs) / (mLb - mLcs) * ((mLb2 - mLcs2 + s) / (2.0 * mLb) * lambdabar - (mLb2 - mLcs2 - s) / (2.0 * mLcs) * lambdabarprime);
+        result += (mLb + mLcs) / (mLb - mLcs) * ((mLb2() - mLcs2() + s) / (2.0 * mLb) * lambdabar() - (mLb2() - mLcs2() - s) / (2.0 * mLcs) * lambdabarprime());
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -462,7 +466,7 @@ namespace eos
         const double C_1 = _b_to_c.c_1_axialvector(omegabar);
 
         // leading-power IWF
-        double result = C_1 * sp + (3.0 * mLb2 + mLcs2 - s) / (2.0 * mLb) * lambdabar - (mLb2 + 3.0 * mLcs2 - s) / (2.0 * mLcs) * lambdabarprime;
+        double result = C_1 * sp + (3.0 * mLb2() + mLcs2() - s) / (2.0 * mLb) * lambdabar() - (mLb2() + 3.0 * mLcs2() - s) / (2.0 * mLcs) * lambdabarprime();
         result *= _z(s);
 
         // next-to-leading-power IWF
@@ -492,9 +496,9 @@ namespace eos
     {
         Diagnostics results;
 
-        // s = s_max
+        // s = s_max()
         {
-            const double s        = s_max;
+            const double s        = s_max();
             const double omega    = this->omega(s);
             const double omegabar = this->omegabar(s);
             const double C_1_v    = _b_to_c.c_1_vector(omegabar);
@@ -514,8 +518,8 @@ namespace eos
             results.add({ C_1_a,          "C_1_a(s_max)"    });
             results.add({ C_2_a,          "C_2_a(s_max)"    });
             results.add({ C_3_a,          "C_3_a(s_max)"    });
-            results.add({ lambdabar,      "LambdaBar"       });
-            results.add({ lambdabarprime, "LambdaBar'"      });
+            results.add({ lambdabar(),      "LambdaBar"     });
+            results.add({ lambdabarprime(), "LambdaBar'"    });
             results.add({ f_time12_v(s),  "F_{1/2,time}"    });
             results.add({ f_long12_v(s),  "F_{1/2,long}"    });
             results.add({ f_perp12_v(s),  "F_{1/2,perp}"    });
@@ -526,9 +530,9 @@ namespace eos
             results.add({ f_perp32_a(s),  "G_{3/2,perp}"    });
         }
 
-        // s = s_max - 3.0
+        // s = s_max() - 3.0
         {
-            const double s        = s_max - 3.0;
+            const double s        = s_max() - 3.0;
             const double omega    = this->omega(s);
             const double omegabar = this->omegabar(s);
             const double C_1_v    = _b_to_c.c_1_vector(omegabar);
@@ -548,8 +552,8 @@ namespace eos
             results.add({ C_1_a,          "C_1_a(s_max)"    });
             results.add({ C_2_a,          "C_2_a(s_max)"    });
             results.add({ C_3_a,          "C_3_a(s_max)"    });
-            results.add({ lambdabar,      "LambdaBar"       });
-            results.add({ lambdabarprime, "LambdaBar'"      });
+            results.add({ lambdabar(),      "LambdaBar"     });
+            results.add({ lambdabarprime(), "LambdaBar'"    });
             results.add({ f_time12_v(s),  "F_{1/2,time}"    });
             results.add({ f_long12_v(s),  "F_{1/2,long}"    });
             results.add({ f_perp12_v(s),  "F_{1/2,perp}"    });

--- a/eos/form-factors/parametric-bbgorvd2018.hh
+++ b/eos/form-factors/parametric-bbgorvd2018.hh
@@ -1,10 +1,10 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2014, 2015, 2016, 2017 Danny van Dyk
- * Copyright (c) 2017 Elena Graverini
- * Copyright (c) 2017, 2018 Marzia Bordone
- * Copyright (c) 2018 Ahmet Kokulu
+ * Copyright (c) 2014-2026 Danny van Dyk
+ * Copyright (c) 2017      Elena Graverini
+ * Copyright (c) 2017-2018 Marzia Bordone
+ * Copyright (c) 2018      Ahmet Kokulu
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -50,25 +50,25 @@ namespace eos
 
             UsedParameter _zeta_max, _rho, _delta_3b, _rho_3b;
 
-            static constexpr double mLb = Process_::m1;
-            static constexpr double mLcs = Process_::m2;
-            static constexpr double mLb2 = mLb * mLb;
-            static constexpr double mLcs2 = mLcs * mLcs;
+            UsedParameter mLb, mLcs;
 
             static constexpr double m_b_pole = 4.8;
             static constexpr double m_c_pole = 1.4;
 
-            static constexpr double lambdabar = mLb - m_b_pole;
-            static constexpr double lambdabarprime = mLcs - m_c_pole;
+            double mLb2() const { return mLb * mLb; }
+            double mLcs2() const { return mLcs * mLcs; }
 
-            static constexpr double s_max = (mLb - mLcs) * (mLb - mLcs);
+            double lambdabar() const { return mLb - m_b_pole; }
+            double lambdabarprime() const { return mLcs - m_c_pole; }
+
+            double s_max() const { return power_of<2>(mLb - mLcs); }
 
             // auxiliary kinematics functions
-            static constexpr double _s_plus(const double & s)
+            double _s_plus(const double & s) const
             {
                 return power_of<2>(mLb + mLcs) - s;
             }
-            static constexpr double _s_minus(const double & s)
+            double _s_minus(const double & s) const
             {
                 return power_of<2>(mLb - mLcs) - s;
             }
@@ -76,23 +76,23 @@ namespace eos
             // parametrization of the Isgur-Wise functions
             double _z(const double & s) const
             {
-                return _zeta_max * (1.0 + _rho * (s / s_max - 1.0));
+                return _zeta_max * (1.0 + _rho * (s / s_max() - 1.0));
             }
 
             double _z3b(const double & s) const
             {
-                return _zeta_max * (_delta_3b + _rho_3b * (s / s_max - 1.0));
+                return _zeta_max * (_delta_3b + _rho_3b * (s / s_max() - 1.0));
             }
 
             inline double omega(const double & s) const
             {
-                return (mLb2 + mLcs2 - s) / (2.0 * mLb * mLcs);
+                return (mLb2() + mLcs2() - s) / (2.0 * mLb * mLcs);
             }
 
             inline double omegabar(const double & s) const
             {
-                return omega(s) * (1.0 + lambdabar / m_b_pole + lambdabarprime / m_c_pole)
-                    - (lambdabar / m_c_pole + lambdabarprime / m_b_pole);
+                return omega(s) * (1.0 + lambdabar() / m_b_pole + lambdabarprime() / m_c_pole)
+                    - (lambdabar() / m_c_pole + lambdabarprime() / m_b_pole);
             }
 
         public:
@@ -129,25 +129,25 @@ namespace eos
 
             UsedParameter _zeta_max, _rho, _delta_3b, _rho_3b;
 
-            static constexpr double mLb = Process_::m1;
-            static constexpr double mLcs = Process_::m2;
-            static constexpr double mLb2 = mLb * mLb;
-            static constexpr double mLcs2 = mLcs * mLcs;
+            UsedParameter mLb, mLcs;
 
             static constexpr double m_b_pole = 4.8;
             static constexpr double m_c_pole = 1.4;
 
-            static constexpr double lambdabar = mLb - m_b_pole;
-            static constexpr double lambdabarprime = mLcs - m_c_pole;
+            double mLb2() const { return mLb * mLb; }
+            double mLcs2() const { return mLcs * mLcs; }
 
-            static constexpr double s_max = (mLb - mLcs) * (mLb - mLcs);
+            double lambdabar() const { return mLb - m_b_pole; }
+            double lambdabarprime() const { return mLcs - m_c_pole; }
+
+            double s_max() const { return power_of<2>(mLb - mLcs); }
 
             // auxiliary kinematics functions
-            static constexpr double _s_plus(const double & s)
+            double _s_plus(const double & s) const
             {
                 return power_of<2>((mLb + mLcs)) - s;
             }
-            static constexpr double _s_minus(const double & s)
+            double _s_minus(const double & s) const
             {
                 return power_of<2>((mLb - mLcs)) - s;
             }
@@ -155,23 +155,23 @@ namespace eos
             // parametrization of the Isgur-Wise functions
             double _z(const double & s) const
             {
-                return _zeta_max * (1.0 + _rho * (s / s_max - 1.0));
+                return _zeta_max * (1.0 + _rho * (s / s_max() - 1.0));
             }
 
             double _z3b(const double & s) const
             {
-                return _zeta_max * (_delta_3b + _rho_3b * (s / s_max - 1.0));
+                return _zeta_max * (_delta_3b + _rho_3b * (s / s_max() - 1.0));
             }
 
             inline double omega(const double & s) const
             {
-                return (mLb2 + mLcs2 - s) / (2.0 * mLb * mLcs);
+                return (mLb2() + mLcs2() - s) / (2.0 * mLb * mLcs);
             }
 
             inline double omegabar(const double & s) const
             {
-                return omega(s) * (1.0 + lambdabar / m_b_pole + lambdabarprime / m_c_pole)
-                    - (lambdabar / m_c_pole + lambdabarprime / m_b_pole);
+                return omega(s) * (1.0 + lambdabar() / m_b_pole + lambdabarprime() / m_c_pole)
+                    - (lambdabar() / m_c_pole + lambdabarprime() / m_b_pole);
             }
 
         public:

--- a/eos/form-factors/parametric-dkmr2017-impl.hh
+++ b/eos/form-factors/parametric-dkmr2017-impl.hh
@@ -1,9 +1,9 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2018 Ahmet Kokulu
- * Copyright (c) 2022 Méril Reboud
- * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2018      Ahmet Kokulu
+ * Copyright (c) 2022      Méril Reboud
+ * Copyright (c) 2023-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -33,9 +33,8 @@ namespace eos
         public:
             // The following parameters are part of the parameterization and should match the
             // the ones used for the extraction of the coefficients of the z-expension
-            const double m_1, m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
+            UsedParameter m_1, m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
             const double m_R_0m, m_R_0p, m_R_1m, m_R_1p;
-            const double tm;
             const double tp_0m, tp_0p, tp_1m, tp_1p; // pair production thresholds
 
             static const std::map<std::tuple<QuarkFlavor, QuarkFlavor>, double> resonance_0m_masses;
@@ -43,19 +42,23 @@ namespace eos
             static const std::map<std::tuple<QuarkFlavor, QuarkFlavor>, double> resonance_1m_masses;
             static const std::map<std::tuple<QuarkFlavor, QuarkFlavor>, double> resonance_1p_masses;
 
-            DKMR2017FormFactorTraits(const Parameters & /* p */) :
-                m_1(Process_::m1),
-                m_2(Process_::m2),
+            DKMR2017FormFactorTraits(const Parameters & p) :
+                m_1(UsedParameter(p[std::string(Process_::name_1) + "@HME"], *this)),
+                m_2(UsedParameter(p[std::string(Process_::name_2) + "@HME"], *this)),
                 m_R_0m(resonance_0m_masses.at(Process_::partonic_transition)),
                 m_R_0p(resonance_0p_masses.at(Process_::partonic_transition)),
                 m_R_1m(resonance_1m_masses.at(Process_::partonic_transition)),
                 m_R_1p(resonance_1p_masses.at(Process_::partonic_transition)),
-                tm((m_1 - m_2) * (m_1 - m_2)),
                 tp_0m(m_R_0m * m_R_0m),
                 tp_0p(m_R_0p * m_R_0p),
                 tp_1m(m_R_1m * m_R_1m),
                 tp_1p(m_R_1p * m_R_1p)
             {
+            }
+
+            double tm() const
+            {
+                return (m_1 - m_2) * (m_1 - m_2);
             }
 
             complex<double> calc_z(const complex<double> & t, const complex<double> & tp, const complex<double> & t0) const
@@ -161,7 +164,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_0p * _traits->m_R_0p;
 
-        const double z = _traits->calc_z(s, _traits->tp_0p, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_0p, _traits->tm()), z2 = z * z;
 
         return 1.0 / (1.0 - s / mR2) * (_alpha_0_time_v() + _alpha_1_time_v() * z + _alpha_2_time_v() * z2);
     }
@@ -172,7 +175,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_1m * _traits->m_R_1m;
 
-        const double z = _traits->calc_z(s, _traits->tp_1m, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_1m, _traits->tm()), z2 = z * z;
 
         return 1.0 / (1.0 - s / mR2) * (_alpha_0_long_v() + _alpha_1_long_v() * z + _alpha_2_long_v() * z2);
     }
@@ -183,7 +186,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_1m * _traits->m_R_1m;
 
-        const double z = _traits->calc_z(s, _traits->tp_1m, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_1m, _traits->tm()), z2 = z * z;
 
         return 1.0 / (1.0 - s / mR2) * (_alpha_0_perp_v() + _alpha_1_perp_v() * z + _alpha_2_perp_v() * z2);
     }
@@ -195,7 +198,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_0m * _traits->m_R_0m;
 
-        const double z = _traits->calc_z(s, _traits->tp_0m, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_0m, _traits->tm()), z2 = z * z;
 
         return 1.0 / (1.0 - s / mR2) * (_alpha_0_time_a() + _alpha_1_time_a() * z + _alpha_2_time_a() * z2);
     }
@@ -206,7 +209,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_1p * _traits->m_R_1p;
 
-        const double z = _traits->calc_z(s, _traits->tp_1p, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_1p, _traits->tm()), z2 = z * z;
 
         return 1.0 / (1.0 - s / mR2) * (_alpha_0_long_a() + _alpha_1_long_a() * z + _alpha_2_long_a() * z2);
     }
@@ -217,7 +220,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_1p * _traits->m_R_1p;
 
-        const double z = _traits->calc_z(s, _traits->tp_1p, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_1p, _traits->tm()), z2 = z * z;
 
         // Using alpha_0_long_a instead of alpha_0_perp_a, in order to
         // fulfill relation eq. (7), [DM:2016A], p. 3.
@@ -231,7 +234,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_1m * _traits->m_R_1m;
 
-        const double z = _traits->calc_z(s, _traits->tp_1m, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_1m, _traits->tm()), z2 = z * z;
 
         return 1.0 / (1.0 - s / mR2) * (_alpha_0_long_t() + _alpha_1_long_t() * z + _alpha_2_long_t() * z2);
     }
@@ -242,7 +245,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_1m * _traits->m_R_1m;
 
-        const double z = _traits->calc_z(s, _traits->tp_1m, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_1m, _traits->tm()), z2 = z * z;
 
         return 1.0 / (1.0 - s / mR2) * (_alpha_0_perp_t() + _alpha_1_perp_t() * z + _alpha_2_perp_t() * z2);
     }
@@ -254,7 +257,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_1p * _traits->m_R_1p;
 
-        const double z = _traits->calc_z(s, _traits->tp_1p, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_1p, _traits->tm()), z2 = z * z;
 
         return 1.0 / (1.0 - s / mR2) * (_alpha_0_long_t5() + _alpha_1_long_t5() * z + _alpha_2_long_t5() * z2);
     }
@@ -265,7 +268,7 @@ namespace eos
     {
         const double mR2 = _traits->m_R_1p * _traits->m_R_1p;
 
-        const double z = _traits->calc_z(s, _traits->tp_1p, _traits->tm), z2 = z * z;
+        const double z = _traits->calc_z(s, _traits->tp_1p, _traits->tm()), z2 = z * z;
 
         // Using alpha_0_long_t5 instead of alpha_0_perp_t5, in order to
         // fulfill relation eq. (8), [DM:2016A], p. 3.

--- a/eos/form-factors/parametric-dkmr2017_TEST.cc
+++ b/eos/form-factors/parametric-dkmr2017_TEST.cc
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Ahmet Kokulu
  * Copyright (c) 2022 Méril Reboud
+ * Copyright (c) 2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -34,7 +35,7 @@ public:
 
     virtual void run() const
     {
-        static const double eps = 1e-3;
+        static const double eps = 1e-5;
 
         Parameters p = Parameters::Defaults();
         std::shared_ptr<FormFactors<OneHalfPlusToOneHalfPlus>> ff = FormFactorFactory<OneHalfPlusToOneHalfPlus>::create("Lambda_b->Lambda_c::DKMR2017", p);
@@ -78,8 +79,8 @@ public:
         p["Lambda_b->Lambda_c::a_1_perp^T5@DKMR2017"]   =  3.14;
         p["Lambda_b->Lambda_c::a_2_perp^T5@DKMR2017"]   =  0.00;
 
-        p["mass::Lambda_b"]                             = 5.61951;
-        p["mass::Lambda_c"]                             = 2.2865;
+        p["mass::Lambda_b@HME"]                         = 5.61951;
+        p["mass::Lambda_c@HME"]                         = 2.28646;
 
         // test of the ten baryonic FFs
         TEST_CHECK_NEARLY_EQUAL(ff->f_time_v( 0.0),  0.299748,  eps);

--- a/eos/form-factors/parametric-dm2016-impl.hh
+++ b/eos/form-factors/parametric-dm2016-impl.hh
@@ -1,8 +1,8 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2014-2023 Danny van Dyk
- * Copyright (c) 2022 Méril Reboud
+ * Copyright (c) 2014-2026 Danny van Dyk
+ * Copyright (c) 2022      Méril Reboud
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -32,11 +32,9 @@ namespace eos
         public:
             // The following parameters are part of the parameterization and must match the
             // the ones used for the extraction of the coefficients of the z-expension
-            const double m_1, m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
+            UsedParameter m_1, m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
             const double m_R_0m, m_R_0p, m_R_1m, m_R_1p;
-            const double tp; // pair production thresholds
-            const double tm; // kinematic endpoint
-            const double t0; // z(t_0) = 0, t_m is the endpoint of the semileptonic process
+            const double tp; // pair production threshold
 
             static const std::map<std::tuple<QuarkFlavor, QuarkFlavor>, double> resonance_0m_masses;
             static const std::map<std::tuple<QuarkFlavor, QuarkFlavor>, double> resonance_0p_masses;
@@ -45,17 +43,27 @@ namespace eos
             static const std::map<std::tuple<QuarkFlavor, QuarkFlavor>, double> threshold_tp_values;
             static const std::map<std::tuple<QuarkFlavor, QuarkFlavor>, double> config_t0_values;
 
-            DM2016FormFactorTraits(const Parameters & /* p */) :
-                m_1(Process_::m1),
-                m_2(Process_::m2),
+            DM2016FormFactorTraits(const Parameters & p) :
+                m_1(UsedParameter(p[std::string(Process_::name_1) + "@HME"], *this)),
+                m_2(UsedParameter(p[std::string(Process_::name_2) + "@HME"], *this)),
                 m_R_0m(resonance_0m_masses.at(Process_::partonic_transition)),
                 m_R_0p(resonance_0p_masses.at(Process_::partonic_transition)),
                 m_R_1m(resonance_1m_masses.at(Process_::partonic_transition)),
                 m_R_1p(resonance_1p_masses.at(Process_::partonic_transition)),
-                tp(threshold_tp_values.at(Process_::partonic_transition)),
-                tm((m_1 - m_2) * (m_1 - m_2)),
-                t0(tm)
+                tp(threshold_tp_values.at(Process_::partonic_transition))
             {
+            }
+
+            // kinematic endpoint
+            double tm() const
+            {
+                return (m_1 - m_2) * (m_1 - m_2);
+            }
+
+            // z(t_0) = 0, t_m is the endpoint of the semileptonic process
+            double t0() const
+            {
+                return tm();
             }
 
             complex<double> calc_z(const complex<double> & t, const complex<double> & tp, const complex<double> & t0) const
@@ -73,7 +81,7 @@ namespace eos
 
             double calc_z(const double & t) const
             {
-                return calc_z(t, this->tp, this->tm);
+                return calc_z(t, this->tp, this->tm());
             }
     };
 

--- a/eos/form-factors/parametric-se-impl-onehalfplus-to-threehalfminus.hh
+++ b/eos/form-factors/parametric-se-impl-onehalfplus-to-threehalfminus.hh
@@ -31,10 +31,9 @@ namespace eos
 {
     template <typename Process_>
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::SEFormFactors(const Parameters & p, const Options &) :
-        _m_1(Process_::m1),
-        _m_2(Process_::m2),
+        _m_1(UsedParameter(p[std::string(Process_::name_1) + "@HME"], *this)),
+        _m_2(UsedParameter(p[std::string(Process_::name_2) + "@HME"], *this)),
         _t_0(Process_::t0),
-        _t_m(Process_::tm),
         _t_p(Process_::tp),
         _a_time12_v{
             UsedParameter(p[_par_name("t12", "V", 1)], *this),
@@ -131,6 +130,13 @@ namespace eos
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::make(const Parameters & parameters, const Options & options)
     {
         return new SEFormFactors(parameters, options);
+    }
+
+    template <typename Process_>
+    double
+    SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_t_m() const
+    {
+        return power_of<2>(_m_1 - _m_2);
     }
 
     template <typename Process_>
@@ -272,15 +278,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_long12_v_0() const
     {
-        const double x_long12_v = this->_phi_long12_v(_t_m) * 2.0 * (_m_1 - _m_2) / (_m_1 + _m_2);
-        const double x_perp32_v = this->_phi_perp32_v(_t_m);
+        const double x_long12_v = this->_phi_long12_v(_t_m()) * 2.0 * (_m_1 - _m_2) / (_m_1 + _m_2);
+        const double x_perp32_v = this->_phi_perp32_v(_t_m());
         std::array<double, 5> a;
         a[0] = x_long12_v * this->_a_perp32_v[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_long12_v * this->_a_perp32_v[i] - x_perp32_v * this->_a_long12_v[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_v);
     }
 
@@ -288,15 +294,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_perp12_v_0() const
     {
-        const double x_perp12_v = - this->_phi_perp12_v(_t_m);
-        const double x_perp32_v =   this->_phi_perp32_v(_t_m);
+        const double x_perp12_v = - this->_phi_perp12_v(_t_m());
+        const double x_perp32_v =   this->_phi_perp32_v(_t_m());
         std::array<double, 5> a;
         a[0] = x_perp12_v * this->_a_perp32_v[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_perp12_v * this->_a_perp32_v[i] - x_perp32_v * this->_a_perp12_v[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_v);
     }
 
@@ -310,7 +316,7 @@ namespace eos
         {
             a[i] = - this->_a_time12_a[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / polynomials[0];
     }
 
@@ -318,15 +324,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_long12_t_0() const
     {
-        const double x_long12_t = this->_phi_long12_t(_t_m) * 2.0 * (_m_1 + _m_2) / (_m_1 - _m_2);
-        const double x_perp32_t = this->_phi_perp32_t(_t_m);
+        const double x_long12_t = this->_phi_long12_t(_t_m()) * 2.0 * (_m_1 + _m_2) / (_m_1 - _m_2);
+        const double x_perp32_t = this->_phi_perp32_t(_t_m());
         std::array<double, 5> a;
         a[0] = x_long12_t * this->_a_perp32_t[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_long12_t * this->_a_perp32_t[i] - x_perp32_t * this->_a_long12_t[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_t);
     }
 
@@ -334,15 +340,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_perp12_t_0() const
     {
-        const double x_perp12_t = - this->_phi_perp12_t(_t_m);
-        const double x_perp32_t =   this->_phi_perp32_t(_t_m);
+        const double x_perp12_t = - this->_phi_perp12_t(_t_m());
+        const double x_perp32_t =   this->_phi_perp32_t(_t_m());
         std::array<double, 5> a;
         a[0] = x_perp12_t * this->_a_perp32_t[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_perp12_t * this->_a_perp32_t[i] - x_perp32_t * this->_a_perp12_t[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_t);
     }
 
@@ -414,16 +420,16 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_perp12_a_0() const
     {
-        const double x_perp12_a = this->_phi_perp12_a(_t_m);
-        const double x_long12_a = this->_phi_long12_a(_t_m);
-        const double x_perp32_a = this->_phi_perp32_a(_t_m);
+        const double x_perp12_a = this->_phi_perp12_a(_t_m());
+        const double x_long12_a = this->_phi_long12_a(_t_m());
+        const double x_perp32_a = this->_phi_perp32_a(_t_m());
         std::array<double, 5> a;
         a[0] = x_perp12_a * (this->_a_long12_a_0() / x_long12_a + this->_a_perp32_a[0] / x_perp32_a);
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_perp12_a * (this->_a_long12_a[i - 1] / x_long12_a + this->_a_perp32_a[i] / x_perp32_a) - this->_a_perp12_a[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / polynomials[0];
     }
 
@@ -431,16 +437,16 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_long12_t5_0() const
     {
-        const double x_long12_t5 = this->_phi_long12_t5(_t_m);
-        const double x_perp12_t5 = this->_phi_perp12_t5(_t_m);
-        const double x_perp32_t5 = this->_phi_perp32_t5(_t_m);
+        const double x_long12_t5 = this->_phi_long12_t5(_t_m());
+        const double x_perp12_t5 = this->_phi_perp12_t5(_t_m());
+        const double x_perp32_t5 = this->_phi_perp32_t5(_t_m());
         std::array<double, 5> a;
         a[0] = x_long12_t5 * (this->_a_perp12_t5_0() / x_perp12_t5 - this->_a_perp32_t5_0() / x_perp32_t5);
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_long12_t5 * (this->_a_perp12_t5[i - 1] / x_perp12_t5 - this->_a_perp32_t5[i - 1] / x_perp32_t5) - this->_a_long12_t5[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / polynomials[0];
     }
 

--- a/eos/form-factors/parametric-se-impl-onehalfplus-to-threehalfminus.hh
+++ b/eos/form-factors/parametric-se-impl-onehalfplus-to-threehalfminus.hh
@@ -31,10 +31,9 @@ namespace eos
 {
     template <typename Process_>
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::SEFormFactors(const Parameters & p, const Options &) :
-        _m_1(UsedParameter(p[std::string(Process_::name_1) + "@HME"], *this)),
-        _m_2(UsedParameter(p[std::string(Process_::name_2) + "@HME"], *this)),
-        _t_0(Process_::t0),
-        _t_p(Process_::tp),
+        _traits(p),
+        _m_1(_traits.m_1),
+        _m_2(_traits.m_2),
         _a_time12_v{
             UsedParameter(p[_par_name("t12", "V", 1)], *this),
             UsedParameter(p[_par_name("t12", "V", 2)], *this),
@@ -133,13 +132,6 @@ namespace eos
     }
 
     template <typename Process_>
-    double
-    SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_t_m() const
-    {
-        return power_of<2>(_m_1 - _m_2);
-    }
-
-    template <typename Process_>
     QualifiedName
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_par_name(const std::string & pol, const std::string & current, unsigned idx) const
     {
@@ -148,29 +140,29 @@ namespace eos
 
     template <typename Process_>
     double
-    SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_z(const double & t, const double & t_0) const
+    SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_z(const double & t, const double & t_p, const double & t_0) const
     {
-        return (std::sqrt(_t_p - t) - std::sqrt(_t_p - t_0)) / (std::sqrt(_t_p - t) + std::sqrt(_t_p - t_0));
+        return (std::sqrt(t_p - t) - std::sqrt(t_p - t_0)) / (std::sqrt(t_p - t) + std::sqrt(t_p - t_0));
     }
 
     template <typename Process_>
     double
-    SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi(const double & s, const double & chi, const double & A, const double & B,
+    SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi(const double & s, const double & t_p, const double & chi, const double & A, const double & B,
                                        const double & d, const double & e, const double & f, const double & g,
                                        const double & n) const
     {
         using std::pow;
         using std::sqrt;
 
-        const double z = _z(s, _t_0);
+        const double z = _z(s, t_p, _traits.t0);
         const double t_pb = power_of<2>(_m_1 + _m_2);
         const double t_mb = power_of<2>(_m_1 - _m_2);
 
         const double norm   = pow(t_pb, 0.5 * A) * pow(t_mb, 0.5 * B) * pow(1 - z, n + g - 0.5 * (e + f + 3.0)) * sqrt(1 + z)
-                            * sqrt(4.0 * (_t_p - _t_0)) / sqrt(16.0 * d * M_PI * M_PI * chi);
-        const double phi1 = - 1.0 / (_t_0 * power_of<2>(1 + z) - 2.0 * _t_p * (1 + z*z) - 2.0 * (1 - z*z) * sqrt(_t_p) * sqrt(_t_p - _t_0));
-        const double phi2 = - power_of<2>(1 - z) * t_mb - power_of<2>(1 + z) * _t_0 + 2.0 * _t_p * (1 + z*z) + 2.0 * (1 - z*z) * sqrt(_t_p - t_mb) * sqrt(_t_p - _t_0);
-        const double phi3 = power_of<2>(1 - z) * t_pb - power_of<2>(1 + z) * _t_0 + 4.0 * _t_p * z;
+                            * sqrt(4.0 * (t_p - _traits.t0)) / sqrt(16.0 * d * M_PI * M_PI * chi);
+        const double phi1 = - 1.0 / (_traits.t0 * power_of<2>(1 + z) - 2.0 * t_p * (1 + z*z) - 2.0 * (1 - z*z) * sqrt(t_p) * sqrt(t_p - _traits.t0));
+        const double phi2 = - power_of<2>(1 - z) * t_mb - power_of<2>(1 + z) * _traits.t0 + 2.0 * t_p * (1 + z*z) + 2.0 * (1 - z*z) * sqrt(t_p - t_mb) * sqrt(t_p - _traits.t0);
+        const double phi3 = power_of<2>(1 - z) * t_pb - power_of<2>(1 + z) * _traits.t0 + 4.0 * t_p * z;
 
         return norm * pow(phi1, 0.5 * (n + g)) * pow(phi2, e / 4.0) * pow(phi3, f / 4.0);
     }
@@ -179,98 +171,98 @@ namespace eos
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_time12_v(const double & q2) const
     {
-        return _phi(q2, Process_::chi_0p_v, 0.0, 1.0,  6.0, 3.0, 1.0, 3.0, 1.0);
+        return _phi(q2, _traits.tp_v, Process_::chi_0p_v, 0.0, 1.0,  6.0, 3.0, 1.0, 3.0, 1.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_long12_v(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1m_v, 1.0, 0.0, 18.0, 1.0, 3.0, 3.0, 2.0);
+        return _phi(q2, _traits.tp_v, Process_::chi_1m_v, 1.0, 0.0, 18.0, 1.0, 3.0, 3.0, 2.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_perp12_v(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1m_v, 0.0, 0.0,  9.0, 1.0, 3.0, 2.0, 2.0);
+        return _phi(q2, _traits.tp_v, Process_::chi_1m_v, 0.0, 0.0,  9.0, 1.0, 3.0, 2.0, 2.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_perp32_v(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1m_v, 0.0, 0.0,  3.0, 1.0, 3.0, 2.0, 2.0);
+        return _phi(q2, _traits.tp_v, Process_::chi_1m_v, 0.0, 0.0,  3.0, 1.0, 3.0, 2.0, 2.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_time12_a(const double & q2) const
     {
-        return _phi(q2, Process_::chi_0m_a, 1.0, 0.0,  6.0, 1.0, 3.0, 3.0, 1.0);
+        return _phi(q2, _traits.tp_a, Process_::chi_0m_a, 1.0, 0.0,  6.0, 1.0, 3.0, 3.0, 1.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_long12_a(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1p_a, 0.0, 1.0, 18.0, 3.0, 1.0, 3.0, 2.0);
+        return _phi(q2, _traits.tp_a, Process_::chi_1p_a, 0.0, 1.0, 18.0, 3.0, 1.0, 3.0, 2.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_perp12_a(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1p_a, 0.0, 0.0,  9.0, 3.0, 1.0, 2.0, 2.0);
+        return _phi(q2, _traits.tp_a, Process_::chi_1p_a, 0.0, 0.0,  9.0, 3.0, 1.0, 2.0, 2.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_perp32_a(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1p_a, 0.0, 0.0,  3.0, 3.0, 1.0, 2.0, 2.0);
+        return _phi(q2, _traits.tp_a, Process_::chi_1p_a, 0.0, 0.0,  3.0, 3.0, 1.0, 2.0, 2.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_long12_t(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1m_t, 0.0, 0.0, 18.0, 1.0, 3.0, 1.0, 3.0);
+        return _phi(q2, _traits.tp_v, Process_::chi_1m_t, 0.0, 0.0, 18.0, 1.0, 3.0, 1.0, 3.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_perp12_t(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1m_t, 1.0, 0.0,  9.0, 1.0, 3.0, 2.0, 3.0);
+        return _phi(q2, _traits.tp_v, Process_::chi_1m_t, 1.0, 0.0,  9.0, 1.0, 3.0, 2.0, 3.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_perp32_t(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1m_t, 1.0, 0.0,  3.0, 1.0, 3.0, 2.0, 3.0);
+        return _phi(q2, _traits.tp_v, Process_::chi_1m_t, 1.0, 0.0,  3.0, 1.0, 3.0, 2.0, 3.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_long12_t5(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1p_t5, 0.0, 0.0, 18.0, 3.0, 1.0, 1.0, 3.0);
+        return _phi(q2, _traits.tp_a, Process_::chi_1p_t5, 0.0, 0.0, 18.0, 3.0, 1.0, 1.0, 3.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_perp12_t5(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1p_t5, 0.0, 1.0,  9.0, 3.0, 1.0, 2.0, 3.0);
+        return _phi(q2, _traits.tp_a, Process_::chi_1p_t5, 0.0, 1.0,  9.0, 3.0, 1.0, 2.0, 3.0);
     }
 
     template <typename Process_>
     inline double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_phi_perp32_t5(const double & q2) const
     {
-        return _phi(q2, Process_::chi_1p_t5, 0.0, 1.0,  3.0, 3.0, 1.0, 2.0, 3.0);
+        return _phi(q2, _traits.tp_a, Process_::chi_1p_t5, 0.0, 1.0,  3.0, 3.0, 1.0, 2.0, 3.0);
     }
 
 
@@ -278,15 +270,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_long12_v_0() const
     {
-        const double x_long12_v = this->_phi_long12_v(_t_m()) * 2.0 * (_m_1 - _m_2) / (_m_1 + _m_2);
-        const double x_perp32_v = this->_phi_perp32_v(_t_m());
+        const double x_long12_v = this->_phi_long12_v(_traits.tm()) * 2.0 * (_m_1 - _m_2) / (_m_1 + _m_2);
+        const double x_perp32_v = this->_phi_perp32_v(_traits.tm());
         std::array<double, 5> a;
         a[0] = x_long12_v * this->_a_perp32_v[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_long12_v * this->_a_perp32_v[i] - x_perp32_v * this->_a_long12_v[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_traits.tm(), _traits.tp_v, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_v);
     }
 
@@ -294,15 +286,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_perp12_v_0() const
     {
-        const double x_perp12_v = - this->_phi_perp12_v(_t_m());
-        const double x_perp32_v =   this->_phi_perp32_v(_t_m());
+        const double x_perp12_v = - this->_phi_perp12_v(_traits.tm());
+        const double x_perp32_v =   this->_phi_perp32_v(_traits.tm());
         std::array<double, 5> a;
         a[0] = x_perp12_v * this->_a_perp32_v[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_perp12_v * this->_a_perp32_v[i] - x_perp32_v * this->_a_perp12_v[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_traits.tm(), _traits.tp_v, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_v);
     }
 
@@ -316,7 +308,7 @@ namespace eos
         {
             a[i] = - this->_a_time12_a[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_traits.tm(), _traits.tp_a, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / polynomials[0];
     }
 
@@ -324,15 +316,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_long12_t_0() const
     {
-        const double x_long12_t = this->_phi_long12_t(_t_m()) * 2.0 * (_m_1 + _m_2) / (_m_1 - _m_2);
-        const double x_perp32_t = this->_phi_perp32_t(_t_m());
+        const double x_long12_t = this->_phi_long12_t(_traits.tm()) * 2.0 * (_m_1 + _m_2) / (_m_1 - _m_2);
+        const double x_perp32_t = this->_phi_perp32_t(_traits.tm());
         std::array<double, 5> a;
         a[0] = x_long12_t * this->_a_perp32_t[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_long12_t * this->_a_perp32_t[i] - x_perp32_t * this->_a_long12_t[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_traits.tm(), _traits.tp_v, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_t);
     }
 
@@ -340,15 +332,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_perp12_t_0() const
     {
-        const double x_perp12_t = - this->_phi_perp12_t(_t_m());
-        const double x_perp32_t =   this->_phi_perp32_t(_t_m());
+        const double x_perp12_t = - this->_phi_perp12_t(_traits.tm());
+        const double x_perp32_t =   this->_phi_perp32_t(_traits.tm());
         std::array<double, 5> a;
         a[0] = x_perp12_t * this->_a_perp32_t[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_perp12_t * this->_a_perp32_t[i] - x_perp32_t * this->_a_perp12_t[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_traits.tm(), _traits.tp_v, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_t);
     }
 
@@ -356,15 +348,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_perp32_t5_0() const
     {
-        const double x_perp32_t5 = - this->_z(0.0, Process_::mR2_1p) * this->_phi_perp32_t5(0.0) * power_of<2>((_m_1 + _m_2) / (_m_1 - _m_2));
-        const double x_perp32_t  =   this->_z(0.0, Process_::mR2_1m) * this->_phi_perp32_t(0.0);
+        const double x_perp32_t5 = - this->_z(0.0, _traits.tp_a, Process_::mR2_1p) * this->_phi_perp32_t5(0.0) * power_of<2>((_m_1 + _m_2) / (_m_1 - _m_2));
+        const double x_perp32_t  =   this->_z(0.0, _traits.tp_v, Process_::mR2_1m) * this->_phi_perp32_t(0.0);
         std::array<double, 5> a;
         a[0] = x_perp32_t5 * this->_a_perp32_t[0];
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_perp32_t5 * this->_a_perp32_t[i] - x_perp32_t * this->_a_perp32_t5[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(0.0, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(0.0, _traits.tp_a, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp32_t);
     }
 
@@ -372,15 +364,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_time12_v_0() const
     {
-        const double x_time12_v = this->_z(0.0, Process_::mR2_0p) * this->_phi_time12_v(0.0) * power_of<2>((_m_1 + _m_2) / (_m_1 - _m_2));
-        const double x_long12_v = this->_z(0.0, Process_::mR2_1m) * this->_phi_long12_v(0.0);
+        const double x_time12_v = this->_z(0.0, _traits.tp_v, Process_::mR2_0p) * this->_phi_time12_v(0.0) * power_of<2>((_m_1 + _m_2) / (_m_1 - _m_2));
+        const double x_long12_v = this->_z(0.0, _traits.tp_v, Process_::mR2_1m) * this->_phi_long12_v(0.0);
         std::array<double, 5> a;
         a[0] = x_time12_v * this->_a_long12_v_0();
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_time12_v * this->_a_long12_v[i - 1] - x_long12_v * this->_a_time12_v[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(0.0, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(0.0, _traits.tp_v, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_long12_v);
     }
 
@@ -388,15 +380,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_long12_a_0() const
     {
-        const double x_long12_a = this->_z(0.0, Process_::mR2_1p) * this->_phi_long12_a(0.0) * power_of<2>((_m_1 + _m_2) / (_m_1 - _m_2));
-        const double x_time12_a = this->_z(0.0, Process_::mR2_0m) * this->_phi_time12_a(0.0);
+        const double x_long12_a = this->_z(0.0, _traits.tp_a, Process_::mR2_1p) * this->_phi_long12_a(0.0) * power_of<2>((_m_1 + _m_2) / (_m_1 - _m_2));
+        const double x_time12_a = this->_z(0.0, _traits.tp_a, Process_::mR2_0m) * this->_phi_time12_a(0.0);
         std::array<double, 5> a;
         a[0] = x_long12_a * this->_a_time12_a_0();
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_long12_a * this->_a_time12_a[i - 1] - x_time12_a * this->_a_long12_a[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(0.0, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(0.0, _traits.tp_a, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_time12_a);
     }
 
@@ -404,15 +396,15 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_perp12_t5_0() const
     {
-        const double x_perp12_t5 = this->_z(0.0, Process_::mR2_1p) * this->_phi_perp12_t5(0.0) * power_of<2>((_m_1 + _m_2) / (_m_1 - _m_2));
-        const double x_perp12_t  = this->_z(0.0, Process_::mR2_1m) * this->_phi_perp12_t(0.0);
+        const double x_perp12_t5 = this->_z(0.0, _traits.tp_a, Process_::mR2_1p) * this->_phi_perp12_t5(0.0) * power_of<2>((_m_1 + _m_2) / (_m_1 - _m_2));
+        const double x_perp12_t  = this->_z(0.0, _traits.tp_v, Process_::mR2_1m) * this->_phi_perp12_t(0.0);
         std::array<double, 5> a;
         a[0] = x_perp12_t5 * this->_a_perp12_t_0();
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_perp12_t5 * this->_a_perp12_t[i - 1] - x_perp12_t * this->_a_perp12_t5[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(0.0, _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(0.0, _traits.tp_a, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / (polynomials[0] * x_perp12_t);
     }
 
@@ -420,16 +412,16 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_perp12_a_0() const
     {
-        const double x_perp12_a = this->_phi_perp12_a(_t_m());
-        const double x_long12_a = this->_phi_long12_a(_t_m());
-        const double x_perp32_a = this->_phi_perp32_a(_t_m());
+        const double x_perp12_a = this->_phi_perp12_a(_traits.tm());
+        const double x_long12_a = this->_phi_long12_a(_traits.tm());
+        const double x_perp32_a = this->_phi_perp32_a(_traits.tm());
         std::array<double, 5> a;
         a[0] = x_perp12_a * (this->_a_long12_a_0() / x_long12_a + this->_a_perp32_a[0] / x_perp32_a);
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_perp12_a * (this->_a_long12_a[i - 1] / x_long12_a + this->_a_perp32_a[i] / x_perp32_a) - this->_a_perp12_a[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_traits.tm(), _traits.tp_a, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / polynomials[0];
     }
 
@@ -437,16 +429,16 @@ namespace eos
     double
     SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus>::_a_long12_t5_0() const
     {
-        const double x_long12_t5 = this->_phi_long12_t5(_t_m());
-        const double x_perp12_t5 = this->_phi_perp12_t5(_t_m());
-        const double x_perp32_t5 = this->_phi_perp32_t5(_t_m());
+        const double x_long12_t5 = this->_phi_long12_t5(_traits.tm());
+        const double x_perp12_t5 = this->_phi_perp12_t5(_traits.tm());
+        const double x_perp32_t5 = this->_phi_perp32_t5(_traits.tm());
         std::array<double, 5> a;
         a[0] = x_long12_t5 * (this->_a_perp12_t5_0() / x_perp12_t5 - this->_a_perp32_t5_0() / x_perp32_t5);
         for (unsigned i = 1 ; i < a.size() ; ++i)
         {
             a[i] = x_long12_t5 * (this->_a_perp12_t5[i - 1] / x_perp12_t5 - this->_a_perp32_t5[i - 1] / x_perp32_t5) - this->_a_long12_t5[i - 1];
         }
-        const auto polynomials = Process_::orthonormal_polynomials(_z(_t_m(), _t_0));
+        const auto polynomials = Process_::orthonormal_polynomials(_z(_traits.tm(), _traits.tp_a, _traits.t0));
         return std::inner_product(a.begin(), a.end(), polynomials.begin(), 0.0) / polynomials[0];
     }
 
@@ -459,9 +451,9 @@ namespace eos
         coefficients[0] = _a_time12_v_0();
         std::copy(_a_time12_v.begin(), _a_time12_v.end(), coefficients.begin() + 1);
         // resonances for 0^+
-        const double blaschke     = _z(q2, Process_::mR2_0p);
+        const double blaschke     = _z(q2, _traits.tp_v, Process_::mR2_0p);
         const double phi          = _phi_time12_v(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_v, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -476,9 +468,9 @@ namespace eos
         coefficients[0] = _a_long12_v_0();
         std::copy(_a_long12_v.begin(), _a_long12_v.end(), coefficients.begin() + 1);
         // resonances for 1^-
-        const double blaschke     = _z(q2, Process_::mR2_1m);
+        const double blaschke     = _z(q2, _traits.tp_v, Process_::mR2_1m);
         const double phi          = _phi_long12_v(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_v, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -493,9 +485,9 @@ namespace eos
         coefficients[0] = _a_perp12_v_0();
         std::copy(_a_perp12_v.begin(), _a_perp12_v.end(), coefficients.begin() + 1);
         // resonances for 1^-
-        const double blaschke     = _z(q2, Process_::mR2_1m);
+        const double blaschke     = _z(q2, _traits.tp_v, Process_::mR2_1m);
         const double phi          = _phi_perp12_v(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_v, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -509,9 +501,9 @@ namespace eos
         std::array<double, 5> coefficients;
         std::copy(_a_perp32_v.begin(), _a_perp32_v.end(), coefficients.begin());
         // resonances for 1^-
-        const double blaschke     = _z(q2, Process_::mR2_1m);
+        const double blaschke     = _z(q2, _traits.tp_v, Process_::mR2_1m);
         const double phi          = _phi_perp32_v(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_v, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -526,9 +518,9 @@ namespace eos
         coefficients[0] = _a_time12_a_0();
         std::copy(_a_time12_a.begin(), _a_time12_a.end(), coefficients.begin() + 1);
         // resonances for 0^-
-        const double blaschke     = _z(q2, Process_::mR2_0m);
+        const double blaschke     = _z(q2, _traits.tp_a, Process_::mR2_0m);
         const double phi          = _phi_time12_a(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_a, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -543,9 +535,9 @@ namespace eos
         coefficients[0] = _a_long12_a_0();
         std::copy(_a_long12_a.begin(), _a_long12_a.end(), coefficients.begin() + 1);
         // resonances for 1^+
-        const double blaschke     = _z(q2, Process_::mR2_1p);
+        const double blaschke     = _z(q2, _traits.tp_a, Process_::mR2_1p);
         const double phi          = _phi_long12_a(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_a, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -560,9 +552,9 @@ namespace eos
         coefficients[0] = _a_perp12_a_0();
         std::copy(_a_perp12_a.begin(), _a_perp12_a.end(), coefficients.begin() + 1);
         // resonances for 1^+
-        const double blaschke     = _z(q2, Process_::mR2_1p);
+        const double blaschke     = _z(q2, _traits.tp_a, Process_::mR2_1p);
         const double phi          = _phi_perp12_a(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_a, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -576,9 +568,9 @@ namespace eos
         std::array<double, 5> coefficients;
         std::copy(_a_perp32_a.begin(), _a_perp32_a.end(), coefficients.begin());
         // resonances for 1^+
-        const double blaschke     = _z(q2, Process_::mR2_1p);
+        const double blaschke     = _z(q2, _traits.tp_a, Process_::mR2_1p);
         const double phi          = _phi_perp32_a(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_a, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -593,9 +585,9 @@ namespace eos
         coefficients[0] = _a_long12_t_0();
         std::copy(_a_long12_t.begin(), _a_long12_t.end(), coefficients.begin() + 1);
         // resonances for T (1^- state)
-        const double blaschke     = _z(q2, Process_::mR2_1m);
+        const double blaschke     = _z(q2, _traits.tp_v, Process_::mR2_1m);
         const double phi          = _phi_long12_t(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_v, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -610,9 +602,9 @@ namespace eos
         coefficients[0] = _a_perp12_t_0();
         std::copy(_a_perp12_t.begin(), _a_perp12_t.end(), coefficients.begin() + 1);
         // resonances for T (1^- state)
-        const double blaschke     = _z(q2, Process_::mR2_1m);
+        const double blaschke     = _z(q2, _traits.tp_v, Process_::mR2_1m);
         const double phi          = _phi_perp12_t(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_v, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -626,9 +618,9 @@ namespace eos
         std::array<double, 5> coefficients;
         std::copy(_a_perp32_t.begin(), _a_perp32_t.end(), coefficients.begin() );
         // resonances for T (1^- state)
-        const double blaschke     = _z(q2, Process_::mR2_1m);
+        const double blaschke     = _z(q2, _traits.tp_v, Process_::mR2_1m);
         const double phi          = _phi_perp32_t(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_v, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -643,9 +635,9 @@ namespace eos
         coefficients[0] = _a_long12_t5_0();
         std::copy(_a_long12_t5.begin(), _a_long12_t5.end(), coefficients.begin() + 1);
         // resonances for T5 (1^+ state)
-        const double blaschke     = _z(q2, Process_::mR2_1p);
+        const double blaschke     = _z(q2, _traits.tp_a, Process_::mR2_1p);
         const double phi          = _phi_long12_t5(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_a, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -660,9 +652,9 @@ namespace eos
         coefficients[0] = _a_perp12_t5_0();
         std::copy(_a_perp12_t5.begin(), _a_perp12_t5.end(), coefficients.begin() + 1);
         // resonances for T5 (1^+ state)
-        const double blaschke     = _z(q2, Process_::mR2_1p);
+        const double blaschke     = _z(q2, _traits.tp_a, Process_::mR2_1p);
         const double phi          = _phi_perp12_t5(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_a, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -677,9 +669,9 @@ namespace eos
         coefficients[0] = _a_perp32_t5_0();
         std::copy(_a_perp32_t5.begin(), _a_perp32_t5.end(), coefficients.begin() + 1);
         // resonances for T5 (1^+ state)
-        const double blaschke     = _z(q2, Process_::mR2_1p);
+        const double blaschke     = _z(q2, _traits.tp_a, Process_::mR2_1p);
         const double phi          = _phi_perp32_t5(q2);
-        const double z            = _z(q2, _t_0);
+        const double z            = _z(q2, _traits.tp_a, _traits.t0);
         const auto   polynomials  = Process_::orthonormal_polynomials(z);
         const double series       = std::inner_product(coefficients.begin(), coefficients.end(), polynomials.begin(), 0.0);
 
@@ -797,8 +789,10 @@ namespace eos
     {
         Diagnostics results;
 
-        results.add({ _z(0.0, Process_::t0),  "z(q2 =  0)" });
-        results.add({ _z(10.0, Process_::t0), "z(q2 = 10)" });
+        // report z(q2) for the "V"-family threshold; tp_a differs in general but
+        // defaults to the same value as tp_v for this process
+        results.add({ _z(0.0, _traits.tp_v, _traits.t0),  "z(q2 =  0)" });
+        results.add({ _z(10.0, _traits.tp_v, _traits.t0), "z(q2 = 10)" });
 
         {
             const auto & [p0, p1, p2, p3, p4, p5] = Process_::orthonormal_polynomials(0.0);
@@ -811,7 +805,7 @@ namespace eos
         }
 
         {
-            const auto & [p0, p1, p2, p3, p4, p5] = Process_::orthonormal_polynomials(_z(10.0, Process_::t0));
+            const auto & [p0, p1, p2, p3, p4, p5] = Process_::orthonormal_polynomials(_z(10.0, _traits.tp_v, _traits.t0));
             results.add({ p0,                     "p_0(z = z(q2 = 10))" });
             results.add({ p1,                     "p_1(z = z(q2 = 10))" });
             results.add({ p2,                     "p_2(z = z(q2 = 10))" });

--- a/eos/form-factors/parametric-se-lambdab-to-lambda1520_TEST.cc
+++ b/eos/form-factors/parametric-se-lambdab-to-lambda1520_TEST.cc
@@ -41,7 +41,14 @@ class SEOneHalfPlusToThreeHalfMinusFormFactorsTest :
             {
                 Parameters p = Parameters::Defaults();
 
-                const auto ratio = (LambdaBToLambda1520::m1 + LambdaBToLambda1520::m2) / (LambdaBToLambda1520::m1 - LambdaBToLambda1520::m2);
+                // Pin to the masses originally used to extract the coefficients below
+                // (mass::Lambda_b@HME's current default, 5.61951, differs from 5.620).
+                p["mass::Lambda_b@HME"]    = 5.620;
+                p["mass::Lambda(1520)@HME"] = 1.520;
+
+                const double m1 = p["mass::Lambda_b@HME"].evaluate();
+                const double m2 = p["mass::Lambda(1520)@HME"].evaluate();
+                const auto ratio = (m1 + m2) / (m1 - m2);
 
                 p["Lambda_b->Lambda(1520)::a^(t12,V)_1@SE"]     =  0.1;
                 p["Lambda_b->Lambda(1520)::a^(012,V)_1@SE"]     = -0.2;
@@ -109,7 +116,7 @@ class SEOneHalfPlusToThreeHalfMinusFormFactorsTest :
                 TEST_CHECK_NEARLY_EQUAL( ff.f_perp12_t5(0.0),   power_of<2>(ratio) * ff.f_perp12_t(0.0), eps);
                 TEST_CHECK_NEARLY_EQUAL( ff.f_perp32_t5(0.0), - power_of<2>(ratio) * ff.f_perp32_t(0.0), eps);
 
-                const auto tm = LambdaBToLambda1520::tm;
+                const auto tm = power_of<2>(m1 - m2);
 
                 TEST_CHECK_NEARLY_EQUAL( ff.f_perp12_v(tm),  - ff.f_perp32_v(tm),                       eps);
                 TEST_CHECK_NEARLY_EQUAL( ff.f_long12_v(tm),    2.0 / ratio * ff.f_perp32_v(tm),         eps);

--- a/eos/form-factors/parametric-se-lambdab-to-lambda_TEST.cc
+++ b/eos/form-factors/parametric-se-lambdab-to-lambda_TEST.cc
@@ -110,7 +110,8 @@ class SEOneHalfPlusToOneHalfPlusFormFactorsTest :
                 p["mass::B_s,1@HME"] = 5.750;
                 // Fix tp_a to tp_v to match the initial publication [BMRvD:2022A]
                 p["Lambda_b->Lambda::tp_a@SE"] = p["Lambda_b->Lambda::tp_v@SE"].evaluate();
-
+                auto m1 = p["mass::Lambda_b@HME"];
+                auto m2 = p["mass::Lambda@HME"];
 
                 SEFormFactors<LambdaBToLambda, OneHalfPlusToOneHalfPlus> ff(p, Options{ });
 
@@ -177,7 +178,7 @@ class SEOneHalfPlusToOneHalfPlusFormFactorsTest :
                 TEST_CHECK_NEARLY_EQUAL(ff.f_long_t5(10.0), 27.11308541, eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.f_perp_t5(10.0), 27.65566599, eps);
 
-                const auto tm = power_of<2>(LambdaBToLambda::m1 - LambdaBToLambda::m2);
+                const auto tm = power_of<2>(m1 - m2);
                 TEST_CHECK_NEARLY_EQUAL(ff.f_time_v (tm),   59.87052714, eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.f_long_v (tm),   88.45600970, eps);
                 TEST_CHECK_NEARLY_EQUAL(ff.f_perp_v (tm),   44.89007817, eps);

--- a/eos/form-factors/parametric-se.hh
+++ b/eos/form-factors/parametric-se.hh
@@ -534,14 +534,53 @@ namespace eos
 
     // 1/2+ -> 3/2-
     template <typename Process_>
+    class SEFormFactorTraits<Process_, OneHalfPlusToThreeHalfMinus> :
+        public virtual ParameterUser
+    {
+        public:
+            // The following parameters are part of the parameterization and should match
+            // the ones used for the extraction of the coefficients of the z-expansion
+            UsedParameter m_1, m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
+            // tp_v is used by the scalar, vector, and tensor form factors; tp_a by the
+            // pseudoscalar, axial-vector, and tensor+gamma5 form factors.
+            UsedParameter tp_v, tp_a, t0;
+
+            SEFormFactorTraits(const Parameters & p) :
+                m_1(UsedParameter(p[std::string(Process_::name_1) + "@HME"], *this)),
+                m_2(UsedParameter(p[std::string(Process_::name_2) + "@HME"], *this)),
+                tp_v(UsedParameter(p[std::string(Process_::label) + "::tp_v@SE"], *this)),
+                tp_a(UsedParameter(p[std::string(Process_::label) + "::tp_a@SE"], *this)),
+                t0(UsedParameter(p[std::string(Process_::label) + "::t0@SE"], *this))
+            {
+            }
+
+            double tm() const
+            {
+                return power_of<2>(m_1 - m_2);
+            }
+
+            complex<double> calc_z(const complex<double> & s, const complex<double> & sp, const complex<double> & s0) const
+            {
+                return (std::sqrt(sp - s) - std::sqrt(sp - s0)) / (std::sqrt(sp - s) + std::sqrt(sp - s0));
+            }
+
+            double calc_z(const double & s, const double & sp, const double & s0) const
+            {
+                if (s > sp)
+                    throw InternalError("The real conformal mapping is used above threshold: " + stringify(s) + " > " + stringify(sp));
+
+                return real(calc_z(complex<double>(s, 0.0), complex<double>(sp, 0.0), complex<double>(s0, 0.0)));
+            }
+    };
+
+    template <typename Process_>
     class SEFormFactors<Process_, OneHalfPlusToThreeHalfMinus> :
         public FormFactors<OneHalfPlusToThreeHalfMinus>
     {
         private:
-            UsedParameter _m_1, _m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
-            const double _t_0, _t_p; // z(t_0) = 0, and t_p is the pair production threshold
+            const SEFormFactorTraits<Process_, OneHalfPlusToThreeHalfMinus> _traits;
 
-            double _t_m() const; // the endpoint of the semileptonic process
+            const UsedParameter & _m_1, _m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
 
             const std::array<UsedParameter, 4> _a_time12_v;  // a_0^(time12,V) is obtained from the EoM f_time12^V(q2 = 0) \propto f_long12^V(q2 = 0)
             const std::array<UsedParameter, 4> _a_long12_v;  // a_0^(long12,V) is obtained from f_long12^V(q2 = q2max) \propto f_perp32^V(q2 = q2max)
@@ -559,8 +598,8 @@ namespace eos
             const std::array<UsedParameter, 4> _a_perp32_t5; // a_0^(perp32,T5) is obtained from the EoM f_perp32^T5(q2 = 0) \propto f_perp32^T(q2 = 0)
 
             QualifiedName _par_name(const std::string & pol, const std::string & current, unsigned idx) const;
-            double _z(const double & t, const double & t_0) const;
-            double _phi(const double & s, const double & chi, const double & A, const double & B, const double & d, const double & e,
+            double _z(const double & t, const double & t_p, const double & t_0) const;
+            double _phi(const double & s, const double & t_p, const double & chi, const double & A, const double & B, const double & d, const double & e,
                         const double & f, const double & g, const double & n) const;
 
             inline double _phi_time12_v(const double & q2) const;

--- a/eos/form-factors/parametric-se.hh
+++ b/eos/form-factors/parametric-se.hh
@@ -538,8 +538,10 @@ namespace eos
         public FormFactors<OneHalfPlusToThreeHalfMinus>
     {
         private:
-            const double _m_1, _m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
-            const double _t_0, _t_m, _t_p; // z(t_0) = 0, t_m is the endpoint of the semileptonic process, and t_p is the pair production threshold,
+            UsedParameter _m_1, _m_2; // m_1 is the mass of the heavier particle, m_2 the mass of the lighter particle
+            const double _t_0, _t_p; // z(t_0) = 0, and t_p is the pair production threshold
+
+            double _t_m() const; // the endpoint of the semileptonic process
 
             const std::array<UsedParameter, 4> _a_time12_v;  // a_0^(time12,V) is obtained from the EoM f_time12^V(q2 = 0) \propto f_long12^V(q2 = 0)
             const std::array<UsedParameter, 4> _a_long12_v;  // a_0^(long12,V) is obtained from f_long12^V(q2 = q2max) \propto f_perp32^V(q2 = q2max)

--- a/eos/parameters/hadronic-matrix-elements.yaml
+++ b/eos/parameters/hadronic-matrix-elements.yaml
@@ -385,6 +385,20 @@ groups:
           max:     +5.61951
           latex:   '$m_{\Lambda_b}^\mathrm{HME}$'
           unit:     'GeV'
+      'mass::Lambda_c(2595)@HME' :
+          central: +2.59225
+          min:     +2.59225
+          max:     +2.59225
+          latex:   '$m_{\Lambda_c(2595)}^\mathrm{HME}$'
+          unit:     'GeV'
+          comments: 'cf. [PDG:2016A], p. 175'
+      'mass::Lambda_c(2625)@HME' :
+          central: +2.62811
+          min:     +2.62811
+          max:     +2.62811
+          latex:   '$m_{\Lambda_c(2625)}^\mathrm{HME}$'
+          unit:     'GeV'
+          comments: 'cf. [PDG:2016A], p. 175'
   # }}}
 
   # Pair-production thresholds t_+ used in the SSE form factor parametrization

--- a/eos/parameters/hadronic-matrix-elements.yaml
+++ b/eos/parameters/hadronic-matrix-elements.yaml
@@ -399,6 +399,13 @@ groups:
           latex:   '$m_{\Lambda_c(2625)}^\mathrm{HME}$'
           unit:     'GeV'
           comments: 'cf. [PDG:2016A], p. 175'
+      'mass::Lambda(1520)@HME' :
+          central: +1.520
+          min:     +1.520
+          max:     +1.520
+          latex:   '$m_{\Lambda(1520)}^\mathrm{HME}$'
+          unit:     'GeV'
+          comments: 'frozen at the value used in the fit of [ABR:2022A]'
   # }}}
 
   # Pair-production thresholds t_+ used in the SSE form factor parametrization

--- a/eos/parameters/hadronic-matrix-elements.yaml
+++ b/eos/parameters/hadronic-matrix-elements.yaml
@@ -8420,6 +8420,26 @@ groups:
             - ["V", "A", "T", "T5"]
             - [0, 1, 2, 3, 4]
           comments: ''
+      'Lambda_b->Lambda(1520)::tp_v@SE' :
+          central: +33.327529
+          min:     +33.327529
+          max:     +33.327529
+          latex:    '$t_+^{V, \Lambda_b \to \Lambda(1520) ,\mathrm{SE}}$'
+          comment:  '(mB + mK)^2, scalar/vector/tensor pair-production threshold'
+          unit:     'GeV^2'
+      'Lambda_b->Lambda(1520)::tp_a@SE' :
+          central: +33.327529
+          min:     +33.327529
+          max:     +33.327529
+          latex:    '$t_+^{A, \Lambda_b \to \Lambda(1520) ,\mathrm{SE}}$'
+          comment:  '(mB + mK)^2, pseudoscalar/axialvector/tensor+gamma5 pair-production threshold'
+          unit:     'GeV^2'
+      'Lambda_b->Lambda(1520)::t0@SE' :
+          central: +9.865
+          min:     +9.865
+          max:     +9.865
+          latex:   '$t_0^{\Lambda_b \to \Lambda(1520) ,\mathrm{SE}}$'
+          unit:     'GeV^2'
   # }}}
 
   #

--- a/eos/rare-b-decays/lambda-b-to-lambda1520-gamma-naive_TEST.cc
+++ b/eos/rare-b-decays/lambda-b-to-lambda1520-gamma-naive_TEST.cc
@@ -73,6 +73,7 @@ class LambdaBToLambda1520GammaNaiveTest :
             p["QED::alpha_e(m_b)"] = 1.;
             p["WET::G_Fermi"] = 1.;
             p["mass::Lambda_b"] = 5.62;
+            p["mass::Lambda_b@HME"] = 5.62;
             p["mass::Lambda(1520)"] = 1.52;
 
             Options oo

--- a/eos/rare-b-decays/lambda-b-to-lambda1520-ll-naive_TEST.cc
+++ b/eos/rare-b-decays/lambda-b-to-lambda1520-ll-naive_TEST.cc
@@ -108,6 +108,7 @@ class LambdaBToLambda1520DileptonNaiveTest :
             p["QED::alpha_e(m_b)"] = 1.;
             p["WET::G_Fermi"] = 1.;
             p["mass::Lambda_b"] = 5.62;
+            p["mass::Lambda_b@HME"] = 5.62;
             p["mass::Lambda(1520)"] = 1.52;
 
             Options oo


### PR DESCRIPTION
Resolves issue #1224.

- 4e539f9b [form-factors] Convert ``DKMR2017FormFactorTraits`` to use parametric masses.
- 94cd89ae [form-factors] Convert ``DM2016FormFactorTraits`` to use parametric masses.
- 6bd25183 [form-factors] Convert baryon ``HQETFormFactors`` to use parametric masses.
- a7248593 [form-factors] Convert baryon ``SEFormFactors`` to use parametric masses.
- 79f0ccaf [form-factors] Convert ``SEFormFactors<..., OneHalfPlusToThreeHalfPlus>`` to use traits.
- 5a6e0f9c [eos] Update changelog for PR #1226.