### PR TITLE
Fix various multithreading problems and race conditions in nested C++/Python operations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,9 @@
 - Default the ``--with-boost-python-suffix`` used at ``./configure`` time to the Python major+minor version (e.g. ``312`` for CPython 3.12), matching the modern Boost.Python naming convention used by conda-forge and current Debian/Ubuntu/Fedora releases, in lieu of the previous OS/codename-based detection (D. van Dyk)
 - Extend the ``inference`` example figure with a residual panel showing each constraint's pull below the main panel (D. van Dyk)
 - Move the implementation of the ``eos-analysis`` command into the new module ``eos.cli.analysis``, leaving the script as a shim, so that its subcommands can be tested and called from Python (D. van Dyk)
+- Notify the callbacks registered with the ``Log`` singleton without holding its lock, and document that they may therefore be invoked concurrently and have to be thread-safe: a callback that waits for a resource held by a thread which is itself emitting a message deadlocked both threads (D. van Dyk)
+- Deliver a native log message to the Python logger synchronously and in order, in lieu of deferring it to the main thread through ``Py_AddPendingCall``; messages emitted after ``atexit`` no longer reach Python, since that is where the callbacks' references are released (D. van Dyk)
+- Bounds-check the id that a parameter name maps to in ``Parameters::operator[]``, matching the check that its ``Parameter::Id`` overload already performs, so that an id outliving its parameter is reported in lieu of read out of bounds (D. van Dyk)
 
 ### Added
 
@@ -38,6 +41,8 @@
 - Add docstrings to the 57 classes and members exported to Python that carried none, among them the ``eos.Parameters``, ``eos.Observables``, ``eos.Constraints``, ``eos.References``, and ``eos.SignalPDFs`` base classes, the section and group classes that organise them, ``eos.KinematicVariable``, ``eos.OptionSpecification``, and all thirteen ``eos.Unit`` factory methods (D. van Dyk)
 - Add ``__repr__``, ``__eq__``, and ``__hash__`` to ``eos.ObservableId``, so that an observable cache handle prints as ``ObservableId(0)``, compares by value, and can serve as a dictionary key (D. van Dyk)
 - Accept the lepton flavor as a ``str`` in ``eos.Model.wilson_coefficients_b_to_s``, which no Python call could satisfy before for want of a converter (D. van Dyk)
+- Add ``ThreadPool::WaitGuard``, a guard that a thread holds while it waits for the work it enqueued, so that an embedding runtime can relinquish exclusive access to its own state for as long as the pool's threads need it in turn; the Python bindings install one that detaches the calling thread from the interpreter (D. van Dyk)
+- Add a test case that races sixteen threads for a singleton's first ``instance()`` call and checks that exactly one instance is constructed (D. van Dyk)
 
 ### Deprecated
 
@@ -65,6 +70,10 @@
 - Fix ``eos.LogPosterior.add``, which accepted a second prior on an already-varied parameter: the set of names that the duplicate check consults was read but never written (D. van Dyk)
 - Fix the keyword names declared for ``eos.make_wilson_polynomial_ratio_observable``, which named only three of its four arguments and therefore bound ``name`` to the numerator and ``reference_observable`` to the denominator (D. van Dyk)
 - Fix the docstring of ``eos.LogPrior.Scale``, which described its scale factor as ``lambda``, a Python reserved word that can never be a keyword argument, in lieu of the declared ``scale`` (D. van Dyk)
+- Fix a segfault when evaluating an observable that a Python provider backs: the ``ObservableCache`` dispatches observables to threads of EOS's own making, which called into the interpreter without holding the GIL; the external log prior and log-likelihood block now acquire it as well, although they are reached on the calling thread (D. van Dyk)
+- Fix a segfault when a callback registered with the native log outlives the caller's last reference to it: the ``Log`` singleton recorded the Python callable as a borrowed reference, and now holds one of its own until ``atexit`` (D. van Dyk)
+- Fix ``eos.Parameters.declare`` appending a second entry for a name it has already declared, which grew the process-wide set of default parameters by one entry for every ``eos.AnalysisFile`` that declares parameters of its own and left two ``eos.Parameters`` objects created at different times disagreeing on which id a name denotes (D. van Dyk)
+- Fix the double-checked locking in ``InstantiationPolicy<T_, Singleton>::instance()``, which read the instance pointer outside its lock without synchronisation and could therefore hand a thread a pointer to an object whose construction it cannot yet observe (D. van Dyk)
 
 
 ## [v1.0.21] - 2026-08-05

--- a/eos/utils/Makefile.am
+++ b/eos/utils/Makefile.am
@@ -135,6 +135,7 @@ TESTS = \
 	expression-parser_TEST \
 	gsl-hacks_TEST \
 	indirect-iterator_TEST \
+	instantiation_policy_TEST \
 	join_TEST \
 	kinematic_TEST \
 	kmatrix_TEST \
@@ -173,6 +174,8 @@ gsl_hacks_TEST_CXXFLAGS = $(AM_CXXFLAGS) $(GSL_CXXFLAGS)
 gsl_hacks_TEST_LDFLAGS = $(GSL_LDFLAGS)
 
 indirect_iterator_TEST_SOURCES = indirect-iterator_TEST.cc
+
+instantiation_policy_TEST_SOURCES = instantiation_policy_TEST.cc
 
 join_TEST_SOURCES = join_TEST.cc
 

--- a/eos/utils/instantiation_policy-impl.hh
+++ b/eos/utils/instantiation_policy-impl.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2008 Danny van Dyk <danny.dyk@uni-dortmund.de>
+ * Copyright (c) 2008-2026 Danny van Dyk <danny.dyk@uni-dortmund.de>
  *
  * Based upon 'instantiation_policy-impl.hh' from Paludis, which is:
  *     Copyright (c) 2005, 2006, 2007 Ciaran McCreesh
@@ -39,52 +39,56 @@ namespace eos
     template <typename T_> class InstantiationPolicy<T_, Singleton>::DeleteOnDestruction
     {
         private:
-            T_ ** const _ptr;
+            std::atomic<T_ *> * const _ptr;
 
         public:
-            DeleteOnDestruction(T_ ** const ptr) :
+            DeleteOnDestruction(std::atomic<T_ *> * const ptr) :
                 _ptr(ptr)
             {
             }
 
             ~DeleteOnDestruction()
             {
-                InstantiationPolicy<T_, Singleton>::_delete(*_ptr);
+                InstantiationPolicy<T_, Singleton>::_delete(_ptr->load(std::memory_order_acquire));
 
-                *_ptr = 0;
+                _ptr->store(nullptr, std::memory_order_release);
             }
     };
 
     template <typename T_>
-    T_ **
+    std::atomic<T_ *> &
     InstantiationPolicy<T_, Singleton>::_instance_ptr()
     {
-        static T_ *                instance(0);
+        static std::atomic<T_ *>   instance(nullptr);
         static DeleteOnDestruction delete_instance(&instance);
 
-        return &instance;
+        return instance;
     }
 
     template <typename T_>
     T_ *
     InstantiationPolicy<T_, Singleton>::instance()
     {
-        T_ ** instance_ptr(_instance_ptr());
+        std::atomic<T_ *> & instance_ptr = _instance_ptr();
 
-        if (0 == *instance_ptr)
+        // the acquire/release pair publishes the constructed object along with the pointer to it
+        T_ * result = instance_ptr.load(std::memory_order_acquire);
+
+        if (nullptr == result)
         {
             static Mutex m;
             Lock         l(m);
 
-            instance_ptr = _instance_ptr();
+            result = instance_ptr.load(std::memory_order_relaxed);
 
-            if (0 == *instance_ptr)
+            if (nullptr == result)
             {
-                *instance_ptr = new T_;
+                result = new T_;
+                instance_ptr.store(result, std::memory_order_release);
             }
         }
 
-        return *instance_ptr;
+        return result;
     }
 } // namespace eos
 

--- a/eos/utils/instantiation_policy.hh
+++ b/eos/utils/instantiation_policy.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2008 Danny van Dyk <danny.dyk@uni-dortmund.de>
+ * Copyright (c) 2008-2026 Danny van Dyk <danny.dyk@uni-dortmund.de>
  *
  * Base upon 'instantiation_policy.hh' from Paludis, which is:
  *     Copyright (c) 2005, 2006, 2007 Ciaran McCreesh
@@ -22,6 +22,8 @@
 
 #ifndef EOS_GUARD_EOS_UTILS_INSTANTIATION_POLICY_HH
 #define EOS_GUARD_EOS_UTILS_INSTANTIATION_POLICY_HH 1
+
+#include <atomic>
 
 namespace eos
 {
@@ -92,8 +94,8 @@ namespace eos
 
             friend class DeleteOnDestruction;
 
-            /// Returns a pointer to our instance pointer.
-            static T_ ** _instance_ptr();
+            /// Returns a reference to our instance pointer.
+            static std::atomic<T_ *> & _instance_ptr();
 
             /// Deletes the object of T_ that is pointed at by ptr.
             static void _delete(T_ * const ptr);

--- a/eos/utils/instantiation_policy_TEST.cc
+++ b/eos/utils/instantiation_policy_TEST.cc
@@ -1,0 +1,95 @@
+/* vim: set sw=4 sts=4 et foldmethod=syntax : */
+
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <eos/utils/instantiation_policy-impl.hh>
+#include <eos/utils/instantiation_policy.hh>
+
+#include <test/test.hh>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using namespace test;
+using namespace eos;
+
+namespace
+{
+    std::atomic<unsigned> constructions(0);
+
+    class Counted : public InstantiationPolicy<Counted, Singleton>
+    {
+        public:
+            unsigned payload;
+
+            Counted() :
+                payload(4711u)
+            {
+                constructions.fetch_add(1u);
+            }
+    };
+} // namespace
+
+class InstantiationPolicySingletonTest : public TestCase
+{
+    public:
+        InstantiationPolicySingletonTest() :
+            TestCase("instantiation_policy_singleton_test")
+        {
+        }
+
+        virtual void
+        run() const
+        {
+            static const unsigned number_of_threads = 16;
+
+            // every thread must observe the one instance, fully constructed
+            std::vector<std::thread> threads;
+            std::vector<Counted *>   instances(number_of_threads, nullptr);
+            std::atomic<unsigned>    ready(0);
+
+            for (unsigned i = 0; i < number_of_threads; ++i)
+            {
+                threads.emplace_back([&instances, &ready, i]()
+                {
+                    // line the threads up, so that they race for the first call
+                    ready.fetch_add(1u);
+                    while (ready.load() < number_of_threads)
+                    {
+                    }
+
+                    instances[i] = Counted::instance();
+                });
+            }
+
+            for (auto & thread : threads)
+            {
+                thread.join();
+            }
+
+            TEST_CHECK_EQUAL(1u, constructions.load());
+
+            for (unsigned i = 0; i < number_of_threads; ++i)
+            {
+                TEST_CHECK(nullptr != instances[i]);
+                TEST_CHECK_EQUAL(instances[0], instances[i]);
+                TEST_CHECK_EQUAL(4711u, instances[i]->payload);
+            }
+        }
+} instantiation_policy_singleton_test;

--- a/eos/utils/log.cc
+++ b/eos/utils/log.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011-2024 Danny van Dyk
+ * Copyright (c) 2011-2026 Danny van Dyk
  *
  * Based upon 'paludis/util/log.cc', which is
  *
@@ -29,6 +29,7 @@
 #include <eos/utils/private_implementation_pattern-impl.hh>
 
 #include <iostream>
+#include <memory>
 #include <set>
 #include <time.h>
 #include <vector>
@@ -130,6 +131,12 @@ namespace eos
 
     template <> struct Implementation<Log>
     {
+            using Callback = std::function<void(const std::string &, const LogLevel &, const std::string &)>;
+
+            // held by value so that an emitting thread can keep reading the list after it has
+            // released our mutex; register_callback replaces the list rather than extending it
+            using Callbacks = std::shared_ptr<const std::vector<Callback>>;
+
             Mutex mutex;
 
             LogLevel log_level;
@@ -138,33 +145,41 @@ namespace eos
 
             std::string program_name;
 
-            std::vector<std::function<void(const std::string &, const LogLevel &, const std::string &)>> callbacks;
+            Callbacks callbacks;
 
             std::set<std::string> one_time_messages;
 
             Implementation() :
                 log_level(ll_error),
-                stream(nullptr)
+                stream(nullptr),
+                callbacks(std::make_shared<const std::vector<Callback>>())
             {
             }
 
-            void
+            /*
+             * Emits the message to the stream, and returns the callbacks that are yet to be
+             * notified, or an empty pointer if the message is filtered out.
+             *
+             * The caller notifies them once it has released our mutex. A callback runs code that we
+             * know nothing about, and may well wait for a resource that another thread holds while
+             * emitting a message of its own; holding any lock of ours across the callback would
+             * deadlock that pair of threads.
+             */
+            Callbacks
             message(const std::string & id, const LogLevel & l, const std::string & m)
             {
+                Lock ll(mutex);
+
                 if (l > log_level)
                 {
-                    return;
+                    return {};
                 }
 
-                // forward message to all callbacks
-                for (auto & c : callbacks)
-                {
-                    c(id, l, m);
-                }
+                Callbacks result = callbacks;
 
                 if (! stream)
                 {
-                    return;
+                    return result;
                 }
 
                 *stream << program_name << '@' << ::time(0) << ": ";
@@ -197,6 +212,8 @@ namespace eos
                 while (false);
 
                 *stream << m << std::endl;
+
+                return result;
             }
     };
 
@@ -209,7 +226,7 @@ namespace eos
 
     Log::~Log() {}
 
-    const LogLevel &
+    LogLevel
     Log::get_log_level() const
     {
         Lock l(_imp->mutex);
@@ -246,15 +263,26 @@ namespace eos
     {
         Lock l(_imp->mutex);
 
-        _imp->callbacks.push_back(callback);
+        auto callbacks = std::make_shared<std::vector<Implementation<Log>::Callback>>(*_imp->callbacks);
+        callbacks->push_back(callback);
+
+        _imp->callbacks = std::move(callbacks);
     }
 
     void
     Log::_message(const std::string & id, const LogLevel & l, const std::string & m)
     {
-        Lock ll(_imp->mutex);
+        const auto callbacks = _imp->message(id, l, m);
 
-        _imp->message(id, l, m);
+        if (! callbacks)
+        {
+            return;
+        }
+
+        for (const auto & c : *callbacks)
+        {
+            c(id, l, m);
+        }
     }
 
     LogMessageHandler
@@ -265,14 +293,16 @@ namespace eos
 
     Log::OneTimeMessage::OneTimeMessage(const std::string & id, const LogLevel & log_level, const std::string & message)
     {
-        auto imp = Log::instance()->_imp;
-
-        Lock ll(imp->mutex);
-
-        if (imp->one_time_messages.insert(id).second)
         {
-            imp->message(id, log_level, message + " (Further messages of this type will be suppressed.)");
+            Lock ll(Log::instance()->_imp->mutex);
+
+            if (! Log::instance()->_imp->one_time_messages.insert(id).second)
+            {
+                return;
+            }
         }
+
+        Log::instance()->_message(id, log_level, message + " (Further messages of this type will be suppressed.)");
     }
 
     /* LogMessageHandler */

--- a/eos/utils/log.hh
+++ b/eos/utils/log.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011-2024 Danny van Dyk
+ * Copyright (c) 2011-2026 Danny van Dyk
  *
  * Based upon 'paludis/util/log.hh', which is
  *
@@ -88,7 +88,7 @@ namespace eos
             ///@{
 
             /// Get the current log level
-            const LogLevel & get_log_level() const;
+            LogLevel get_log_level() const;
 
             /*!
              * Set the log level.
@@ -107,6 +107,10 @@ namespace eos
 
             /*!
              * Register a callback hook with the Log class.
+             *
+             * A callback is invoked without any of the Log's own locks held, so that it may wait
+             * for a resource that another thread holds while emitting a message of its own. Two
+             * threads may therefore invoke it at the same time, and it has to be thread-safe.
              */
             void register_callback(const std::function<void(const std::string &, const LogLevel &, const std::string &)> &);
 

--- a/eos/utils/log_TEST.cc
+++ b/eos/utils/log_TEST.cc
@@ -22,6 +22,11 @@
 
 #include <test/test.hh>
 
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
 using namespace test;
 using namespace eos;
 
@@ -186,3 +191,80 @@ class LogOneTimeMessageTest : public TestCase
             }
         }
 } one_time_message_test;
+
+class LogCallbackLockingTest : public TestCase
+{
+    public:
+        LogCallbackLockingTest() :
+            TestCase("log_callback_locking_test")
+        {
+        }
+
+        // the callback outlives run(), so it must not capture anything local to it
+        mutable std::mutex              mutex;
+        mutable std::condition_variable condition;
+        mutable bool                    within_callback      = false;
+        mutable bool                    other_emitted        = false;
+        mutable bool                    emitted_concurrently = false;
+
+        static const std::string &
+        id()
+        {
+            static const std::string result = "test-callback-locking";
+
+            return result;
+        }
+
+        virtual void
+        run() const
+        {
+            static const auto timeout = std::chrono::seconds(5);
+
+            // this callback holds up the emitting thread until a second thread has emitted a
+            // message of its own; that second message needs the Log's lock, which must therefore
+            // not be held while we are here
+            std::function<void(const std::string &, const LogLevel &, const std::string &)> callback = [this, timeout](const std::string & i, const LogLevel &, const std::string &)
+            {
+                if (id() != i)
+                {
+                    return;
+                }
+
+                std::unique_lock<std::mutex> l(mutex);
+
+                within_callback = true;
+                condition.notify_all();
+
+                // the second thread reaches us only if we do not hold the Log's lock; waiting in
+                // vain means that it is blocked on that lock until we return
+                emitted_concurrently = condition.wait_for(l, timeout, [this]() { return other_emitted; });
+            };
+            Log::instance()->register_callback(callback);
+
+            std::thread other([this, timeout]()
+            {
+                {
+                    std::unique_lock<std::mutex> l(mutex);
+
+                    if (! condition.wait_for(l, timeout, [this]() { return within_callback; }))
+                    {
+                        return;
+                    }
+                }
+
+                Log::instance()->message(id() + "-other", ll_debug) << "emitted while the first thread is within the callback";
+
+                std::unique_lock<std::mutex> l(mutex);
+
+                other_emitted = true;
+                condition.notify_all();
+            });
+
+            Log::instance()->message(id(), ll_debug) << "emitted from the first thread";
+
+            other.join();
+
+            TEST_CHECK(other_emitted);
+            TEST_CHECK(emitted_concurrently);
+        }
+} log_callback_locking_test;

--- a/eos/utils/log_TEST.cc
+++ b/eos/utils/log_TEST.cc
@@ -223,7 +223,7 @@ class LogCallbackLockingTest : public TestCase
             // this callback holds up the emitting thread until a second thread has emitted a
             // message of its own; that second message needs the Log's lock, which must therefore
             // not be held while we are here
-            std::function<void(const std::string &, const LogLevel &, const std::string &)> callback = [this, timeout](const std::string & i, const LogLevel &, const std::string &)
+            std::function<void(const std::string &, const LogLevel &, const std::string &)> callback = [this](const std::string & i, const LogLevel &, const std::string &)
             {
                 if (id() != i)
                 {
@@ -241,7 +241,7 @@ class LogCallbackLockingTest : public TestCase
             };
             Log::instance()->register_callback(callback);
 
-            std::thread other([this, timeout]()
+            std::thread other([this]()
             {
                 {
                     std::unique_lock<std::mutex> l(mutex);

--- a/eos/utils/log_TEST.cc
+++ b/eos/utils/log_TEST.cc
@@ -155,39 +155,60 @@ class LogOneTimeMessageTest : public TestCase
         {
         }
 
+        // the callback outlives run() and may be invoked concurrently, so it must neither capture
+        // anything local to run() nor record a message without holding our mutex
+        mutable std::mutex                                                  mutex;
         mutable std::vector<std::tuple<std::string, LogLevel, std::string>> messages;
+
+        unsigned
+        number_of_messages() const
+        {
+            std::unique_lock<std::mutex> l(mutex);
+
+            return messages.size();
+        }
 
         virtual void
         run() const
         {
-            // the callback outlives this call, so it must not capture anything local to it
+            static const std::string id_of_interest = "test-one-time-message";
 
             // register callback
             std::function<void(const std::string &, const LogLevel &, const std::string &)> callback =
-                    [this](const std::string & id, const LogLevel & level, const std::string & message) { messages.push_back(std::make_tuple(id, level, message)); };
+                    [this](const std::string & id, const LogLevel & level, const std::string & message)
+            {
+                if (id_of_interest != id)
+                {
+                    return;
+                }
+
+                std::unique_lock<std::mutex> l(mutex);
+
+                messages.push_back(std::make_tuple(id, level, message));
+            };
             Log::instance()->register_callback(callback);
 
             // first message
             {
                 // no messages yet
-                TEST_CHECK_EQUAL(0u, messages.size());
+                TEST_CHECK_EQUAL(0u, number_of_messages());
 
                 // emit message
-                static const Log::OneTimeMessage first_emission("test-one-time-message", ll_informational, "This is a test message.");
+                static const Log::OneTimeMessage first_emission(id_of_interest, ll_informational, "This is a test message.");
 
                 // one message
-                TEST_CHECK_EQUAL(1u, messages.size());
+                TEST_CHECK_EQUAL(1u, number_of_messages());
 
                 // check message
-                TEST_CHECK_EQUAL("test-one-time-message", std::get<0>(messages.back()));
+                TEST_CHECK_EQUAL(id_of_interest, std::get<0>(messages.back()));
                 TEST_CHECK_EQUAL(ll_informational, std::get<1>(messages.back()));
                 TEST_CHECK_EQUAL("This is a test message. (Further messages of this type will be suppressed.)", std::get<2>(messages.back()));
 
                 // try emitting another message with the same id
-                static const Log::OneTimeMessage second_emission("test-one-time-message", ll_informational, "This is a test message.");
+                static const Log::OneTimeMessage second_emission(id_of_interest, ll_informational, "This is a test message.");
 
                 // still one message
-                TEST_CHECK_EQUAL(1u, messages.size());
+                TEST_CHECK_EQUAL(1u, number_of_messages());
             }
         }
 } one_time_message_test;

--- a/eos/utils/log_TEST.cc
+++ b/eos/utils/log_TEST.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2011-2024 Danny van Dyk
+ * Copyright (c) 2011-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -150,14 +150,16 @@ class LogOneTimeMessageTest : public TestCase
         {
         }
 
+        mutable std::vector<std::tuple<std::string, LogLevel, std::string>> messages;
+
         virtual void
         run() const
         {
-            std::vector<std::tuple<std::string, LogLevel, std::string>> messages;
+            // the callback outlives this call, so it must not capture anything local to it
 
             // register callback
             std::function<void(const std::string &, const LogLevel &, const std::string &)> callback =
-                    [&messages](const std::string & id, const LogLevel & level, const std::string & message) { messages.push_back(std::make_tuple(id, level, message)); };
+                    [this](const std::string & id, const LogLevel & level, const std::string & message) { messages.push_back(std::make_tuple(id, level, message)); };
             Log::instance()->register_callback(callback);
 
             // first message

--- a/eos/utils/observable_cache.cc
+++ b/eos/utils/observable_cache.cc
@@ -227,6 +227,9 @@ namespace eos
     void
     ObservableCache::update()
     {
+        // an observable may call back into the embedding runtime from one of the pool's threads
+        const auto guard = ThreadPool::instance()->wait_guard();
+
         // parallelize the evaluation of the observables
         std::vector<Ticket> cacheable_tickets;
         cacheable_tickets.reserve(_imp->cacheable_observables.size());

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -878,6 +878,11 @@ namespace eos
             throw UnknownParameterError(name);
         }
 
+        if (i->second >= _imp->parameters.size())
+        {
+            throw InternalError("Parameters::operator[] (QualifiedName): name '" + name.str() + "' maps to invalid id '" + stringify(i->second) + "'");
+        }
+
         return Parameter(_imp->parameters_data, i->second);
     }
 

--- a/eos/utils/parameters.cc
+++ b/eos/utils/parameters.cc
@@ -303,6 +303,12 @@ namespace eos
 
             std::vector<ParameterSection> _sections;
 
+            static bool
+            _identical_declarations(const Parameter::Template & lhs, const Parameter::Template & rhs)
+            {
+                return (lhs.name == rhs.name) && (lhs.min == rhs.min) && (lhs.central == rhs.central) && (lhs.max == rhs.max) && (lhs.latex == rhs.latex) && (lhs.unit == rhs.unit);
+            }
+
             ParameterDefaults() :
                 _data(new Parameters::Data)
             {
@@ -671,6 +677,20 @@ namespace eos
             Parameter::Id
             declare(const QualifiedName & key, const Parameter::Template & value)
             {
+                // keep the parameter already in place, so that ids handed out earlier still denote it
+                auto i = _map.find(key);
+                if (_map.end() != i)
+                {
+                    if (! _identical_declarations(_data->data[i->second], value))
+                    {
+                        Log::instance()->message("[parameters.declare]", ll_error)
+                                << "Parameter '" << key
+                                << "' is already declared with different values, returning the existing instance; check your code for conflicting duplicate declarations";
+                    }
+
+                    return i->second;
+                }
+
                 unsigned idx = _data->data.size();
                 _data->data.push_back(Parameter::Data{ value, idx });
                 _map[key] = idx;

--- a/eos/utils/parameters_TEST.cc
+++ b/eos/utils/parameters_TEST.cc
@@ -19,6 +19,7 @@
  */
 
 #include <eos/utils/exception.hh>
+#include <eos/utils/log.hh>
 #include <eos/utils/parameters.hh>
 
 #include <test/test.hh>
@@ -26,6 +27,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <vector>
 
 using namespace test;
 using namespace eos;
@@ -36,6 +38,24 @@ class ParametersTest : public TestCase
         ParametersTest() :
             TestCase("parameters_test")
         {
+            Log::instance()->register_callback([this](const std::string &, const LogLevel &, const std::string & message) { messages.push_back(message); });
+        }
+
+        // the callback outlives run(), so it must not capture anything local to it
+        mutable std::vector<std::string> messages;
+
+        /// Counts the messages recorded so far that name the given parameter.
+        unsigned
+        count_messages(const std::string & name) const
+        {
+            unsigned result = 0;
+
+            for (const auto & message : messages)
+            {
+                result += (std::string::npos != message.find("Parameter '" + name + "' is already declared")) ? 1 : 0;
+            }
+
+            return result;
         }
 
         virtual void
@@ -316,6 +336,35 @@ class ParametersTest : public TestCase
 
                 TEST_CHECK_EQUAL(first.id(), second.id());
                 TEST_CHECK_NEARLY_EQUAL(second.central(), 1.0, 1e-12); // the original value, not the second call's
+            }
+
+            // D2: static Parameters::declare keeps the parameter that a repeated declaration names,
+            //     and reports only a declaration that differs
+            {
+                const std::string identical = "test::declare-dup-identical";
+                const std::string differing = "test::declare-dup-differing";
+
+                Parameter::Id first  = Parameters::declare(identical, R"(\text{dup})", Unit::None(), 1.0, 0.0, 2.0);
+                Parameter::Id second = Parameters::declare(identical, R"(\text{dup})", Unit::None(), 1.0, 0.0, 2.0);
+
+                // the same declaration twice: the same id, and nothing reported
+                TEST_CHECK_EQUAL(first, second);
+                TEST_CHECK_EQUAL(0u, count_messages(identical));
+
+                // the default set does not grow on the repeated declaration
+                Parameters p = Parameters::Defaults();
+                TEST_CHECK_EQUAL(p[identical].id(), first);
+                TEST_CHECK_NEARLY_EQUAL(p[identical].central(), 1.0, 1e-12);
+
+                Parameter::Id third  = Parameters::declare(differing, R"(\text{dup})", Unit::None(), 1.0, 0.0, 2.0);
+                Parameter::Id fourth = Parameters::declare(differing, R"(\text{dup})", Unit::None(), 9.0, 0.0, 2.0);
+
+                // a differing declaration: still the same id, but reported
+                TEST_CHECK_EQUAL(third, fourth);
+                TEST_CHECK_EQUAL(1u, count_messages(differing));
+
+                // the original declaration is the one that survives
+                TEST_CHECK_NEARLY_EQUAL(Parameters::Defaults()[differing].central(), 1.0, 1e-12);
             }
 
             // E: Parameters::set unknown-name error; static Parameters::redirect (undone afterwards)

--- a/eos/utils/thread_pool.cc
+++ b/eos/utils/thread_pool.cc
@@ -28,6 +28,7 @@
 
 #include <atomic>
 #include <list>
+#include <memory>
 #include <unistd.h>
 
 namespace eos
@@ -53,6 +54,8 @@ namespace eos
             std::list<std::pair<Ticket, std::function<void(void)>>> queue;
 
             std::list<Thread *> threads;
+
+            std::function<std::unique_ptr<ThreadPool::WaitGuard>()> wait_guard_factory;
 
             void
             thread_function()
@@ -202,6 +205,30 @@ namespace eos
     ThreadPool::instance()
     {
         return InstantiationPolicy<ThreadPool, Singleton>::instance();
+    }
+
+    ThreadPool::WaitGuard::~WaitGuard() = default;
+
+    void
+    ThreadPool::set_wait_guard_factory(const std::function<std::unique_ptr<WaitGuard>()> & factory)
+    {
+        Lock l(*_imp->job_mutex);
+
+        _imp->wait_guard_factory = factory;
+    }
+
+    std::unique_ptr<ThreadPool::WaitGuard>
+    ThreadPool::wait_guard() const
+    {
+        std::function<std::unique_ptr<WaitGuard>()> factory;
+
+        {
+            Lock l(*_imp->job_mutex);
+
+            factory = _imp->wait_guard_factory;
+        }
+
+        return factory ? factory() : std::unique_ptr<WaitGuard>();
     }
 
     void

--- a/eos/utils/thread_pool.hh
+++ b/eos/utils/thread_pool.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=syntax : */
 
 /*
- * Copyright (c) 2010, 2011, 2015 Danny van Dyk
+ * Copyright (c) 2010-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -25,6 +25,7 @@
 #include <eos/utils/ticket.hh>
 
 #include <functional>
+#include <memory>
 
 namespace eos
 {
@@ -38,6 +39,26 @@ namespace eos
             Ticket enqueue(const std::function<void(void)> & work);
 
             static ThreadPool * instance();
+
+            /*!
+             * A guard that a thread holds while it waits for the work it enqueued.
+             *
+             * An embedding runtime that serialises access to its own state -- the Python
+             * interpreter, say -- must relinquish it for as long as a thread waits, since the
+             * pool's threads need it in turn. Such a runtime derives from this class and
+             * relinquishes that access for as long as one of its guards lives.
+             */
+            class WaitGuard
+            {
+                public:
+                    virtual ~WaitGuard();
+            };
+
+            /// Sets the factory that supplies the wait guards.
+            void set_wait_guard_factory(const std::function<std::unique_ptr<WaitGuard>()> & factory);
+
+            /// Creates a wait guard, or an empty pointer if no factory has been set.
+            std::unique_ptr<WaitGuard> wait_guard() const;
 
             void wait_for_free_capacity();
 

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -181,6 +181,7 @@ _eos_la_SOURCES = \
 	_eos/external-log-likelihood-block.cc _eos/external-log-likelihood-block.hh \
 	_eos/external-log-prior.cc _eos/external-log-prior.hh \
 	_eos/external-observable.cc _eos/external-observable.hh \
+	_eos/gil.hh \
 	_eos/log.cc _eos/log.hh \
 	_eos/version.cc _eos/version.hh \
 	_eos/wrappers.cc _eos/wrappers.hh

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -37,6 +37,7 @@
 #include "eos/utils/parameters.hh"
 #include "eos/utils/qualified-name.hh"
 #include "eos/utils/reference-name.hh"
+#include "eos/utils/thread_pool.hh"
 #include "eos/utils/units.hh"
 #include "eos/utils/wilson-polynomial.hh"
 
@@ -44,6 +45,7 @@
 #include "python/_eos/external-log-likelihood-block.hh"
 #include "python/_eos/external-log-prior.hh"
 #include "python/_eos/external-observable.hh"
+#include "python/_eos/gil.hh"
 #include "python/_eos/log.hh"
 #include "python/_eos/version.hh"
 #include "python/_eos/wrappers.hh"
@@ -51,6 +53,7 @@
 #include <boost/python.hpp>
 #include <boost/python/raw_function.hpp>
 
+#include <memory>
 #include <tuple>
 
 using namespace boost::python;
@@ -2188,4 +2191,7 @@ BOOST_PYTHON_MODULE(_eos)
     // Release the Python references held by external observables while the interpreter is still alive.
     def("_release_python_observables", &release_python_observables);
     import("atexit").attr("register")(object(scope().attr("_release_python_observables")));
+
+    // Let the pool's threads attach themselves to the interpreter while the dispatching thread waits.
+    ThreadPool::instance()->set_wait_guard_factory([]() { return std::make_unique<::impl::ScopedGILRelease>(); });
 } // BOOST_PYTHON_MODULE(_eos)

--- a/python/_eos.cc
+++ b/python/_eos.cc
@@ -2192,6 +2192,10 @@ BOOST_PYTHON_MODULE(_eos)
     def("_release_python_observables", &release_python_observables);
     import("atexit").attr("register")(object(scope().attr("_release_python_observables")));
 
+    // The same for the references held by the log callbacks.
+    def("_release_python_log_callbacks", &::impl::release_python_log_callbacks);
+    import("atexit").attr("register")(object(scope().attr("_release_python_log_callbacks")));
+
     // Let the pool's threads attach themselves to the interpreter while the dispatching thread waits.
     ThreadPool::instance()->set_wait_guard_factory([]() { return std::make_unique<::impl::ScopedGILRelease>(); });
 } // BOOST_PYTHON_MODULE(_eos)

--- a/python/_eos/external-log-likelihood-block.cc
+++ b/python/_eos/external-log-likelihood-block.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker : */
 
 /*
- * Copyright (c) 2023 Danny van Dyk
+ * Copyright (c) 2023-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -20,6 +20,8 @@
 #include "python/_eos/external-log-likelihood-block.hh"
 
 #include "eos/statistics/test-statistic-impl.hh"
+
+#include "python/_eos/gil.hh"
 
 using boost::python::extract;
 using boost::python::object;
@@ -62,6 +64,9 @@ namespace eos
     double
     ExternalLogLikelihoodBlock::evaluate() const
     {
+        // guarded in case a caller has detached its thread from the interpreter
+        ::impl::ScopedGILAcquire gil;
+
         return extract<double>(_evaluate());
     }
 

--- a/python/_eos/external-log-prior.cc
+++ b/python/_eos/external-log-prior.cc
@@ -19,6 +19,8 @@
 
 #include "python/_eos/external-log-prior.hh"
 
+#include "python/_eos/gil.hh"
+
 using boost::python::extract;
 using boost::python::object;
 using boost::python::stl_input_iterator;
@@ -80,18 +82,25 @@ namespace eos
     double
     ExternalLogPrior::operator() () const
     {
+        // guarded in case a caller has detached its thread from the interpreter
+        ::impl::ScopedGILAcquire gil;
+
         return extract<double>(_evaluate());
     }
 
     void
     ExternalLogPrior::sample()
     {
+        ::impl::ScopedGILAcquire gil;
+
         _sample();
     }
 
     void
     ExternalLogPrior::compute_cdf()
     {
+        ::impl::ScopedGILAcquire gil;
+
         _compute_cdf();
     }
 

--- a/python/_eos/external-observable.cc
+++ b/python/_eos/external-observable.cc
@@ -23,6 +23,8 @@
 #include <eos/utils/instantiation_policy-impl.hh>
 #include <eos/utils/wrapped_forward_iterator-impl.hh>
 
+#include "python/_eos/gil.hh"
+
 #include <vector>
 
 using boost::python::extract;
@@ -80,6 +82,9 @@ namespace eos
     double
     ExternalObservable::evaluate() const
     {
+        // the ThreadPool evaluates observables on threads that are unknown to the interpreter
+        ::impl::ScopedGILAcquire gil;
+
         return extract<double>(_evaluate());
     }
 

--- a/python/_eos/gil.hh
+++ b/python/_eos/gil.hh
@@ -1,0 +1,91 @@
+/* vim: set sw=4 sts=4 et foldmethod=marker : */
+
+/*
+ * Copyright (c) 2026 Danny van Dyk
+ *
+ * This file is part of the EOS project. EOS is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU General
+ * Public License version 2, as published by the Free Software Foundation.
+ *
+ * EOS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "eos/utils/thread_pool.hh"
+
+#include <boost/python.hpp>
+
+#ifndef EOS_PYTHON__EOS_GIL_HH
+#  define EOS_PYTHON__EOS_GIL_HH 1
+
+namespace impl
+{
+    /*!
+     * Attaches the calling thread to the interpreter for the duration of the scope.
+     *
+     * Every use of the Python API from a thread that EOS created itself -- a thread of the
+     * ``ThreadPool``, say -- must be wrapped in this guard. Nesting is permitted, both within
+     * itself and within ``ScopedGILRelease``.
+     *
+     * ``PyGILState_Ensure`` and ``PyGILState_Release`` express thread-state attachment rather
+     * than lock acquisition, which is what a free-threaded interpreter requires as well: there,
+     * attachment carries no serialisation, so the same code parallelises instead of blocking.
+     */
+    class ScopedGILAcquire
+    {
+        private:
+            PyGILState_STATE _state;
+
+        public:
+            ScopedGILAcquire() :
+                _state(PyGILState_Ensure())
+            {
+            }
+
+            ~ScopedGILAcquire() { PyGILState_Release(_state); }
+
+            ScopedGILAcquire(const ScopedGILAcquire &)              = delete;
+            ScopedGILAcquire & operator= (const ScopedGILAcquire &) = delete;
+    };
+
+    /*!
+     * Detaches the calling thread from the interpreter for the duration of the scope.
+     *
+     * A thread that dispatches work to threads of EOS's own making must hold this guard while
+     * it waits, so that those threads can attach themselves via ``ScopedGILAcquire``. The
+     * calling thread must not touch the Python API while detached. Constructing the guard on a
+     * thread that is already detached does nothing.
+     *
+     * This is the pool's ``WaitGuard`` for the interpreter, and doubles as a plain scope guard.
+     */
+    class ScopedGILRelease : public eos::ThreadPool::WaitGuard
+    {
+        private:
+            PyThreadState * _state;
+
+        public:
+            ScopedGILRelease() :
+                _state(PyGILState_Check() ? PyEval_SaveThread() : nullptr)
+            {
+            }
+
+            ~ScopedGILRelease()
+            {
+                if (nullptr != _state)
+                {
+                    PyEval_RestoreThread(_state);
+                }
+            }
+
+            ScopedGILRelease(const ScopedGILRelease &)              = delete;
+            ScopedGILRelease & operator= (const ScopedGILRelease &) = delete;
+    };
+} // namespace impl
+
+#endif // EOS_PYTHON__EOS_GIL_HH

--- a/python/_eos/log.cc
+++ b/python/_eos/log.cc
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker : */
 
 /*
- * Copyright (c) 2023-2025 Danny van Dyk
+ * Copyright (c) 2023-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -19,53 +19,80 @@
 
 #include "python/_eos/log.hh"
 
-#include <iostream>
+#include "python/_eos/gil.hh"
+
+#include <memory>
+#include <vector>
 
 using namespace boost::python;
 
 namespace impl
 {
-    struct LoggingCallbackPayload
+    namespace
     {
-            PyObject *          callback;
-            const std::string   id;
-            const eos::LogLevel log_level;
-            const std::string   message;
-    };
-
-    int
-    thread_safe_logging_callback(void * p)
-    {
-        // this function is only supposed to be called from the main thread
-        // via Py_AddPendingCall, so we can safely call the Python API here
-        const LoggingCallbackPayload * const payload = static_cast<const LoggingCallbackPayload *>(p);
-
-        call<void>(payload->callback, payload->id, payload->log_level, payload->message);
-
-        delete payload;
-
-        return 0;
-    }
-
-    void
-    logging_callback(PyObject * c, const std::string & id, const eos::LogLevel & l, const std::string & m)
-    {
-        LoggingCallbackPayload * const payload = new LoggingCallbackPayload{ c, id, l, m };
-
-        int result = Py_AddPendingCall(&thread_safe_logging_callback, payload);
-
-        if (result != 0)
+        // Holds a reference to a registered Python callable for as long as the interpreter is alive.
+        struct LogCallback
         {
-            std::cerr << "eos::Log: Warning: Could not schedule log callback via Py_AddPendingCall, error code " << result << "." << std::endl;
+                object callback;
+        };
 
-            delete payload;
+        std::vector<std::shared_ptr<LogCallback>> &
+        registered_callbacks()
+        {
+            static std::vector<std::shared_ptr<LogCallback>> result;
+
+            return result;
         }
-    }
+
+        void
+        logging_callback(const std::shared_ptr<LogCallback> & c, const std::string & id, const eos::LogLevel & l, const std::string & m)
+        {
+            // a message emitted from a static destructor arrives once the interpreter has gone
+            if (! Py_IsInitialized())
+            {
+                return;
+            }
+
+            // the Log notifies us from whichever thread emitted the message, holding no lock of its own
+            ScopedGILAcquire gil;
+
+            // release_python_log_callbacks() has dropped the callable
+            if (c->callback.is_none())
+            {
+                return;
+            }
+
+            try
+            {
+                call<void>(c->callback.ptr(), id, l, m);
+            }
+            catch (const error_already_set &)
+            {
+                // the Log notifies us from a destructor, so nothing may be thrown from here
+                PyErr_WriteUnraisable(c->callback.ptr());
+            }
+        }
+    } // namespace
 
     void
     register_log_callback(PyObject * c)
     {
-        eos::Log::instance()->register_callback(std::bind(&logging_callback, c, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+        auto callback = std::make_shared<LogCallback>(LogCallback{ object(handle<>(borrowed(c))) });
+
+        registered_callbacks().push_back(callback);
+
+        eos::Log::instance()->register_callback(std::bind(&logging_callback, callback, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+    }
+
+    void
+    release_python_log_callbacks()
+    {
+        for (auto & c : registered_callbacks())
+        {
+            c->callback = object();
+        }
+
+        registered_callbacks().clear();
     }
 
     void

--- a/python/_eos/log.hh
+++ b/python/_eos/log.hh
@@ -1,7 +1,7 @@
 /* vim: set sw=4 sts=4 et foldmethod=marker : */
 
 /*
- * Copyright (c) 2023-2025 Danny van Dyk
+ * Copyright (c) 2023-2026 Danny van Dyk
  *
  * This file is part of the EOS project. EOS is free software;
  * you can redistribute it and/or modify it under the terms of the GNU General
@@ -26,9 +26,16 @@
 
 namespace impl
 {
-    void logging_callback(PyObject * c, const std::string & id, const eos::LogLevel & l, const std::string & m);
-
     void register_log_callback(PyObject * c);
+
+    /*!
+     * Drop the references that the registered log callbacks hold on their Python callables.
+     *
+     * The callbacks live in a process-wide singleton that outlives the Python interpreter.
+     * Releasing their references during static destruction would do so after the interpreter has
+     * shut down, hence this is registered with ``atexit`` and run while it is still alive.
+     */
+    void release_python_log_callbacks();
 
     void set_native_log_level(const eos::LogLevel & log_level);
 

--- a/python/_eos_TEST.py
+++ b/python/_eos_TEST.py
@@ -446,6 +446,7 @@ BINDINGS_TESTS = {
 
     (MODULE, '_emit_native_log'):                ('eos._eos_TEST', _eos._NativeLogLevel.DEBUG, 'test message'),
     (MODULE, '_register_log_callback'):          lambda _: _eos._register_log_callback(lambda *args: None),
+    (MODULE, '_release_python_log_callbacks'):   (),
     (MODULE, '_release_python_observables'):     (),
     (MODULE, '_set_native_log_level'):           (_eos._NativeLogLevel.SILENT,),
     (MODULE, 'analyze_expression'):              ('<<B->D::f_+(q2)>>',),

--- a/python/eos_TEST.py
+++ b/python/eos_TEST.py
@@ -398,6 +398,30 @@ class LoggingTests(unittest.TestCase):
                     [r"""ERROR:EOS:[ConcreteObservableEntry.make] Observable 'B->pilnu::BR' forces option key 'P' to value 'pi', overriding user-provided value 'D'"""])
 
 
+class LogCallbackLifetimeTests(unittest.TestCase):
+
+    def test_callback_outlives_the_caller(self):
+        "Check that a registered callback survives the loss of every other reference to it."
+        import gc
+
+        import _eos
+
+        emitted = []
+
+        # the Log keeps the callback for the lifetime of the process, so registering one that the
+        # caller does not hold on to must not leave a dangling reference behind
+        _eos._register_log_callback(lambda id, level, message: emitted.append((id, message)))
+        gc.collect()
+
+        _eos._set_native_log_level(_eos._NativeLogLevel.WARNING)
+        try:
+            _eos._emit_native_log('test-callback-lifetime', _eos._NativeLogLevel.WARNING, 'a message')
+        finally:
+            _eos._set_native_log_level(_eos._NativeLogLevel.INFO)
+
+        self.assertIn(('test-callback-lifetime', 'a message'), emitted)
+
+
 class ExternalLogPriorTests(unittest.TestCase):
 
     def test_creation(self):

--- a/python/eos_TEST.py
+++ b/python/eos_TEST.py
@@ -471,5 +471,42 @@ class ExternalLogPriorTests(unittest.TestCase):
             eos.LogPrior.External(parameters, _IncompleteProvider)
 
 
+class ExternalObservableTests(unittest.TestCase):
+
+    def test_evaluation_within_a_cache(self):
+        "Check that an external observable survives evaluation by the thread pool."
+        import _eos
+        import eos
+
+        class _Provider:
+            kinematic_variables = []
+
+            def __init__(self, parameters, kinematics, options):
+                self._p = parameters['mass::b(MSbar)']
+
+            def evaluate(self):
+                # allocating keeps the interpreter busy for the duration of the call
+                return sum(self._p.evaluate() for _ in range(4)) / 4.0
+
+        names = [f'test::external-observable-{i}' for i in range(4)]
+        for name in names:
+            _eos.register_python_observable(name, _Provider, '', eos.Unit.Unity())
+
+        parameters = eos.Parameters()
+        cache = eos.ObservableCache(parameters)
+        ids = [cache.add(eos.Observable.make(name, parameters, eos.Kinematics(), eos.Options()))
+               for name in names]
+
+        # ObservableCache.update() dispatches the observables to the thread pool, so each
+        # evaluation calls back into the interpreter from a thread that EOS created itself
+        mass_b = parameters['mass::b(MSbar)']
+        for i in range(2000):
+            mass_b.set(4.18 + 1.0e-6 * i)
+            cache.update()
+
+            for id in ids:
+                self.assertAlmostEqual(cache[id], 4.18 + 1.0e-6 * i, places=13)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=5)


### PR DESCRIPTION
- 13d8a7dd [utils] Add ``ThreadPool::WaitGuard`` and use it in multithreaded paths.
- b524f53c [python] Make the Python bindings thread-safe when using nested Python/C++ calls.
- a7b382d2 [utils] Fix a dangling capture in the log test.
- 293d1ce0 [utils] Notify the log's callbacks without holding its lock.
- 91ed66c7 [python] Own the log callbacks' references and notify them under the GIL.
- f778e628 [utils] Bounds-check the id that a parameter name maps to.
- d4d5bd58 [utils] Keep the parameter that a repeated declaration names.
- e6d7407e [utils] Fix the double-checked locking in the singleton accessor.
- 9350a993 [python] Acquire the GIL for the external prior and likelihood block.
- 8dd496c6 [utils] Drop needless captures in the log test.
- 5a2e7830 [utils] Synchronise the log test's message collector.
- da28fc87 [eos] Update changelog for PR #1235.